### PR TITLE
Contract macro refactoring

### DIFF
--- a/crates/contracts/ab-contract-example/src/lib.rs
+++ b/crates/contracts/ab-contract-example/src/lib.rs
@@ -5,7 +5,7 @@ use ab_contracts_common::{Address, Balance, ContractError};
 use ab_contracts_io_type::maybe_data::MaybeData;
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_io_type::variable_bytes::VariableBytes;
-use ab_contracts_macros::contract_impl;
+use ab_contracts_macros::contract;
 use core::cmp::Ordering;
 
 #[derive(Debug, Default, Copy, Clone, TrivialType)]
@@ -33,7 +33,7 @@ pub struct ExampleContract {
 
 // TODO: Support traits
 // TODO: Can state possibly also be a slot so `#[init]` no longer needs to exit?
-#[contract_impl]
+#[contract]
 impl ExampleContract {
     #[init]
     pub fn new(

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -87,6 +87,7 @@ pub enum ContractMetadataKind {
     /// Encoding is the same as [`Self::Init`].
     ViewStatefulRo,
 
+    // TODO: `#[env] can be made implicit assuming the name is of the struct is always the same
     /// Read-only `#[env]` argument.
     ///
     /// Example: `#[env] env: &Env,`
@@ -97,12 +98,14 @@ pub enum ContractMetadataKind {
     EnvRw,
     /// Read-only `#[tmp]` argument.
     ///
-    /// Example: `#[tmp] tmp: &MaybeData<Slot>,`
+    /// Example: `#[tmp] tmp: &MaybeData<Tmp>,`
     TmpRo,
     /// Read-write `#[tmp]` argument.
     ///
-    /// Example: `#[tmp] tmp: &mut MaybeData<Slot>,`
+    /// Example: `#[tmp] tmp: &mut MaybeData<Tmp>,`
     TmpRw,
+    // TODO: What if address is mandatory for slots? Then it would be possible to make `#[slot]`
+    //  implicit
     /// Read-only `#[slot]` argument with an address.
     ///
     /// Example: `#[slot] (from_address, from): (&Address, &MaybeData<Slot>),`
@@ -127,6 +130,7 @@ pub enum ContractMetadataKind {
     ///
     /// Example: `#[output] out: &mut VariableBytes<1024>,`
     Output,
+    // TODO: Is explicit result needed? If not then `#[input]` and `#[output]` can be made implicit
     /// Explicit `#[result`] argument or `T` of [`Result<T, ContractError>`] return type or simply
     /// return type if it is not fallible.
     ///

--- a/crates/contracts/ab-contracts-macros/src/contract/init.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/init.rs
@@ -76,7 +76,7 @@ pub(super) fn process_init_fn(
                     .get(&attr.path().segments[0].ident)
                     .expect("Matched above to be one of the supported attributes; qed");
 
-                processor(input_span, &*pat_type, &mut methods_details)?;
+                processor(&mut methods_details, input_span, &*pat_type)?;
             }
         }
     }

--- a/crates/contracts/ab-contracts-macros/src/contract/methods.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/methods.rs
@@ -657,6 +657,29 @@ impl MethodDetails {
             }
         }
 
+        let original_method_name = &impl_item_fn.sig.ident;
+
+        let guest_fn = self.generate_guest_fn(impl_item_fn)?;
+        let external_args_struct = self.generate_external_args_struct(impl_item_fn)?;
+        let metadata = self.generate_metadata(impl_item_fn)?;
+
+        Ok(quote! {
+            pub mod #original_method_name {
+                use super::*;
+
+                #guest_fn
+                #external_args_struct
+                #metadata
+            }
+        })
+    }
+
+    pub(super) fn generate_guest_fn(
+        &self,
+        impl_item_fn: &ImplItemFn,
+    ) -> Result<TokenStream, Error> {
+        let struct_name = &self.struct_name;
+
         // `internal_args_pointers` will generate pointers in `InternalArgs` fields
         let mut internal_args_pointers = Vec::new();
         // `internal_args_sizes` will generate sizes in `InternalArgs` fields
@@ -1133,18 +1156,9 @@ impl MethodDetails {
             }
         };
 
-        let external_args_struct = self.generate_external_args_struct(impl_item_fn)?;
-        let metadata = self.generate_metadata(impl_item_fn)?;
-
         Ok(quote! {
-            pub mod #original_method_name {
-                use super::*;
-
-                #internal_args_struct
-                #guest_fn
-                #external_args_struct
-                #metadata
-            }
+            #internal_args_struct
+            #guest_fn
         })
     }
 

--- a/crates/contracts/ab-contracts-macros/src/contract/methods.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/methods.rs
@@ -247,28 +247,28 @@ impl MethodDetails {
     }
 
     pub(super) fn process_env_arg_ro(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        Self::process_env_arg(input_span, pat_type, details, false)
+        self.process_env_arg(input_span, pat_type, false)
     }
 
     pub(super) fn process_env_arg_rw(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        Self::process_env_arg(input_span, pat_type, details, true)
+        self.process_env_arg(input_span, pat_type, true)
     }
 
     fn process_env_arg(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
         allow_mut: bool,
     ) -> Result<(), Error> {
-        if details.env.is_some() || details.tmp.is_some() || !details.io.is_empty() {
+        if self.env.is_some() || self.tmp.is_some() || !self.io.is_empty() {
             return Err(Error::new(
                 input_span,
                 "`#[env]` must be the first non-Self argument and only appear once",
@@ -285,7 +285,7 @@ impl MethodDetails {
                 ));
             }
 
-            details.env.replace(type_reference.mutability);
+            self.env.replace(type_reference.mutability);
             Ok(())
         } else {
             Err(Error::new(
@@ -296,25 +296,25 @@ impl MethodDetails {
     }
 
     pub(super) fn process_state_arg_ro(
+        &mut self,
         input_span: Span,
         ty: &Type,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        Self::process_state_arg(input_span, ty, details, false)
+        self.process_state_arg(input_span, ty, false)
     }
 
     pub(super) fn process_state_arg_rw(
+        &mut self,
         input_span: Span,
         ty: &Type,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        Self::process_state_arg(input_span, ty, details, true)
+        self.process_state_arg(input_span, ty, true)
     }
 
     fn process_state_arg(
+        &mut self,
         input_span: Span,
         ty: &Type,
-        details: &mut Self,
         allow_mut: bool,
     ) -> Result<(), Error> {
         // Only accept `&self` or `&mut self`
@@ -329,7 +329,7 @@ impl MethodDetails {
                 ));
             }
 
-            details.state.replace(type_reference.mutability);
+            self.state.replace(type_reference.mutability);
             Ok(())
         } else {
             Err(Error::new(
@@ -340,11 +340,11 @@ impl MethodDetails {
     }
 
     pub(super) fn process_tmp_arg(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        if details.tmp.is_some() || !details.io.is_empty() {
+        if self.tmp.is_some() || !self.io.is_empty() {
             return Err(Error::new(
                 input_span,
                 "`#[tmp]` must appear only once before any inputs or outputs",
@@ -360,7 +360,7 @@ impl MethodDetails {
                 ));
             };
 
-            details.tmp.replace(Tmp {
+            self.tmp.replace(Tmp {
                 type_name: type_reference.elem.as_ref().clone(),
                 arg_name,
                 mutability: type_reference.mutability,
@@ -377,28 +377,28 @@ impl MethodDetails {
     }
 
     pub(super) fn process_slot_arg_ro(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        Self::process_slot_arg(input_span, pat_type, details, false)
+        self.process_slot_arg(input_span, pat_type, false)
     }
 
     pub(super) fn process_slot_arg_rw(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        Self::process_slot_arg(input_span, pat_type, details, true)
+        self.process_slot_arg(input_span, pat_type, true)
     }
 
     fn process_slot_arg(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
         allow_mut: bool,
     ) -> Result<(), Error> {
-        if !details.io.is_empty() {
+        if !self.io.is_empty() {
             return Err(Error::new(
                 input_span,
                 "`#[slot]` must appear before any inputs or outputs",
@@ -422,7 +422,7 @@ impl MethodDetails {
                     ));
                 };
 
-                details.slots.push(Slot {
+                self.slots.push(Slot {
                     with_address_arg: None,
                     type_name: type_reference.elem.as_ref().clone(),
                     arg_name,
@@ -460,7 +460,7 @@ impl MethodDetails {
                         ));
                     };
 
-                    details.slots.push(Slot {
+                    self.slots.push(Slot {
                         with_address_arg: Some(address_arg),
                         type_name: outer_slot_type.elem.as_ref().clone(),
                         arg_name,
@@ -483,11 +483,11 @@ impl MethodDetails {
     }
 
     pub(super) fn process_input_arg(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        if details
+        if self
             .io
             .iter()
             .any(|io_arg| !matches!(io_arg, IoArg::Input { .. }))
@@ -513,7 +513,7 @@ impl MethodDetails {
                 ));
             }
 
-            details.io.push(IoArg::Input {
+            self.io.push(IoArg::Input {
                 type_name: type_reference.elem.as_ref().clone(),
                 arg_name,
             });
@@ -528,11 +528,11 @@ impl MethodDetails {
     }
 
     pub(super) fn process_output_arg(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        if details
+        if self
             .io
             .iter()
             .any(|io_arg| matches!(io_arg, IoArg::Result { .. }))
@@ -554,7 +554,7 @@ impl MethodDetails {
                 ));
             };
 
-            details.io.push(IoArg::Output {
+            self.io.push(IoArg::Output {
                 type_name: type_reference.elem.as_ref().clone(),
                 arg_name: pat_ident.ident.clone(),
             });
@@ -569,11 +569,11 @@ impl MethodDetails {
     }
 
     pub(super) fn process_result_arg(
+        &mut self,
         input_span: Span,
         pat_type: &PatType,
-        details: &mut Self,
     ) -> Result<(), Error> {
-        if !details.result_type.unit_result_type() {
+        if !self.result_type.unit_result_type() {
             return Err(Error::new(
                 input_span,
                 "`#[result]` must only be used with methods that either return `()` or \
@@ -604,10 +604,10 @@ impl MethodDetails {
                 && let Type::Path(type_path) = &first_generic_argument
                 && type_path.path.is_ident("Self")
             {
-                *first_generic_argument = details.struct_name.clone();
+                *first_generic_argument = self.struct_name.clone();
             }
 
-            details.io.push(IoArg::Result {
+            self.io.push(IoArg::Result {
                 type_name,
                 arg_name: pat_ident.ident.clone(),
             });

--- a/crates/contracts/ab-contracts-macros/src/contract/update.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/update.rs
@@ -47,11 +47,7 @@ pub(super) fn process_update_fn(
                     ));
                 }
 
-                MethodDetails::process_state_arg_rw(
-                    input_span,
-                    &receiver.ty,
-                    &mut methods_details,
-                )?;
+                methods_details.process_state_arg_rw(input_span, &receiver.ty)?;
             }
             FnArg::Typed(pat_type) => {
                 let mut attrs = pat_type.attrs.extract_if(.., |attr| match &attr.meta {
@@ -86,7 +82,7 @@ pub(super) fn process_update_fn(
                     .get(&attr.path().segments[0].ident)
                     .expect("Matched above to be one of the supported attributes; qed");
 
-                processor(input_span, &*pat_type, &mut methods_details)?;
+                processor(&mut methods_details, input_span, &*pat_type)?;
             }
         }
     }

--- a/crates/contracts/ab-contracts-macros/src/contract/view.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/view.rs
@@ -46,11 +46,7 @@ pub(super) fn process_view_fn(
                     ));
                 }
 
-                MethodDetails::process_state_arg_ro(
-                    input_span,
-                    &receiver.ty,
-                    &mut methods_details,
-                )?;
+                methods_details.process_state_arg_ro(input_span, &receiver.ty)?;
             }
             FnArg::Typed(pat_type) => {
                 let mut attrs = pat_type.attrs.extract_if(.., |attr| match &attr.meta {
@@ -85,7 +81,7 @@ pub(super) fn process_view_fn(
                     .get(&attr.path().segments[0].ident)
                     .expect("Matched above to be one of the supported attributes; qed");
 
-                processor(input_span, &*pat_type, &mut methods_details)?;
+                processor(&mut methods_details, input_span, &*pat_type)?;
             }
         }
     }

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -70,7 +70,7 @@ use proc_macro::TokenStream;
 /// This macro is supposed to be applied to an implementation of the struct that in turn implements
 /// `IoType` trait.
 #[proc_macro_attribute]
-pub fn contract_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn contract(_attr: TokenStream, item: TokenStream) -> TokenStream {
     contract::contract_impl(item.into())
         .unwrap_or_else(|error| error.to_compile_error())
         .into()

--- a/crates/contracts/ab-system-contract-address-allocator/src/lib.rs
+++ b/crates/contracts/ab-system-contract-address-allocator/src/lib.rs
@@ -3,7 +3,7 @@
 use ab_contracts_common::env::Env;
 use ab_contracts_common::{Address, ContractError, ShardIndex};
 use ab_contracts_io_type::trivial_type::TrivialType;
-use ab_contracts_macros::contract_impl;
+use ab_contracts_macros::contract;
 
 #[derive(Copy, Clone, TrivialType)]
 #[repr(C)]
@@ -14,7 +14,7 @@ pub struct AddressAllocator {
     pub max_address: u64,
 }
 
-#[contract_impl]
+#[contract]
 impl AddressAllocator {
     /// Initialize address allocator for a shard
     #[init]

--- a/crates/contracts/ab-system-contract-code/src/lib.rs
+++ b/crates/contracts/ab-system-contract-code/src/lib.rs
@@ -4,7 +4,7 @@ use ab_contracts_common::env::{Env, MethodContext};
 use ab_contracts_common::{Address, ContractError};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_io_type::variable_bytes::VariableBytes;
-use ab_contracts_macros::contract_impl;
+use ab_contracts_macros::contract;
 use ab_system_contract_address_allocator::AddressAllocatorExt;
 
 // TODO: How/where should this limit defined?
@@ -14,7 +14,7 @@ pub const MAX_CODE_SIZE: u32 = 1024 * 1024;
 #[repr(C)]
 pub struct Code;
 
-#[contract_impl]
+#[contract]
 impl Code {
     /// Deploy a new contract with specified code
     #[update]


### PR DESCRIPTION
This splits large method into several that should help when implementing trait support.

There are also some cleanups and TODOs there as well.