### PR TITLE
Rework variable size data handing

### DIFF
--- a/crates/contracts/ab-contract-example/src/lib.rs
+++ b/crates/contracts/ab-contract-example/src/lib.rs
@@ -108,7 +108,7 @@ impl ExampleContract {
     }
 
     #[view]
-    pub fn var_bytes(#[output] _out: &mut VariableBytes<1000>) {
+    pub fn var_bytes(#[output] _out: &mut VariableBytes<1024>) {
         // TODO
     }
 

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -33,8 +33,7 @@ pub enum ContractMethodMetadata {
     ///   * [`Self::SlotWithAddressRw`]
     ///   * [`Self::SlotWithoutAddressRo`]
     ///   * [`Self::SlotWithoutAddressRw`]
-    ///   * [`Self::InputRo`]
-    ///   * [`Self::InputRw`]
+    ///   * [`Self::Input`]
     ///   * [`Self::Output`]
     ///   * [`Self::Result`]
     /// * Length of the argument name in bytes (u8)
@@ -313,14 +312,10 @@ pub enum ContractMethodMetadata {
     ///
     /// Example: `#[slot] from: &mut MaybeData<Slot>,`
     SlotWithoutAddressRw,
-    /// Read-only `#[input]` argument.
+    /// `#[input]` argument.
     ///
     /// Example: `#[input] balance: &Balance,`
-    InputRo,
-    /// Read-write `#[input]` argument.
-    ///
-    /// Example: `#[input] balance: &mut Balance,`
-    InputRw,
+    Input,
     /// `#[output]` argument.
     ///
     /// Example: `#[output] out: &mut VariableBytes<1024>,`

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -226,20 +226,20 @@ pub enum IoTypeMetadata {
     ArrayU8x2028,
     /// Compact alias for `[u8; 4096]`
     ArrayU8x4096,
-    /// Variable bytes with up to 2^8 bytes capacity.
+    /// Variable bytes with up to 2^8 bytes recommended allocation.
     ///
     /// Variable bytes with up to 2^8 encoded as follows:
-    /// * 1 byte capacity in bytes
+    /// * 1 byte recommended allocation in bytes
     VariableBytes8b,
-    /// Variable bytes with up to 2^16 bytes capacity.
+    /// Variable bytes with up to 2^16 bytes recommended allocation.
     ///
     /// Variable bytes with up to 2^16 encoded as follows:
-    /// * 2 bytes capacity in bytes (little-endian)
+    /// * 2 bytes recommended allocation in bytes (little-endian)
     VariableBytes16b,
-    /// Variable bytes with up to 2^32 bytes capacity.
+    /// Variable bytes with up to 2^32 bytes recommended allocation.
     ///
     /// Variable bytes with up to 2^8 encoded as follows:
-    /// * 4 bytes capacity in bytes (little-endian)
+    /// * 4 bytes recommended allocation in bytes (little-endian)
     VariableBytes32b,
     /// Compact alias [`VariableBytes<512>`](crate::variable_bytes::VariableBytes)
     VariableBytes512,
@@ -306,12 +306,6 @@ impl IoTypeMetadata {
 /// In case of variable state size is needed, create a wrapper struct around `VariableBytes` and
 /// implement traits on it by forwarding everything to inner implementation.
 pub unsafe trait IoType {
-    /// Nominal size of the type.
-    ///
-    /// For fixed size types like those implementing [`TrivialType`] trait this is the final size,
-    /// while for types that can store variable amount of data the used bytes can be smaller than
-    /// this during read-only access even allocation itself can actually be smaller.
-    const CAPACITY: u32;
     /// Data structure metadata in binary form, describing shape and types of the contents, see
     /// [`IoTypeMetadata`] for encoding details.
     const METADATA: &[u8];
@@ -321,6 +315,9 @@ pub unsafe trait IoType {
 
     /// How many bytes are currently used to store data
     fn size(&self) -> u32;
+
+    /// How many bytes are allocated right now
+    fn capacity(&self) -> u32;
 
     /// Set number of used bytes
     ///
@@ -341,6 +338,7 @@ pub unsafe trait IoType {
     unsafe fn from_ptr<'a>(
         ptr: &'a NonNull<Self::PointerType>,
         size: &'a u32,
+        capacity: u32,
     ) -> impl Deref<Target = Self> + 'a;
 
     /// Create a mutable reference to a type, which is represented by provided memory.
@@ -357,6 +355,7 @@ pub unsafe trait IoType {
     unsafe fn from_ptr_mut<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,
+        capacity: u32,
     ) -> impl DerefMut<Target = Self> + 'a;
 }
 

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -319,25 +319,14 @@ pub unsafe trait IoType {
     /// Pointer with trivial type that this `IoType` represents
     type PointerType: TrivialType;
 
-    /// How many bytes are currently used to store data.
-    ///
-    /// This is the same as [`Self::CAPACITY`] for simple [`TrivialType`] and can vary between `0` and
-    /// [`Self::CAPACITY`] for [`VariableBytes`](crate::variable_bytes::VariableBytes).
-    #[inline]
-    fn size(&self) -> u32 {
-        Self::CAPACITY
-    }
+    /// How many bytes are currently used to store data
+    fn size(&self) -> u32;
 
     /// Set number of used bytes
     ///
     /// # Safety
     /// `size` must be set to number of properly bytes
-    unsafe fn set_size(&mut self, size: u32) {
-        debug_assert!(
-            size == Self::CAPACITY,
-            "`set_size` called with invalid input"
-        );
-    }
+    unsafe fn set_size(&mut self, size: u32);
 
     /// Create a reference to a type, which is represented by provided memory.
     ///

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -324,18 +324,18 @@ pub unsafe trait IoType {
     /// This is the same as [`Self::CAPACITY`] for simple [`TrivialType`] and can vary between `0` and
     /// [`Self::CAPACITY`] for [`VariableBytes`](crate::variable_bytes::VariableBytes).
     #[inline]
-    fn used_bytes(&self) -> u32 {
+    fn size(&self) -> u32 {
         Self::CAPACITY
     }
 
     /// Set number of used bytes
     ///
     /// # Safety
-    /// `used_bytes` must be set to number of properly bytes
-    unsafe fn set_used_bytes(&mut self, used_bytes: u32) {
+    /// `size` must be set to number of properly bytes
+    unsafe fn set_size(&mut self, size: u32) {
         debug_assert!(
-            used_bytes == Self::CAPACITY,
-            "`set_used_bytes` called with invalid input"
+            size == Self::CAPACITY,
+            "`set_size` called with invalid input"
         );
     }
 
@@ -344,14 +344,14 @@ pub unsafe trait IoType {
     /// Memory must be correctly aligned and sufficient in size, but padding beyond the size of the
     /// type is allowed. Memory behind pointer must not be written to in the meantime either.
     ///
-    /// Only `used_bytes` are guaranteed to be allocated for types that can store variable amount of
+    /// Only `size` are guaranteed to be allocated for types that can store variable amount of
     /// data due to read-only nature of read-only access here.
     ///
     /// # Safety
     /// Input bytes must be previously produced by taking underlying bytes of the same type.
     unsafe fn from_ptr<'a>(
         ptr: &'a NonNull<Self::PointerType>,
-        used_bytes: &'a u32,
+        size: &'a u32,
     ) -> impl Deref<Target = Self> + 'a;
 
     /// Create a mutable reference to a type, which is represented by provided memory.
@@ -360,14 +360,14 @@ pub unsafe trait IoType {
     /// padding beyond the size of the type is allowed. Memory behind pointer must not be read or
     /// written to in the meantime either.
     ///
-    /// `used_bytes` indicates how many bytes are used within larger allocation for types that can
+    /// `size` indicates how many bytes are used within larger allocation for types that can
     /// store variable amount of data.
     ///
     /// # Safety
     /// Input bytes must be previously produced by taking underlying bytes of the same type.
     unsafe fn from_ptr_mut<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
-        used_bytes: &'a mut u32,
+        size: &'a mut u32,
     ) -> impl DerefMut<Target = Self> + 'a;
 }
 

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -33,20 +33,20 @@ where
 ///
 /// This is somewhat similar to [`VariableBytes`](crate::variable_bytes::VariableBytes), but instead
 /// of variable size data structure allows to either have it or not have the contents or not have
-/// it, which is simpler and sufficient in many cases.
+/// it, which is simpler and more convenient API that is also sufficient in many cases.
 pub struct MaybeData<Data>
 where
     Data: TrivialType,
 {
     data: NonNull<Data>,
     size: NonNull<u32>,
+    capacity: u32,
 }
 
 unsafe impl<Data> IoType for MaybeData<Data>
 where
     Data: TrivialType,
 {
-    const CAPACITY: u32 = Data::CAPACITY;
     const METADATA: &[u8] = Data::METADATA;
 
     type PointerType = Data;
@@ -58,9 +58,14 @@ where
     }
 
     #[inline]
+    fn capacity(&self) -> u32 {
+        self.size()
+    }
+
+    #[inline]
     unsafe fn set_size(&mut self, size: u32) {
         debug_assert!(
-            size == 0 || size == Data::CAPACITY,
+            size == 0 || size == self.size(),
             "`set_size` called with invalid input"
         );
 
@@ -72,30 +77,42 @@ where
     unsafe fn from_ptr<'a>(
         ptr: &'a NonNull<Self::PointerType>,
         size: &'a u32,
+        capacity: u32,
     ) -> impl Deref<Target = Self> + 'a {
-        debug_assert!(ptr.is_aligned());
-        debug_assert!(*size == 0 || *size == Self::CAPACITY);
+        debug_assert!(ptr.is_aligned(), "Misaligned pointer");
+        debug_assert!(*size == 0 || *size == capacity, "Invalid size");
+        debug_assert!(capacity as usize == size_of::<Data>(), "Invalid capacity");
 
         let data = ptr.cast::<Data>();
         // TODO: Use `NonNull::from_ref()` once stable
         let size = NonNull::from(size);
 
-        MaybeDataWrapper(MaybeData { data, size })
+        MaybeDataWrapper(MaybeData {
+            data,
+            size,
+            capacity,
+        })
     }
 
     #[inline]
     unsafe fn from_ptr_mut<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,
+        capacity: u32,
     ) -> impl DerefMut<Target = Self> + 'a {
-        debug_assert!(ptr.is_aligned());
-        debug_assert!(*size == 0 || *size == Self::CAPACITY);
+        debug_assert!(ptr.is_aligned(), "Misaligned pointer");
+        debug_assert!(*size == 0 || *size == capacity, "Invalid size");
+        debug_assert!(capacity as usize == size_of::<Data>(), "Invalid capacity");
 
         let data = ptr.cast::<Data>();
         // TODO: Use `NonNull::from_ref()` once stable
         let size = NonNull::from(size);
 
-        MaybeDataWrapper(MaybeData { data, size })
+        MaybeDataWrapper(MaybeData {
+            data,
+            size,
+            capacity,
+        })
     }
 }
 
@@ -117,7 +134,7 @@ where
     #[inline]
     pub fn get(&self) -> Option<&Data> {
         // SAFETY: guaranteed to be initialized by constructors
-        if unsafe { self.size.read() } == Data::CAPACITY {
+        if unsafe { self.size.read() } == self.capacity {
             // SAFETY: initialized
             Some(unsafe { self.data.as_ref() })
         } else {
@@ -129,7 +146,7 @@ where
     #[inline]
     pub fn get_mut(&mut self) -> Option<&mut Data> {
         // SAFETY: guaranteed to be initialized by constructors
-        if unsafe { self.size.read() } == Data::CAPACITY {
+        if unsafe { self.size.read() } == self.capacity {
             // SAFETY: initialized
             Some(unsafe { self.data.as_mut() })
         } else {
@@ -142,7 +159,7 @@ where
     pub fn replace(&mut self, data: Data) -> &mut Data {
         // SAFETY: guaranteed to be initialized by constructors
         unsafe {
-            self.size.write(Data::CAPACITY);
+            self.size.write(self.capacity);
         }
         // SAFETY: constructor guarantees that memory is aligned
         unsafe {
@@ -168,14 +185,14 @@ where
         Init: FnOnce(NonNull<Data>) -> &'a mut Data,
     {
         // SAFETY: guaranteed to be initialized by constructors
-        if unsafe { self.size.read() } == Data::CAPACITY {
+        if unsafe { self.size.read() } == self.capacity {
             // SAFETY: initialized
             unsafe { self.data.as_mut() }
         } else {
             let data = init(self.data);
             // SAFETY: guaranteed to be initialized by constructors
             unsafe {
-                self.size.write(Data::CAPACITY);
+                self.size.write(self.capacity);
             }
             data
         }
@@ -188,7 +205,7 @@ where
     #[inline]
     pub unsafe fn assume_init(&mut self) -> &mut Data {
         // SAFETY: guaranteed to be initialized by constructors
-        self.size.write(Data::CAPACITY);
+        self.size.write(self.capacity);
         self.data.as_mut()
     }
 }

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -57,6 +57,7 @@ where
         unsafe { self.size.read() }
     }
 
+    #[inline]
     unsafe fn set_size(&mut self, size: u32) {
         debug_assert!(
             size == 0 || size == Data::CAPACITY,
@@ -67,6 +68,7 @@ where
         self.size.write(size);
     }
 
+    #[inline]
     unsafe fn from_ptr<'a>(
         ptr: &'a NonNull<Self::PointerType>,
         size: &'a u32,
@@ -81,6 +83,7 @@ where
         MaybeDataWrapper(MaybeData { data, size })
     }
 
+    #[inline]
     unsafe fn from_ptr_mut<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,

--- a/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
@@ -179,10 +179,10 @@ where
 
     unsafe fn from_ptr<'a>(
         ptr: &'a NonNull<Self::PointerType>,
-        used_bytes: &'a u32,
+        size: &'a u32,
     ) -> impl Deref<Target = Self> + 'a {
         debug_assert!(ptr.is_aligned());
-        debug_assert!(*used_bytes == Self::CAPACITY);
+        debug_assert!(*size == Self::CAPACITY);
 
         // SAFETY: guaranteed by this function signature
         ptr.as_ref()
@@ -190,10 +190,10 @@ where
 
     unsafe fn from_ptr_mut<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
-        used_bytes: &'a mut u32,
+        size: &'a mut u32,
     ) -> impl DerefMut<Target = Self> + 'a {
         debug_assert!(ptr.is_aligned());
-        debug_assert!(*used_bytes == Self::CAPACITY);
+        debug_assert!(*size == Self::CAPACITY);
 
         // SAFETY: guaranteed by this function signature
         ptr.as_mut()

--- a/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
@@ -177,6 +177,20 @@ where
 
     type PointerType = T;
 
+    #[inline]
+    fn size(&self) -> u32 {
+        size_of::<T>() as u32
+    }
+
+    #[inline]
+    unsafe fn set_size(&mut self, size: u32) {
+        debug_assert!(
+            size == Self::CAPACITY,
+            "`set_size` called with invalid input"
+        );
+    }
+
+    #[inline]
     unsafe fn from_ptr<'a>(
         ptr: &'a NonNull<Self::PointerType>,
         size: &'a u32,
@@ -188,6 +202,7 @@ where
         ptr.as_ref()
     }
 
+    #[inline]
     unsafe fn from_ptr_mut<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -92,6 +92,7 @@ unsafe impl<const CAPACITY: u32> IoType for VariableBytes<CAPACITY> {
         self.size()
     }
 
+    #[inline]
     unsafe fn set_size(&mut self, size: u32) {
         debug_assert!(size <= CAPACITY, "`set_size` called with invalid input");
 

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -4,10 +4,12 @@ use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use core::{ptr, slice};
 
-struct VariableBytesWrapper<const CAPACITY: u32>(VariableBytes<CAPACITY>);
+struct VariableBytesWrapper<const RECOMMENDED_ALLOCATION: u32>(
+    VariableBytes<RECOMMENDED_ALLOCATION>,
+);
 
-impl<const CAPACITY: u32> Deref for VariableBytesWrapper<CAPACITY> {
-    type Target = VariableBytes<CAPACITY>;
+impl<const RECOMMENDED_ALLOCATION: u32> Deref for VariableBytesWrapper<RECOMMENDED_ALLOCATION> {
+    type Target = VariableBytes<RECOMMENDED_ALLOCATION>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -15,7 +17,7 @@ impl<const CAPACITY: u32> Deref for VariableBytesWrapper<CAPACITY> {
     }
 }
 
-impl<const CAPACITY: u32> DerefMut for VariableBytesWrapper<CAPACITY> {
+impl<const RECOMMENDED_ALLOCATION: u32> DerefMut for VariableBytesWrapper<RECOMMENDED_ALLOCATION> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
@@ -24,67 +26,73 @@ impl<const CAPACITY: u32> DerefMut for VariableBytesWrapper<CAPACITY> {
 
 /// Container for storing variable number of bytes.
 ///
-/// The total allocation is specified by `CAPACITY` constant generic, but actual number of bytes in
-/// use can vary between `0` and `CAPACITY`. This is useful to minimize amount of data persisted in
-/// the state, while keep host/guest API dealing with fixed size types and avoid dynamic allocations
-/// on the heap in most cases.
-pub struct VariableBytes<const CAPACITY: u32> {
+/// `RECOMMENDED_ALLOCATION` is what is being used when host needs to allocate memory for call into
+/// guest, but guest may receive an allocation with more or less memory in practice depending on
+/// other circumstances, like when called from another contract with specific allocation specified.
+pub struct VariableBytes<const RECOMMENDED_ALLOCATION: u32> {
     bytes: NonNull<u8>,
     size: NonNull<u32>,
+    capacity: u32,
 }
 
-unsafe impl<const CAPACITY: u32> IoType for VariableBytes<CAPACITY> {
-    const CAPACITY: u32 = CAPACITY;
+unsafe impl<const RECOMMENDED_ALLOCATION: u32> IoType for VariableBytes<RECOMMENDED_ALLOCATION> {
     const METADATA: &[u8] = {
-        const fn metadata(size: u32) -> ([u8; 4096], usize) {
-            if size == 512 {
+        const fn metadata(max_capacity: u32) -> ([u8; 4096], usize) {
+            if max_capacity == 512 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes512 as u8]]);
-            } else if size == 1024 {
+            } else if max_capacity == 1024 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes1024 as u8]]);
-            } else if size == 2028 {
+            } else if max_capacity == 2028 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes2028 as u8]]);
-            } else if size == 4096 {
+            } else if max_capacity == 4096 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes4096 as u8]]);
-            } else if size == 8192 {
+            } else if max_capacity == 8192 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes8192 as u8]]);
-            } else if size == 16384 {
+            } else if max_capacity == 16384 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes16384 as u8]]);
-            } else if size == 32768 {
+            } else if max_capacity == 32768 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes32768 as u8]]);
-            } else if size == 65536 {
+            } else if max_capacity == 65536 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes65536 as u8]]);
-            } else if size == 131072 {
+            } else if max_capacity == 131072 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes131072 as u8]]);
-            } else if size == 262144 {
+            } else if max_capacity == 262144 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes262144 as u8]]);
-            } else if size == 524288 {
+            } else if max_capacity == 524288 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes524288 as u8]]);
-            } else if size == 1048576 {
+            } else if max_capacity == 1048576 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes1048576 as u8]]);
-            } else if size == 4194304 {
+            } else if max_capacity == 4194304 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes4194304 as u8]]);
-            } else if size == 8388608 {
+            } else if max_capacity == 8388608 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes8388608 as u8]]);
-            } else if size == 16777216 {
+            } else if max_capacity == 16777216 {
                 return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes16777216 as u8]]);
             }
 
-            let (io_type, size_bytes) = if size < 2u32.pow(8) {
+            let (io_type, size_bytes) = if max_capacity < 2u32.pow(8) {
                 (IoTypeMetadata::VariableBytes8b, 1)
-            } else if size < 2u32.pow(16) {
+            } else if max_capacity < 2u32.pow(16) {
                 (IoTypeMetadata::VariableBytes16b, 2)
             } else {
                 (IoTypeMetadata::VariableBytes32b, 4)
             };
 
-            concat_metadata_sources(&[&[io_type as u8], size.to_le_bytes().split_at(size_bytes).0])
+            concat_metadata_sources(&[
+                &[io_type as u8],
+                max_capacity.to_le_bytes().split_at(size_bytes).0,
+            ])
         }
 
         // Strange syntax to allow Rust to extend lifetime of metadata scratch automatically
-        metadata(CAPACITY).0.split_at(metadata(CAPACITY).1).0
+        metadata(RECOMMENDED_ALLOCATION)
+            .0
+            .split_at(metadata(RECOMMENDED_ALLOCATION).1)
+            .0
     };
 
-    // TODO: Use `[u8; CAPACITY as usize]` once stabilized `generic_const_exprs` allows us to do so
+    // TODO: Use `[u8; RECOMMENDED_ALLOCATION as usize]` once stabilized `generic_const_exprs`
+    //  allows us to do so
     type PointerType = u8;
 
     #[inline]
@@ -93,8 +101,16 @@ unsafe impl<const CAPACITY: u32> IoType for VariableBytes<CAPACITY> {
     }
 
     #[inline]
+    fn capacity(&self) -> u32 {
+        self.capacity
+    }
+
+    #[inline]
     unsafe fn set_size(&mut self, size: u32) {
-        debug_assert!(size <= CAPACITY, "`set_size` called with invalid input");
+        debug_assert!(
+            size <= self.capacity,
+            "`set_size` called with invalid input"
+        );
 
         // SAFETY: guaranteed to be initialized by constructors
         self.size.write(size);
@@ -104,14 +120,16 @@ unsafe impl<const CAPACITY: u32> IoType for VariableBytes<CAPACITY> {
     unsafe fn from_ptr<'a>(
         ptr: &'a NonNull<Self::PointerType>,
         size: &'a u32,
+        capacity: u32,
     ) -> impl Deref<Target = Self> + 'a {
-        debug_assert!(ptr.is_aligned());
-        debug_assert!(*size <= CAPACITY);
+        debug_assert!(ptr.is_aligned(), "Misaligned pointer");
+        debug_assert!(*size <= capacity, "Size larger than capacity");
 
         VariableBytesWrapper(Self {
             bytes: *ptr,
             // TODO: Use `NonNull::from_ref()` once stable
             size: NonNull::from(size),
+            capacity,
         })
     }
 
@@ -119,30 +137,37 @@ unsafe impl<const CAPACITY: u32> IoType for VariableBytes<CAPACITY> {
     unsafe fn from_ptr_mut<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,
+        capacity: u32,
     ) -> impl DerefMut<Target = Self> + 'a {
-        debug_assert!(ptr.is_aligned());
-        debug_assert!(*size <= CAPACITY);
+        debug_assert!(ptr.is_aligned(), "Misaligned pointer");
+        debug_assert!(*size <= capacity, "Size larger than capacity");
 
         VariableBytesWrapper(Self {
             bytes: *ptr,
             // TODO: Use `NonNull::from_ref()` once stable
             size: NonNull::from(size),
+            capacity,
         })
     }
 }
 
-impl<const CAPACITY: u32> IoTypeOptional for VariableBytes<CAPACITY> {
+impl<const RECOMMENDED_ALLOCATION: u32> IoTypeOptional for VariableBytes<RECOMMENDED_ALLOCATION> {
     #[inline]
     fn as_mut_ptr(&mut self) -> &mut NonNull<Self::PointerType> {
         &mut self.bytes
     }
 }
 
-impl<const CAPACITY: u32> VariableBytes<CAPACITY> {
+impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
     #[inline]
     pub fn size(&self) -> u32 {
         // SAFETY: guaranteed to be initialized by constructors
         unsafe { self.size.read() }
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> u32 {
+        self.capacity
     }
 
     /// Try to get access to initialized bytes
@@ -170,7 +195,7 @@ impl<const CAPACITY: u32> VariableBytes<CAPACITY> {
     #[must_use = "Operation may fail"]
     pub fn append(&mut self, bytes: &[u8]) -> bool {
         let size = self.size();
-        if bytes.len() as u32 > size + CAPACITY {
+        if bytes.len() as u32 > size + self.capacity {
             return false;
         }
 
@@ -221,14 +246,15 @@ impl<const CAPACITY: u32> VariableBytes<CAPACITY> {
 
     /// Assume that the first `size` are initialized and can be read.
     ///
-    /// Returns `Some(initialized_bytes)` on success or `None` if `size` is larger than
-    /// `CAPACITY`.
+    /// Returns `Some(initialized_bytes)` on success or `None` if `size` is larger than its
+    /// capacity.
     ///
     /// # Safety
     /// Caller must ensure `size` are actually initialized
     #[inline]
+    #[must_use = "Operation may fail"]
     pub unsafe fn assume_init(&mut self, size: u32) -> Option<&mut [u8]> {
-        if size > CAPACITY {
+        if size > self.capacity {
             return None;
         }
 

--- a/crates/contracts/ab-contracts-macros/src/contract/methods.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/methods.rs
@@ -1094,7 +1094,7 @@ impl MethodDetails {
                     quote! {
                         // Write result into `InternalArgs`, return exit code
                         args.ok_result_size =
-                            ::ab_contracts_io_type::IoType::used_bytes(&#result_var_name);
+                            ::ab_contracts_io_type::IoType::size(&#result_var_name);
                         args.ok_result_ptr.write(#result_var_name);
                         ::ab_contracts_common::ExitCode::Ok
                     }
@@ -1114,7 +1114,7 @@ impl MethodDetails {
                         match #result_var_name {
                             Ok(result) => {
                                 args.ok_result_size =
-                                    ::ab_contracts_io_type::IoType::used_bytes(&#result_var_name);
+                                    ::ab_contracts_io_type::IoType::size(&#result_var_name);
                                 args.ok_result_ptr.write(result);
                                 ::ab_contracts_common::ExitCode::Ok
                             }
@@ -1327,7 +1327,7 @@ impl MethodDetails {
             let struct_field_capacity = format_ident!("{arg_name}_capacity");
 
             args_sizes.push(quote! {
-                #struct_field_size: ::ab_contracts_io_type::IoType::used_bytes(#arg_name),
+                #struct_field_size: ::ab_contracts_io_type::IoType::size(#arg_name),
             });
             match io_arg {
                 IoArg::Input {
@@ -1356,7 +1356,7 @@ impl MethodDetails {
                         #struct_field_capacity: <#type_name as ::ab_contracts_io_type::IoType>::CAPACITY,
                     });
                     result_processing.push(quote! {
-                        ::ab_contracts_io_type::IoType::set_used_bytes(
+                        ::ab_contracts_io_type::IoType::set_size(
                             #arg_name,
                             args.#struct_field_size,
                         );
@@ -1384,7 +1384,7 @@ impl MethodDetails {
                         #struct_field_capacity: <#type_name as ::ab_contracts_io_type::IoType>::CAPACITY,
                     });
                     result_processing.push(quote! {
-                        ::ab_contracts_io_type::IoType::set_used_bytes(
+                        ::ab_contracts_io_type::IoType::set_size(
                             #arg_name,
                             args.#struct_field_size,
                         );

--- a/crates/contracts/ab-contracts-macros/src/contract/view.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/view.rs
@@ -67,7 +67,8 @@ pub(super) fn process_view_fn(
                     return Err(Error::new(
                         input_span,
                         "Each `#[view]` argument (except `&self`) must be annotated with \
-                        exactly one of: `#[slot]`, `#[input]` or `#[output]`, in that order",
+                        exactly one of: `#[env]`, `#[slot]`, `#[input]` or `#[output]`, in that \
+                        order",
                     ));
                 };
 
@@ -75,7 +76,8 @@ pub(super) fn process_view_fn(
                     return Err(Error::new(
                         next_attr.span(),
                         "Each `#[view]` argument (except `&self`) must be annotated with \
-                        exactly one of: `#[slot]`, `#[input]` or `#[output]`, in that order",
+                        exactly one of: `#[env]`, `#[slot]`, `#[input]` or `#[output]`, in that \
+                        order",
                     ));
                 }
 

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -13,8 +13,7 @@
 //! * `#[env]` - environment variable, used to access ephemeral execution environment, call methods
 //!   on other contracts, etc.
 //! * `#[slot]` - slot corresponding to this contract
-//! * `#[input]` - method input coming from user transaction or invocation from another contract,
-//!   inputs can also support in-place updates if needed
+//! * `#[input]` - method input coming from user transaction or invocation from another contract
 //! * `#[output]` - method output
 //! * `#[result]` - a single optional method result as an alternative to returning values from a
 //!   function directly, useful to reduce stack usage
@@ -26,7 +25,7 @@
 //! Following arguments are supported by this method (must be in this order):
 //! * `#[env]` read-only and read-write
 //! * `#[slot]` read-only and read-write
-//! * `#[input]` read-only and read-write
+//! * `#[input]`
 //! * `#[output]`
 //! * `#[result]`
 //!
@@ -41,7 +40,7 @@
 //! * `&self` or `&mut self` depending on whether state reads and/or modification are required
 //! * `#[env]` read-only and read-write
 //! * `#[slot]` read-only and read-write
-//! * `#[input]` read-only and read-write
+//! * `#[input]`
 //! * `#[output]`
 //! * `#[result]`
 //!
@@ -54,8 +53,8 @@
 //! * `&self`
 //! * `#[env]` read-only
 //! * `#[slot]` read-only
-//! * `#[input]` read-only and read-write, though read-write only makes sense within block context
-//! * `#[output]`, though only makes sense within block context
+//! * `#[input]`
+//! * `#[output]`
 //! * `#[result]`
 
 mod contract;


### PR DESCRIPTION
Two big changes here.

First, return type can only be `TrivialType` now, for variable size types `#[result]` must be used.

Second, `CAPACITY` is no longer a constant, but rather a dynamic parameter. `VariableBytes` still has a constant in it now called `RECOMMENDED_ALLOCATION` to allow host to call into methods with variable size outputs since it needs to know how much memory to allocate, but it is now possible for host or another contract to provide more or less than `RECOMMENDED_ALLOCATION` if necessary.