### PR TITLE
Replace bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,6 @@ dependencies = [
  "ab-system-contract-address-allocator",
  "ab-system-contract-code",
  "ab-system-contract-state",
- "bytes",
  "inventory",
  "parking_lot",
  "thiserror",
@@ -125,12 +124,6 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
-
-[[package]]
-name = "bytes"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cfg-if"

--- a/crates/contracts/ab-contracts-executor/Cargo.toml
+++ b/crates/contracts/ab-contracts-executor/Cargo.toml
@@ -15,7 +15,6 @@ ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
 ab-system-contract-address-allocator = { version = "0.0.1", path = "../ab-system-contract-address-allocator", optional = true }
 ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code", optional = true }
 ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state", optional = true }
-bytes = "1.9.0"
 inventory = "0.3.19"
 parking_lot = "0.12.3"
 thiserror = "2.0.11"

--- a/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
+++ b/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
@@ -1,0 +1,272 @@
+#[cfg(test)]
+mod tests;
+
+use std::mem::MaybeUninit;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::{mem, slice};
+
+#[repr(C, align(16))]
+struct AlignedBytes([u8; Self::SIZE]);
+
+impl AlignedBytes {
+    const SIZE: usize = 16;
+}
+
+/// Owned aligned buffer for executor purposes.
+///
+/// See [`SharedAlignedBuffer`] for a version that can be cheaply cloned, while reusing the original
+/// allocation.
+///
+/// Data is aligned to 16 bytes (128 bits), which is the largest alignment required by primitive
+/// types and by extension any type that implements `TrivialType`/`IoType`.
+#[derive(Debug)]
+pub(super) struct OwnedAlignedBuffer {
+    buffer: Arc<[MaybeUninit<AlignedBytes>]>,
+    len: u32,
+}
+
+impl Deref for OwnedAlignedBuffer {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl DerefMut for OwnedAlignedBuffer {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl PartialEq for OwnedAlignedBuffer {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.len == other.len && self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for OwnedAlignedBuffer {}
+
+impl OwnedAlignedBuffer {
+    /// Create a new instance with at least specified capacity.
+    ///
+    /// NOTE: Actual capacity might be larger due to alignment requirements.
+    #[inline]
+    pub(super) fn with_capacity(capacity: u32) -> Self {
+        Self {
+            buffer: Arc::new_uninit_slice((capacity as usize).div_ceil(AlignedBytes::SIZE)),
+            len: 0,
+        }
+    }
+
+    /// Create a new instance from provided bytes.
+    ///
+    /// # Panics
+    /// If `bytes.len()` doesn't fit into `u32`
+    #[inline]
+    pub(super) fn from_bytes(bytes: &[u8]) -> Self {
+        let mut instance = Self::with_capacity(0);
+        instance.copy_from_slice(bytes);
+        instance
+    }
+
+    #[inline]
+    pub(super) fn as_slice(&self) -> &[u8] {
+        let len = self.len as usize;
+        // SAFETY: Not null and length is a protected invariant of the implementation
+        unsafe { slice::from_raw_parts(self.as_ptr(), len) }
+    }
+
+    #[inline]
+    pub(super) fn as_mut_slice(&mut self) -> &mut [u8] {
+        let len = self.len as usize;
+        // SAFETY: Not null and length is a protected invariant of the implementation
+        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
+    }
+
+    #[inline]
+    pub(super) fn as_ptr(&self) -> *const u8 {
+        self.buffer.as_ptr().cast::<u8>()
+    }
+
+    #[inline]
+    pub(super) fn as_mut_ptr(&mut self) -> *mut u8 {
+        Arc::get_mut(&mut self.buffer)
+            .expect("Owned by this data structure; qed")
+            .as_mut_ptr()
+            .cast::<u8>()
+    }
+
+    #[inline]
+    pub(super) fn into_shared(self) -> SharedAlignedBuffer {
+        SharedAlignedBuffer {
+            buffer: self.buffer,
+            len: self.len,
+        }
+    }
+
+    /// Will re-allocate if capacity is not enough to store provided bytes.
+    ///
+    /// # Panics
+    /// If `bytes.len()` doesn't fit into `u32`
+    #[inline]
+    pub(super) fn copy_from_slice(&mut self, bytes: &[u8]) {
+        let Ok(len) = u32::try_from(bytes.len()) else {
+            panic!("Too many bytes");
+        };
+
+        if len > self.capacity() {
+            // Drop old buffer
+            mem::take(&mut self.buffer);
+            // Allocate new buffer
+            self.buffer = Self::with_capacity(len).buffer;
+        }
+
+        // SAFETY: Sufficient capacity guaranteed above, natural alignment of bytes is 1 for input
+        // and output, non-overlapping allocations guaranteed by type system
+        unsafe {
+            self.as_mut_ptr()
+                .copy_from_nonoverlapping(bytes.as_ptr(), bytes.len());
+        }
+
+        self.len = len;
+    }
+
+    #[inline]
+    pub(super) fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
+    pub(super) fn len(&self) -> u32 {
+        self.len
+    }
+
+    #[inline]
+    pub(super) fn capacity(&self) -> u32 {
+        (self.buffer.len() * AlignedBytes::SIZE) as u32
+    }
+
+    /// Set the length of the useful data to specified value.
+    ///
+    /// # Safety
+    /// There must be `new_len` bytes initialized in the buffer.
+    ///
+    /// # Panics
+    /// If `bytes.len()` doesn't fit into `u32`
+    #[inline]
+    pub(super) unsafe fn set_len(&mut self, new_len: u32) {
+        if new_len > self.capacity() {
+            panic!("Too many bytes");
+        }
+        self.len = new_len;
+    }
+}
+
+/// Shared aligned buffer for executor purposes.
+///
+/// See [`OwnedAlignedBuffer`] for a version that can be mutated.
+///
+/// Data is aligned to 16 bytes (128 bits), which is the largest alignment required by primitive
+/// types and by extension any type that implements `TrivialType`/`IoType`.
+#[derive(Debug, Default, Clone)]
+pub(super) struct SharedAlignedBuffer {
+    buffer: Arc<[MaybeUninit<AlignedBytes>]>,
+    len: u32,
+}
+
+impl Deref for SharedAlignedBuffer {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl PartialEq for SharedAlignedBuffer {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.len == other.len && self.as_slice() == other.as_slice()
+    }
+}
+
+impl PartialEq<OwnedAlignedBuffer> for SharedAlignedBuffer {
+    #[inline]
+    fn eq(&self, other: &OwnedAlignedBuffer) -> bool {
+        self.len == other.len && self.as_slice() == other.as_slice()
+    }
+}
+
+impl PartialEq<SharedAlignedBuffer> for OwnedAlignedBuffer {
+    #[inline]
+    fn eq(&self, other: &SharedAlignedBuffer) -> bool {
+        self.len == other.len && self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for SharedAlignedBuffer {}
+
+impl SharedAlignedBuffer {
+    /// Create a new instance from provided bytes.
+    ///
+    /// # Panics
+    /// If `bytes.len()` doesn't fit into `u32`
+    #[inline]
+    pub(super) fn from_bytes(bytes: &[u8]) -> Self {
+        OwnedAlignedBuffer::from_bytes(bytes).into_shared()
+    }
+
+    /// Convert into owned buffer.
+    ///
+    /// If this is the last shared instance, then allocation will be reused, otherwise new
+    /// allocation will be created.
+    ///
+    /// Returns `None` if there exit other shared instances.
+    #[inline]
+    #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
+    pub(super) fn into_owned(mut self) -> OwnedAlignedBuffer {
+        // Check if this is the last instance of the buffer
+        if Arc::get_mut(&mut self.buffer).is_some() {
+            OwnedAlignedBuffer {
+                buffer: self.buffer,
+                len: self.len,
+            }
+        } else {
+            let mut instance = OwnedAlignedBuffer::with_capacity(self.capacity());
+            instance.copy_from_slice(self.as_slice());
+            instance
+        }
+    }
+
+    #[inline]
+    pub(super) fn as_slice(&self) -> &[u8] {
+        // SAFETY: Not null and size is a protected invariant of the implementation
+        unsafe { slice::from_raw_parts(self.buffer.as_ptr().cast::<u8>(), self.len as usize) }
+    }
+
+    #[inline]
+    pub(super) fn as_ptr(&self) -> *const u8 {
+        self.buffer.as_ptr().cast::<u8>()
+    }
+
+    #[inline]
+    #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
+    pub(super) fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
+    pub(super) fn len(&self) -> u32 {
+        self.len
+    }
+
+    #[inline]
+    pub(super) fn capacity(&self) -> u32 {
+        (self.buffer.len() * AlignedBytes::SIZE) as u32
+    }
+}

--- a/crates/contracts/ab-contracts-executor/src/aligned_buffer/tests.rs
+++ b/crates/contracts/ab-contracts-executor/src/aligned_buffer/tests.rs
@@ -1,0 +1,164 @@
+use crate::aligned_buffer::{AlignedBytes, OwnedAlignedBuffer};
+
+const EXPECTED_ALIGNMENT: usize = size_of::<AlignedBytes>();
+
+#[test]
+fn basic() {
+    for capacity in 0..=EXPECTED_ALIGNMENT as u32 {
+        let mut owned = OwnedAlignedBuffer::with_capacity(capacity);
+        assert_eq!(owned.len(), 0, "Capacity {capacity}");
+        assert!(owned.capacity() >= capacity, "Capacity {capacity}");
+        assert!(owned.is_empty(), "Capacity {capacity}");
+        assert!(owned.as_slice().is_empty(), "Capacity {capacity}");
+        assert!(owned.as_mut_slice().is_empty(), "Capacity {capacity}");
+        assert_eq!(owned.as_ptr(), owned.as_mut_ptr(), "Capacity {capacity}");
+        assert!(
+            owned.as_ptr().is_aligned_to(EXPECTED_ALIGNMENT),
+            "Capacity {capacity}"
+        );
+
+        let ptr_before = owned.as_ptr();
+
+        // Using part of the capacity
+        {
+            let len = owned.capacity().saturating_sub(1);
+            let bytes = vec![1; len as usize];
+            owned.copy_from_slice(&bytes);
+            assert_eq!(owned.len(), len, "Capacity {capacity}");
+            assert_eq!(owned.as_slice().len(), len as usize, "Capacity {capacity}");
+            assert_eq!(
+                owned.as_mut_slice().len(),
+                len as usize,
+                "Capacity {capacity}"
+            );
+            assert!(owned.capacity() >= capacity, "Capacity {capacity}");
+            if len != 0 {
+                assert!(!owned.is_empty(), "Capacity {capacity}");
+                assert!(!owned.as_slice().is_empty(), "Capacity {capacity}");
+                assert!(!owned.as_mut_slice().is_empty(), "Capacity {capacity}");
+            }
+            assert_eq!(owned.as_ptr(), owned.as_mut_ptr(), "Capacity {capacity}");
+            assert_eq!(owned.as_ptr(), ptr_before, "Capacity {capacity}");
+            assert!(
+                owned.as_ptr().is_aligned_to(EXPECTED_ALIGNMENT),
+                "Capacity {capacity}"
+            );
+
+            let mut owned2 = OwnedAlignedBuffer::from_bytes(&bytes);
+            assert_eq!(owned, owned2, "Capacity {capacity}");
+            assert_eq!(owned.len(), owned2.len(), "Capacity {capacity}");
+            assert_eq!(owned.is_empty(), owned2.is_empty(), "Capacity {capacity}");
+            assert_eq!(owned.as_slice(), owned2.as_slice(), "Capacity {capacity}");
+            assert_eq!(
+                owned.as_mut_slice(),
+                owned2.as_mut_slice(),
+                "Capacity {capacity}"
+            );
+        }
+
+        // Using full capacity
+        {
+            let len = owned.capacity();
+            let bytes = vec![1; len as usize];
+            owned.copy_from_slice(&bytes);
+            assert_eq!(owned.len(), len, "Capacity {capacity}");
+            assert_eq!(owned.as_slice().len(), len as usize, "Capacity {capacity}");
+            assert_eq!(
+                owned.as_mut_slice().len(),
+                len as usize,
+                "Capacity {capacity}"
+            );
+            assert!(owned.capacity() >= capacity, "Capacity {capacity}");
+            if len != 0 {
+                assert!(!owned.is_empty(), "Capacity {capacity}");
+                assert!(!owned.as_slice().is_empty(), "Capacity {capacity}");
+                assert!(!owned.as_mut_slice().is_empty(), "Capacity {capacity}");
+            }
+            assert_eq!(owned.as_ptr(), owned.as_mut_ptr(), "Capacity {capacity}");
+            assert_eq!(owned.as_ptr(), ptr_before, "Capacity {capacity}");
+            assert!(
+                owned.as_ptr().is_aligned_to(EXPECTED_ALIGNMENT),
+                "Capacity {capacity}"
+            );
+
+            let mut owned2 = OwnedAlignedBuffer::from_bytes(&bytes);
+            assert_eq!(owned, owned2, "Capacity {capacity}");
+            assert_eq!(owned.len(), owned2.len(), "Capacity {capacity}");
+            assert_eq!(owned.is_empty(), owned2.is_empty(), "Capacity {capacity}");
+            assert_eq!(owned.as_slice(), owned2.as_slice(), "Capacity {capacity}");
+            assert_eq!(
+                owned.as_mut_slice(),
+                owned2.as_mut_slice(),
+                "Capacity {capacity}"
+            );
+        }
+
+        // Exceed capacity, resulting in reallocation
+        {
+            let len = owned.capacity() + 1;
+            let bytes = vec![1; len as usize];
+            owned.copy_from_slice(&bytes);
+            assert_eq!(owned.len(), len, "Capacity {capacity}");
+            assert_eq!(owned.as_slice().len(), len as usize, "Capacity {capacity}");
+            assert_eq!(
+                owned.as_mut_slice().len(),
+                len as usize,
+                "Capacity {capacity}"
+            );
+            assert!(owned.capacity() >= capacity, "Capacity {capacity}");
+            assert!(!owned.is_empty(), "Capacity {capacity}");
+            assert!(!owned.as_slice().is_empty(), "Capacity {capacity}");
+            assert!(!owned.as_mut_slice().is_empty(), "Capacity {capacity}");
+            assert_eq!(owned.as_ptr(), owned.as_mut_ptr(), "Capacity {capacity}");
+            assert_ne!(owned.as_ptr(), ptr_before, "Capacity {capacity}");
+            assert!(
+                owned.as_ptr().is_aligned_to(EXPECTED_ALIGNMENT),
+                "Capacity {capacity}"
+            );
+
+            let mut owned2 = OwnedAlignedBuffer::from_bytes(&bytes);
+            assert_eq!(owned, owned2, "Capacity {capacity}");
+            assert_eq!(owned.len(), owned2.len(), "Capacity {capacity}");
+            assert_eq!(owned.is_empty(), owned2.is_empty(), "Capacity {capacity}");
+            assert_eq!(owned.as_slice(), owned2.as_slice(), "Capacity {capacity}");
+            assert_eq!(
+                owned.as_mut_slice(),
+                owned2.as_mut_slice(),
+                "Capacity {capacity}"
+            );
+
+            let shorter_len = owned2.len() - 1;
+            // SAFETY: length is guaranteed to be within stored bytes
+            unsafe { owned2.set_len(shorter_len) };
+            assert_eq!(&owned[..shorter_len as usize], owned2.as_slice());
+        }
+
+        // Create a shared instance
+        let shared = owned.into_shared();
+        let ptr_before = shared.as_ptr();
+        // Turn back into owned and confirm that it points to the same memory (meaning no additional
+        // allocation)
+        let owned = shared.into_owned();
+        assert_eq!(owned.as_ptr(), ptr_before, "Capacity {capacity}");
+
+        let shared = owned.into_shared();
+        // Cloned shared instance will result in new allocation
+        let owned = shared.clone().into_owned();
+        assert_ne!(owned.as_ptr(), ptr_before, "Capacity {capacity}");
+
+        let shared2 = shared.clone();
+        assert_eq!(shared, shared2, "Capacity {capacity}");
+        assert_eq!(shared2, shared, "Capacity {capacity}");
+        assert_eq!(shared, owned, "Capacity {capacity}");
+        assert_eq!(owned, shared, "Capacity {capacity}");
+
+        assert_eq!(shared.len(), shared2.len(), "Capacity {capacity}");
+        assert_eq!(shared.len(), owned.len(), "Capacity {capacity}");
+        assert_eq!(shared.capacity(), shared2.capacity(), "Capacity {capacity}");
+        assert_eq!(shared.capacity(), owned.capacity(), "Capacity {capacity}");
+        assert_eq!(shared.is_empty(), shared2.is_empty(), "Capacity {capacity}");
+        assert_eq!(shared.is_empty(), owned.is_empty(), "Capacity {capacity}");
+        assert_eq!(shared.as_ptr(), shared2.as_ptr(), "Capacity {capacity}");
+        assert_eq!(shared.as_slice(), shared2.as_slice(), "Capacity {capacity}");
+    }
+}

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -79,7 +79,11 @@ where
             *size == 0 || *size == capacity,
             "Invalid size {size} for capacity {capacity}"
         );
-        debug_assert_eq!(capacity, Data::SIZE, "Invalid capacity");
+        debug_assert!(
+            capacity >= Data::SIZE,
+            "Invalid capacity {capacity} for size {}",
+            Data::SIZE
+        );
 
         let data = ptr.cast::<Data>();
         let size = NonNull::from_ref(size);
@@ -110,7 +114,11 @@ where
                 "Invalid size {size} for capacity {capacity}"
             );
         }
-        debug_assert_eq!(capacity, Data::SIZE, "Invalid capacity");
+        debug_assert!(
+            capacity >= Data::SIZE,
+            "Invalid capacity {capacity} for size {}",
+            Data::SIZE
+        );
 
         let data = ptr.cast::<Data>();
 

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -2,6 +2,8 @@
 #[doc(hidden)]
 pub mod __private;
 
+// TODO: Should size + capacity be a single tuple struct that can be passed down as a single
+//  pointer?
 /// `#[contract]` macro to derive smart contract implementation.
 ///
 /// This macro is supposed to be applied to an implementation of the struct that in turn implements


### PR DESCRIPTION
`Bytes` and `BytesMut` do not guarantee necessary alignment. Since we don't need dynamic resizing or other complex features, it is possible to implement a simpler version with alignment guarantees and better domain-specific API.