### PR TITLE
FFI refactoring

### DIFF
--- a/crates/contracts/ab-contracts-common/src/env.rs
+++ b/crates/contracts/ab-contracts-common/src/env.rs
@@ -90,7 +90,7 @@ impl Env {
 
     /// Prepare a single method for calling at specified address and with specified arguments.
     ///
-    /// Result is to be used with [`Self::call_many()`] afterward.
+    /// The result is to be used with [`Self::call_many()`] afterward.
     pub fn prepare_method_call<'a, Args>(
         contract: &'a Address,
         args: &'a mut Args,
@@ -100,21 +100,17 @@ impl Env {
         Args: ExternalArgs,
     {
         PreparedMethod {
-            // TODO: Use `NonNull::from_ref()` once stable
-            address: NonNull::from(contract),
-            // TODO: Use `NonNull::from_ref()` once stable
-            fingerprint: NonNull::from(&Args::FINGERPRINT),
-            // TODO: Use `NonNull::from_ref()` once stable
-            args: NonNull::from(args).cast(),
-            // TODO: Use `NonNull::from_ref()` once stable
-            method_context: NonNull::from(method_context).cast(),
+            address: NonNull::from_ref(contract),
+            fingerprint: NonNull::from_ref(&Args::FINGERPRINT),
+            args: NonNull::from_mut(args).cast(),
+            method_context: NonNull::from_ref(method_context).cast(),
             _phantom: PhantomData,
         }
     }
 
-    /// Invoke provided methods and wait for results.
+    /// Invoke provided methods and wait for the result.
     ///
-    /// Remaining gas will be split equally between all individual invocations.
+    /// The remaining gas will be split equally between all individual invocations.
     pub fn call_many<'a, Methods>(&'a self, methods: Methods) -> Result<(), ContractError>
     where
         Methods: IntoIterator<Item = PreparedMethod<'a>>,

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(non_null_from_ref)]
 #![no_std]
 
 pub mod env;

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -155,7 +155,7 @@ pub unsafe trait IoType {
     // `impl DerefMut` is used to tie lifetime of returned value to inputs, but still treat it as an
     // exclusive reference for most practical purposes. While lifetime here is somewhat superficial
     // due to `Copy` nature of the value, it must be respected.
-    unsafe fn from_ptr_mut<'a>(
+    unsafe fn from_mut_ptr<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,
         capacity: u32,

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -30,6 +30,24 @@ static_assertions::const_assert_eq!(align_of::<i32>(), 4);
 static_assertions::const_assert_eq!(align_of::<i64>(), 8);
 static_assertions::const_assert_eq!(align_of::<i128>(), 16);
 
+struct DerefWrapper<T>(T);
+
+impl<T> Deref for DerefWrapper<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for DerefWrapper<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 // TODO: A way to point output types to input types in order to avoid unnecessary memory copy
 //  (setting a pointer)
 /// Trait that is used for types that are crossing host/guest boundary in smart contracts.

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(non_null_from_ref)]
 #![no_std]
 
 pub mod maybe_data;

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -61,8 +61,7 @@ where
         debug_assert!(capacity as usize == size_of::<Data>(), "Invalid capacity");
 
         let data = ptr.cast::<Data>();
-        // TODO: Use `NonNull::from_ref()` once stable
-        let size = NonNull::from(size);
+        let size = NonNull::from_ref(size);
 
         DerefWrapper(MaybeData {
             data,
@@ -82,8 +81,7 @@ where
         debug_assert!(capacity as usize == size_of::<Data>(), "Invalid capacity");
 
         let data = ptr.cast::<Data>();
-        // TODO: Use `NonNull::from_ref()` once stable
-        let size = NonNull::from(size);
+        let size = NonNull::from_ref(size);
 
         DerefWrapper(MaybeData {
             data,
@@ -116,16 +114,14 @@ where
     pub fn from_buffer(data: Option<&'_ Data>) -> impl Deref<Target = Self> + '_ {
         let capacity = size_of::<Data>() as u32;
         let (data, size) = if let Some(data) = data {
-            (NonNull::from(data), capacity)
+            (NonNull::from_ref(data), capacity)
         } else {
             (NonNull::dangling(), 0)
         };
 
         DerefWrapper(Self {
-            // TODO: Use `NonNull::from_ref()` once stable
             data: data.cast::<<Self as IoType>::PointerType>(),
-            // TODO: Use `NonNull::from_ref()` once stable
-            size: NonNull::from(&size),
+            size: NonNull::from_ref(&size),
             capacity,
         })
     }
@@ -147,10 +143,8 @@ where
         debug_assert!(*size == 0 || *size == capacity, "Invalid size");
 
         DerefWrapper(Self {
-            // TODO: Use `NonNull::from_mut()` once stable
-            data: NonNull::from(buffer).cast::<<Self as IoType>::PointerType>(),
-            // TODO: Use `NonNull::from_mut()` once stable
-            size: NonNull::from(size),
+            data: NonNull::from_mut(buffer).cast::<<Self as IoType>::PointerType>(),
+            size: NonNull::from_ref(size),
             capacity,
         })
     }
@@ -173,10 +167,8 @@ where
         debug_assert!(*size == 0, "Invalid size");
 
         DerefWrapper(Self {
-            // TODO: Use `NonNull::from_ref()` once stable
-            data: NonNull::from(uninit).cast::<<Self as IoType>::PointerType>(),
-            // TODO: Use `NonNull::from_mut()` once stable
-            size: NonNull::from(size),
+            data: NonNull::from_mut(uninit).cast::<<Self as IoType>::PointerType>(),
+            size: NonNull::from_mut(size),
             capacity,
         })
     }

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -33,8 +33,23 @@ where
     }
 
     #[inline]
+    unsafe fn size_ptr(&self) -> impl Deref<Target = NonNull<u32>> {
+        DerefWrapper(self.size)
+    }
+
+    #[inline]
+    unsafe fn size_mut_ptr(&mut self) -> impl DerefMut<Target = NonNull<u32>> {
+        DerefWrapper(self.size)
+    }
+
+    #[inline]
     fn capacity(&self) -> u32 {
         self.size()
+    }
+
+    #[inline]
+    unsafe fn capacity_ptr(&self) -> impl Deref<Target = NonNull<u32>> {
+        DerefWrapper(NonNull::from_ref(&self.capacity))
     }
 
     #[inline]

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -86,7 +86,7 @@ where
     }
 
     #[inline]
-    unsafe fn from_ptr_mut<'a>(
+    unsafe fn from_mut_ptr<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,
         capacity: u32,

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -1,40 +1,14 @@
 use crate::trivial_type::TrivialType;
-use crate::{IoType, IoTypeOptional};
+use crate::{DerefWrapper, IoType, IoTypeOptional};
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
-
-struct MaybeDataWrapper<Data>(MaybeData<Data>)
-where
-    Data: TrivialType;
-
-impl<Data> Deref for MaybeDataWrapper<Data>
-where
-    Data: TrivialType,
-{
-    type Target = MaybeData<Data>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<Data> DerefMut for MaybeDataWrapper<Data>
-where
-    Data: TrivialType,
-{
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 /// Wrapper type for `Data` that may or may not be filled with contents.
 ///
 /// This is somewhat similar to [`VariableBytes`](crate::variable_bytes::VariableBytes), but instead
 /// of variable size data structure allows to either have it or not have the contents or not have
-/// it, which is simpler and more convenient API that is also sufficient in many cases.
+/// it, which is a simpler and more convenient API that is also sufficient in many cases.
 pub struct MaybeData<Data>
 where
     Data: TrivialType,
@@ -90,7 +64,7 @@ where
         // TODO: Use `NonNull::from_ref()` once stable
         let size = NonNull::from(size);
 
-        MaybeDataWrapper(MaybeData {
+        DerefWrapper(MaybeData {
             data,
             size,
             capacity,
@@ -111,7 +85,7 @@ where
         // TODO: Use `NonNull::from_ref()` once stable
         let size = NonNull::from(size);
 
-        MaybeDataWrapper(MaybeData {
+        DerefWrapper(MaybeData {
             data,
             size,
             capacity,
@@ -147,7 +121,7 @@ where
             (NonNull::dangling(), 0)
         };
 
-        MaybeDataWrapper(Self {
+        DerefWrapper(Self {
             // TODO: Use `NonNull::from_ref()` once stable
             data: data.cast::<<Self as IoType>::PointerType>(),
             // TODO: Use `NonNull::from_ref()` once stable
@@ -172,7 +146,7 @@ where
         let capacity = size_of::<Data>() as u32;
         debug_assert!(*size == 0 || *size == capacity, "Invalid size");
 
-        MaybeDataWrapper(Self {
+        DerefWrapper(Self {
             // TODO: Use `NonNull::from_mut()` once stable
             data: NonNull::from(buffer).cast::<<Self as IoType>::PointerType>(),
             // TODO: Use `NonNull::from_mut()` once stable
@@ -198,7 +172,7 @@ where
         let capacity = size_of::<Data>() as u32;
         debug_assert!(*size == 0, "Invalid size");
 
-        MaybeDataWrapper(Self {
+        DerefWrapper(Self {
             // TODO: Use `NonNull::from_ref()` once stable
             data: NonNull::from(uninit).cast::<<Self as IoType>::PointerType>(),
             // TODO: Use `NonNull::from_mut()` once stable

--- a/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
@@ -183,8 +183,23 @@ where
     }
 
     #[inline]
+    unsafe fn size_ptr(&self) -> impl Deref<Target = NonNull<u32>> {
+        DerefWrapper(NonNull::from_ref(&(size_of::<T>() as u32)))
+    }
+
+    #[inline]
+    unsafe fn size_mut_ptr(&mut self) -> impl DerefMut<Target = NonNull<u32>> {
+        DerefWrapper(NonNull::from_mut(&mut (size_of::<T>() as u32)))
+    }
+
+    #[inline]
     fn capacity(&self) -> u32 {
         self.size()
+    }
+
+    #[inline]
+    unsafe fn capacity_ptr(&self) -> impl Deref<Target = NonNull<u32>> {
+        DerefWrapper(NonNull::from_ref(&(size_of::<T>() as u32)))
     }
 
     #[inline]

--- a/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
@@ -1,25 +1,9 @@
-use crate::IoType;
 use crate::metadata::{IoTypeMetadataKind, MAX_METADATA_CAPACITY, concat_metadata_sources};
+use crate::{DerefWrapper, IoType};
 pub use ab_contracts_trivial_type_derive::TrivialType;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use core::{mem, slice};
-
-struct PtrWrapper<T>(NonNull<T>);
-
-impl<T> Deref for PtrWrapper<T> {
-    type Target = NonNull<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> DerefMut for PtrWrapper<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 /// Simple wrapper data type that is designed in such a way that its serialization/deserialization
 /// is the same as the type itself.
@@ -242,12 +226,12 @@ where
     #[inline]
     unsafe fn as_ptr(&self) -> impl Deref<Target = NonNull<Self::PointerType>> {
         // TODO: Use `NonNull::from_ref()` once stable
-        PtrWrapper(NonNull::from(self))
+        DerefWrapper(NonNull::from(self))
     }
 
     #[inline]
     unsafe fn as_mut_ptr(&mut self) -> impl DerefMut<Target = NonNull<Self::PointerType>> {
         // TODO: Use `NonNull::from_mut()` once stable
-        PtrWrapper(NonNull::from(self))
+        DerefWrapper(NonNull::from(self))
     }
 }

--- a/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
@@ -225,7 +225,7 @@ where
     }
 
     #[inline]
-    unsafe fn from_ptr_mut<'a>(
+    unsafe fn from_mut_ptr<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,
         capacity: u32,

--- a/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
@@ -225,13 +225,11 @@ where
 
     #[inline]
     unsafe fn as_ptr(&self) -> impl Deref<Target = NonNull<Self::PointerType>> {
-        // TODO: Use `NonNull::from_ref()` once stable
-        DerefWrapper(NonNull::from(self))
+        DerefWrapper(NonNull::from_ref(self))
     }
 
     #[inline]
     unsafe fn as_mut_ptr(&mut self) -> impl DerefMut<Target = NonNull<Self::PointerType>> {
-        // TODO: Use `NonNull::from_mut()` once stable
-        DerefWrapper(NonNull::from(self))
+        DerefWrapper(NonNull::from_mut(self))
     }
 }

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -1,29 +1,9 @@
 use crate::metadata::{IoTypeMetadataKind, MAX_METADATA_CAPACITY, concat_metadata_sources};
-use crate::{IoType, IoTypeOptional};
+use crate::{DerefWrapper, IoType, IoTypeOptional};
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use core::{ptr, slice};
-
-struct VariableBytesWrapper<const RECOMMENDED_ALLOCATION: u32>(
-    VariableBytes<RECOMMENDED_ALLOCATION>,
-);
-
-impl<const RECOMMENDED_ALLOCATION: u32> Deref for VariableBytesWrapper<RECOMMENDED_ALLOCATION> {
-    type Target = VariableBytes<RECOMMENDED_ALLOCATION>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<const RECOMMENDED_ALLOCATION: u32> DerefMut for VariableBytesWrapper<RECOMMENDED_ALLOCATION> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 /// Container for storing variable number of bytes.
 ///
@@ -147,7 +127,7 @@ unsafe impl<const RECOMMENDED_ALLOCATION: u32> IoType for VariableBytes<RECOMMEN
         debug_assert!(ptr.is_aligned(), "Misaligned pointer");
         debug_assert!(*size <= capacity, "Size larger than capacity");
 
-        VariableBytesWrapper(Self {
+        DerefWrapper(Self {
             bytes: *ptr,
             // TODO: Use `NonNull::from_ref()` once stable
             size: NonNull::from(size),
@@ -164,7 +144,7 @@ unsafe impl<const RECOMMENDED_ALLOCATION: u32> IoType for VariableBytes<RECOMMEN
         debug_assert!(ptr.is_aligned(), "Misaligned pointer");
         debug_assert!(*size <= capacity, "Size larger than capacity");
 
-        VariableBytesWrapper(Self {
+        DerefWrapper(Self {
             bytes: *ptr,
             // TODO: Use `NonNull::from_ref()` once stable
             size: NonNull::from(size),
@@ -194,7 +174,7 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         let size = buffer.len() as u32;
         let capacity = size;
 
-        VariableBytesWrapper(Self {
+        DerefWrapper(Self {
             // TODO: Use `NonNull::from_ref()` once stable
             bytes: NonNull::from(buffer).cast::<<Self as IoType>::PointerType>(),
             // TODO: Use `NonNull::from_ref()` once stable
@@ -216,7 +196,7 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         debug_assert!(buffer.len() == *size as usize, "Invalid size");
         let capacity = *size;
 
-        VariableBytesWrapper(Self {
+        DerefWrapper(Self {
             // TODO: Use `NonNull::from_mut()` once stable
             bytes: NonNull::from(buffer).cast::<<Self as IoType>::PointerType>(),
             // TODO: Use `NonNull::from_mut()` once stable
@@ -240,7 +220,7 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         debug_assert!(*size as usize <= CAPACITY, "Size larger than capacity");
         let capacity = CAPACITY as u32;
 
-        VariableBytesWrapper(Self {
+        DerefWrapper(Self {
             // TODO: Use `NonNull::from_ref()` once stable
             bytes: NonNull::from(uninit).cast::<<Self as IoType>::PointerType>(),
             // TODO: Use `NonNull::from_mut()` once stable

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -150,7 +150,7 @@ unsafe impl<const RECOMMENDED_ALLOCATION: u32> IoType for VariableBytes<RECOMMEN
     }
 
     #[inline]
-    unsafe fn from_ptr_mut<'a>(
+    unsafe fn from_mut_ptr<'a>(
         ptr: &'a mut NonNull<Self::PointerType>,
         size: &'a mut u32,
         capacity: u32,

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -129,8 +129,7 @@ unsafe impl<const RECOMMENDED_ALLOCATION: u32> IoType for VariableBytes<RECOMMEN
 
         DerefWrapper(Self {
             bytes: *ptr,
-            // TODO: Use `NonNull::from_ref()` once stable
-            size: NonNull::from(size),
+            size: NonNull::from_ref(size),
             capacity,
         })
     }
@@ -146,8 +145,7 @@ unsafe impl<const RECOMMENDED_ALLOCATION: u32> IoType for VariableBytes<RECOMMEN
 
         DerefWrapper(Self {
             bytes: *ptr,
-            // TODO: Use `NonNull::from_ref()` once stable
-            size: NonNull::from(size),
+            size: NonNull::from_mut(size),
             capacity,
         })
     }
@@ -175,10 +173,8 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         let capacity = size;
 
         DerefWrapper(Self {
-            // TODO: Use `NonNull::from_ref()` once stable
-            bytes: NonNull::from(buffer).cast::<<Self as IoType>::PointerType>(),
-            // TODO: Use `NonNull::from_ref()` once stable
-            size: NonNull::from(&size),
+            bytes: NonNull::from_ref(buffer).cast::<<Self as IoType>::PointerType>(),
+            size: NonNull::from_ref(&size),
             capacity,
         })
     }
@@ -197,10 +193,8 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         let capacity = *size;
 
         DerefWrapper(Self {
-            // TODO: Use `NonNull::from_mut()` once stable
-            bytes: NonNull::from(buffer).cast::<<Self as IoType>::PointerType>(),
-            // TODO: Use `NonNull::from_mut()` once stable
-            size: NonNull::from(size),
+            bytes: NonNull::from_mut(buffer).cast::<<Self as IoType>::PointerType>(),
+            size: NonNull::from_mut(size),
             capacity,
         })
     }
@@ -221,10 +215,8 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         let capacity = CAPACITY as u32;
 
         DerefWrapper(Self {
-            // TODO: Use `NonNull::from_ref()` once stable
-            bytes: NonNull::from(uninit).cast::<<Self as IoType>::PointerType>(),
-            // TODO: Use `NonNull::from_mut()` once stable
-            size: NonNull::from(size),
+            bytes: NonNull::from_mut(uninit).cast::<<Self as IoType>::PointerType>(),
+            size: NonNull::from_mut(size),
             capacity,
         })
     }

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -101,8 +101,23 @@ unsafe impl<const RECOMMENDED_ALLOCATION: u32> IoType for VariableBytes<RECOMMEN
     }
 
     #[inline]
+    unsafe fn size_ptr(&self) -> impl Deref<Target = NonNull<u32>> {
+        DerefWrapper(self.size)
+    }
+
+    #[inline]
+    unsafe fn size_mut_ptr(&mut self) -> impl DerefMut<Target = NonNull<u32>> {
+        DerefWrapper(self.size)
+    }
+
+    #[inline]
     fn capacity(&self) -> u32 {
         self.capacity
+    }
+
+    #[inline]
+    unsafe fn capacity_ptr(&self) -> impl Deref<Target = NonNull<u32>> {
+        DerefWrapper(NonNull::from_ref(&self.capacity))
     }
 
     #[inline]

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
@@ -766,7 +766,7 @@ impl MethodDetails {
                         assert_impl_io_type::<#self_type>();
                     };
 
-                    <#self_type as ::ab_contracts_macros::__private::IoType>::from_ptr_mut(
+                    <#self_type as ::ab_contracts_macros::__private::IoType>::from_mut_ptr(
                         &mut args.state_ptr,
                         &mut args.state_size,
                         args.state_capacity,
@@ -854,7 +854,7 @@ impl MethodDetails {
                         assert_impl_io_type_optional::<#type_name>();
                     };
 
-                    <#type_name as ::ab_contracts_macros::__private::IoType>::from_ptr_mut(
+                    <#type_name as ::ab_contracts_macros::__private::IoType>::from_mut_ptr(
                         &mut args.#ptr_field,
                         &mut args.#size_field,
                         args.#capacity_field,
@@ -934,7 +934,7 @@ impl MethodDetails {
                         assert_impl_io_type_optional::<#type_name>();
                     };
 
-                    <#type_name as ::ab_contracts_macros::__private::IoType>::from_ptr_mut(
+                    <#type_name as ::ab_contracts_macros::__private::IoType>::from_mut_ptr(
                         &mut args.#ptr_field,
                         &mut args.#size_field,
                         args.#capacity_field,
@@ -1047,7 +1047,7 @@ impl MethodDetails {
                             assert_impl_io_type_optional::<#type_name>();
                         };
 
-                        <#type_name as ::ab_contracts_macros::__private::IoType>::from_ptr_mut(
+                        <#type_name as ::ab_contracts_macros::__private::IoType>::from_mut_ptr(
                             &mut args.#ptr_field,
                             &mut args.#size_field,
                             args.#capacity_field,


### PR DESCRIPTION
This places size and capacity as pointers next to the data pointer in both `InternalArgs` and `ExternalArgs` for easier processing by the host. Specifically this allows to read and write data structures sequentially in a single pass and for native executor simply map I/O pointers directly to each other rather than copying them manually after FFI call.

Refactoring before last commit is done to simplify things in the last commit and make ^ change possible.