### PR TITLE
More examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ab-contract-example-ft"
+version = "0.0.1"
+dependencies = [
+ "ab-contracts-common",
+ "ab-contracts-executor",
+ "ab-contracts-io-type",
+ "ab-contracts-macros",
+ "ab-contracts-standards",
+ "ab-system-contract-code",
+]
+
+[[package]]
 name = "ab-contract-playground"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 4
 
 [[package]]
-name = "ab-contract-example"
+name = "ab-contract-playground"
 version = "0.0.1"
 dependencies = [
  "ab-contracts-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "ab-contracts-common",
  "ab-contracts-io-type",
  "ab-contracts-macros-impl",
+ "const_format",
  "inventory",
 ]
 
@@ -159,6 +160,26 @@ name = "const-sha1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "derive_more"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "ab-contract-example-flipper"
+version = "0.0.1"
+dependencies = [
+ "ab-contracts-common",
+ "ab-contracts-executor",
+ "ab-contracts-io-type",
+ "ab-contracts-macros",
+ "ab-system-contract-code",
+]
+
+[[package]]
 name = "ab-contract-example-ft"
 version = "0.0.1"
 dependencies = [

--- a/crates/contracts/ab-contract-example-flipper/Cargo.toml
+++ b/crates/contracts/ab-contract-example-flipper/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "ab-contract-example-flipper"
+description = ""
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
+ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
+
+[dev-dependencies]
+ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-executor = { version = "0.0.1", path = "../ab-contracts-executor", features = ["system-contracts"] }
+ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
+
+[features]
+guest = [
+    "ab-contracts-macros/guest",
+]

--- a/crates/contracts/ab-contract-example-flipper/src/lib.rs
+++ b/crates/contracts/ab-contract-example-flipper/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_macros::contract;
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct Flipper {
+    pub value: bool,
+}
+
+#[contract]
+impl Flipper {
+    #[init]
+    pub fn new(#[input] &init_value: &bool) -> Self {
+        Self { value: init_value }
+    }
+
+    #[update]
+    pub fn flip(&mut self) {
+        self.value = !self.value;
+    }
+
+    #[view]
+    pub fn value(&self) -> bool {
+        self.value
+    }
+}

--- a/crates/contracts/ab-contract-example-flipper/tests/basic.rs
+++ b/crates/contracts/ab-contract-example-flipper/tests/basic.rs
@@ -1,0 +1,43 @@
+use ab_contract_example_flipper::{Flipper, FlipperExt};
+use ab_contracts_common::env::MethodContext;
+use ab_contracts_common::{Address, Contract, ShardIndex};
+use ab_contracts_executor::NativeExecutor;
+use ab_contracts_io_type::variable_bytes::VariableBytes;
+use ab_system_contract_code::CodeExt;
+
+#[test]
+fn basic() {
+    let shard_index = ShardIndex::from_u32(1).unwrap();
+    let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
+    executor.deploy_typical_system_contracts().unwrap();
+
+    let env = &mut *executor.null_env();
+
+    // Deploy
+    let flipper_address = env
+        .code_deploy(
+            MethodContext::Keep,
+            Address::SYSTEM_CODE,
+            &VariableBytes::from_buffer(
+                Flipper::CRATE_NAME.as_bytes(),
+                &(Flipper::CRATE_NAME.len() as u32),
+            ),
+        )
+        .unwrap();
+
+    let init_value = true;
+
+    // Initialize state
+    env.flipper_new(MethodContext::Keep, flipper_address, &init_value)
+        .unwrap();
+
+    // Check initial value
+    assert_eq!(env.flipper_value(flipper_address).unwrap(), init_value);
+
+    // Flip
+    env.flipper_flip(MethodContext::Keep, flipper_address)
+        .unwrap();
+
+    // Check new value
+    assert_eq!(env.flipper_value(flipper_address).unwrap(), !init_value);
+}

--- a/crates/contracts/ab-contract-example-flipper/tests/basic.rs
+++ b/crates/contracts/ab-contract-example-flipper/tests/basic.rs
@@ -2,7 +2,6 @@ use ab_contract_example_flipper::{Flipper, FlipperExt};
 use ab_contracts_common::env::MethodContext;
 use ab_contracts_common::{Address, Contract, ShardIndex};
 use ab_contracts_executor::NativeExecutor;
-use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_system_contract_code::CodeExt;
 
 #[test]
@@ -15,14 +14,7 @@ fn basic() {
 
     // Deploy
     let flipper_address = env
-        .code_deploy(
-            MethodContext::Keep,
-            Address::SYSTEM_CODE,
-            &VariableBytes::from_buffer(
-                Flipper::CRATE_NAME.as_bytes(),
-                &(Flipper::CRATE_NAME.len() as u32),
-            ),
-        )
+        .code_deploy(MethodContext::Keep, Address::SYSTEM_CODE, &Flipper::code())
         .unwrap();
 
     let init_value = true;

--- a/crates/contracts/ab-contract-example-flipper/tests/basic.rs
+++ b/crates/contracts/ab-contract-example-flipper/tests/basic.rs
@@ -10,7 +10,7 @@ fn basic() {
     let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
     executor.deploy_typical_system_contracts().unwrap();
 
-    let env = &mut *executor.null_env();
+    let mut env = executor.null_env();
 
     // Deploy
     let flipper_address = env

--- a/crates/contracts/ab-contract-example-ft/Cargo.toml
+++ b/crates/contracts/ab-contract-example-ft/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ab-contract-example-ft"
+description = ""
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[dependencies]
+ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
+ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
+ab-contracts-standards = { version = "0.0.1", path = "../ab-contracts-standards" }
+
+[dev-dependencies]
+ab-contracts-executor = { version = "0.0.1", path = "../ab-contracts-executor", features = ["system-contracts"] }
+ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
+
+[features]
+guest = [
+    "ab-contracts-common/guest",
+    "ab-contracts-standards/guest",
+]

--- a/crates/contracts/ab-contract-example-ft/Cargo.toml
+++ b/crates/contracts/ab-contract-example-ft/Cargo.toml
@@ -23,5 +23,6 @@ ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-cod
 [features]
 guest = [
     "ab-contracts-common/guest",
+    "ab-contracts-macros/guest",
     "ab-contracts-standards/guest",
 ]

--- a/crates/contracts/ab-contract-example-ft/src/lib.rs
+++ b/crates/contracts/ab-contract-example-ft/src/lib.rs
@@ -1,0 +1,144 @@
+#![no_std]
+
+use ab_contracts_common::env::{Env, MethodContext};
+use ab_contracts_common::{Address, Balance, ContractError};
+use ab_contracts_io_type::maybe_data::MaybeData;
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_macros::contract;
+use ab_contracts_standards::Fungible;
+use core::cmp::Ordering;
+
+#[derive(Debug, Default, Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct Slot {
+    pub balance: Balance,
+}
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct ExampleFt {
+    pub total_supply: Balance,
+    pub owner: Address,
+    pub padding: [u8; 8],
+}
+
+#[contract]
+impl Fungible for ExampleFt {
+    #[update]
+    fn transfer(
+        #[env] env: &mut Env,
+        #[input] from: &Address,
+        #[input] to: &Address,
+        #[input] amount: &Balance,
+    ) -> Result<(), ContractError> {
+        if !(env.context() == from || env.caller() == from || env.caller() == env.own_address()) {
+            return Err(ContractError::Forbidden);
+        }
+
+        env.example_ft_transfer(MethodContext::Replace, env.own_address(), from, to, amount)
+    }
+
+    #[view]
+    fn balance(#[env] env: &Env, #[input] address: &Address) -> Result<Balance, ContractError> {
+        env.example_ft_balance(env.own_address(), address)
+    }
+}
+
+#[contract]
+impl ExampleFt {
+    #[init]
+    pub fn new(
+        #[slot] (owner_addr, owner): (&Address, &mut MaybeData<Slot>),
+        #[input] total_supply: &Balance,
+    ) -> Self {
+        owner.replace(Slot {
+            balance: *total_supply,
+        });
+        Self {
+            total_supply: *total_supply,
+            owner: *owner_addr,
+            padding: [0; 8],
+        }
+    }
+
+    #[update]
+    pub fn mint(
+        &mut self,
+        #[env] env: &mut Env,
+        #[slot] to: &mut MaybeData<Slot>,
+        #[input] &value: &Balance,
+    ) -> Result<(), ContractError> {
+        if env.context() != self.owner && env.caller() != self.owner {
+            return Err(ContractError::Forbidden);
+        }
+
+        if Balance::MAX - value > self.total_supply {
+            return Err(ContractError::BadInput);
+        }
+
+        self.total_supply += value;
+
+        match to.get_mut() {
+            Some(contents) => {
+                contents.balance += value;
+            }
+            None => {
+                to.replace(Slot { balance: value });
+            }
+        }
+
+        Ok(())
+    }
+
+    #[view]
+    pub fn balance(#[slot] target: &MaybeData<Slot>) -> Balance {
+        target
+            .get()
+            .map_or_else(Balance::default, |slot| slot.balance)
+    }
+
+    #[update]
+    pub fn transfer(
+        #[env] env: &mut Env,
+        #[slot] (from_address, from): (&Address, &mut MaybeData<Slot>),
+        #[slot] to: &mut MaybeData<Slot>,
+        #[input] &amount: &Balance,
+    ) -> Result<(), ContractError> {
+        if !(env.context() == from_address
+            || env.caller() == from_address
+            || env.caller() == env.own_address())
+        {
+            return Err(ContractError::Forbidden);
+        }
+
+        {
+            let Some(contents) = from.get_mut() else {
+                return Err(ContractError::PreconditionFailed);
+            };
+
+            match contents.balance.cmp(&amount) {
+                Ordering::Less => {
+                    return Err(ContractError::BadInput);
+                }
+                Ordering::Equal => {
+                    // All balance is transferred out, remove slot contents
+                    from.remove();
+                }
+                Ordering::Greater => {
+                    contents.balance -= amount;
+                }
+            }
+        }
+
+        match to.get_mut() {
+            Some(contents) => {
+                contents.balance += amount;
+            }
+            None => {
+                to.replace(Slot { balance: amount });
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/contracts/ab-contract-example-ft/tests/basic.rs
+++ b/crates/contracts/ab-contract-example-ft/tests/basic.rs
@@ -11,7 +11,7 @@ fn basic() {
     let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
     executor.deploy_typical_system_contracts().unwrap();
     let token_address = {
-        let env = &mut *executor.null_env();
+        let mut env = executor.null_env();
 
         let token_address = env
             .code_deploy(
@@ -32,7 +32,7 @@ fn basic() {
     };
 
     {
-        let env = &mut *executor.env(token_address, Address::NULL);
+        let mut env = executor.env(token_address, Address::NULL);
 
         let from = token_address;
         let mut previous_from_balance = Balance::MAX;

--- a/crates/contracts/ab-contract-example-ft/tests/basic.rs
+++ b/crates/contracts/ab-contract-example-ft/tests/basic.rs
@@ -2,7 +2,6 @@ use ab_contract_example_ft::{ExampleFt, ExampleFtExt};
 use ab_contracts_common::env::MethodContext;
 use ab_contracts_common::{Address, Balance, Contract, ShardIndex};
 use ab_contracts_executor::NativeExecutor;
-use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_standards::FungibleExt;
 use ab_system_contract_code::CodeExt;
 
@@ -18,10 +17,7 @@ fn basic() {
             .code_deploy(
                 MethodContext::Keep,
                 Address::SYSTEM_CODE,
-                &VariableBytes::from_buffer(
-                    ExampleFt::CRATE_NAME.as_bytes(),
-                    &(ExampleFt::CRATE_NAME.len() as u32),
-                ),
+                &ExampleFt::code(),
             )
             .unwrap();
         env.example_ft_new(

--- a/crates/contracts/ab-contract-example-ft/tests/basic.rs
+++ b/crates/contracts/ab-contract-example-ft/tests/basic.rs
@@ -1,0 +1,103 @@
+use ab_contract_example_ft::{ExampleFt, ExampleFtExt};
+use ab_contracts_common::env::MethodContext;
+use ab_contracts_common::{Address, Balance, Contract, ShardIndex};
+use ab_contracts_executor::NativeExecutor;
+use ab_contracts_io_type::variable_bytes::VariableBytes;
+use ab_contracts_standards::FungibleExt;
+use ab_system_contract_code::CodeExt;
+
+#[test]
+fn basic() {
+    let shard_index = ShardIndex::from_u32(1).unwrap();
+    let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
+    executor.deploy_typical_system_contracts().unwrap();
+    let token_address = {
+        let env = &mut *executor.null_env();
+
+        let token_address = env
+            .code_deploy(
+                MethodContext::Keep,
+                Address::SYSTEM_CODE,
+                &VariableBytes::from_buffer(
+                    ExampleFt::CRATE_NAME.as_bytes(),
+                    &(ExampleFt::CRATE_NAME.len() as u32),
+                ),
+            )
+            .unwrap();
+        env.example_ft_new(
+            MethodContext::Keep,
+            token_address,
+            &token_address,
+            &Balance::MAX,
+        )
+        .unwrap();
+
+        token_address
+    };
+
+    {
+        let env = &mut *executor.env(token_address, Address::NULL);
+
+        let from = token_address;
+        let mut previous_from_balance = Balance::MAX;
+        let to = Address::SYSTEM_CODE;
+        let mut previous_to_balance = Balance::from(0);
+        let amount = Balance::from(10);
+
+        // Direct
+        assert_eq!(
+            env.example_ft_balance(token_address, &from).unwrap(),
+            previous_from_balance
+        );
+        // Through `Fungible` trait
+        assert_eq!(
+            env.fungible_balance(token_address, &from).unwrap(),
+            previous_from_balance
+        );
+
+        // Direct
+        env.example_ft_transfer(MethodContext::Keep, token_address, &from, &to, &amount)
+            .unwrap();
+
+        // Direct
+        {
+            let remaining_balance = env.example_ft_balance(token_address, &from).unwrap();
+            let code_balance = env.example_ft_balance(token_address, &to).unwrap();
+
+            assert_eq!(remaining_balance, previous_from_balance - amount);
+            assert_eq!(code_balance, previous_to_balance + amount);
+        }
+        // Through `Fungible` trait
+        {
+            let remaining_balance = env.fungible_balance(token_address, &from).unwrap();
+            let code_balance = env.fungible_balance(token_address, &to).unwrap();
+
+            assert_eq!(remaining_balance, previous_from_balance - amount);
+            assert_eq!(code_balance, previous_to_balance + amount);
+        }
+
+        previous_from_balance -= amount;
+        previous_to_balance += amount;
+
+        // Through `Fungible` trait
+        env.fungible_transfer(MethodContext::Keep, token_address, &from, &to, &amount)
+            .unwrap();
+
+        // Direct
+        {
+            let remaining_balance = env.example_ft_balance(token_address, &from).unwrap();
+            let code_balance = env.example_ft_balance(token_address, &to).unwrap();
+
+            assert_eq!(remaining_balance, previous_from_balance - amount);
+            assert_eq!(code_balance, previous_to_balance + amount);
+        }
+        // Through `Fungible` trait
+        {
+            let remaining_balance = env.fungible_balance(token_address, &from).unwrap();
+            let code_balance = env.fungible_balance(token_address, &to).unwrap();
+
+            assert_eq!(remaining_balance, previous_from_balance - amount);
+            assert_eq!(code_balance, previous_to_balance + amount);
+        }
+    }
+}

--- a/crates/contracts/ab-contract-playground/Cargo.toml
+++ b/crates/contracts/ab-contract-playground/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ab-contract-example"
+name = "ab-contract-playground"
 description = ""
 license = "0BSD"
 version = "0.0.1"

--- a/crates/contracts/ab-contract-playground/Cargo.toml
+++ b/crates/contracts/ab-contract-playground/Cargo.toml
@@ -24,5 +24,6 @@ tracing-subscriber = "0.3.19"
 [features]
 guest = [
     "ab-contracts-common/guest",
+    "ab-contracts-macros/guest",
     "ab-contracts-standards/guest",
 ]

--- a/crates/contracts/ab-contract-playground/src/lib.rs
+++ b/crates/contracts/ab-contract-playground/src/lib.rs
@@ -26,14 +26,14 @@ pub struct Slot {
 
 #[derive(Copy, Clone, TrivialType)]
 #[repr(C)]
-pub struct Example {
+pub struct Playground {
     pub total_supply: Balance,
     pub owner: Address,
     pub padding: [u8; 8],
 }
 
 #[contract]
-impl Fungible for Example {
+impl Fungible for Playground {
     #[update]
     fn transfer(
         #[env] env: &mut Env,
@@ -45,17 +45,17 @@ impl Fungible for Example {
             return Err(ContractError::Forbidden);
         }
 
-        env.example_transfer(MethodContext::Replace, env.own_address(), from, to, amount)
+        env.playground_transfer(MethodContext::Replace, env.own_address(), from, to, amount)
     }
 
     #[view]
     fn balance(#[env] env: &Env, #[input] address: &Address) -> Result<Balance, ContractError> {
-        env.example_balance(env.own_address(), address)
+        env.playground_balance(env.own_address(), address)
     }
 }
 
 #[contract]
-impl Example {
+impl Playground {
     #[init]
     pub fn new(
         #[slot] (owner_addr, owner): (&Address, &mut MaybeData<Slot>),

--- a/crates/contracts/ab-contract-playground/tests/basic.rs
+++ b/crates/contracts/ab-contract-playground/tests/basic.rs
@@ -13,7 +13,7 @@ fn basic() {
     let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
     executor.deploy_typical_system_contracts().unwrap();
     let playground_token = {
-        let env = &mut *executor.null_env();
+        let mut env = executor.null_env();
 
         let playground_address = env
             .code_deploy(
@@ -34,7 +34,7 @@ fn basic() {
     };
 
     {
-        let env = &mut *executor.env(playground_token, Address::NULL);
+        let mut env = executor.env(playground_token, Address::NULL);
 
         let from = playground_token;
         let mut previous_from_balance = Balance::MAX;

--- a/crates/contracts/ab-contract-playground/tests/basic.rs
+++ b/crates/contracts/ab-contract-playground/tests/basic.rs
@@ -1,4 +1,4 @@
-use ab_contract_example::{Example, ExampleExt};
+use ab_contract_playground::{Playground, PlaygroundExt};
 use ab_contracts_common::env::MethodContext;
 use ab_contracts_common::{Address, Balance, Contract, ShardIndex};
 use ab_contracts_executor::NativeExecutor;
@@ -13,34 +13,34 @@ fn basic() {
     let shard_index = ShardIndex::from_u32(1).unwrap();
     let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
     executor.deploy_typical_system_contracts().unwrap();
-    let example_token = {
+    let playground_token = {
         let env = &mut *executor.null_env();
 
-        let example_address = env
+        let playground_address = env
             .code_deploy(
                 MethodContext::Keep,
                 Address::SYSTEM_CODE,
                 &VariableBytes::from_buffer(
-                    Example::CRATE_NAME.as_bytes(),
-                    &(Example::CRATE_NAME.len() as u32),
+                    Playground::CRATE_NAME.as_bytes(),
+                    &(Playground::CRATE_NAME.len() as u32),
                 ),
             )
             .unwrap();
-        env.example_new(
+        env.playground_new(
             MethodContext::Keep,
-            example_address,
-            &example_address,
+            playground_address,
+            &playground_address,
             &Balance::MAX,
         )
         .unwrap();
 
-        example_address
+        playground_address
     };
 
     {
-        let env = &mut *executor.env(example_token, Address::NULL);
+        let env = &mut *executor.env(playground_token, Address::NULL);
 
-        let from = example_token;
+        let from = playground_token;
         let mut previous_from_balance = Balance::MAX;
         let to = Address::SYSTEM_CODE;
         let mut previous_to_balance = Balance::from(0);
@@ -48,31 +48,31 @@ fn basic() {
 
         // Direct
         assert_eq!(
-            env.example_balance(example_token, &from).unwrap(),
+            env.playground_balance(playground_token, &from).unwrap(),
             previous_from_balance
         );
         // Through `Fungible` trait
         assert_eq!(
-            env.fungible_balance(example_token, &from).unwrap(),
+            env.fungible_balance(playground_token, &from).unwrap(),
             previous_from_balance
         );
 
         // Direct
-        env.example_transfer(MethodContext::Keep, example_token, &from, &to, &amount)
+        env.playground_transfer(MethodContext::Keep, playground_token, &from, &to, &amount)
             .unwrap();
 
         // Direct
         {
-            let remaining_balance = env.example_balance(example_token, &from).unwrap();
-            let code_balance = env.example_balance(example_token, &to).unwrap();
+            let remaining_balance = env.playground_balance(playground_token, &from).unwrap();
+            let code_balance = env.playground_balance(playground_token, &to).unwrap();
 
             assert_eq!(remaining_balance, previous_from_balance - amount);
             assert_eq!(code_balance, previous_to_balance + amount);
         }
         // Through `Fungible` trait
         {
-            let remaining_balance = env.fungible_balance(example_token, &from).unwrap();
-            let code_balance = env.fungible_balance(example_token, &to).unwrap();
+            let remaining_balance = env.fungible_balance(playground_token, &from).unwrap();
+            let code_balance = env.fungible_balance(playground_token, &to).unwrap();
 
             assert_eq!(remaining_balance, previous_from_balance - amount);
             assert_eq!(code_balance, previous_to_balance + amount);
@@ -82,21 +82,21 @@ fn basic() {
         previous_to_balance += amount;
 
         // Through `Fungible` trait
-        env.fungible_transfer(MethodContext::Keep, example_token, &from, &to, &amount)
+        env.fungible_transfer(MethodContext::Keep, playground_token, &from, &to, &amount)
             .unwrap();
 
         // Direct
         {
-            let remaining_balance = env.example_balance(example_token, &from).unwrap();
-            let code_balance = env.example_balance(example_token, &to).unwrap();
+            let remaining_balance = env.playground_balance(playground_token, &from).unwrap();
+            let code_balance = env.playground_balance(playground_token, &to).unwrap();
 
             assert_eq!(remaining_balance, previous_from_balance - amount);
             assert_eq!(code_balance, previous_to_balance + amount);
         }
         // Through `Fungible` trait
         {
-            let remaining_balance = env.fungible_balance(example_token, &from).unwrap();
-            let code_balance = env.fungible_balance(example_token, &to).unwrap();
+            let remaining_balance = env.fungible_balance(playground_token, &from).unwrap();
+            let code_balance = env.fungible_balance(playground_token, &to).unwrap();
 
             assert_eq!(remaining_balance, previous_from_balance - amount);
             assert_eq!(code_balance, previous_to_balance + amount);

--- a/crates/contracts/ab-contract-playground/tests/basic.rs
+++ b/crates/contracts/ab-contract-playground/tests/basic.rs
@@ -2,7 +2,6 @@ use ab_contract_playground::{Playground, PlaygroundExt};
 use ab_contracts_common::env::MethodContext;
 use ab_contracts_common::{Address, Balance, Contract, ShardIndex};
 use ab_contracts_executor::NativeExecutor;
-use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_standards::FungibleExt;
 use ab_system_contract_code::CodeExt;
 
@@ -20,10 +19,7 @@ fn basic() {
             .code_deploy(
                 MethodContext::Keep,
                 Address::SYSTEM_CODE,
-                &VariableBytes::from_buffer(
-                    Playground::CRATE_NAME.as_bytes(),
-                    &(Playground::CRATE_NAME.len() as u32),
-                ),
+                &Playground::code(),
             )
             .unwrap();
         env.playground_new(

--- a/crates/contracts/ab-contracts-common/src/env.rs
+++ b/crates/contracts/ab-contracts-common/src/env.rs
@@ -79,16 +79,17 @@ pub trait ExecutorContext: alloc::fmt::Debug {
 /// context is also present
 #[derive(Debug)]
 #[repr(C)]
-pub struct Env {
+pub struct Env<'a> {
     state: EnvState,
     #[cfg(any(unix, windows))]
     executor_context: Arc<dyn ExecutorContext>,
+    phantom_data: PhantomData<&'a ()>,
 }
 
 // TODO: API to "attach" data structures to the environment to make sure pointers to it can be
 //  returned safely, will likely require `Pin` and return some reference from which pointer is to
 //  be created
-impl Env {
+impl Env<'_> {
     /// Instantiate environment with executor context
     #[cfg(any(unix, windows))]
     #[inline]
@@ -99,6 +100,7 @@ impl Env {
         Self {
             state,
             executor_context,
+            phantom_data: PhantomData,
         }
     }
 

--- a/crates/contracts/ab-contracts-common/src/metadata.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata.rs
@@ -29,7 +29,7 @@ pub enum ContractMetadataKind {
     ///   * [`Self::UpdateStatefulRo`]
     ///   * [`Self::UpdateStatefulRw`]
     ///   * [`Self::ViewStateless`]
-    ///   * [`Self::ViewStatefulRo`]
+    ///   * [`Self::ViewStateful`]
     ///
     /// [`IoTypeMetadataKind`]: ab_contracts_io_type::metadata::IoTypeMetadataKind
     Contract,
@@ -94,7 +94,7 @@ pub enum ContractMetadataKind {
     /// Stateful read-only `#[view]` method (has `&self` in its arguments).
     ///
     /// Encoding is the same as [`Self::Init`].
-    ViewStatefulRo,
+    ViewStateful,
 
     // TODO: `#[env] can be made implicit assuming the name is of the struct is always the same
     /// Read-only `#[env]` argument.
@@ -153,7 +153,7 @@ impl ContractMetadataKind {
             4 => Self::UpdateStatefulRo,
             5 => Self::UpdateStatefulRw,
             6 => Self::ViewStateless,
-            7 => Self::ViewStatefulRo,
+            7 => Self::ViewStateful,
             8 => Self::EnvRo,
             9 => Self::EnvRw,
             10 => Self::TmpRo,

--- a/crates/contracts/ab-contracts-common/src/metadata/compact.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata/compact.rs
@@ -103,7 +103,7 @@ const fn compact_metadata_inner<'i, 'o>(
         | ContractMetadataKind::UpdateStatefulRo
         | ContractMetadataKind::UpdateStatefulRw
         | ContractMetadataKind::ViewStateless
-        | ContractMetadataKind::ViewStatefulRo => {
+        | ContractMetadataKind::ViewStateful => {
             // Copy method name
             let method_name_length = input[0] as usize;
             (input, output) = forward_option!(copy_n_bytes(input, output, 1 + method_name_length));
@@ -163,7 +163,7 @@ const fn compact_method_argument<'i, 'o>(
         | ContractMetadataKind::UpdateStatefulRo
         | ContractMetadataKind::UpdateStatefulRw
         | ContractMetadataKind::ViewStateless
-        | ContractMetadataKind::ViewStatefulRo => {
+        | ContractMetadataKind::ViewStateful => {
             // Expected argument here
             return None;
         }

--- a/crates/contracts/ab-contracts-common/src/metadata/decode.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata/decode.rs
@@ -132,7 +132,7 @@ impl<'metadata> MetadataDecoder<'metadata> {
             | ContractMetadataKind::UpdateStatefulRo
             | ContractMetadataKind::UpdateStatefulRw
             | ContractMetadataKind::ViewStateless
-            | ContractMetadataKind::ViewStatefulRo
+            | ContractMetadataKind::ViewStateful
             | ContractMetadataKind::EnvRo
             | ContractMetadataKind::EnvRw
             | ContractMetadataKind::TmpRo
@@ -276,8 +276,8 @@ pub enum MethodKind {
     UpdateStatefulRw,
     /// Corresponds to [`ContractMetadataKind::ViewStateless`]
     ViewStateless,
-    /// Corresponds to [`ContractMetadataKind::ViewStatefulRo`]
-    ViewStatefulRo,
+    /// Corresponds to [`ContractMetadataKind::ViewStateful`]
+    ViewStateful,
 }
 
 impl MethodKind {
@@ -286,7 +286,7 @@ impl MethodKind {
             MethodKind::Init | MethodKind::UpdateStateless | MethodKind::ViewStateless => false,
             MethodKind::UpdateStatefulRo
             | MethodKind::UpdateStatefulRw
-            | MethodKind::ViewStatefulRo => true,
+            | MethodKind::ViewStateful => true,
         }
     }
 }
@@ -340,7 +340,7 @@ impl<'a, 'metadata> MethodMetadataDecoder<'a, 'metadata> {
             ContractMetadataKind::UpdateStatefulRo => MethodKind::UpdateStatefulRo,
             ContractMetadataKind::UpdateStatefulRw => MethodKind::UpdateStatefulRw,
             ContractMetadataKind::ViewStateless => MethodKind::ViewStateless,
-            ContractMetadataKind::ViewStatefulRo => MethodKind::ViewStatefulRo,
+            ContractMetadataKind::ViewStateful => MethodKind::ViewStateful,
             // The rest are not methods and can't appear here
             ContractMetadataKind::Contract
             | ContractMetadataKind::Trait
@@ -364,13 +364,13 @@ impl<'a, 'metadata> MethodMetadataDecoder<'a, 'metadata> {
                 | MethodKind::UpdateStatefulRo
                 | MethodKind::UpdateStatefulRw
                 | MethodKind::ViewStateless
-                | MethodKind::ViewStatefulRo => true,
+                | MethodKind::ViewStateful => true,
             },
             MethodsContainerKind::Trait => match method_kind {
                 MethodKind::Init
                 | MethodKind::UpdateStatefulRo
                 | MethodKind::UpdateStatefulRw
-                | MethodKind::ViewStatefulRo => false,
+                | MethodKind::ViewStateful => false,
                 MethodKind::UpdateStateless | MethodKind::ViewStateless => true,
             },
         };
@@ -504,7 +504,7 @@ impl<'metadata> ArgumentsMetadataDecoder<'_, 'metadata> {
             | ContractMetadataKind::UpdateStatefulRo
             | ContractMetadataKind::UpdateStatefulRw
             | ContractMetadataKind::ViewStateless
-            | ContractMetadataKind::ViewStatefulRo => {
+            | ContractMetadataKind::ViewStateful => {
                 return Err(MetadataDecodingError::ExpectedArgumentKind { metadata_kind });
             }
         };
@@ -525,7 +525,7 @@ impl<'metadata> ArgumentsMetadataDecoder<'_, 'metadata> {
                 | ArgumentKind::Output
                 | ArgumentKind::Result => true,
             },
-            MethodKind::ViewStateless | MethodKind::ViewStatefulRo => match argument_kind {
+            MethodKind::ViewStateless | MethodKind::ViewStateful => match argument_kind {
                 ArgumentKind::EnvRo
                 | ArgumentKind::SlotRo
                 | ArgumentKind::Input

--- a/crates/contracts/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/ab-contracts-executor/src/context.rs
@@ -219,7 +219,7 @@ impl ExecutorContext for NativeExecutorContext {
                 MethodKind::UpdateStateless | MethodKind::ViewStateless => {
                     // No state handling is needed
                 }
-                MethodKind::UpdateStatefulRo | MethodKind::ViewStatefulRo => {
+                MethodKind::UpdateStatefulRo | MethodKind::ViewStateful => {
                     let state_bytes = used_slots.use_ro(contract, &Address::SYSTEM_STATE)?;
 
                     delayed_processing.push(DelayedProcessing::SlotReadOnly {

--- a/crates/contracts/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/ab-contracts-executor/src/context.rs
@@ -247,7 +247,7 @@ impl ExecutorContext for NativeExecutorContext {
                     delayed_processing.push(DelayedProcessing::SlotReadWrite {
                         // Is updated below
                         data_ptr: NonNull::dangling(),
-                        slot_ptr: NonNull::from_mut(&mut *state_bytes),
+                        slot_ptr: NonNull::from_mut(state_bytes),
                         size: state_bytes.len(),
                         capacity: state_bytes.capacity(),
                     });
@@ -338,7 +338,7 @@ impl ExecutorContext for NativeExecutorContext {
                         delayed_processing.push(DelayedProcessing::SlotReadWrite {
                             // Is updated below
                             data_ptr: NonNull::dangling(),
-                            slot_ptr: NonNull::from_mut(&mut *tmp_bytes),
+                            slot_ptr: NonNull::from_mut(tmp_bytes),
                             size: tmp_bytes.len(),
                             capacity: tmp_bytes.capacity(),
                         });
@@ -397,7 +397,7 @@ impl ExecutorContext for NativeExecutorContext {
                         delayed_processing.push(DelayedProcessing::SlotReadWrite {
                             // Is updated below
                             data_ptr: NonNull::dangling(),
-                            slot_ptr: NonNull::from_mut(&mut *slot_bytes),
+                            slot_ptr: NonNull::from_mut(slot_bytes),
                             size: slot_bytes.len(),
                             capacity: slot_bytes.capacity(),
                         });
@@ -469,7 +469,7 @@ impl ExecutorContext for NativeExecutorContext {
                             delayed_processing.push(DelayedProcessing::SlotReadWrite {
                                 // Is updated below
                                 data_ptr: NonNull::dangling(),
-                                slot_ptr: NonNull::from_mut(&mut *state_bytes),
+                                slot_ptr: NonNull::from_mut(state_bytes),
                                 size: 0,
                                 capacity: state_bytes.capacity(),
                             });

--- a/crates/contracts/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/ab-contracts-executor/src/context.rs
@@ -439,7 +439,7 @@ impl ExecutorContext for NativeExecutorContext {
                         unsafe {
                             // Output
                             copy_ptr!(external_args_cursor => internal_args_cursor as *mut u8);
-                            // Size
+                            // Size (might be a null pointer for trivial types)
                             let size_ptr =
                                 copy_ptr!(external_args_cursor => internal_args_cursor as *mut u32);
                             if !size_ptr.is_null() {
@@ -498,7 +498,7 @@ impl ExecutorContext for NativeExecutorContext {
                             unsafe {
                                 // Output
                                 copy_ptr!(external_args_cursor => internal_args_cursor as *mut u8);
-                                // Size
+                                // Size (might be a null pointer for trivial types)
                                 let size_ptr = copy_ptr!(external_args_cursor => internal_args_cursor as *mut u32);
                                 if !size_ptr.is_null() {
                                     // Override output size to be zero even if caller guest tried to

--- a/crates/contracts/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/ab-contracts-executor/src/lib.rs
@@ -16,31 +16,8 @@ use ab_system_contract_code::Code;
 #[cfg(feature = "system-contracts")]
 use ab_system_contract_state::State;
 use std::collections::HashMap;
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use tracing::error;
-
-pub struct NativeEnv<'a> {
-    env: Env,
-    phantom_data: PhantomData<&'a ()>,
-}
-
-impl Deref for NativeEnv<'_> {
-    type Target = Env;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.env
-    }
-}
-
-impl DerefMut for NativeEnv<'_> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.env
-    }
-}
 
 /// Native executor errors
 #[derive(Debug, thiserror::Error)]
@@ -136,7 +113,7 @@ impl NativeExecutor {
     }
 
     /// Run a function under fresh execution environment
-    pub fn env(&mut self, context: Address, caller: Address) -> NativeEnv<'_> {
+    pub fn env(&mut self, context: Address, caller: Address) -> Env<'_> {
         let env_state = EnvState {
             shard_index: self.context.shard_index(),
             own_address: Address::NULL,
@@ -144,17 +121,12 @@ impl NativeExecutor {
             caller,
         };
 
-        let env = Env::with_executor_context(env_state, Arc::clone(&self.context) as _);
-
-        NativeEnv {
-            env,
-            phantom_data: PhantomData,
-        }
+        Env::with_executor_context(env_state, Arc::clone(&self.context) as _)
     }
 
     /// Shortcut for [`Self::env`] with context and caller set to [`Address::NULL`]
     #[inline]
-    pub fn null_env(&mut self) -> NativeEnv<'_> {
+    pub fn null_env(&mut self) -> Env<'_> {
         self.env(Address::NULL, Address::NULL)
     }
 
@@ -170,7 +142,7 @@ impl NativeExecutor {
         self.deploy_system_contract_at::<State>(Address::SYSTEM_STATE);
 
         // Initialize shard state
-        let env = &mut *self.null_env();
+        let env = &mut self.null_env();
         env.address_allocator_new(MethodContext::Keep, address_allocator_address)?;
 
         Ok(())

--- a/crates/contracts/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/ab-contracts-executor/src/lib.rs
@@ -57,15 +57,17 @@ pub enum NativeExecutorError {
     #[error("Expected contract metadata, found trait")]
     ExpectedContractMetadataFoundTrait,
     /// Duplicate method in contract
-    #[error("Duplicate method in contract {crate_name}: {method_fingerprint}")]
+    #[error("Duplicate method fingerprint {method_fingerprint} for contract code {contact_code}")]
     DuplicateMethodInContract {
         /// Name of the crate in which method was duplicated
-        crate_name: &'static str,
+        contact_code: &'static str,
         /// Method fingerprint
         method_fingerprint: &'static MethodFingerprint,
     },
 }
 
+// TODO: `NativeExecutorBuilder` that allows to inject contracts and trait implementations
+//  explicitly instead of relying on `inventory` that silently doesn't work under Miri
 pub struct NativeExecutor {
     context: Arc<NativeExecutorContext>,
 }
@@ -78,7 +80,7 @@ impl NativeExecutor {
         let mut methods_by_code = HashMap::<_, HashMap<_, _>>::new();
         for &contract_methods_fn_pointer in inventory::iter::<ContractsMethodsFnPointer> {
             let ContractsMethodsFnPointer {
-                crate_name,
+                contact_code,
                 main_contract_metadata,
                 method_fingerprint,
                 method_metadata,
@@ -107,7 +109,7 @@ impl NativeExecutor {
                 recommended_capacities;
 
             if methods_by_code
-                .entry(crate_name.as_bytes())
+                .entry(contact_code.as_bytes())
                 .or_default()
                 .insert(
                     *method_fingerprint,
@@ -122,7 +124,7 @@ impl NativeExecutor {
                 .is_some()
             {
                 return Err(NativeExecutorError::DuplicateMethodInContract {
-                    crate_name,
+                    contact_code,
                     method_fingerprint,
                 });
             }
@@ -183,6 +185,6 @@ impl NativeExecutor {
         C: Contract,
     {
         self.context
-            .force_insert(address, Address::SYSTEM_CODE, C::CRATE_NAME.as_bytes());
+            .force_insert(address, Address::SYSTEM_CODE, C::code().get_initialized());
     }
 }

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -9,6 +9,7 @@ use core::ptr::NonNull;
 /// This is somewhat similar to [`VariableBytes`](crate::variable_bytes::VariableBytes), but instead
 /// of variable size data structure allows to either have it or not have the contents or not have
 /// it, which is a simpler and more convenient API that is also sufficient in many cases.
+#[derive(Debug)]
 pub struct MaybeData<Data>
 where
     Data: TrivialType,
@@ -150,7 +151,7 @@ where
     //
     // `impl Deref` is used to tie lifetime of returned value to inputs, but still treat it as a
     // shared reference for most practical purposes.
-    pub fn from_buffer(data: Option<&'_ Data>) -> impl Deref<Target = Self> + '_ {
+    pub const fn from_buffer(data: Option<&'_ Data>) -> impl Deref<Target = Self> + '_ {
         let (data, size) = if let Some(data) = data {
             (NonNull::from_ref(data), &Data::SIZE)
         } else {
@@ -219,7 +220,7 @@ where
 
     /// Try to get access to initialized `Data`, returns `None` if not initialized
     #[inline]
-    pub fn get(&self) -> Option<&Data> {
+    pub const fn get(&self) -> Option<&Data> {
         // SAFETY: guaranteed to be initialized by constructors
         if unsafe { self.size.read() } == self.capacity {
             // SAFETY: initialized

--- a/crates/contracts/ab-contracts-io-type/src/metadata/tests.rs
+++ b/crates/contracts/ab-contracts-io-type/src/metadata/tests.rs
@@ -10,7 +10,7 @@ fn check_repr() {
         (ContractMetadataKind::UpdateStatefulRo, 4),
         (ContractMetadataKind::UpdateStatefulRw, 5),
         (ContractMetadataKind::ViewStateless, 6),
-        (ContractMetadataKind::ViewStatefulRo, 7),
+        (ContractMetadataKind::ViewStateful, 7),
         (ContractMetadataKind::EnvRo, 8),
         (ContractMetadataKind::EnvRw, 9),
         (ContractMetadataKind::TmpRo, 10),

--- a/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/ab-contracts-io-type/src/trivial_type.rs
@@ -199,7 +199,7 @@ where
 
     #[inline]
     unsafe fn capacity_ptr(&self) -> impl Deref<Target = NonNull<u32>> {
-        DerefWrapper(NonNull::from_ref(&(size_of::<T>() as u32)))
+        DerefWrapper(NonNull::from_ref(&Self::SIZE))
     }
 
     #[inline]

--- a/crates/contracts/ab-contracts-macros-impl/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract.rs
@@ -612,7 +612,7 @@ fn generate_extension_trait(
             #( #definitions )*
         }
 
-        impl #trait_name for ::ab_contracts_macros::__private::Env {
+        impl #trait_name for ::ab_contracts_macros::__private::Env<'_> {
             #( #impls )*
         }
     })

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
@@ -748,9 +748,9 @@ impl MethodDetails {
             if mutability.is_some() {
                 internal_args_pointers.push(quote! {
                     /// Size of the contents `self_ptr` points to
-                    pub self_size: *mut u32,
+                    pub self_size: *mut ::core::primitive::u32,
                     /// Capacity of the allocated memory following `self_ptr` points to
-                    pub self_capacity: ::core::ptr::NonNull<u32>,
+                    pub self_capacity: ::core::ptr::NonNull<::core::primitive::u32>,
                 });
 
                 original_fn_args.push(quote! {&mut *{
@@ -773,7 +773,7 @@ impl MethodDetails {
             } else {
                 internal_args_pointers.push(quote! {
                     /// Size of the contents `self_ptr` points to
-                    pub self_size: ::core::ptr::NonNull<u32>,
+                    pub self_size: ::core::ptr::NonNull<::core::primitive::u32>,
                 });
 
                 original_fn_args.push(quote! {&*{
@@ -845,9 +845,9 @@ impl MethodDetails {
             if mutability.is_some() {
                 internal_args_pointers.push(quote! {
                     #[doc = #size_doc]
-                    pub #size_field: *mut u32,
+                    pub #size_field: *mut ::core::primitive::u32,
                     #[doc = #capacity_doc]
-                    pub #capacity_field: ::core::ptr::NonNull<u32>,
+                    pub #capacity_field: ::core::ptr::NonNull<::core::primitive::u32>,
                 });
 
                 original_fn_args.push(quote! {&mut *{
@@ -871,7 +871,7 @@ impl MethodDetails {
             } else {
                 internal_args_pointers.push(quote! {
                     #[doc = #size_doc]
-                    pub #size_field: ::core::ptr::NonNull<u32>,
+                    pub #size_field: ::core::ptr::NonNull<::core::primitive::u32>,
                 });
 
                 original_fn_args.push(quote! {&*{
@@ -926,9 +926,9 @@ impl MethodDetails {
             let arg_extraction = if mutability.is_some() {
                 internal_args_pointers.push(quote! {
                     #[doc = #size_doc]
-                    pub #size_field: *mut u32,
+                    pub #size_field: *mut ::core::primitive::u32,
                     #[doc = #capacity_doc]
-                    pub #capacity_field: ::core::ptr::NonNull<u32>,
+                    pub #capacity_field: ::core::ptr::NonNull<::core::primitive::u32>,
                 });
 
                 quote! {&mut *{
@@ -952,7 +952,7 @@ impl MethodDetails {
             } else {
                 internal_args_pointers.push(quote! {
                     #[doc = #size_doc]
-                    pub #size_field: ::core::ptr::NonNull<u32>,
+                    pub #size_field: ::core::ptr::NonNull<::core::primitive::u32>,
                 });
 
                 quote! {&*{
@@ -1009,7 +1009,7 @@ impl MethodDetails {
                             <#type_name as ::ab_contracts_macros::__private::IoType>::PointerType,
                         >,
                         #[doc = #size_doc]
-                        pub #size_field: ::core::ptr::NonNull<u32>,
+                        pub #size_field: ::core::ptr::NonNull<::core::primitive::u32>,
                     });
 
                     original_fn_args.push(quote! {&*{
@@ -1037,9 +1037,9 @@ impl MethodDetails {
                             <#type_name as ::ab_contracts_macros::__private::IoType>::PointerType,
                         >,
                         #[doc = #size_doc]
-                        pub #size_field: *mut u32,
+                        pub #size_field: *mut ::core::primitive::u32,
                         #[doc = #capacity_doc]
-                        pub #capacity_field: ::core::ptr::NonNull<u32>,
+                        pub #capacity_field: ::core::ptr::NonNull<::core::primitive::u32>,
                     });
 
                     original_fn_args.push(quote! {&mut *{
@@ -1076,9 +1076,9 @@ impl MethodDetails {
                 internal_args_pointers.push(quote! {
                     pub ok_result_ptr: ::core::ptr::NonNull<#result_type>,
                     /// The size of the contents `ok_result_ptr` points to
-                    pub ok_result_size: *mut u32,
+                    pub ok_result_size: *mut ::core::primitive::u32,
                     /// Capacity of the allocated memory `ok_result_ptr` points to
-                    pub ok_result_capacity: ::core::ptr::NonNull<u32>,
+                    pub ok_result_capacity: ::core::ptr::NonNull<::core::primitive::u32>,
                 });
 
                 // Ensure return type implements not only `IoType`, which is required for crossing
@@ -1189,7 +1189,8 @@ impl MethodDetails {
                 ///
                 /// Caller must ensure the provided pointer corresponds to expected ABI.
                 #[cfg_attr(feature = "guest", unsafe(no_mangle))]
-                #[allow(clippy::new_ret_no_self, reason = "Method was re-written for FFI purposes")]
+                #[allow(clippy::new_ret_no_self, reason = "Method was re-written for FFI purposes without `Self`")]
+                #[allow(clippy::absurd_extreme_comparisons, reason = "Macro-generated code doesn't know the size upfront")]
                 pub unsafe extern "C" fn #ffi_fn_name(
                     mut args: ::core::ptr::NonNull<InternalArgs>,
                 ) -> ::ab_contracts_macros::__private::ExitCode {
@@ -1248,7 +1249,7 @@ impl MethodDetails {
 
                     ::ab_contracts_macros::__private::inventory::submit! {
                         ::ab_contracts_macros::__private::ContractsMethodsFnPointer {
-                            crate_name: <#struct_name as ::ab_contracts_macros::__private::Contract>::CRATE_NAME,
+                            contact_code: <#struct_name as ::ab_contracts_macros::__private::Contract>::CODE,
                             main_contract_metadata: <#struct_name as ::ab_contracts_macros::__private::Contract>::MAIN_CONTRACT_METADATA,
                             method_fingerprint: &<#args_struct_name as ::ab_contracts_macros::__private::ExternalArgs>::FINGERPRINT,
                             method_metadata: METADATA,
@@ -1303,7 +1304,7 @@ impl MethodDetails {
                             <#type_name as ::ab_contracts_macros::__private::IoType>::PointerType,
                         >,
                         #[doc = #size_doc]
-                        pub #size_field: ::core::ptr::NonNull<u32>,
+                        pub #size_field: ::core::ptr::NonNull<::core::primitive::u32>,
                     });
                 }
                 IoArg::Output { .. } => {
@@ -1312,9 +1313,9 @@ impl MethodDetails {
                             <#type_name as ::ab_contracts_macros::__private::IoType>::PointerType,
                         >,
                         #[doc = #size_doc]
-                        pub #size_field: *mut u32,
+                        pub #size_field: *mut ::core::primitive::u32,
                         #[doc = #capacity_doc]
-                        pub #capacity_field: ::core::ptr::NonNull<u32>,
+                        pub #capacity_field: ::core::ptr::NonNull<::core::primitive::u32>,
                     });
                 }
                 IoArg::Result { .. } => {
@@ -1326,9 +1327,9 @@ impl MethodDetails {
                                 <#type_name as ::ab_contracts_macros::__private::IoType>::PointerType,
                             >,
                             #[doc = #size_doc]
-                            pub #size_field: *mut u32,
+                            pub #size_field: *mut ::core::primitive::u32,
                             #[doc = #capacity_doc]
-                            pub #capacity_field: ::core::ptr::NonNull<u32>,
+                            pub #capacity_field: ::core::ptr::NonNull<::core::primitive::u32>,
                         });
                     }
                 }
@@ -1348,9 +1349,9 @@ impl MethodDetails {
             external_args_fields.push(quote! {
                 pub ok_result_ptr: ::core::ptr::NonNull<#result_type>,
                 /// Size of the contents `ok_result_ptr` points to
-                pub ok_result_size: *mut u32,
+                pub ok_result_size: *mut ::core::primitive::u32,
                 /// Capacity of the allocated memory `ok_result_ptr` points to
-                pub ok_result_capacity: ::core::ptr::NonNull<u32>,
+                pub ok_result_capacity: ::core::ptr::NonNull<::core::primitive::u32>,
             });
         }
         let args_struct_doc = format!(
@@ -1399,7 +1400,7 @@ impl MethodDetails {
 
             let env_metadata_type = format_ident!("{env_metadata_type}");
             method_metadata.push(quote! {
-                &[::ab_contracts_macros::__private::ContractMetadataKind::#env_metadata_type as u8],
+                &[::ab_contracts_macros::__private::ContractMetadataKind::#env_metadata_type as ::core::primitive::u8],
             });
         }
 
@@ -1413,7 +1414,7 @@ impl MethodDetails {
             let tmp_metadata_type = format_ident!("{tmp_metadata_type}");
             let arg_name_metadata = derive_ident_metadata(&tmp.arg_name)?;
             method_metadata.push(quote! {
-                &[::ab_contracts_macros::__private::ContractMetadataKind::#tmp_metadata_type as u8],
+                &[::ab_contracts_macros::__private::ContractMetadataKind::#tmp_metadata_type as ::core::primitive::u8],
                 #arg_name_metadata,
             });
         }
@@ -1428,7 +1429,7 @@ impl MethodDetails {
             let slot_metadata_type = format_ident!("{slot_metadata_type}");
             let arg_name_metadata = derive_ident_metadata(&slot.arg_name)?;
             method_metadata.push(quote! {
-                &[::ab_contracts_macros::__private::ContractMetadataKind::#slot_metadata_type as u8],
+                &[::ab_contracts_macros::__private::ContractMetadataKind::#slot_metadata_type as ::core::primitive::u8],
                 #arg_name_metadata,
             });
         }
@@ -1455,7 +1456,7 @@ impl MethodDetails {
                 })
             };
             method_metadata.push(quote! {
-                &[::ab_contracts_macros::__private::ContractMetadataKind::#io_metadata_type as u8],
+                &[::ab_contracts_macros::__private::ContractMetadataKind::#io_metadata_type as ::core::primitive::u8],
                 #arg_name_metadata,
                 #with_type_metadata
             });
@@ -1475,7 +1476,7 @@ impl MethodDetails {
             };
             method_metadata.push(quote! {
                 &[
-                    ::ab_contracts_macros::__private::ContractMetadataKind::Result as u8,
+                    ::ab_contracts_macros::__private::ContractMetadataKind::Result as ::core::primitive::u8,
                     #arg_name_metadata,
                 ],
                 #with_type_metadata
@@ -1528,7 +1529,7 @@ impl MethodDetails {
                 -> ([u8; ::ab_contracts_macros::__private::MAX_METADATA_CAPACITY], usize)
             {
                 ::ab_contracts_macros::__private::concat_metadata_sources(&[
-                    &[::ab_contracts_macros::__private::ContractMetadataKind::#method_type as u8],
+                    &[::ab_contracts_macros::__private::ContractMetadataKind::#method_type as ::core::primitive::u8],
                     #method_name_metadata,
                     &[#number_of_arguments],
                     #( #method_metadata )*
@@ -1539,7 +1540,7 @@ impl MethodDetails {
             ///
             /// [`ContractMetadataKind`]: ::ab_contracts_macros::__private::ContractMetadataKind
             // Strange syntax to allow Rust to extend the lifetime of metadata scratch automatically
-            pub const METADATA: &[u8] =
+            pub const METADATA: &[::core::primitive::u8] =
                 metadata()
                     .0
                     .split_at(metadata().1)

--- a/crates/contracts/ab-contracts-macros/Cargo.toml
+++ b/crates/contracts/ab-contracts-macros/Cargo.toml
@@ -17,3 +17,8 @@ ab-contracts-macros-impl = { version = "0.0.1", path = "../ab-contracts-macros-i
 
 [target.'cfg(any(unix, windows))'.dependencies]
 inventory = "0.3.19"
+
+[features]
+guest = [
+    "ab-contracts-common/guest"
+]

--- a/crates/contracts/ab-contracts-macros/Cargo.toml
+++ b/crates/contracts/ab-contracts-macros/Cargo.toml
@@ -16,6 +16,7 @@ ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
 ab-contracts-macros-impl = { version = "0.0.1", path = "../ab-contracts-macros-impl" }
 
 [target.'cfg(any(unix, windows))'.dependencies]
+const_format = "0.2.34"
 inventory = "0.3.19"
 
 [features]

--- a/crates/contracts/ab-contracts-macros/src/__private.rs
+++ b/crates/contracts/ab-contracts-macros/src/__private.rs
@@ -1,5 +1,3 @@
-#[cfg(any(unix, windows))]
-pub use ab_contracts_common::ContractsMethodsFnPointer;
 pub use ab_contracts_common::env::{Env, MethodContext};
 pub use ab_contracts_common::metadata::ContractMetadataKind;
 pub use ab_contracts_common::method::{ExternalArgs, MethodFingerprint};
@@ -7,5 +5,13 @@ pub use ab_contracts_common::{Address, Contract, ContractError, ExitCode};
 pub use ab_contracts_io_type::metadata::{MAX_METADATA_CAPACITY, concat_metadata_sources};
 pub use ab_contracts_io_type::trivial_type::TrivialType;
 pub use ab_contracts_io_type::{IoType, IoTypeOptional};
+
+// This bunch is only needed for native execution environment
+#[cfg(any(unix, windows))]
+pub use ab_contracts_common::{ContractsMethodsFnPointer, MAX_CODE_SIZE};
+#[cfg(any(unix, windows))]
+pub use ab_contracts_io_type::variable_bytes::VariableBytes;
+#[cfg(any(unix, windows))]
+pub use const_format::concatcp;
 #[cfg(any(unix, windows))]
 pub use inventory;

--- a/crates/contracts/ab-contracts-standards/Cargo.toml
+++ b/crates/contracts/ab-contracts-standards/Cargo.toml
@@ -15,4 +15,7 @@ ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
 ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
 
 [features]
-guest = []
+guest = [
+    "ab-contracts-common/guest",
+    "ab-contracts-macros/guest",
+]

--- a/crates/contracts/ab-system-contract-address-allocator/Cargo.toml
+++ b/crates/contracts/ab-system-contract-address-allocator/Cargo.toml
@@ -18,4 +18,5 @@ ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
 [features]
 guest = [
     "ab-contracts-common/guest",
+    "ab-contracts-macros/guest",
 ]

--- a/crates/contracts/ab-system-contract-code/Cargo.toml
+++ b/crates/contracts/ab-system-contract-code/Cargo.toml
@@ -19,4 +19,5 @@ ab-system-contract-address-allocator = { version = "0.0.1", path = "../ab-system
 [features]
 guest = [
     "ab-contracts-common/guest",
+    "ab-contracts-macros/guest",
 ]

--- a/crates/contracts/ab-system-contract-code/src/lib.rs
+++ b/crates/contracts/ab-system-contract-code/src/lib.rs
@@ -1,14 +1,11 @@
 #![no_std]
 
 use ab_contracts_common::env::{Env, MethodContext};
-use ab_contracts_common::{Address, ContractError};
+use ab_contracts_common::{Address, ContractError, MAX_CODE_SIZE};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_macros::contract;
 use ab_system_contract_address_allocator::AddressAllocatorExt;
-
-// TODO: How/where should this limit defined?
-pub const MAX_CODE_SIZE: u32 = 1024 * 1024;
 
 #[derive(Copy, Clone, TrivialType)]
 #[repr(C)]

--- a/crates/contracts/ab-system-contract-state/Cargo.toml
+++ b/crates/contracts/ab-system-contract-state/Cargo.toml
@@ -18,4 +18,5 @@ ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
 [features]
 guest = [
     "ab-contracts-common/guest",
+    "ab-contracts-macros/guest",
 ]


### PR DESCRIPTION
This adds more examples of simpler contracts, including a trivial "flipper" contract (inspired by [ink!](https://use.ink/basics/contract-template/)).

There are also several API improvements that remove the need to use awkward and/or verbose syntax in integration tests.

And I also found some small bugs that were fixed too.