### PR TITLE
Infra updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-system-contract-state"
+version = "0.0.1"
+dependencies = [
+ "ab-contracts-common",
+ "ab-contracts-io-type",
+ "ab-contracts-macros",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/contracts/ab-contract-example/src/lib.rs
+++ b/crates/contracts/ab-contract-example/src/lib.rs
@@ -54,7 +54,6 @@ impl Fungible for Example {
     }
 }
 
-// TODO: Can state possibly also be a slot so `#[init]` no longer needs to exit?
 #[contract]
 impl Example {
     #[init]

--- a/crates/contracts/ab-contract-example/src/lib.rs
+++ b/crates/contracts/ab-contract-example/src/lib.rs
@@ -26,14 +26,14 @@ pub struct Slot {
 
 #[derive(Copy, Clone, TrivialType)]
 #[repr(C)]
-pub struct ExampleContract {
+pub struct Example {
     pub total_supply: Balance,
     pub owner: Address,
     pub padding: [u8; 8],
 }
 
 #[contract]
-impl Fungible for ExampleContract {
+impl Fungible for Example {
     #[update]
     fn transfer(
         #[env] env: &mut Env,
@@ -45,18 +45,18 @@ impl Fungible for ExampleContract {
             return Err(ContractError::AccessDenied);
         }
 
-        env.transfer(&MethodContext::Keep, env.own_address(), from, to, amount)
+        env.example_transfer(&MethodContext::Keep, env.own_address(), from, to, amount)
     }
 
     #[view]
     fn balance(#[env] env: &Env, #[input] address: &Address) -> Result<Balance, ContractError> {
-        env.balance(env.own_address(), address)
+        env.example_balance(env.own_address(), address)
     }
 }
 
 // TODO: Can state possibly also be a slot so `#[init]` no longer needs to exit?
 #[contract]
-impl ExampleContract {
+impl Example {
     #[init]
     pub fn new(
         #[slot] (owner_addr, owner): (&Address, &mut MaybeData<Slot>),

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -311,6 +311,8 @@ impl Address {
     pub const NULL: Self = Self([0; 8]);
     /// System contract for managing code of other contracts
     pub const SYSTEM_CODE: Self = Self([1; 8]);
+    /// System contract for managing state of other contracts
+    pub const SYSTEM_STATE: Self = Self([2; 8]);
 
     /// System contract for address allocation on a particular shard index
     pub const fn system_address_allocator(shard_index: ShardIndex) -> Address {

--- a/crates/contracts/ab-contracts-macros/src/contract/methods.rs
+++ b/crates/contracts/ab-contracts-macros/src/contract/methods.rs
@@ -1023,12 +1023,7 @@ impl MethodDetails {
         }
 
         let original_method_name = &fn_sig.ident;
-        let ffi_fn_name = if let Some(trait_name) = trait_name {
-            let ffi_fn_prefix = RenameRule::SnakeCase.apply_to_variant(trait_name.to_string());
-            format_ident!("{ffi_fn_prefix}_{original_method_name}")
-        } else {
-            format_ident!("{original_method_name}")
-        };
+        let ffi_fn_name = derive_ffi_fn_name(original_method_name, trait_name);
         let result_type = self.result_type.result_type();
 
         let result_var_name = format_ident!("result");
@@ -1130,12 +1125,6 @@ impl MethodDetails {
                 }
             };
 
-            let ffi_fn_name = if let Some(trait_name) = trait_name {
-                let ffi_fn_prefix = RenameRule::SnakeCase.apply_to_variant(trait_name.to_string());
-                format_ident!("{ffi_fn_prefix}_{original_method_name}")
-            } else {
-                format_ident!("{original_method_name}")
-            };
             let full_struct_name = if let Some(trait_name) = trait_name {
                 quote! { <#self_type as #trait_name> }
             } else {
@@ -1263,12 +1252,7 @@ impl MethodDetails {
         }
 
         let original_method_name = &fn_sig.ident;
-        let ffi_fn_name = if let Some(trait_name) = trait_name {
-            let ffi_fn_prefix = RenameRule::SnakeCase.apply_to_variant(trait_name.to_string());
-            format_ident!("{ffi_fn_prefix}_{original_method_name}")
-        } else {
-            format_ident!("{original_method_name}")
-        };
+        let ffi_fn_name = derive_ffi_fn_name(original_method_name, trait_name);
 
         // Initializer's return type will be `()` for caller, state is stored by the host and not
         // returned to the caller, also if explicit `#[result]` argument is used return type is
@@ -1454,12 +1438,7 @@ impl MethodDetails {
         let number_of_arguments = Literal::u8_unsuffixed(number_of_arguments);
 
         let original_method_name = &fn_sig.ident;
-        let ffi_fn_name = if let Some(trait_name) = trait_name {
-            let ffi_fn_prefix = RenameRule::SnakeCase.apply_to_variant(trait_name.to_string());
-            format_ident!("{ffi_fn_prefix}_{original_method_name}")
-        } else {
-            format_ident!("{original_method_name}")
-        };
+        let ffi_fn_name = derive_ffi_fn_name(original_method_name, trait_name);
         let method_name_metadata = derive_ident_metadata(&ffi_fn_name)?;
         Ok(quote_spanned! {fn_sig.span() =>
             const fn metadata() -> ([u8; 4096], usize) {
@@ -1727,5 +1706,14 @@ fn extract_arg_name(mut pat: &Pat) -> Option<Ident> {
                 return None;
             }
         }
+    }
+}
+
+fn derive_ffi_fn_name(original_method_name: &Ident, trait_name: Option<&Ident>) -> Ident {
+    if let Some(trait_name) = trait_name {
+        let ffi_fn_prefix = RenameRule::SnakeCase.apply_to_variant(trait_name.to_string());
+        format_ident!("{ffi_fn_prefix}_{original_method_name}")
+    } else {
+        format_ident!("{original_method_name}")
     }
 }

--- a/crates/contracts/ab-system-contract-code/src/lib.rs
+++ b/crates/contracts/ab-system-contract-code/src/lib.rs
@@ -22,12 +22,12 @@ impl Code {
         #[env] env: &mut Env,
         #[input] code: &VariableBytes<MAX_CODE_SIZE>,
     ) -> Result<Address, ContractError> {
-        let new_contract_address = env.allocate_address(
+        let new_contract_address = env.address_allocator_allocate_address(
             &MethodContext::Replace,
             &Address::system_address_allocator(env.shard_index()),
         )?;
 
-        env.store(
+        env.code_store(
             &MethodContext::Replace,
             env.own_address(),
             &new_contract_address,

--- a/crates/contracts/ab-system-contract-code/src/lib.rs
+++ b/crates/contracts/ab-system-contract-code/src/lib.rs
@@ -44,20 +44,33 @@ impl Code {
     #[update]
     pub fn store(
         #[env] env: &mut Env,
-        #[slot] (target_address, target): (&Address, &mut VariableBytes<MAX_CODE_SIZE>),
-        #[input] code: &VariableBytes<MAX_CODE_SIZE>,
+        #[slot] (address, contract_code): (&Address, &mut VariableBytes<MAX_CODE_SIZE>),
+        #[input] new_code: &VariableBytes<MAX_CODE_SIZE>,
     ) -> Result<(), ContractError> {
         // TODO: Would it be helpful to allow indirect updates?
         // Allow updates to system deploy contract (for initial deployment) and to contract itself
         // for upgrades, but only direct calls
-        if !(env.caller() == env.own_address() || env.caller() == target_address) {
+        if !(env.caller() == env.own_address() || env.caller() == address) {
             return Err(ContractError::AccessDenied);
         }
 
-        if !target.copy_from(code) {
+        if !contract_code.copy_from(new_code) {
             return Err(ContractError::InvalidInput);
         }
 
         Ok(())
+    }
+
+    /// Read contract's code
+    #[view]
+    pub fn read(
+        #[slot] contract_code: &VariableBytes<MAX_CODE_SIZE>,
+        #[output] code: &mut VariableBytes<MAX_CODE_SIZE>,
+    ) -> Result<(), ContractError> {
+        if code.copy_from(contract_code) {
+            Ok(())
+        } else {
+            Err(ContractError::InvalidInput)
+        }
     }
 }

--- a/crates/contracts/ab-system-contract-state/Cargo.toml
+++ b/crates/contracts/ab-system-contract-state/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ab-system-contract-state"
+description = ""
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2021"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
+ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
+
+[features]
+guest = []

--- a/crates/contracts/ab-system-contract-state/src/lib.rs
+++ b/crates/contracts/ab-system-contract-state/src/lib.rs
@@ -1,0 +1,55 @@
+#![no_std]
+
+use ab_contracts_common::env::Env;
+use ab_contracts_common::{Address, ContractError};
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_io_type::variable_bytes::VariableBytes;
+use ab_contracts_macros::contract;
+
+// TODO: How/where should this limit defined?
+pub const MAX_STATE_SIZE: u32 = 1024 * 1024;
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct State;
+
+#[contract]
+impl State {
+    /// Write contract's state
+    #[update]
+    pub fn write(
+        #[env] env: &mut Env,
+        #[slot] (address, contract_state): (&Address, &mut VariableBytes<MAX_STATE_SIZE>),
+        #[input] new_state: &VariableBytes<MAX_STATE_SIZE>,
+    ) -> Result<(), ContractError> {
+        // TODO: Check shard
+        if env.caller() != address {
+            return Err(ContractError::AccessDenied);
+        }
+
+        if !contract_state.copy_from(new_state) {
+            return Err(ContractError::InvalidInput);
+        }
+
+        Ok(())
+    }
+
+    /// Read contract's state
+    #[view]
+    pub fn read(
+        #[slot] contract_state: &VariableBytes<MAX_STATE_SIZE>,
+        #[output] state: &mut VariableBytes<MAX_STATE_SIZE>,
+    ) -> Result<(), ContractError> {
+        if state.copy_from(contract_state) {
+            Ok(())
+        } else {
+            Err(ContractError::InvalidInput)
+        }
+    }
+
+    /// Check if contract's state is empty
+    #[view]
+    pub fn is_empty(#[slot] contract_state: &VariableBytes<MAX_STATE_SIZE>) -> bool {
+        contract_state.size() == 0
+    }
+}


### PR DESCRIPTION
This upgrades infrastructure in a few ways:
* API to read contract's code
* prefix for extension trait methods to prevent confusion
* `ab-system-contract-state` that is similar to `ab-system-contract-code` and manages state of other contracts (contracts overview in the book is updated to reflect this)