### PR TITLE
Rename `#[constructor]` to `#[init]`

### DIFF
--- a/crates/contracts/ab-contract-example/src/lib.rs
+++ b/crates/contracts/ab-contract-example/src/lib.rs
@@ -31,7 +31,7 @@ pub struct ExampleContract {
 
 #[contract_impl]
 impl ExampleContract {
-    #[constructor]
+    #[init]
     pub fn new(#[env] env: &mut Env, #[input] total_supply: &Balance) -> Self {
         Self {
             total_supply: *total_supply,
@@ -40,7 +40,7 @@ impl ExampleContract {
         }
     }
 
-    #[constructor]
+    #[init]
     pub fn new_result(
         #[env] env: &mut Env,
         #[input] total_supply: &Balance,

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -19,9 +19,9 @@ use derive_more::{
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u8)]
 pub enum ContractMethodMetadata {
-    /// `#[constructor]` method with `1` argument.
+    /// `#[init]` method with `1` argument.
     ///
-    /// Constructors are encoded af follows:
+    /// Initializers are encoded af follows:
     /// * Length of method name in bytes (u8)
     /// * Method name as UTF-8 bytes
     ///
@@ -46,247 +46,247 @@ pub enum ContractMethodMetadata {
     /// encoded as a separate argument and counts towards number of arguments. At the same time
     /// `self` doesn't count towards the number of arguments as it is implicitly defined by the
     /// variant of this struct.
-    Constructor1,
-    /// `#[constructor]` method with `2` arguments.
+    Init1,
+    /// `#[init]` method with `2` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor2,
-    /// `#[constructor]` method with `3` arguments.
+    /// Encoding is the same as [`Self::Init1`]
+    Init2,
+    /// `#[init]` method with `3` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor3,
-    /// `#[constructor]` method with `4` arguments.
+    /// Encoding is the same as [`Self::Init1`]
+    Init3,
+    /// `#[init]` method with `4` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor4,
-    /// `#[constructor]` method with `5` arguments.
+    /// Encoding is the same as [`Self::Init1`]
+    Init4,
+    /// `#[init]` method with `5` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor5,
-    /// `#[constructor]` method with `6` arguments.
+    /// Encoding is the same as [`Self::Init1`]
+    Init5,
+    /// `#[init]` method with `6` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor6,
-    /// `#[constructor]` method with `7` arguments.
+    /// Encoding is the same as [`Self::Init1`]
+    Init6,
+    /// `#[init]` method with `7` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor7,
-    /// `#[constructor]` method with `8` arguments.
+    /// Encoding is the same as [`Self::Init1`]
+    Init7,
+    /// `#[init]` method with `8` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor8,
-    /// `#[constructor]` method with `9` arguments.
+    /// Encoding is the same as [`Self::Init1`]
+    Init8,
+    /// `#[init]` method with `9` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor9,
-    /// `#[constructor]` method with `10` arguments.
+    /// Encoding is the same as [`Self::Init1`]
+    Init9,
+    /// `#[init]` method with `10` arguments.
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
-    Constructor10,
+    /// Encoding is the same as [`Self::Init1`]
+    Init10,
 
     /// Stateless `#[call]` method with `1` argument (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless1,
     /// Stateless `#[call]` method with `2` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless2,
     /// Stateless `#[call]` method with `3` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless3,
     /// Stateless `#[call]` method with `4` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless4,
     /// Stateless `#[call]` method with `5` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless5,
     /// Stateless `#[call]` method with `6` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless6,
     /// Stateless `#[call]` method with `7` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless7,
     /// Stateless `#[call]` method with `8` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless8,
     /// Stateless `#[call]` method with `9` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless9,
     /// Stateless `#[call]` method with `10` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStateless10,
 
     /// Stateful read-only `#[call]` method with `1` argument (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo1,
     /// Stateful read-only `#[call]` method with `2` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo2,
     /// Stateful read-only `#[call]` method with `3` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo3,
     /// Stateful read-only `#[call]` method with `4` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo4,
     /// Stateful read-only `#[call]` method with `5` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo5,
     /// Stateful read-only `#[call]` method with `6` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo6,
     /// Stateful read-only `#[call]` method with `7` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo7,
     /// Stateful read-only `#[call]` method with `8` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo8,
     /// Stateful read-only `#[call]` method with `9` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo9,
     /// Stateful read-only `#[call]` method with `10` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo10,
 
     /// Stateful read-write `#[call]` method with `1` argument (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw1,
     /// Stateful read-write `#[call]` method with `2` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw2,
     /// Stateful read-write `#[call]` method with `3` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw3,
     /// Stateful read-write `#[call]` method with `4` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw4,
     /// Stateful read-write `#[call]` method with `5` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw5,
     /// Stateful read-write `#[call]` method with `6` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw6,
     /// Stateful read-write `#[call]` method with `7` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw7,
     /// Stateful read-write `#[call]` method with `8` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw8,
     /// Stateful read-write `#[call]` method with `9` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw9,
     /// Stateful read-write `#[call]` method with `10` arguments (has `&mut self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw10,
 
     /// Stateless `#[view]` method with `1` argument (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless1,
     /// Stateless `#[view]` method with `2` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless2,
     /// Stateless `#[view]` method with `3` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless3,
     /// Stateless `#[view]` method with `4` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless4,
     /// Stateless `#[view]` method with `5` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless5,
     /// Stateless `#[view]` method with `6` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless6,
     /// Stateless `#[view]` method with `7` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless7,
     /// Stateless `#[view]` method with `8` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless8,
     /// Stateless `#[view]` method with `9` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless9,
     /// Stateless `#[view]` method with `10` arguments (doesn't have `self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStateless10,
 
     /// Stateful read-only `#[view]` method with `1` argument (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo1,
     /// Stateful read-only `#[view]` method with `2` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo2,
     /// Stateful read-only `#[view]` method with `3` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo3,
     /// Stateful read-only `#[view]` method with `4` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo4,
     /// Stateful read-only `#[view]` method with `5` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo5,
     /// Stateful read-only `#[view]` method with `6` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo6,
     /// Stateful read-only `#[view]` method with `7` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo7,
     /// Stateful read-only `#[view]` method with `8` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo8,
     /// Stateful read-only `#[view]` method with `9` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo9,
     /// Stateful read-only `#[view]` method with `10` arguments (has `&self` in its arguments).
     ///
-    /// Encoding is the same as [`Self::Constructor1`]
+    /// Encoding is the same as [`Self::Init1`]
     ViewStatefulRo10,
 
     /// Read-only `#[env]` argument.

--- a/crates/contracts/ab-contracts-macros/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract.rs
@@ -1,10 +1,10 @@
 mod call;
-mod constructor;
+mod init;
 mod methods;
 mod view;
 
 use crate::contract::call::process_call_fn;
-use crate::contract::constructor::process_constructor_fn;
+use crate::contract::init::process_init_fn;
 use crate::contract::methods::{ExtTraitComponents, MethodDetails};
 use crate::contract::view::process_view_fn;
 use proc_macro2::{Ident, Literal, TokenStream, TokenTree};
@@ -157,7 +157,7 @@ fn process_fn(
     contract_details: &mut ContractDetails,
 ) -> Result<MethodOutput, Error> {
     let supported_attrs = HashMap::<_, fn(_, _, _) -> _>::from_iter([
-        (format_ident!("constructor"), process_constructor_fn as _),
+        (format_ident!("init"), process_init_fn as _),
         (format_ident!("call"), process_call_fn as _),
         (format_ident!("view"), process_view_fn as _),
     ]);
@@ -181,8 +181,7 @@ fn process_fn(
     if let Some(next_attr) = attrs.take(1).next() {
         return Err(Error::new(
             next_attr.span(),
-            "Function can only have one of `#[constructor]`, `#[call]` or `#[view]` \
-            attributes specified",
+            "Function can only have one of `#[init]`, `#[call]` or `#[view]` attributes specified",
         ));
     }
 

--- a/crates/contracts/ab-contracts-macros/src/contract/init.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/init.rs
@@ -5,12 +5,12 @@ use std::collections::HashMap;
 use syn::spanned::Spanned;
 use syn::{Error, FnArg, ImplItemFn, Meta, Type};
 
-pub(super) fn process_constructor_fn(
+pub(super) fn process_init_fn(
     struct_name: Type,
     impl_item_fn: &mut ImplItemFn,
     contract_details: &mut ContractDetails,
 ) -> Result<MethodOutput, Error> {
-    let mut methods_details = MethodDetails::new(MethodType::Constructor, struct_name);
+    let mut methods_details = MethodDetails::new(MethodType::Init, struct_name);
 
     methods_details.process_output(&impl_item_fn.sig.output)?;
 
@@ -41,7 +41,7 @@ pub(super) fn process_constructor_fn(
             FnArg::Receiver(_receiver) => {
                 return Err(Error::new(
                     impl_item_fn.sig.span(),
-                    "`#[constructor]` must return `Self`, not take it as an argument",
+                    "`#[init]` must return `Self`, not take it as an argument",
                 ));
             }
             FnArg::Typed(pat_type) => {
@@ -58,16 +58,16 @@ pub(super) fn process_constructor_fn(
                 let Some(attr) = attrs.next() else {
                     return Err(Error::new(
                         input_span,
-                        "Each `#[constructor]` argument must be annotated with exactly one of: \
-                        `#[env]` or `#[input]`, in that order",
+                        "Each `#[init]` argument must be annotated with exactly one of: `#[env]` \
+                        or `#[input]`, in that order",
                     ));
                 };
 
                 if let Some(next_attr) = attrs.take(1).next() {
                     return Err(Error::new(
                         next_attr.span(),
-                        "Each `#[constructor]` argument must be annotated with exactly one of: \
-                        `#[env]` or `#[input]`, in that order",
+                        "Each `#[init]` argument must be annotated with exactly one of: `#[env]` \
+                        or `#[input]`, in that order",
                     ));
                 }
 

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(extract_if, iter_map_windows, let_chains)]
 
 //! `#[contract_impl]` macro will process *public* methods annotated with following attributes:
-//! * `#[constructor]` - method that can be called to produce an initial state of the contract,
+//! * `#[init]` - method that can be called to produce an initial state of the contract,
 //!   called once during contacts lifetime
 //! * `#[call]` - method that can read and/or modify state and/or slots of the contact, may be
 //!   called by user transaction directly or by another contract
@@ -19,9 +19,9 @@
 //! * `#[result]` - a single optional method result as an alternative to returning values from a
 //!   function directly, useful to reduce stack usage
 //!
-//! # #\[constructor]
+//! # #\[init]
 //!
-//! Constructor's purpose is to produce the initial state of the contract.
+//! Initializer's purpose is to produce the initial state of the contract.
 //!
 //! Following arguments are supported by this method (must be in this order):
 //! * `#[env]` read-only and read-write


### PR DESCRIPTION
Better represents its purpose