### PR TITLE
Slots refactoring (more like rewrite)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,8 +57,10 @@ dependencies = [
  "ab-system-contract-address-allocator",
  "ab-system-contract-code",
  "ab-system-contract-state",
+ "halfbrown",
  "inventory",
  "parking_lot",
+ "smallvec",
  "thiserror",
  "tracing",
 ]
@@ -138,6 +140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +214,40 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "halfbrown"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
+dependencies = [
+ "arrayvec",
+ "hashbrown",
+ "rustc-hash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -324,6 +372,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "static_assertions"

--- a/crates/contracts/ab-contract-example-flipper/Cargo.toml
+++ b/crates/contracts/ab-contract-example-flipper/Cargo.toml
@@ -16,7 +16,7 @@ ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
 
 [dev-dependencies]
 ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
-ab-contracts-executor = { version = "0.0.1", path = "../ab-contracts-executor", features = ["system-contracts"] }
+ab-contracts-executor = { version = "0.0.1", path = "../ab-contracts-executor" }
 ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
 
 [features]

--- a/crates/contracts/ab-contract-example-flipper/tests/basic.rs
+++ b/crates/contracts/ab-contract-example-flipper/tests/basic.rs
@@ -7,8 +7,7 @@ use ab_system_contract_code::CodeExt;
 #[test]
 fn basic() {
     let shard_index = ShardIndex::from_u32(1).unwrap();
-    let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
-    executor.deploy_typical_system_contracts().unwrap();
+    let mut executor = NativeExecutor::in_memory_empty(shard_index).unwrap();
 
     let mut env = executor.null_env();
 

--- a/crates/contracts/ab-contract-example-ft/Cargo.toml
+++ b/crates/contracts/ab-contract-example-ft/Cargo.toml
@@ -17,7 +17,7 @@ ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
 ab-contracts-standards = { version = "0.0.1", path = "../ab-contracts-standards" }
 
 [dev-dependencies]
-ab-contracts-executor = { version = "0.0.1", path = "../ab-contracts-executor", features = ["system-contracts"] }
+ab-contracts-executor = { version = "0.0.1", path = "../ab-contracts-executor" }
 ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
 
 [features]

--- a/crates/contracts/ab-contract-example-ft/tests/basic.rs
+++ b/crates/contracts/ab-contract-example-ft/tests/basic.rs
@@ -8,8 +8,7 @@ use ab_system_contract_code::CodeExt;
 #[test]
 fn basic() {
     let shard_index = ShardIndex::from_u32(1).unwrap();
-    let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
-    executor.deploy_typical_system_contracts().unwrap();
+    let mut executor = NativeExecutor::in_memory_empty(shard_index).unwrap();
     let token_address = {
         let mut env = executor.null_env();
 

--- a/crates/contracts/ab-contract-playground/Cargo.toml
+++ b/crates/contracts/ab-contract-playground/Cargo.toml
@@ -17,7 +17,7 @@ ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
 ab-contracts-standards = { version = "0.0.1", path = "../ab-contracts-standards" }
 
 [dev-dependencies]
-ab-contracts-executor = { version = "0.0.1", path = "../ab-contracts-executor", features = ["system-contracts"] }
+ab-contracts-executor = { version = "0.0.1", path = "../ab-contracts-executor" }
 ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
 tracing-subscriber = "0.3.19"
 

--- a/crates/contracts/ab-contract-playground/tests/basic.rs
+++ b/crates/contracts/ab-contract-playground/tests/basic.rs
@@ -10,8 +10,7 @@ fn basic() {
     tracing_subscriber::fmt::init();
 
     let shard_index = ShardIndex::from_u32(1).unwrap();
-    let mut executor = NativeExecutor::in_memory(shard_index).unwrap();
-    executor.deploy_typical_system_contracts().unwrap();
+    let mut executor = NativeExecutor::in_memory_empty(shard_index).unwrap();
     let playground_token = {
         let mut env = executor.null_env();
 

--- a/crates/contracts/ab-contracts-common/src/env.rs
+++ b/crates/contracts/ab-contracts-common/src/env.rs
@@ -64,7 +64,7 @@ pub struct EnvState {
 
 /// Executor context that can be used to interact with executor
 #[cfg(any(unix, windows))]
-pub trait ExecutorContext: alloc::fmt::Debug {
+pub trait ExecutorContext: alloc::fmt::Debug + Send {
     /// Call multiple methods
     fn call_many(
         &self,
@@ -166,9 +166,12 @@ impl Env<'_> {
         }
     }
 
-    /// Invoke provided methods and wait for the result.
+    /// Invoke provided methods and wait for the results.
     ///
-    /// The remaining gas will be split equally between all individual invocations.
+    /// Only `#[view]` methods may be called if more than one method is provided as an argument.
+    ///
+    /// In most cases, this doesn't need to be called directly. Extension traits provide a more
+    /// convenient way to make method calls and are enough in most cases.
     #[inline]
     pub fn call_many<const N: usize>(
         &self,

--- a/crates/contracts/ab-contracts-executor/Cargo.toml
+++ b/crates/contracts/ab-contracts-executor/Cargo.toml
@@ -15,8 +15,10 @@ ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
 ab-system-contract-address-allocator = { version = "0.0.1", path = "../ab-system-contract-address-allocator" }
 ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
 ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state" }
+halfbrown = { version = "0.3.0", features = ["arraybackend", "fxhash"] }
 inventory = "0.3.19"
 parking_lot = { version = "0.12.3", features = ["arc_lock"] }
+smallvec = "1.14.0"
 thiserror = "2.0.11"
 tracing = "0.1.41"
 

--- a/crates/contracts/ab-contracts-executor/Cargo.toml
+++ b/crates/contracts/ab-contracts-executor/Cargo.toml
@@ -12,18 +12,12 @@ include = [
 
 [dependencies]
 ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
-ab-system-contract-address-allocator = { version = "0.0.1", path = "../ab-system-contract-address-allocator", optional = true }
-ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code", optional = true }
-ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state", optional = true }
+ab-system-contract-address-allocator = { version = "0.0.1", path = "../ab-system-contract-address-allocator" }
+ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
+ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state" }
 inventory = "0.3.19"
-parking_lot = "0.12.3"
+parking_lot = { version = "0.12.3", features = ["arc_lock"] }
 thiserror = "2.0.11"
 tracing = "0.1.41"
 
 [features]
-# Enables support for built-in contracts, which helps with boilerplate
-system-contracts = [
-    "dep:ab-system-contract-address-allocator",
-    "dep:ab-system-contract-code",
-    "dep:ab-system-contract-state",
-]

--- a/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
+++ b/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
@@ -20,7 +20,7 @@ impl AlignedBytes {
 ///
 /// Data is aligned to 16 bytes (128 bits), which is the largest alignment required by primitive
 /// types and by extension any type that implements `TrivialType`/`IoType`.
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub(super) struct OwnedAlignedBuffer {
     buffer: Arc<[MaybeUninit<AlignedBytes>]>,
     len: u32,
@@ -41,16 +41,6 @@ impl DerefMut for OwnedAlignedBuffer {
         self.as_mut_slice()
     }
 }
-
-impl PartialEq for OwnedAlignedBuffer {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        (self.len == other.len && self.as_ptr() == other.as_ptr())
-            || (self.as_slice() == other.as_slice())
-    }
-}
-
-impl Eq for OwnedAlignedBuffer {}
 
 impl OwnedAlignedBuffer {
     /// Create a new instance with at least specified capacity.
@@ -107,6 +97,18 @@ impl OwnedAlignedBuffer {
         SharedAlignedBuffer {
             buffer: self.buffer,
             len: self.len,
+        }
+    }
+
+    /// Ensure capacity of the buffer is at least `capacity`.
+    ///
+    /// Will re-allocate if necessary.
+    #[inline]
+    pub(super) fn ensure_capacity(&mut self, capacity: u32) {
+        if capacity > self.capacity() {
+            let mut new_buffer = Self::with_capacity(capacity);
+            new_buffer.copy_from_slice(self.as_slice());
+            *self = new_buffer;
         }
     }
 
@@ -189,32 +191,6 @@ impl Deref for SharedAlignedBuffer {
     }
 }
 
-impl PartialEq for SharedAlignedBuffer {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        (self.len == other.len && self.as_ptr() == other.as_ptr())
-            || (self.as_slice() == other.as_slice())
-    }
-}
-
-impl PartialEq<OwnedAlignedBuffer> for SharedAlignedBuffer {
-    #[inline]
-    fn eq(&self, other: &OwnedAlignedBuffer) -> bool {
-        (self.len == other.len && self.as_ptr() == other.as_ptr())
-            || (self.as_slice() == other.as_slice())
-    }
-}
-
-impl PartialEq<SharedAlignedBuffer> for OwnedAlignedBuffer {
-    #[inline]
-    fn eq(&self, other: &SharedAlignedBuffer) -> bool {
-        (self.len == other.len && self.as_ptr() == other.as_ptr())
-            || (self.as_slice() == other.as_slice())
-    }
-}
-
-impl Eq for SharedAlignedBuffer {}
-
 impl SharedAlignedBuffer {
     /// Create a new instance from provided bytes.
     ///
@@ -232,7 +208,6 @@ impl SharedAlignedBuffer {
     ///
     /// Returns `None` if there exit other shared instances.
     #[inline]
-    #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
     pub(super) fn into_owned(mut self) -> OwnedAlignedBuffer {
         // Check if this is the last instance of the buffer
         if Arc::get_mut(&mut self.buffer).is_some() {

--- a/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
+++ b/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
@@ -20,7 +20,7 @@ impl AlignedBytes {
 ///
 /// Data is aligned to 16 bytes (128 bits), which is the largest alignment required by primitive
 /// types and by extension any type that implements `TrivialType`/`IoType`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub(super) struct OwnedAlignedBuffer {
     buffer: Arc<[MaybeUninit<AlignedBytes>]>,
     len: u32,

--- a/crates/contracts/ab-contracts-executor/src/aligned_buffer/tests.rs
+++ b/crates/contracts/ab-contracts-executor/src/aligned_buffer/tests.rs
@@ -1,4 +1,4 @@
-use crate::aligned_buffer::{AlignedBytes, OwnedAlignedBuffer};
+use crate::aligned_buffer::{AlignedBytes, OwnedAlignedBuffer, SharedAlignedBuffer};
 
 const EXPECTED_ALIGNMENT: usize = size_of::<AlignedBytes>();
 
@@ -45,10 +45,13 @@ fn basic() {
             );
 
             let mut owned2 = OwnedAlignedBuffer::from_bytes(&bytes);
-            assert_eq!(owned, owned2, "Capacity {capacity}");
+            let shared = SharedAlignedBuffer::from_bytes(&bytes);
             assert_eq!(owned.len(), owned2.len(), "Capacity {capacity}");
+            assert_eq!(owned.len(), shared.len(), "Capacity {capacity}");
             assert_eq!(owned.is_empty(), owned2.is_empty(), "Capacity {capacity}");
+            assert_eq!(owned.is_empty(), shared.is_empty(), "Capacity {capacity}");
             assert_eq!(owned.as_slice(), owned2.as_slice(), "Capacity {capacity}");
+            assert_eq!(owned.as_slice(), shared.as_slice(), "Capacity {capacity}");
             assert_eq!(
                 owned.as_mut_slice(),
                 owned2.as_mut_slice(),
@@ -82,10 +85,13 @@ fn basic() {
             );
 
             let mut owned2 = OwnedAlignedBuffer::from_bytes(&bytes);
-            assert_eq!(owned, owned2, "Capacity {capacity}");
+            let shared = SharedAlignedBuffer::from_bytes(&bytes);
             assert_eq!(owned.len(), owned2.len(), "Capacity {capacity}");
+            assert_eq!(owned.len(), shared.len(), "Capacity {capacity}");
             assert_eq!(owned.is_empty(), owned2.is_empty(), "Capacity {capacity}");
+            assert_eq!(owned.is_empty(), shared.is_empty(), "Capacity {capacity}");
             assert_eq!(owned.as_slice(), owned2.as_slice(), "Capacity {capacity}");
+            assert_eq!(owned.as_slice(), shared.as_slice(), "Capacity {capacity}");
             assert_eq!(
                 owned.as_mut_slice(),
                 owned2.as_mut_slice(),
@@ -117,10 +123,13 @@ fn basic() {
             );
 
             let mut owned2 = OwnedAlignedBuffer::from_bytes(&bytes);
-            assert_eq!(owned, owned2, "Capacity {capacity}");
+            let shared = SharedAlignedBuffer::from_bytes(&bytes);
             assert_eq!(owned.len(), owned2.len(), "Capacity {capacity}");
+            assert_eq!(owned.len(), shared.len(), "Capacity {capacity}");
             assert_eq!(owned.is_empty(), owned2.is_empty(), "Capacity {capacity}");
+            assert_eq!(owned.is_empty(), shared.is_empty(), "Capacity {capacity}");
             assert_eq!(owned.as_slice(), owned2.as_slice(), "Capacity {capacity}");
+            assert_eq!(owned.as_slice(), shared.as_slice(), "Capacity {capacity}");
             assert_eq!(
                 owned.as_mut_slice(),
                 owned2.as_mut_slice(),
@@ -147,10 +156,8 @@ fn basic() {
         assert_ne!(owned.as_ptr(), ptr_before, "Capacity {capacity}");
 
         let shared2 = shared.clone();
-        assert_eq!(shared, shared2, "Capacity {capacity}");
-        assert_eq!(shared2, shared, "Capacity {capacity}");
-        assert_eq!(shared, owned, "Capacity {capacity}");
-        assert_eq!(owned, shared, "Capacity {capacity}");
+        assert_eq!(shared.as_slice(), shared2.as_slice(), "Capacity {capacity}");
+        assert_eq!(owned.as_slice(), shared.as_slice(), "Capacity {capacity}");
 
         assert_eq!(shared.len(), shared2.len(), "Capacity {capacity}");
         assert_eq!(shared.len(), owned.len(), "Capacity {capacity}");

--- a/crates/contracts/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/ab-contracts-executor/src/context.rs
@@ -1,37 +1,17 @@
 mod ffi_call;
 
-use crate::aligned_buffer::OwnedAlignedBuffer;
 use crate::context::ffi_call::FfiCall;
-use crate::slots::{Slots, UsedSlots};
+use crate::slots::Slots;
 use ab_contracts_common::env::{EnvState, ExecutorContext, MethodContext, PreparedMethod};
-use ab_contracts_common::method::MethodFingerprint;
+use ab_contracts_common::method::{ExternalArgs, MethodFingerprint};
 use ab_contracts_common::{Address, ContractError, ExitCode, ShardIndex};
+use ab_system_contract_address_allocator::ffi::allocate_address::AddressAllocatorAllocateAddressArgs;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::ptr::NonNull;
 use std::sync::Arc;
 use tracing::{error, info_span};
-
-/// Stores details about arguments that need to be processed after FFI call
-enum DelayedProcessing {
-    SlotReadOnly {
-        size: u32,
-    },
-    SlotReadWrite {
-        /// Pointer to `InternalArgs` where guest will store a pointer to potentially updated slot
-        /// contents
-        data_ptr: NonNull<*mut u8>,
-        /// Pointer to slot's bytes buffer here bytes from `data_ptr` will need to be written
-        /// after FFI function call
-        slot_ptr: NonNull<OwnedAlignedBuffer>,
-        /// Pointer to `InternalArgs` where guest will store potentially updated slot size,
-        /// corresponds to `data_ptr`, filled during the second pass through the arguments
-        /// (while reading `ExternalArgs`)
-        size: u32,
-        capacity: u32,
-    },
-}
 
 #[derive(Debug, Copy, Clone)]
 pub(super) struct MethodDetails {
@@ -45,6 +25,7 @@ pub(super) struct MethodDetails {
 #[derive(Debug)]
 pub(super) struct NativeExecutorContext {
     shard_index: ShardIndex,
+    system_allocator_address: Address,
     /// Indexed by contract's code (crate name is treated as "code")
     methods_by_code: Arc<HashMap<&'static [u8], HashMap<MethodFingerprint, MethodDetails>>>,
     slots: Arc<Mutex<Slots>>,
@@ -57,100 +38,127 @@ impl ExecutorContext for NativeExecutorContext {
         previous_env_state: &EnvState,
         prepared_methods: &mut [PreparedMethod<'_>],
     ) -> Result<(), ContractError> {
-        // TODO: Check slot misuse across recursive calls
-        // `used_slots` must be before processing of the method because in the process of method
-        // handling, some data structures will store pointers to `UsedSlot`'s internals.
-        let mut used_slots = UsedSlots::new(Arc::clone(&self.slots));
-
-        // TODO: Parallelism
-        for prepared_method in prepared_methods {
-            let PreparedMethod {
-                contract,
-                fingerprint,
-                external_args,
-                method_context,
-                ..
-            } = prepared_method;
-
-            let env_state = EnvState {
-                shard_index: self.shard_index,
-                own_address: *contract,
-                context: match method_context {
-                    MethodContext::Keep => previous_env_state.context,
-                    MethodContext::Reset => Address::NULL,
-                    MethodContext::Replace => previous_env_state.own_address,
-                },
-                caller: previous_env_state.own_address,
+        let ffi_calls = {
+            // For call to multiple methods only read-only `#[view]` is allowed
+            let force_view_only = prepared_methods.len() > 1;
+            let nested_slots = if self.allow_env_mutation {
+                // Create nested slots instance to avoid persisting any access in slots owned by the
+                // context
+                self.slots.lock().new_nested()
+            } else {
+                // If mutation wasn't allowed on higher level, then reuse existing slots instance
+                Arc::clone(&self.slots)
             };
 
-            let span = info_span!("NativeExecutorContext", %contract);
-            let _span_guard = span.enter();
+            prepared_methods
+                .iter_mut()
+                .map(|prepared_method| {
+                    let PreparedMethod {
+                        contract,
+                        fingerprint,
+                        external_args,
+                        method_context,
+                        ..
+                    } = prepared_method;
 
-            let method_details = {
-                let code = self
-                    .slots
-                    .lock()
-                    .get(contract, &Address::SYSTEM_CODE)
-                    .ok_or_else(|| {
-                        error!("Contract or its code not found");
-                        ContractError::NotFound
-                    })?;
-                *self
-                    .methods_by_code
-                    .get(code.as_slice())
-                    .ok_or_else(|| {
-                        let code = String::from_utf8_lossy(&code);
-                        error!(%code, "Contract's code not found in methods map");
-                        ContractError::InternalError
-                    })?
-                    .get(fingerprint)
-                    .ok_or_else(|| {
-                        let code = String::from_utf8_lossy(&code);
-                        error!(%code, %fingerprint, "Method's fingerprint not found");
-                        ContractError::NotImplemented
-                    })?
-            };
+                    let env_state = EnvState {
+                        shard_index: self.shard_index,
+                        own_address: *contract,
+                        context: match method_context {
+                            MethodContext::Keep => previous_env_state.context,
+                            MethodContext::Reset => Address::NULL,
+                            MethodContext::Replace => previous_env_state.own_address,
+                        },
+                        caller: previous_env_state.own_address,
+                    };
 
-            let ffi_call = FfiCall::new(
-                self,
-                &mut used_slots,
-                *contract,
-                method_details,
-                external_args,
-                env_state,
-            )?;
+                    let span = info_span!("NativeExecutorContext", %contract);
+                    let _span_guard = span.enter();
 
-            let result = ffi_call.dispatch()?;
-            result.persist()?;
+                    let method_details = {
+                        let code = nested_slots.lock().get_code(*contract).ok_or_else(|| {
+                            error!("Contract or its code not found");
+                            ContractError::NotFound
+                        })?;
+                        *self
+                            .methods_by_code
+                            .get(code.as_slice())
+                            .ok_or_else(|| {
+                                let code = String::from_utf8_lossy(&code);
+                                error!(%code, "Contract's code not found in methods map");
+                                ContractError::InternalError
+                            })?
+                            .get(fingerprint)
+                            .ok_or_else(|| {
+                                let code = String::from_utf8_lossy(&code);
+                                error!(%code, %fingerprint, "Method's fingerprint not found");
+                                ContractError::NotImplemented
+                            })?
+                    };
+                    let is_allocate_new_address_method = contract == &self.system_allocator_address
+                        && fingerprint == &AddressAllocatorAllocateAddressArgs::FINGERPRINT;
+
+                    FfiCall::new(
+                        self,
+                        force_view_only,
+                        is_allocate_new_address_method,
+                        Arc::clone(&nested_slots),
+                        *contract,
+                        method_details,
+                        external_args,
+                        env_state,
+                    )
+                })
+                .collect::<Result<Vec<FfiCall>, _>>()?
+        };
+
+        // TODO: Parallelism, but with panic unwinding it'll require to catch panics, which is
+        //  really annoying
+        // Collect all results regardless of success for deterministic behavior
+        let results = ffi_calls
+            .into_iter()
+            .map(|ffi_call| {
+                let result = ffi_call.dispatch()?;
+                result.persist()
+            })
+            .collect::<Vec<_>>();
+
+        for result in results {
+            let () = result?;
         }
 
-        used_slots.persist();
+        if self.slots.lock().access_violation() {
+            return Err(ContractError::Forbidden);
+        }
 
         Ok(())
     }
 }
 
 impl NativeExecutorContext {
+    #[inline]
     pub(super) fn new(
         shard_index: ShardIndex,
         methods_by_code: Arc<HashMap<&'static [u8], HashMap<MethodFingerprint, MethodDetails>>>,
         slots: Arc<Mutex<Slots>>,
-        allow_env_mutation: bool,
     ) -> Self {
         Self {
             shard_index,
+            system_allocator_address: Address::system_address_allocator(shard_index),
             methods_by_code,
             slots,
-            allow_env_mutation,
+            allow_env_mutation: true,
         }
     }
 
-    fn new_nested(&self, allow_env_mutation: bool) -> Self {
-        Self::new(
-            self.shard_index,
-            Arc::clone(&self.methods_by_code),
-            Arc::clone(&self.slots),
+    #[inline]
+    fn new_nested(&self, slots: Arc<Mutex<Slots>>, allow_env_mutation: bool) -> Self {
+        Self {
+            shard_index: self.shard_index,
+            system_allocator_address: self.system_allocator_address,
+            methods_by_code: Arc::clone(&self.methods_by_code),
+            slots,
             allow_env_mutation,
-        )
+        }
     }
 }

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -227,9 +227,9 @@ pub mod __private;
 /// pointer field is generated:
 /// ```ignore
 /// #[repr(C)]
-/// pub struct InternalArgs {
+/// pub struct InternalArgs<'__internal_args> {
 ///     // ...
-///     pub env_ptr: NonNull<Env>,
+///     pub env_ptr: NonNull<Env<'__internal_args>>,
 ///     // ...
 /// }
 /// ```
@@ -241,9 +241,9 @@ pub mod __private;
 /// is generated:
 /// ```ignore
 /// #[repr(C)]
-/// pub struct InternalArgs {
+/// pub struct InternalArgs<'__internal_args> {
 ///     // ...
-///     pub env_ptr: NonNull<Env>,
+///     pub env_ptr: NonNull<Env<'__internal_args>>,
 ///     // ...
 /// }
 /// ```


### PR DESCRIPTION
This is a big rewrite of how slots are processed.

The key changes:
* tracking of changes across recursive method calls and catching conflicts correctly
* calling many methods at once is only allowed for `#[view]` method (efficiency constraint, see below)
* deterministic outcomes regardless of whether many methods are processed sequentially or in parallel
* more efficient data structures with some inline values for all key internals of `Slots`

I've attempted this probably more than 5 times, hitting complexity or efficiency roadblocks.

One of the features I wanted to have, but ultimately didn't find a way to achieve was recovering from slot access errors by method caller. This implies cloning (additional allocations) of several data structures that might be modified by the called method. Ultimately this is a feature of questionable usefulness and I decided to make access violations as a hard error that aborts the whole transaction.

Another feature I was seriously considering was allowing mutation when calling multiple methods. Attempting this results in a lot more complexity that is hard to get right. Thinking about potential use cases for calling multiple methods, it is more likely that a single method will be called multiple times with different data to maximize compute utilization. For simple data shuffling calling multiple methods concurrently will likely not be worth the inherent gas overhead resulting from added complexity that the execution environment would have to process.

As the result recursive method calls are supported, including calling multiple methods with constraint to `#[view]` methods, all while avoiding unnecessary memory allocations.

I'm quite happy with the architecture of slots in the end. Yes, it would be possible to make it more featureful with more complexity, but it would be slower and A LOT more complex to maintain.

Can finally switch to other things now :relieved: 

---

Did a quick flipper benchmark, it can create `Env` instance + flip the value in a loop **~4M times/second on a single core** or **~250ns** per iteration. This is the performance to strive for. Anything that is further from this can be safely classified as containing overhead that must be minimized.