### PR TITLE
Introduce `Contract` trait

### DIFF
--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -10,6 +10,19 @@ use derive_more::{
     Add, AddAssign, Display, Div, DivAssign, From, Into, Mul, MulAssign, Sub, SubAssign,
 };
 
+/// A trait that indicates the struct is a contact definition.
+///
+/// NOTE: This trait is required, but not sufficient for contract implementation, do not implement
+/// this trait manually, use `#[contract]` attribute macro instead.
+pub trait Contract {
+    /// Main contract metadata, see [`ContractMetadataKind`] for encoding details.
+    ///
+    /// More metadata can be contributed by trait implementations.
+    ///
+    /// [`ContractMetadataKind`]: crate::metadata::ContractMetadataKind
+    const MAIN_CONTRACT_METADATA: &[u8];
+}
+
 #[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 #[repr(u8)]
 pub enum ContractError {

--- a/crates/contracts/ab-contracts-macros/src/__private.rs
+++ b/crates/contracts/ab-contracts-macros/src/__private.rs
@@ -1,7 +1,7 @@
 pub use ab_contracts_common::env::{Env, MethodContext};
 pub use ab_contracts_common::metadata::ContractMetadataKind;
 pub use ab_contracts_common::methods::{ExternalArgs, MethodFingerprint};
-pub use ab_contracts_common::{Address, ContractError, ExitCode};
+pub use ab_contracts_common::{Address, Contract, ContractError, ExitCode};
 pub use ab_contracts_io_type::metadata::{MAX_METADATA_CAPACITY, concat_metadata_sources};
 pub use ab_contracts_io_type::trivial_type::TrivialType;
 pub use ab_contracts_io_type::{IoType, IoTypeOptional};


### PR DESCRIPTION
This will be helpful for running contracts where they need to be distinguished from each other