### PR TITLE
Contracts upgrades

### DIFF
--- a/crates/contracts/ab-contract-example/src/lib.rs
+++ b/crates/contracts/ab-contract-example/src/lib.rs
@@ -32,22 +32,24 @@ pub struct ExampleContract {
 #[contract_impl]
 impl ExampleContract {
     #[init]
-    pub fn new(#[env] env: &mut Env, #[input] total_supply: &Balance) -> Self {
+    pub fn new(
+        #[slot] (owner_addr, owner): (&Address, &mut MaybeData<Slot>),
+        #[input] total_supply: &Balance,
+    ) -> Self {
+        owner.replace(Slot {
+            balance: *total_supply,
+        });
         Self {
             total_supply: *total_supply,
-            owner: *env.context(),
+            owner: *owner_addr,
             padding: [0; 8],
         }
     }
 
     #[init]
-    pub fn new_result(
-        #[env] env: &mut Env,
-        #[input] total_supply: &Balance,
-        #[result] result: &mut MaybeData<Self>,
-    ) {
+    pub fn new_result(#[env] env: &mut Env, #[result] result: &mut MaybeData<Self>) {
         result.replace(Self {
-            total_supply: *total_supply,
+            total_supply: Balance::MIN,
             owner: *env.context(),
             padding: [0; 8],
         });

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -29,6 +29,8 @@ pub enum ContractMethodMetadata {
     /// * Argument type as u8, one of:
     ///   * [`Self::EnvRo`]
     ///   * [`Self::EnvRw`]
+    ///   * [`Self::TmpRo`]
+    ///   * [`Self::TmpRw`]
     ///   * [`Self::SlotWithAddressRo`]
     ///   * [`Self::SlotWithAddressRw`]
     ///   * [`Self::SlotWithoutAddressRo`]
@@ -296,6 +298,14 @@ pub enum ContractMethodMetadata {
     ///
     /// Example: `#[env] env: &mut Env,`
     EnvRw,
+    /// Read-only `#[tmp]` argument.
+    ///
+    /// Example: `#[tmp] tmp: &MaybeData<Slot>,`
+    TmpRo,
+    /// Read-write `#[tmp]` argument.
+    ///
+    /// Example: `#[tmp] tmp: &mut MaybeData<Slot>,`
+    TmpRw,
     /// Read-only `#[slot]` argument with an address.
     ///
     /// Example: `#[slot] (from_address, from): (&Address, &MaybeData<Slot>),`

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -335,6 +335,8 @@ pub unsafe trait IoType {
     ///
     /// # Safety
     /// Input bytes must be previously produced by taking underlying bytes of the same type.
+    // `impl Deref` is used to tie lifetime of returned value to inputs, but still treat it as a
+    // shared reference for most practical purposes.
     unsafe fn from_ptr<'a>(
         ptr: &'a NonNull<Self::PointerType>,
         size: &'a u32,
@@ -352,6 +354,8 @@ pub unsafe trait IoType {
     ///
     /// # Safety
     /// Input bytes must be previously produced by taking underlying bytes of the same type.
+    // `impl DerefMut` is used to tie lifetime of returned value to inputs, but still treat it as an
+    // exclusive reference for most practical purposes.
     unsafe fn from_ptr_mut<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,

--- a/crates/contracts/ab-contracts-macros/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract.rs
@@ -60,6 +60,19 @@ pub(super) fn contract_impl(item: TokenStream) -> Result<TokenStream, Error> {
         }
     }
 
+    let same_tmp_types = MethodDetails::same_tmp_types(
+        contract_details
+            .methods
+            .iter()
+            .map(|method| &method.methods_details),
+    );
+    if !same_tmp_types {
+        return Err(Error::new(
+            item_impl.span(),
+            "All `#[tmp]` arguments must be of the same type",
+        ));
+    }
+
     let same_slot_types = MethodDetails::same_slot_types(
         contract_details
             .methods

--- a/crates/contracts/ab-contracts-macros/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract.rs
@@ -11,7 +11,7 @@ use proc_macro2::{Ident, Literal, TokenStream, TokenTree};
 use quote::{format_ident, quote};
 use std::collections::HashMap;
 use syn::spanned::Spanned;
-use syn::{parse, Error, ImplItem, ImplItemFn, ItemImpl, Meta, Type, Visibility};
+use syn::{parse2, Error, ImplItem, ImplItemFn, ItemImpl, Meta, Type, Visibility};
 
 #[derive(Default)]
 struct MethodOutput {
@@ -30,11 +30,8 @@ struct ContractDetails {
     methods: Vec<Method>,
 }
 
-pub(super) fn contract_impl(
-    _attr: proc_macro::TokenStream,
-    item: proc_macro::TokenStream,
-) -> Result<proc_macro::TokenStream, Error> {
-    let mut item_impl = parse::<ItemImpl>(item)?;
+pub(super) fn contract_impl(item: TokenStream) -> Result<TokenStream, Error> {
+    let mut item_impl = parse2::<ItemImpl>(item)?;
     let struct_name = item_impl.self_ty.as_ref();
 
     if let Some(trait_) = item_impl.trait_ {
@@ -148,7 +145,7 @@ pub(super) fn contract_impl(
         const _CONTRACT_DEFINED: () = ();
     };
 
-    Ok(output.into())
+    Ok(output)
 }
 
 fn process_fn(

--- a/crates/contracts/ab-contracts-macros/src/contract/init.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/init.rs
@@ -19,6 +19,7 @@ pub(super) fn process_init_fn(
         // TODO: Moving this outside of the loop causes confusing lifetime issues
         let supported_attrs = HashMap::<_, fn(_, _, _) -> _>::from_iter([
             (format_ident!("env"), MethodDetails::process_env_arg_rw as _),
+            (format_ident!("tmp"), MethodDetails::process_tmp_arg as _),
             (
                 format_ident!("slot"),
                 MethodDetails::process_slot_arg_rw as _,

--- a/crates/contracts/ab-contracts-macros/src/contract/update.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/update.rs
@@ -19,6 +19,7 @@ pub(super) fn process_update_fn(
         // TODO: Moving this outside of the loop causes confusing lifetime issues
         let supported_attrs = HashMap::<_, fn(_, _, _) -> _>::from_iter([
             (format_ident!("env"), MethodDetails::process_env_arg_rw as _),
+            (format_ident!("tmp"), MethodDetails::process_tmp_arg as _),
             (
                 format_ident!("slot"),
                 MethodDetails::process_slot_arg_rw as _,

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -9,9 +9,10 @@
 //!   contract, but can't modify their contents
 //!
 //! Each argument (except `self`) of these methods has to be annotated with one of the following
-//! attributes:
+//! attributes (must be in this order):
 //! * `#[env]` - environment variable, used to access ephemeral execution environment, call methods
 //!   on other contracts, etc.
+//! * `#[tmp]` - temporary ephemeral value to store auxiliary data while processing a transaction
 //! * `#[slot]` - slot corresponding to this contract
 //! * `#[input]` - method input coming from user transaction or invocation from another contract
 //! * `#[output]` - method output
@@ -24,6 +25,7 @@
 //!
 //! Following arguments are supported by this method (must be in this order):
 //! * `#[env]` read-only and read-write
+//! * `#[tmp]`
 //! * `#[slot]` read-only and read-write
 //! * `#[input]`
 //! * `#[output]`
@@ -39,6 +41,7 @@
 //! Following arguments are supported by this method (must be in this order):
 //! * `&self` or `&mut self` depending on whether state reads and/or modification are required
 //! * `#[env]` read-only and read-write
+//! * `#[tmp]`
 //! * `#[slot]` read-only and read-write
 //! * `#[input]`
 //! * `#[output]`

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -67,9 +67,8 @@ use proc_macro::TokenStream;
 /// This macro is supposed to be applied to an implementation of the struct that in turn implements
 /// `IoType` trait.
 #[proc_macro_attribute]
-pub fn contract_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
-    match contract::contract_impl(attr, item) {
-        Ok(tokens) => tokens,
-        Err(error) => error.to_compile_error().into(),
-    }
+pub fn contract_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    contract::contract_impl(item.into())
+        .unwrap_or_else(|error| error.to_compile_error())
+        .into()
 }


### PR DESCRIPTION
First of all this provides safe constructors for `MaybeData` and `VariableBytes`, which are handy for calls into smart contracts.

Second, `#[tmp]` argument is now supported that allows contract to store auxiliary information while processing a transaction. For example it is possible to make a call into contract to approve balance transfer and then another contract with `Address::NOBODY` context would still be able to enact the transfer on behalf of the contract that approved transfer earlier in transaction processing. This should allow for fairly creative workflows.