### PR TITLE
Metadata tweaks

### DIFF
--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -19,12 +19,28 @@ use derive_more::{
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u8)]
 pub enum ContractMetadataKind {
+    /// Main contract metadata.
+    ///
+    /// Contracts are encoded af follows:
+    /// * Encoding of the state struct as described in [`IoTypeMetadataKind`]
+    /// * Number of methods (u8)
+    /// * Recursive metadata of methods as defined in one of:
+    ///   * [`Self::Init`]
+    ///   * [`Self::UpdateStateless`]
+    ///   * [`Self::UpdateStatefulRo`]
+    ///   * [`Self::UpdateStatefulRw`]
+    ///   * [`Self::ViewStateless`]
+    ///   * [`Self::ViewStatefulRo`]
+    ///
+    /// [`IoTypeMetadataKind`]: ab_contracts_io_type::IoTypeMetadataKind
+    Contract,
+
     /// `#[init]` method.
     ///
     /// Initializers are encoded af follows:
     /// * Length of method name in bytes (u8)
     /// * Method name as UTF-8 bytes
-    /// * Number of arguments (u8)
+    /// * Number of named arguments (u8, excluding state argument `&self` or `&mut self`)
     ///
     /// Each argument is encoded as follows:
     /// * Argument type as u8, one of:
@@ -41,35 +57,31 @@ pub enum ContractMetadataKind {
     ///   * [`Self::Result`]
     /// * Length of the argument name in bytes (u8)
     /// * Argument name as UTF-8 bytes
-    /// * Recursive metadata of argument's type as described in
-    ///   [`IoTypeMetadataKind`](ab_contracts_io_type::IoTypeMetadataKind).
+    /// * Recursive metadata of argument's type as described in [`IoTypeMetadataKind`]
+    ///
+    /// [`IoTypeMetadataKind`]: ab_contracts_io_type::IoTypeMetadataKind
     ///
     /// NOTE: Result, regardless of whether it is a return type or explicit `#[result]` argument, is
     /// encoded as a separate argument and counts towards number of arguments. At the same time
     /// `self` doesn't count towards the number of arguments as it is implicitly defined by the
     /// variant of this struct.
     Init,
-
     /// Stateless `#[update]` method (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init`].
     UpdateStateless,
-
     /// Stateful read-only `#[update]` method (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init`].
     UpdateStatefulRo,
-
     /// Stateful read-write `#[update]` method (has `&mut self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init`].
     UpdateStatefulRw,
-
     /// Stateless `#[view]` method (doesn't have `self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init`].
     ViewStateless,
-
     /// Stateful read-only `#[view]` method (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init`].

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -18,7 +18,7 @@ use derive_more::{
 /// language bindings, auto-generate UI forms, etc.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u8)]
-pub enum ContractMethodMetadata {
+pub enum ContractMetadataKind {
     /// `#[init]` method.
     ///
     /// Initializers are encoded af follows:
@@ -42,7 +42,7 @@ pub enum ContractMethodMetadata {
     /// * Length of the argument name in bytes (u8)
     /// * Argument name as UTF-8 bytes
     /// * Recursive metadata of argument's type as described in
-    ///   [`IoTypeMetadata`](ab_contracts_io_type::IoTypeMetadata).
+    ///   [`IoTypeMetadataKind`](ab_contracts_io_type::IoTypeMetadataKind).
     ///
     /// NOTE: Result, regardless of whether it is a return type or explicit `#[result]` argument, is
     /// encoded as a separate argument and counts towards number of arguments. At the same time

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -389,18 +389,6 @@ pub enum IoTypeMetadataKind {
     VariableBytes16777216,
 }
 
-impl IoTypeMetadataKind {
-    /// This is helpful for host allocations that do not need to think about allocation alignment
-    /// and can simply allocate all data structures at 4096 bytes alignment.
-    ///
-    /// Without this types metadata would have to store alignment alongside other details, but since
-    /// alignment beyond 4096 bytes is unlikely to be used in practice, metadata can be simplified.
-    // TODO: Reject alignment customizations instead, such that it can be inferred automatically
-    pub const MAX_ALIGNMENT: usize = 4096;
-    // TODO: Add more constants once above variants are extended with shortcuts for typical data
-    //  types
-}
-
 // TODO: A way to point output types to input types in order to avoid unnecessary memory copy
 //  (setting a pointer)
 /// Trait that is used for types that are crossing host/guest boundary in smart contracts.

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -40,7 +40,7 @@ static_assertions::const_assert_eq!(align_of::<i128>(), 16);
 // TODO: Function that generates compact metadata
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u8)]
-pub enum IoTypeMetadata {
+pub enum IoTypeMetadataKind {
     /// `()`
     Unit,
     /// `bool`
@@ -389,7 +389,7 @@ pub enum IoTypeMetadata {
     VariableBytes16777216,
 }
 
-impl IoTypeMetadata {
+impl IoTypeMetadataKind {
     /// This is helpful for host allocations that do not need to think about allocation alignment
     /// and can simply allocate all data structures at 4096 bytes alignment.
     ///
@@ -425,7 +425,7 @@ impl IoTypeMetadata {
 /// implement traits on it by forwarding everything to inner implementation.
 pub unsafe trait IoType {
     /// Data structure metadata in binary form, describing shape and types of the contents, see
-    /// [`IoTypeMetadata`] for encoding details.
+    /// [`IoTypeMetadataKind`] for encoding details.
     const METADATA: &[u8];
 
     /// Pointer with trivial type that this `IoType` represents

--- a/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
@@ -1,5 +1,5 @@
 use crate::utils::concat_metadata_sources;
-use crate::{IoType, IoTypeMetadata};
+use crate::{IoType, IoTypeMetadataKind};
 pub use ab_contracts_trivial_type_derive::TrivialType;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
@@ -43,7 +43,7 @@ where
     const SIZE: u32 = size_of::<Self>() as u32;
     // TODO: Compact metadata without field and struct names
     /// Data structure metadata in binary form, describing shape and types of the contents, see
-    /// [`IoTypeMetadata`] for encoding details.
+    /// [`IoTypeMetadataKind`] for encoding details.
     const METADATA: &[u8];
 
     /// Create a reference to a type, which is represented by provided memory.
@@ -94,73 +94,73 @@ where
 }
 
 unsafe impl TrivialType for () {
-    const METADATA: &[u8] = &[IoTypeMetadata::Unit as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::Unit as u8];
 }
 unsafe impl TrivialType for bool {
-    const METADATA: &[u8] = &[IoTypeMetadata::Bool as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::Bool as u8];
 }
 unsafe impl TrivialType for u8 {
-    const METADATA: &[u8] = &[IoTypeMetadata::U8 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::U8 as u8];
 }
 unsafe impl TrivialType for u16 {
-    const METADATA: &[u8] = &[IoTypeMetadata::U16 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::U16 as u8];
 }
 unsafe impl TrivialType for u32 {
-    const METADATA: &[u8] = &[IoTypeMetadata::U32 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::U32 as u8];
 }
 unsafe impl TrivialType for u64 {
-    const METADATA: &[u8] = &[IoTypeMetadata::U64 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::U64 as u8];
 }
 unsafe impl TrivialType for u128 {
-    const METADATA: &[u8] = &[IoTypeMetadata::U128 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::U128 as u8];
 }
 unsafe impl TrivialType for i8 {
-    const METADATA: &[u8] = &[IoTypeMetadata::I8 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::I8 as u8];
 }
 unsafe impl TrivialType for i16 {
-    const METADATA: &[u8] = &[IoTypeMetadata::I16 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::I16 as u8];
 }
 unsafe impl TrivialType for i32 {
-    const METADATA: &[u8] = &[IoTypeMetadata::I32 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::I32 as u8];
 }
 unsafe impl TrivialType for i64 {
-    const METADATA: &[u8] = &[IoTypeMetadata::I64 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::I64 as u8];
 }
 unsafe impl TrivialType for i128 {
-    const METADATA: &[u8] = &[IoTypeMetadata::I128 as u8];
+    const METADATA: &[u8] = &[IoTypeMetadataKind::I128 as u8];
 }
 
 const fn array_metadata(size: u32, inner_metadata: &[u8]) -> ([u8; 4096], usize) {
-    if inner_metadata.len() == 1 && inner_metadata[0] == IoTypeMetadata::U8 as u8 {
+    if inner_metadata.len() == 1 && inner_metadata[0] == IoTypeMetadataKind::U8 as u8 {
         if size == 8 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x8 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x8 as u8]]);
         } else if size == 16 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x16 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x16 as u8]]);
         } else if size == 32 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x32 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x32 as u8]]);
         } else if size == 64 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x64 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x64 as u8]]);
         } else if size == 128 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x128 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x128 as u8]]);
         } else if size == 256 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x256 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x256 as u8]]);
         } else if size == 512 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x512 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x512 as u8]]);
         } else if size == 1024 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x1024 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x1024 as u8]]);
         } else if size == 2028 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x2028 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x2028 as u8]]);
         } else if size == 4096 {
-            return concat_metadata_sources(&[&[IoTypeMetadata::ArrayU8x4096 as u8]]);
+            return concat_metadata_sources(&[&[IoTypeMetadataKind::ArrayU8x4096 as u8]]);
         }
     }
 
     let (io_type, size_bytes) = if size < 2u32.pow(8) {
-        (IoTypeMetadata::Array8b, 1)
+        (IoTypeMetadataKind::Array8b, 1)
     } else if size < 2u32.pow(16) {
-        (IoTypeMetadata::Array16b, 2)
+        (IoTypeMetadataKind::Array16b, 2)
     } else {
-        (IoTypeMetadata::Array32b, 4)
+        (IoTypeMetadataKind::Array32b, 4)
     };
 
     concat_metadata_sources(&[

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -1,5 +1,5 @@
 use crate::utils::concat_metadata_sources;
-use crate::{IoType, IoTypeMetadata, IoTypeOptional};
+use crate::{IoType, IoTypeMetadataKind, IoTypeOptional};
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
@@ -40,45 +40,61 @@ unsafe impl<const RECOMMENDED_ALLOCATION: u32> IoType for VariableBytes<RECOMMEN
     const METADATA: &[u8] = {
         const fn metadata(max_capacity: u32) -> ([u8; 4096], usize) {
             if max_capacity == 512 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes512 as u8]]);
+                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableBytes512 as u8]]);
             } else if max_capacity == 1024 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes1024 as u8]]);
+                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableBytes1024 as u8]]);
             } else if max_capacity == 2028 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes2028 as u8]]);
+                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableBytes2028 as u8]]);
             } else if max_capacity == 4096 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes4096 as u8]]);
+                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableBytes4096 as u8]]);
             } else if max_capacity == 8192 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes8192 as u8]]);
+                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableBytes8192 as u8]]);
             } else if max_capacity == 16384 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes16384 as u8]]);
+                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableBytes16384 as u8]]);
             } else if max_capacity == 32768 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes32768 as u8]]);
+                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableBytes32768 as u8]]);
             } else if max_capacity == 65536 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes65536 as u8]]);
+                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableBytes65536 as u8]]);
             } else if max_capacity == 131072 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes131072 as u8]]);
+                return concat_metadata_sources(&[
+                    &[IoTypeMetadataKind::VariableBytes131072 as u8],
+                ]);
             } else if max_capacity == 262144 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes262144 as u8]]);
+                return concat_metadata_sources(&[
+                    &[IoTypeMetadataKind::VariableBytes262144 as u8],
+                ]);
             } else if max_capacity == 524288 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes524288 as u8]]);
+                return concat_metadata_sources(&[
+                    &[IoTypeMetadataKind::VariableBytes524288 as u8],
+                ]);
             } else if max_capacity == 1048576 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes1048576 as u8]]);
+                return concat_metadata_sources(&[&[
+                    IoTypeMetadataKind::VariableBytes1048576 as u8
+                ]]);
             } else if max_capacity == 2097152 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes2097152 as u8]]);
+                return concat_metadata_sources(&[&[
+                    IoTypeMetadataKind::VariableBytes2097152 as u8
+                ]]);
             } else if max_capacity == 4194304 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes4194304 as u8]]);
+                return concat_metadata_sources(&[&[
+                    IoTypeMetadataKind::VariableBytes4194304 as u8
+                ]]);
             } else if max_capacity == 8388608 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes8388608 as u8]]);
+                return concat_metadata_sources(&[&[
+                    IoTypeMetadataKind::VariableBytes8388608 as u8
+                ]]);
             } else if max_capacity == 16777216 {
-                return concat_metadata_sources(&[&[IoTypeMetadata::VariableBytes16777216 as u8]]);
+                return concat_metadata_sources(&[&[
+                    IoTypeMetadataKind::VariableBytes16777216 as u8
+                ]]);
             }
 
             let (io_type, size_bytes) = if max_capacity < 2u32.pow(8) {
-                (IoTypeMetadata::VariableBytes8b, 1)
+                (IoTypeMetadataKind::VariableBytes8b, 1)
             } else if max_capacity < 2u32.pow(16) {
-                (IoTypeMetadata::VariableBytes16b, 2)
+                (IoTypeMetadataKind::VariableBytes16b, 2)
             } else {
-                (IoTypeMetadata::VariableBytes32b, 4)
+                (IoTypeMetadataKind::VariableBytes32b, 4)
             };
 
             concat_metadata_sources(&[

--- a/crates/contracts/ab-contracts-macros/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract.rs
@@ -104,35 +104,38 @@ pub(super) fn contract_impl(item: TokenStream) -> Result<TokenStream, Error> {
         // * Number of methods
         // * Metadata of methods
         quote! {
-            /// Contract metadata
+            /// Main contract metadata
             ///
             /// Enabled with `guest` feature to appear in the final binary, also prevents from
             /// `guest` feature being enabled in dependencies at the same time since that'll cause
             /// duplicated symbols.
             ///
-            /// See [`#struct_name::CONTRACT_METADATA`] for details.
+            /// See [`#struct_name::MAIN_CONTRACT_METADATA`] for details.
             #[cfg(feature = "guest")]
             #[used]
+            #[unsafe(no_mangle)]
             #[unsafe(link_section = "CONTRACT_METADATA")]
-            static CONTRACT_METADATA: [u8; #struct_name::CONTRACT_METADATA.len()] =
-                unsafe { *#struct_name::CONTRACT_METADATA.as_ptr().cast() };
+            static MAIN_CONTRACT_METADATA: [u8; #struct_name::MAIN_CONTRACT_METADATA.len()] =
+                unsafe { *#struct_name::MAIN_CONTRACT_METADATA.as_ptr().cast() };
 
             impl #struct_name {
-                /// Contract metadata, starts with metadata of the state struct, followed by number
-                /// method of methods with their metadata next, see [`ContractMetadataKind`]
-                /// for encoding details
+                /// Main contract metadata, see [`ContractMetadataKind`] for encoding details.
+                ///
+                /// More metadata can be contributed by trait implementations.
                 ///
                 /// [`ContractMetadataKind`]: ::ab_contracts_common::ContractMetadataKind
-                pub const CONTRACT_METADATA: &[u8] = {
+                pub const MAIN_CONTRACT_METADATA: &[u8] = {
                     const fn metadata() -> ([u8; 4096], usize) {
                         ::ab_contracts_io_type::utils::concat_metadata_sources(&[
+                            &[::ab_contracts_common::ContractMetadataKind::Contract as u8],
                             <#struct_name as ::ab_contracts_io_type::IoType>::METADATA,
                             &[#num_methods],
                             #( ffi::#methods::METADATA, )*
                         ])
                     }
 
-                    // // Strange syntax to allow Rust to extend lifetime of metadata scratch automatically
+                    // Strange syntax to allow Rust to extend lifetime of metadata scratch
+                    // automatically
                     metadata()
                         .0
                         .split_at(metadata().1)

--- a/crates/contracts/ab-contracts-macros/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract.rs
@@ -119,10 +119,10 @@ pub(super) fn contract_impl(item: TokenStream) -> Result<TokenStream, Error> {
 
             impl #struct_name {
                 /// Contract metadata, starts with metadata of the state struct, followed by number
-                /// of methods with their metadata next, see [`ContractMethodMetadata`] for method
-                /// encoding details
+                /// method of methods with their metadata next, see [`ContractMetadataKind`]
+                /// for encoding details
                 ///
-                /// [`ContractMethodMetadata`]: ::ab_contracts_common::ContractMethodMetadata
+                /// [`ContractMetadataKind`]: ::ab_contracts_common::ContractMetadataKind
                 pub const CONTRACT_METADATA: &[u8] = {
                     const fn metadata() -> ([u8; 4096], usize) {
                         ::ab_contracts_io_type::utils::concat_metadata_sources(&[

--- a/crates/contracts/ab-contracts-macros/src/contract/methods.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/methods.rs
@@ -1374,9 +1374,9 @@ impl MethodDetails {
                     ])
                 }
 
-                /// Method metadata, see
-                /// [`ContractMetadataKind`](::ab_contracts_common::ContractMetadataKind) for
-                /// encoding details
+                /// Method metadata, see [`ContractMetadataKind`] for encoding details
+                ///
+                /// [`ContractMetadataKind`]: ::ab_contracts_common::ContractMetadataKind
                 // Strange syntax to allow Rust to extend lifetime of metadata scratch automatically
                 pub const METADATA: &[u8] =
                     metadata()

--- a/crates/contracts/ab-contracts-macros/src/contract/methods.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/methods.rs
@@ -743,7 +743,7 @@ impl MethodDetails {
                 });
 
                 method_metadata.push(quote! {
-                    &[::ab_contracts_common::ContractMethodMetadata::EnvRw as u8],
+                    &[::ab_contracts_common::ContractMetadataKind::EnvRw as u8],
                 });
             } else {
                 original_fn_args.push(quote! {
@@ -752,7 +752,7 @@ impl MethodDetails {
                 });
 
                 method_metadata.push(quote! {
-                    &[::ab_contracts_common::ContractMethodMetadata::EnvRo as u8],
+                    &[::ab_contracts_common::ContractMetadataKind::EnvRo as u8],
                 });
             }
         }
@@ -828,7 +828,7 @@ impl MethodDetails {
             let arg_name_metadata = derive_ident_metadata(&tmp.arg_name)?;
             method_metadata.push(quote! {
                 &[
-                    ::ab_contracts_common::ContractMethodMetadata::#slot_metadata_type as u8,
+                    ::ab_contracts_common::ContractMetadataKind::#slot_metadata_type as u8,
                     #( #arg_name_metadata, )*
                 ],
                 <#type_name as ::ab_contracts_io_type::IoType>::METADATA,
@@ -943,7 +943,7 @@ impl MethodDetails {
             let arg_name_metadata = derive_ident_metadata(&slot.arg_name)?;
             method_metadata.push(quote! {
                 &[
-                    ::ab_contracts_common::ContractMethodMetadata::#slot_metadata_type as u8,
+                    ::ab_contracts_common::ContractMetadataKind::#slot_metadata_type as u8,
                     #( #arg_name_metadata, )*
                 ],
                 <#type_name as ::ab_contracts_io_type::IoType>::METADATA,
@@ -1115,7 +1115,7 @@ impl MethodDetails {
             let arg_name_metadata = derive_ident_metadata(io_arg.arg_name())?;
             method_metadata.push(quote! {
                 &[
-                    ::ab_contracts_common::ContractMethodMetadata::#io_metadata_type as u8,
+                    ::ab_contracts_common::ContractMetadataKind::#io_metadata_type as u8,
                     #( #arg_name_metadata, )*
                 ],
                 <#type_name as ::ab_contracts_io_type::IoType>::METADATA,
@@ -1166,7 +1166,7 @@ impl MethodDetails {
                 let arg_name_metadata = derive_ident_metadata(&result_var_name)?;
                 method_metadata.push(quote! {
                     &[
-                        ::ab_contracts_common::ContractMethodMetadata::Result as u8,
+                        ::ab_contracts_common::ContractMetadataKind::Result as u8,
                         #( #arg_name_metadata, )*
                     ],
                     <#result_type as ::ab_contracts_io_type::IoType>::METADATA,
@@ -1366,7 +1366,7 @@ impl MethodDetails {
                 const fn metadata() -> ([u8; 4096], usize) {
                     ::ab_contracts_io_type::utils::concat_metadata_sources(&[
                         &[
-                            ::ab_contracts_common::ContractMethodMetadata::#method_type as u8,
+                            ::ab_contracts_common::ContractMetadataKind::#method_type as u8,
                             #( #method_name_metadata, )*
                             #number_of_arguments,
                         ],
@@ -1375,7 +1375,7 @@ impl MethodDetails {
                 }
 
                 /// Method metadata, see
-                /// [`ContractMethodMetadata`](::ab_contracts_common::ContractMethodMetadata) for
+                /// [`ContractMetadataKind`](::ab_contracts_common::ContractMetadataKind) for
                 /// encoding details
                 // Strange syntax to allow Rust to extend lifetime of metadata scratch automatically
                 pub const METADATA: &[u8] =

--- a/crates/contracts/ab-contracts-trivial-type-derive/src/lib.rs
+++ b/crates/contracts/ab-contracts-trivial-type-derive/src/lib.rs
@@ -83,12 +83,6 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
                         "Struct must not have implicit padding"
                     );
 
-                    // See constant description for details
-                    assert!(
-                        align_of::<#type_name>() <= ::ab_contracts_io_type::IoTypeMetadataKind::MAX_ALIGNMENT,
-                        "Alignment must not exceed `IoTypeMetadataKind::MAX_ALIGNMENT`"
-                    );
-
                     // Assert that type doesn't exceed 32-bit size limit
                     assert!(
                         u32::MAX as usize >= ::core::mem::size_of::<#type_name>(),
@@ -152,12 +146,6 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
 
             quote! {
                 const _: () = {
-                    // See constant description for details
-                    assert!(
-                        align_of::<#type_name>() <= ::ab_contracts_io_type::IoTypeMetadataKind::MAX_ALIGNMENT,
-                        "Alignment must not exceed `IoTypeMetadataKind::MAX_ALIGNMENT`"
-                    );
-
                     // Assert that type doesn't exceed 32-bit size limit
                     assert!(
                         u32::MAX as usize >= ::core::mem::size_of::<#type_name>(),

--- a/crates/contracts/ab-contracts-trivial-type-derive/src/lib.rs
+++ b/crates/contracts/ab-contracts-trivial-type-derive/src/lib.rs
@@ -85,8 +85,8 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
 
                     // See constant description for details
                     assert!(
-                        align_of::<#type_name>() <= ::ab_contracts_io_type::IoTypeMetadata::MAX_ALIGNMENT,
-                        "Alignment must not exceed `IoTypeMetadata::MAX_ALIGNMENT`"
+                        align_of::<#type_name>() <= ::ab_contracts_io_type::IoTypeMetadataKind::MAX_ALIGNMENT,
+                        "Alignment must not exceed `IoTypeMetadataKind::MAX_ALIGNMENT`"
                     );
 
                     // Assert that type doesn't exceed 32-bit size limit
@@ -154,8 +154,8 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
                 const _: () = {
                     // See constant description for details
                     assert!(
-                        align_of::<#type_name>() <= ::ab_contracts_io_type::IoTypeMetadata::MAX_ALIGNMENT,
-                        "Alignment must not exceed `IoTypeMetadata::MAX_ALIGNMENT`"
+                        align_of::<#type_name>() <= ::ab_contracts_io_type::IoTypeMetadataKind::MAX_ALIGNMENT,
+                        "Alignment must not exceed `IoTypeMetadataKind::MAX_ALIGNMENT`"
                     );
 
                     // Assert that type doesn't exceed 32-bit size limit
@@ -293,7 +293,7 @@ fn generate_struct_metadata(ident: &Ident, data_struct: &DataStruct) -> Result<T
     Ok(quote! {{
         const fn metadata() -> ([u8; 4096], usize) {
             ::ab_contracts_io_type::utils::concat_metadata_sources(&[
-                &[::ab_contracts_io_type::IoTypeMetadata::#io_type_metadata as u8],
+                &[::ab_contracts_io_type::IoTypeMetadataKind::#io_type_metadata as u8],
                 #( #inner_struct_metadata )*
             ])
         }
@@ -362,7 +362,7 @@ fn generate_enum_metadata(ident: &Ident, data_enum: &DataEnum) -> Result<TokenSt
 
         quote! {
             &[
-                ::ab_contracts_io_type::IoTypeMetadata::#io_type_metadata as u8,
+                ::ab_contracts_io_type::IoTypeMetadataKind::#io_type_metadata as u8,
                 #( #enum_metadata_header, )*
             ]
         }


### PR DESCRIPTION
This prepares for trait support where `CONTRACT_METADATA` section will contain not a single static of main contract implementation, but also other statics corresponding to various implemented traits.

Contract's main metadata now starts with `ContractMetadataKind::Contract` to distinguish from trait metadata.