### PR TITLE
Environment improvements

### DIFF
--- a/crates/contracts/ab-contract-example/src/lib.rs
+++ b/crates/contracts/ab-contract-example/src/lib.rs
@@ -53,7 +53,7 @@ impl ExampleContract {
         });
     }
 
-    #[call]
+    #[update]
     pub fn mint(
         &mut self,
         #[env] env: &mut Env,
@@ -112,7 +112,7 @@ impl ExampleContract {
         // TODO
     }
 
-    #[call]
+    #[update]
     pub fn transfer(
         #[env] env: &mut Env,
         #[slot] (from_address, from): (&Address, &mut MaybeData<Slot>),

--- a/crates/contracts/ab-contract-example/src/lib.rs
+++ b/crates/contracts/ab-contract-example/src/lib.rs
@@ -35,7 +35,7 @@ impl ExampleContract {
     pub fn new(#[env] env: &mut Env, #[input] total_supply: &Balance) -> Self {
         Self {
             total_supply: *total_supply,
-            owner: *env.origin(),
+            owner: *env.context(),
             padding: [0; 8],
         }
     }
@@ -48,7 +48,7 @@ impl ExampleContract {
     ) {
         result.replace(Self {
             total_supply: *total_supply,
-            owner: *env.origin(),
+            owner: *env.context(),
             padding: [0; 8],
         });
     }
@@ -60,8 +60,8 @@ impl ExampleContract {
         #[slot] to: &mut MaybeData<Slot>,
         #[input] &value: &Balance,
     ) -> Result<(), ContractError> {
-        if env.origin() != &self.owner {
-            return Err(ContractError::BadOrigin);
+        if env.context() != &self.owner && env.caller() != &self.owner {
+            return Err(ContractError::AccessDenied);
         }
 
         if Balance::MAX - value > self.total_supply {
@@ -119,8 +119,8 @@ impl ExampleContract {
         #[slot] to: &mut MaybeData<Slot>,
         #[input] &value: &Balance,
     ) -> Result<(), ContractError> {
-        if env.origin() != from_address {
-            return Err(ContractError::BadOrigin);
+        if env.context() != from_address && env.caller() != from_address {
+            return Err(ContractError::AccessDenied);
         }
 
         {

--- a/crates/contracts/ab-contracts-common/src/env.rs
+++ b/crates/contracts/ab-contracts-common/src/env.rs
@@ -38,6 +38,7 @@ pub struct PreparedMethod<'a> {
     _phantom: PhantomData<&'a ()>,
 }
 
+// TODO: More APIs
 /// Ephemeral execution environment
 #[derive(Debug, Copy, Clone, TrivialType)]
 #[repr(C)]
@@ -49,15 +50,13 @@ pub struct Env {
 }
 
 impl Env {
-    // TODO: Platform-specific env
-
     /// Context of the execution
-    pub fn context(&mut self) -> &Address {
+    pub fn context<'a>(self: &'a &'a mut Self) -> &'a Address {
         &self.context
     }
 
     /// Caller of this contract
-    pub fn caller(&mut self) -> &Address {
+    pub fn caller<'a>(self: &'a &'a mut Self) -> &'a Address {
         &self.caller
     }
 

--- a/crates/contracts/ab-contracts-common/src/env.rs
+++ b/crates/contracts/ab-contracts-common/src/env.rs
@@ -43,16 +43,22 @@ pub struct PreparedMethod<'a> {
 #[repr(C)]
 #[non_exhaustive]
 pub struct Env {
-    origin: Address,
+    context: Address,
+    caller: Address,
     own_address: Address,
 }
 
 impl Env {
     // TODO: Platform-specific env
 
-    /// Method call origin
-    pub fn origin(&mut self) -> &Address {
-        &self.origin
+    /// Context of the execution
+    pub fn context(&mut self) -> &Address {
+        &self.context
+    }
+
+    /// Caller of this contract
+    pub fn caller(&mut self) -> &Address {
+        &self.caller
     }
 
     /// Address of this contract itself

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -339,7 +339,7 @@ pub enum ContractMethodMetadata {
 pub enum ContractError {
     InvalidState = 1,
     InvalidInput,
-    BadOrigin,
+    AccessDenied,
 }
 
 impl ContractError {
@@ -351,7 +351,7 @@ impl ContractError {
         match self {
             Self::InvalidState => ExitCode::InvalidState,
             Self::InvalidInput => ExitCode::InvalidInput,
-            Self::BadOrigin => ExitCode::BadOrigin,
+            Self::AccessDenied => ExitCode::BadOrigin,
         }
     }
 }
@@ -390,7 +390,7 @@ impl From<ExitCode> for Result<(), ContractError> {
             ExitCode::Ok => Ok(()),
             ExitCode::InvalidState => Err(ContractError::InvalidState),
             ExitCode::InvalidInput => Err(ContractError::InvalidInput),
-            ExitCode::BadOrigin => Err(ContractError::BadOrigin),
+            ExitCode::BadOrigin => Err(ContractError::AccessDenied),
         }
     }
 }

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -84,125 +84,125 @@ pub enum ContractMethodMetadata {
     /// Encoding is the same as [`Self::Init1`]
     Init10,
 
-    /// Stateless `#[call]` method with `1` argument (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `1` argument (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless1,
-    /// Stateless `#[call]` method with `2` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `2` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless2,
-    /// Stateless `#[call]` method with `3` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `3` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless3,
-    /// Stateless `#[call]` method with `4` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `4` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless4,
-    /// Stateless `#[call]` method with `5` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `5` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless5,
-    /// Stateless `#[call]` method with `6` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `6` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless6,
-    /// Stateless `#[call]` method with `7` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `7` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless7,
-    /// Stateless `#[call]` method with `8` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `8` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless8,
-    /// Stateless `#[call]` method with `9` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `9` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless9,
-    /// Stateless `#[call]` method with `10` arguments (doesn't have `self` in its arguments).
+    /// Stateless `#[update]` method with `10` arguments (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStateless10,
 
-    /// Stateful read-only `#[call]` method with `1` argument (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `1` argument (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo1,
-    /// Stateful read-only `#[call]` method with `2` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `2` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo2,
-    /// Stateful read-only `#[call]` method with `3` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `3` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo3,
-    /// Stateful read-only `#[call]` method with `4` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `4` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo4,
-    /// Stateful read-only `#[call]` method with `5` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `5` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo5,
-    /// Stateful read-only `#[call]` method with `6` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `6` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo6,
-    /// Stateful read-only `#[call]` method with `7` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `7` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo7,
-    /// Stateful read-only `#[call]` method with `8` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `8` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo8,
-    /// Stateful read-only `#[call]` method with `9` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `9` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo9,
-    /// Stateful read-only `#[call]` method with `10` arguments (has `&self` in its arguments).
+    /// Stateful read-only `#[update]` method with `10` arguments (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRo10,
 
-    /// Stateful read-write `#[call]` method with `1` argument (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `1` argument (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw1,
-    /// Stateful read-write `#[call]` method with `2` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `2` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw2,
-    /// Stateful read-write `#[call]` method with `3` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `3` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw3,
-    /// Stateful read-write `#[call]` method with `4` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `4` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw4,
-    /// Stateful read-write `#[call]` method with `5` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `5` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw5,
-    /// Stateful read-write `#[call]` method with `6` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `6` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw6,
-    /// Stateful read-write `#[call]` method with `7` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `7` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw7,
-    /// Stateful read-write `#[call]` method with `8` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `8` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw8,
-    /// Stateful read-write `#[call]` method with `9` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `9` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw9,
-    /// Stateful read-write `#[call]` method with `10` arguments (has `&mut self` in its arguments).
+    /// Stateful read-write `#[update]` method with `10` arguments (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init1`]
     CallStatefulRw10,

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -442,5 +442,6 @@ impl fmt::Display for Address {
 impl Address {
     // TODO: Various system contracts
     /// System address
-    pub const SYSTEM: Self = Self([0; 8]);
+    pub const SYSTEM: Self = Self([1; 8]);
+    pub const NOBODY: Self = Self([0; 8]);
 }

--- a/crates/contracts/ab-contracts-macros/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract.rs
@@ -1,11 +1,11 @@
-mod call;
 mod init;
 mod methods;
+mod update;
 mod view;
 
-use crate::contract::call::process_call_fn;
 use crate::contract::init::process_init_fn;
 use crate::contract::methods::{ExtTraitComponents, MethodDetails};
+use crate::contract::update::process_update_fn;
 use crate::contract::view::process_view_fn;
 use proc_macro2::{Ident, Literal, TokenStream, TokenTree};
 use quote::{format_ident, quote};
@@ -158,7 +158,7 @@ fn process_fn(
 ) -> Result<MethodOutput, Error> {
     let supported_attrs = HashMap::<_, fn(_, _, _) -> _>::from_iter([
         (format_ident!("init"), process_init_fn as _),
-        (format_ident!("call"), process_call_fn as _),
+        (format_ident!("update"), process_update_fn as _),
         (format_ident!("view"), process_view_fn as _),
     ]);
     let mut attrs = impl_item_fn.attrs.extract_if(.., |attr| match &attr.meta {
@@ -181,7 +181,7 @@ fn process_fn(
     if let Some(next_attr) = attrs.take(1).next() {
         return Err(Error::new(
             next_attr.span(),
-            "Function can only have one of `#[init]`, `#[call]` or `#[view]` attributes specified",
+            "Function can only have one of `#[init]`, `#[update]` or `#[view]` attributes specified",
         ));
     }
 

--- a/crates/contracts/ab-contracts-macros/src/contract/methods.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/methods.rs
@@ -1501,6 +1501,7 @@ impl MethodDetails {
             quote! {
                 fn #original_method_name(
                     &#env_mutability self,
+                    method_context: &::ab_contracts_common::env::MethodContext,
                     #( #method_args )*
                 ) -> ::core::result::Result<#result_type, ::ab_contracts_common::ContractError>
             }
@@ -1508,6 +1509,7 @@ impl MethodDetails {
             quote! {
                 fn #original_method_name(
                     &#env_mutability self,
+                    method_context: &::ab_contracts_common::env::MethodContext,
                     #( #method_args )*
                 ) -> ::core::result::Result<(), ::ab_contracts_common::ContractError>
             }
@@ -1528,7 +1530,7 @@ impl MethodDetails {
                     #( #args_capacities )*
                 };
 
-                self.invoke(&contract, &mut args)?;
+                self.call(&contract, &mut args, method_context)?;
 
                 // SAFETY: Non-error result above indicates successful storing of the result
                 let result = unsafe {

--- a/crates/contracts/ab-contracts-macros/src/contract/methods.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/methods.rs
@@ -9,7 +9,7 @@ use syn::{
 #[derive(Copy, Clone)]
 pub(super) enum MethodType {
     Init,
-    Call,
+    Update,
     View,
 }
 
@@ -17,7 +17,7 @@ impl MethodType {
     fn attr_str(&self) -> &'static str {
         match self {
             MethodType::Init => "init",
-            MethodType::Call => "call",
+            MethodType::Update => "update",
             MethodType::View => "view",
         }
     }
@@ -1270,7 +1270,7 @@ impl MethodDetails {
         let metadata = {
             let method_type = match self.method_type {
                 MethodType::Init => "Init",
-                MethodType::Call => {
+                MethodType::Update => {
                     if let Some(mutable) = &self.state {
                         if mutable.is_some() {
                             "CallStatefulRw"

--- a/crates/contracts/ab-contracts-macros/src/contract/update.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/update.rs
@@ -5,12 +5,12 @@ use std::collections::HashMap;
 use syn::spanned::Spanned;
 use syn::{Error, FnArg, ImplItemFn, Meta, Type};
 
-pub(super) fn process_call_fn(
+pub(super) fn process_update_fn(
     struct_name: Type,
     impl_item_fn: &mut ImplItemFn,
     contract_details: &mut ContractDetails,
 ) -> Result<MethodOutput, Error> {
-    let mut methods_details = MethodDetails::new(MethodType::Call, struct_name);
+    let mut methods_details = MethodDetails::new(MethodType::Update, struct_name);
 
     methods_details.process_output(&impl_item_fn.sig.output)?;
 
@@ -42,7 +42,7 @@ pub(super) fn process_call_fn(
                 if receiver.reference.is_none() {
                     return Err(Error::new(
                         impl_item_fn.sig.span(),
-                        "`#[call]` can't consume `Self`, use `&self` or `&mut self` instead",
+                        "`#[update]` can't consume `Self`, use `&self` or `&mut self` instead",
                     ));
                 }
 
@@ -66,7 +66,7 @@ pub(super) fn process_call_fn(
                 let Some(attr) = attrs.next() else {
                     return Err(Error::new(
                         input_span,
-                        "Each `#[call]` argument (except `&self`/`&mut self`) must be \
+                        "Each `#[update]` argument (except `&self`/`&mut self`) must be \
                         annotated with exactly one of: `#[env]`, `#[slot]`, `#[input]` or \
                         `#[output]`, in that order",
                     ));
@@ -75,7 +75,7 @@ pub(super) fn process_call_fn(
                 if let Some(next_attr) = attrs.take(1).next() {
                     return Err(Error::new(
                         next_attr.span(),
-                        "Each `#[call]` argument (except `&self`/`&mut self`) must be \
+                        "Each `#[update]` argument (except `&self`/`&mut self`) must be \
                         annotated with exactly one of: `#[env]`, `#[slot]`, `#[input]` or \
                         `#[output]`, in that order",
                     ));

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -3,7 +3,7 @@
 //! `#[contract_impl]` macro will process *public* methods annotated with following attributes:
 //! * `#[init]` - method that can be called to produce an initial state of the contract,
 //!   called once during contacts lifetime
-//! * `#[call]` - method that can read and/or modify state and/or slots of the contact, may be
+//! * `#[update]` - method that can read and/or modify state and/or slots of the contact, may be
 //!   called by user transaction directly or by another contract
 //! * `#[view]` - method that can only read blockchain data, can read state or slots of the
 //!   contract, but can't modify their contents
@@ -33,9 +33,9 @@
 //! `self` argument is not supported in any way in this context since state of the contract is just
 //! being created.
 //!
-//! # #\[call]
+//! # #\[update]
 //!
-//! Generic call into contract that can both update contract's own state and contents of slots.
+//! Generic method into contract that can both update contract's own state and contents of slots.
 //!
 //! Following arguments are supported by this method (must be in this order):
 //! * `&self` or `&mut self` depending on whether state reads and/or modification are required
@@ -47,7 +47,7 @@
 //!
 //! # #\[view]
 //!
-//! Similar to `#[call]`, but can only access read-only view of the state and slots, can be called
+//! Similar to `#[update]`, but can only access read-only view of the state and slots, can be called
 //! outside of block context and can only call other `#[view]` methods.
 //!
 //! Following arguments are supported by this method (must be in this order):


### PR DESCRIPTION
This renames `#[call]` to `#[update]` for consistency in terminology and to reduce confusion. Similarly `Env::invoke()` is renamed to `Env::call()`.

The bigger change here is usage of a bit esoteric `self: &&mut Env` for non-`#[view]` methods that allows to both share `&Env` as such, but still prevents calling non-`#[view]` methods from `#[view]` methods through helper methods.

Some smaller improvements: `Env::origin()` as replaced with `Env::context()` and `Env::caller()`. Context is for context under which operations are happening, meaning token transfers from "Context" contract are typically allowed, while `Env::caller()` is the previous contract in call stack. `Address::NOBODY` is introduced as a sentinel value for these purposes.