### PR TITLE
First system contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-system-contract-code"
+version = "0.0.1"
+dependencies = [
+ "ab-contracts-common",
+ "ab-contracts-io-type",
+ "ab-contracts-macros",
+ "ab-system-contract-address-allocator",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-system-contract-address-allocator"
+version = "0.0.1"
+dependencies = [
+ "ab-contracts-common",
+ "ab-contracts-io-type",
+ "ab-contracts-macros",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/contracts/ab-contracts-common/src/env.rs
+++ b/crates/contracts/ab-contracts-common/src/env.rs
@@ -1,5 +1,5 @@
 use crate::method::{ExternalArgs, MethodFingerprint};
-use crate::{Address, ContractError};
+use crate::{Address, ContractError, ShardIndex};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use core::ffi::c_void;
 use core::marker::PhantomData;
@@ -44,12 +44,23 @@ pub struct PreparedMethod<'a> {
 #[repr(C)]
 #[non_exhaustive]
 pub struct Env {
+    shard_index: ShardIndex,
+    own_address: Address,
     context: Address,
     caller: Address,
-    own_address: Address,
 }
 
 impl Env {
+    /// Context of the execution
+    pub fn shard_index(&self) -> ShardIndex {
+        self.shard_index
+    }
+
+    /// Address of this contract itself
+    pub fn own_address(&self) -> &Address {
+        &self.own_address
+    }
+
     /// Context of the execution
     pub fn context<'a>(self: &'a &'a mut Self) -> &'a Address {
         &self.context
@@ -58,11 +69,6 @@ impl Env {
     /// Caller of this contract
     pub fn caller<'a>(self: &'a &'a mut Self) -> &'a Address {
         &self.caller
-    }
-
-    /// Address of this contract itself
-    pub fn own_address(&self) -> &Address {
-        &self.own_address
     }
 
     /// Call a single method at specified address and with specified arguments.

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -311,6 +311,28 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         true
     }
 
+    /// Copy contents from another instance.
+    ///
+    /// Returns `false` if actual capacity of the instance is not enough to copy contents of `src`
+    #[inline]
+    #[must_use = "Operation may fail"]
+    pub fn copy_from(&mut self, src: &Self) -> bool {
+        let src_size = src.size();
+        if src_size > self.capacity {
+            return false;
+        }
+
+        // Safety: `src` can't be the same as `&mut self` if invariants of constructor arguments
+        // were upheld, size is checked to be within capacity above
+        unsafe {
+            self.bytes
+                .copy_from_nonoverlapping(src.bytes, src_size as usize);
+            self.size.write(src_size);
+        }
+
+        true
+    }
+
     /// Get exclusive access to underlying pointer with no checks.
     ///
     /// Can be used for initialization with [`Self::assume_init()`] called afterward to confirm how

--- a/crates/contracts/ab-system-contract-address-allocator/Cargo.toml
+++ b/crates/contracts/ab-system-contract-address-allocator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ab-system-contract-address-allocator"
+description = ""
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2021"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
+ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
+
+[features]
+guest = []

--- a/crates/contracts/ab-system-contract-address-allocator/src/lib.rs
+++ b/crates/contracts/ab-system-contract-address-allocator/src/lib.rs
@@ -1,0 +1,47 @@
+#![no_std]
+
+use ab_contracts_common::env::Env;
+use ab_contracts_common::{Address, ContractError, ShardIndex};
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_macros::contract_impl;
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct AddressAllocator {
+    /// Next address to be allocated on this shard
+    pub next_address: u64,
+    /// Max address to be allocated on this shard
+    pub max_address: u64,
+}
+
+#[contract_impl]
+impl AddressAllocator {
+    /// Initialize address allocator for a shard
+    #[init]
+    pub fn new(#[env] env: &Env) -> Self {
+        let shard_index = env.shard_index();
+        Self {
+            next_address: shard_index.to_u32() as u64 * ShardIndex::MAX_SHARDS as u64,
+            max_address: (shard_index.to_u32() as u64 + 1) * ShardIndex::MAX_SHARDS as u64 - 1,
+        }
+    }
+
+    /// Allocate a new address for a contract.
+    ///
+    /// This can only be called by [`Address::SYSTEM_CODE`] contract.
+    #[update]
+    pub fn allocate_address(&mut self, #[env] env: &mut Env) -> Result<Address, ContractError> {
+        if env.caller() != &Address::SYSTEM_CODE {
+            return Err(ContractError::AccessDenied);
+        }
+
+        let next_address = self.next_address;
+        if next_address == self.max_address {
+            // No more addresses can be allocated on this shard
+            return Err(ContractError::InvalidState);
+        }
+
+        self.next_address += 1;
+        Ok(Address::from(next_address))
+    }
+}

--- a/crates/contracts/ab-system-contract-code/Cargo.toml
+++ b/crates/contracts/ab-system-contract-code/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ab-system-contract-code"
+description = ""
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2021"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
+ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
+ab-system-contract-address-allocator = { version = "0.0.1", path = "../ab-system-contract-address-allocator" }
+
+[features]
+guest = []

--- a/crates/contracts/ab-system-contract-code/src/lib.rs
+++ b/crates/contracts/ab-system-contract-code/src/lib.rs
@@ -1,0 +1,62 @@
+#![no_std]
+
+use ab_contracts_common::env::{Env, MethodContext};
+use ab_contracts_common::{Address, ContractError};
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_io_type::variable_bytes::VariableBytes;
+use ab_contracts_macros::contract_impl;
+use ab_system_contract_address_allocator::AddressAllocatorExt;
+
+// TODO: How/where should this limit defined?
+pub const MAX_CODE_SIZE: u32 = 1024 * 1024;
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct Code;
+
+#[contract_impl]
+impl Code {
+    /// Deploy a new contract with specified code
+    #[update]
+    pub fn deploy(
+        #[env] env: &mut Env,
+        #[input] code: &VariableBytes<MAX_CODE_SIZE>,
+    ) -> Result<Address, ContractError> {
+        let new_contract_address = env.allocate_address(
+            &MethodContext::Replace,
+            &Address::system_address_allocator(env.shard_index()),
+        )?;
+
+        env.store(
+            &MethodContext::Replace,
+            env.own_address(),
+            &new_contract_address,
+            code,
+        )?;
+
+        Ok(new_contract_address)
+    }
+
+    /// Store contact's code overriding previous code that might have been there.
+    ///
+    /// Updates can only be done by the contract itself with direct calls.
+    #[update]
+    pub fn store(
+        #[env] env: &mut Env,
+        #[slot] (target_address, target): (&Address, &mut VariableBytes<MAX_CODE_SIZE>),
+        #[input] code: &VariableBytes<MAX_CODE_SIZE>,
+    ) -> Result<(), ContractError> {
+        // TODO: Would it be helpful to allow indirect updates?
+        // Allow updates to system deploy contract (for initial deployment) and to contract itself
+        // for upgrades, but only direct calls
+        if !(env.caller() == env.own_address() || env.caller() == target_address) {
+            return Err(ContractError::AccessDenied);
+        }
+
+        if !target.copy_from(code) {
+            return Err(ContractError::InvalidInput);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This introduces first 2 system contract that should in theory be sufficient to deploy contracts.

One is responsible for per-shard address allocations and another manages code of contracts in its slot.