### PR TITLE
Follow up slots fixes

### DIFF
--- a/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
+++ b/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
@@ -234,7 +234,6 @@ impl SharedAlignedBuffer {
     }
 
     #[inline]
-    #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
     pub(super) fn is_empty(&self) -> bool {
         self.len == 0
     }


### PR DESCRIPTION
This ensures `#[init]` returns non-empty state, stateful methods are only called after successful `#[init]` and adds a bit more logging for debugging purposes