### PR TITLE
Simplify slots FFI

### DIFF
--- a/crates/contracts/ab-contracts-common/src/metadata.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata.rs
@@ -57,10 +57,8 @@ pub enum ContractMetadataKind {
     ///   * [`Self::EnvRw`]
     ///   * [`Self::TmpRo`]
     ///   * [`Self::TmpRw`]
-    ///   * [`Self::SlotWithAddressRo`]
-    ///   * [`Self::SlotWithAddressRw`]
-    ///   * [`Self::SlotWithoutAddressRo`]
-    ///   * [`Self::SlotWithoutAddressRw`]
+    ///   * [`Self::SlotRo`]
+    ///   * [`Self::SlotRw`]
     ///   * [`Self::Input`]
     ///   * [`Self::Output`]
     ///   * [`Self::Result`]
@@ -120,19 +118,11 @@ pub enum ContractMetadataKind {
     /// Read-only `#[slot]` argument with an address.
     ///
     /// Example: `#[slot] (from_address, from): (&Address, &MaybeData<Slot>),`
-    SlotWithAddressRo,
+    SlotRo,
     /// Read-write `#[slot]` argument with an address.
     ///
     /// Example: `#[slot] (from_address, from): (&Address, &mut MaybeData<Slot>),`
-    SlotWithAddressRw,
-    /// Read-only `#[slot]` argument without an address.
-    ///
-    /// Example: `#[slot] from: &MaybeData<Slot>,`
-    SlotWithoutAddressRo,
-    /// Read-write `#[slot]` argument without an address.
-    ///
-    /// Example: `#[slot] from: &mut MaybeData<Slot>,`
-    SlotWithoutAddressRw,
+    SlotRw,
     /// `#[input]` argument.
     ///
     /// Example: `#[input] balance: &Balance,`
@@ -168,13 +158,11 @@ impl ContractMetadataKind {
             9 => Self::EnvRw,
             10 => Self::TmpRo,
             11 => Self::TmpRw,
-            12 => Self::SlotWithAddressRo,
-            13 => Self::SlotWithAddressRw,
-            14 => Self::SlotWithoutAddressRo,
-            15 => Self::SlotWithoutAddressRw,
-            16 => Self::Input,
-            17 => Self::Output,
-            18 => Self::Result,
+            12 => Self::SlotRo,
+            13 => Self::SlotRw,
+            14 => Self::Input,
+            15 => Self::Output,
+            16 => Self::Result,
             _ => {
                 return None;
             }

--- a/crates/contracts/ab-contracts-common/src/metadata/compact.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata/compact.rs
@@ -130,10 +130,8 @@ const fn compact_metadata_inner<'i, 'o>(
         | ContractMetadataKind::EnvRw
         | ContractMetadataKind::TmpRo
         | ContractMetadataKind::TmpRw
-        | ContractMetadataKind::SlotWithAddressRo
-        | ContractMetadataKind::SlotWithAddressRw
-        | ContractMetadataKind::SlotWithoutAddressRo
-        | ContractMetadataKind::SlotWithoutAddressRw
+        | ContractMetadataKind::SlotRo
+        | ContractMetadataKind::SlotRw
         | ContractMetadataKind::Input
         | ContractMetadataKind::Output
         | ContractMetadataKind::Result => {
@@ -174,10 +172,8 @@ const fn compact_method_argument<'i, 'o>(
         }
         ContractMetadataKind::TmpRo
         | ContractMetadataKind::TmpRw
-        | ContractMetadataKind::SlotWithAddressRo
-        | ContractMetadataKind::SlotWithAddressRw
-        | ContractMetadataKind::SlotWithoutAddressRo
-        | ContractMetadataKind::SlotWithoutAddressRw => {
+        | ContractMetadataKind::SlotRo
+        | ContractMetadataKind::SlotRw => {
             if input.is_empty() || output.is_empty() {
                 return None;
             }

--- a/crates/contracts/ab-contracts-common/src/metadata/decode.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata/decode.rs
@@ -137,10 +137,8 @@ impl<'metadata> MetadataDecoder<'metadata> {
             | ContractMetadataKind::EnvRw
             | ContractMetadataKind::TmpRo
             | ContractMetadataKind::TmpRw
-            | ContractMetadataKind::SlotWithAddressRo
-            | ContractMetadataKind::SlotWithAddressRw
-            | ContractMetadataKind::SlotWithoutAddressRo
-            | ContractMetadataKind::SlotWithoutAddressRw
+            | ContractMetadataKind::SlotRo
+            | ContractMetadataKind::SlotRw
             | ContractMetadataKind::Input
             | ContractMetadataKind::Output
             | ContractMetadataKind::Result => {
@@ -350,10 +348,8 @@ impl<'a, 'metadata> MethodMetadataDecoder<'a, 'metadata> {
             | ContractMetadataKind::EnvRw
             | ContractMetadataKind::TmpRo
             | ContractMetadataKind::TmpRw
-            | ContractMetadataKind::SlotWithAddressRo
-            | ContractMetadataKind::SlotWithAddressRw
-            | ContractMetadataKind::SlotWithoutAddressRo
-            | ContractMetadataKind::SlotWithoutAddressRw
+            | ContractMetadataKind::SlotRo
+            | ContractMetadataKind::SlotRw
             | ContractMetadataKind::Input
             | ContractMetadataKind::Output
             | ContractMetadataKind::Result => {
@@ -433,14 +429,10 @@ pub enum ArgumentKind {
     TmpRo,
     /// Corresponds to [`ContractMetadataKind::TmpRw`]
     TmpRw,
-    /// Corresponds to [`ContractMetadataKind::SlotWithAddressRo`]
-    SlotWithAddressRo,
-    /// Corresponds to [`ContractMetadataKind::SlotWithAddressRw`]
-    SlotWithAddressRw,
-    /// Corresponds to [`ContractMetadataKind::SlotWithoutAddressRo`]
-    SlotWithoutAddressRo,
-    /// Corresponds to [`ContractMetadataKind::SlotWithoutAddressRw`]
-    SlotWithoutAddressRw,
+    /// Corresponds to [`ContractMetadataKind::SlotRo`]
+    SlotRo,
+    /// Corresponds to [`ContractMetadataKind::SlotRw`]
+    SlotRw,
     /// Corresponds to [`ContractMetadataKind::Input`]
     Input,
     /// Corresponds to [`ContractMetadataKind::Output`]
@@ -499,10 +491,8 @@ impl<'metadata> ArgumentsMetadataDecoder<'_, 'metadata> {
             ContractMetadataKind::EnvRw => ArgumentKind::EnvRw,
             ContractMetadataKind::TmpRo => ArgumentKind::TmpRo,
             ContractMetadataKind::TmpRw => ArgumentKind::TmpRw,
-            ContractMetadataKind::SlotWithAddressRo => ArgumentKind::SlotWithAddressRo,
-            ContractMetadataKind::SlotWithAddressRw => ArgumentKind::SlotWithAddressRw,
-            ContractMetadataKind::SlotWithoutAddressRo => ArgumentKind::SlotWithoutAddressRo,
-            ContractMetadataKind::SlotWithoutAddressRw => ArgumentKind::SlotWithoutAddressRw,
+            ContractMetadataKind::SlotRo => ArgumentKind::SlotRo,
+            ContractMetadataKind::SlotRw => ArgumentKind::SlotRw,
             ContractMetadataKind::Input => ArgumentKind::Input,
             ContractMetadataKind::Output => ArgumentKind::Output,
             ContractMetadataKind::Result => ArgumentKind::Result,
@@ -529,26 +519,22 @@ impl<'metadata> ArgumentsMetadataDecoder<'_, 'metadata> {
                 | ArgumentKind::EnvRw
                 | ArgumentKind::TmpRo
                 | ArgumentKind::TmpRw
-                | ArgumentKind::SlotWithAddressRo
-                | ArgumentKind::SlotWithAddressRw
-                | ArgumentKind::SlotWithoutAddressRo
-                | ArgumentKind::SlotWithoutAddressRw
+                | ArgumentKind::SlotRo
+                | ArgumentKind::SlotRw
                 | ArgumentKind::Input
                 | ArgumentKind::Output
                 | ArgumentKind::Result => true,
             },
             MethodKind::ViewStateless | MethodKind::ViewStatefulRo => match argument_kind {
                 ArgumentKind::EnvRo
-                | ArgumentKind::SlotWithAddressRo
-                | ArgumentKind::SlotWithoutAddressRo
+                | ArgumentKind::SlotRo
                 | ArgumentKind::Input
                 | ArgumentKind::Output
                 | ArgumentKind::Result => true,
                 ArgumentKind::EnvRw
                 | ArgumentKind::TmpRo
                 | ArgumentKind::TmpRw
-                | ArgumentKind::SlotWithAddressRw
-                | ArgumentKind::SlotWithoutAddressRw => false,
+                | ArgumentKind::SlotRw => false,
             },
         };
 
@@ -563,10 +549,8 @@ impl<'metadata> ArgumentsMetadataDecoder<'_, 'metadata> {
             ArgumentKind::EnvRo | ArgumentKind::EnvRw => ("env", None),
             ArgumentKind::TmpRo
             | ArgumentKind::TmpRw
-            | ArgumentKind::SlotWithAddressRo
-            | ArgumentKind::SlotWithAddressRw
-            | ArgumentKind::SlotWithoutAddressRo
-            | ArgumentKind::SlotWithoutAddressRw
+            | ArgumentKind::SlotRo
+            | ArgumentKind::SlotRw
             | ArgumentKind::Input
             | ArgumentKind::Output
             | ArgumentKind::Result => {
@@ -597,10 +581,8 @@ impl<'metadata> ArgumentsMetadataDecoder<'_, 'metadata> {
                     | ArgumentKind::EnvRw
                     | ArgumentKind::TmpRo
                     | ArgumentKind::TmpRw
-                    | ArgumentKind::SlotWithAddressRo
-                    | ArgumentKind::SlotWithAddressRw
-                    | ArgumentKind::SlotWithoutAddressRo
-                    | ArgumentKind::SlotWithoutAddressRw => None,
+                    | ArgumentKind::SlotRo
+                    | ArgumentKind::SlotRw => None,
                     ArgumentKind::Input | ArgumentKind::Output => {
                         let recommended_capacity;
                         (recommended_capacity, *self.metadata) =

--- a/crates/contracts/ab-contracts-io-type/src/metadata/tests.rs
+++ b/crates/contracts/ab-contracts-io-type/src/metadata/tests.rs
@@ -15,13 +15,11 @@ fn check_repr() {
         (ContractMetadataKind::EnvRw, 9),
         (ContractMetadataKind::TmpRo, 10),
         (ContractMetadataKind::TmpRw, 11),
-        (ContractMetadataKind::SlotWithAddressRo, 12),
-        (ContractMetadataKind::SlotWithAddressRw, 13),
-        (ContractMetadataKind::SlotWithoutAddressRo, 14),
-        (ContractMetadataKind::SlotWithoutAddressRw, 15),
-        (ContractMetadataKind::Input, 16),
-        (ContractMetadataKind::Output, 17),
-        (ContractMetadataKind::Result, 18),
+        (ContractMetadataKind::SlotRo, 12),
+        (ContractMetadataKind::SlotRw, 13),
+        (ContractMetadataKind::Input, 14),
+        (ContractMetadataKind::Output, 15),
+        (ContractMetadataKind::Result, 16),
     ];
 
     for (kind, repr_byte) in known_variants {


### PR DESCRIPTION
This not only simplifies code, it also provides more flexibility to implementers since adding or removing slot address argument doesn't impact metadata anymore