### PR TITLE
Larger address and fix slots

### DIFF
--- a/crates/contracts/ab-contract-example-ft/src/lib.rs
+++ b/crates/contracts/ab-contract-example-ft/src/lib.rs
@@ -19,7 +19,6 @@ pub struct Slot {
 pub struct ExampleFt {
     pub total_supply: Balance,
     pub owner: Address,
-    pub padding: [u8; 8],
 }
 
 #[contract]
@@ -57,7 +56,6 @@ impl ExampleFt {
         Self {
             total_supply: *total_supply,
             owner: *owner_addr,
-            padding: [0; 8],
         }
     }
 

--- a/crates/contracts/ab-contract-playground/src/lib.rs
+++ b/crates/contracts/ab-contract-playground/src/lib.rs
@@ -29,7 +29,6 @@ pub struct Slot {
 pub struct Playground {
     pub total_supply: Balance,
     pub owner: Address,
-    pub padding: [u8; 8],
 }
 
 #[contract]
@@ -67,7 +66,6 @@ impl Playground {
         Self {
             total_supply: *total_supply,
             owner: *owner_addr,
-            padding: [0; 8],
         }
     }
 
@@ -76,7 +74,6 @@ impl Playground {
         result.replace(Self {
             total_supply: Balance::MIN,
             owner: env.context(),
-            padding: [0; 8],
         });
     }
 

--- a/crates/contracts/ab-contracts-common/src/env.rs
+++ b/crates/contracts/ab-contracts-common/src/env.rs
@@ -54,6 +54,8 @@ pub struct PreparedMethod<'a> {
 pub struct EnvState {
     /// Shard index where execution is happening
     pub shard_index: ShardIndex,
+    /// Explicit padding, contents does not matter
+    pub padding_0: [u8; 12],
     /// Own address of the contract
     pub own_address: Address,
     /// Context of the execution

--- a/crates/contracts/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/ab-contracts-executor/src/context.rs
@@ -62,6 +62,7 @@ impl ExecutorContext for NativeExecutorContext {
 
                     let env_state = EnvState {
                         shard_index: self.shard_index,
+                        padding_0: Default::default(),
                         own_address: *contract,
                         context: match method_context {
                             MethodContext::Keep => previous_env_state.context,

--- a/crates/contracts/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/ab-contracts-executor/src/context.rs
@@ -1,11 +1,12 @@
 mod ffi_call;
 
 use crate::context::ffi_call::FfiCall;
-use crate::slots::{HashMap, Slots};
+use crate::slots::Slots;
 use ab_contracts_common::env::{EnvState, ExecutorContext, MethodContext, PreparedMethod};
 use ab_contracts_common::method::{ExternalArgs, MethodFingerprint};
 use ab_contracts_common::{Address, ContractError, ExitCode, ShardIndex};
 use ab_system_contract_address_allocator::ffi::allocate_address::AddressAllocatorAllocateAddressArgs;
+use halfbrown::HashMap;
 use parking_lot::Mutex;
 use std::ffi::c_void;
 use std::ptr::NonNull;

--- a/crates/contracts/ab-contracts-executor/src/context/ffi_call.rs
+++ b/crates/contracts/ab-contracts-executor/src/context/ffi_call.rs
@@ -1,5 +1,5 @@
 use crate::context::{MethodDetails, NativeExecutorContext};
-use crate::slots::{SlotIndex, Slots};
+use crate::slots::{SlotIndex, SlotKey, Slots};
 use ab_contracts_common::env::{Env, EnvState};
 use ab_contracts_common::metadata::decode::{
     ArgumentKind, ArgumentMetadataItem, MethodKind, MethodMetadataDecoder, MethodMetadataItem,
@@ -269,7 +269,10 @@ impl<'a> FfiCall<'a> {
             }
             MethodKind::UpdateStatefulRo | MethodKind::ViewStateful => {
                 let state_bytes = slots_guard
-                    .use_ro((contract, Address::SYSTEM_STATE))
+                    .use_ro(SlotKey {
+                        owner: contract,
+                        contract: Address::SYSTEM_STATE,
+                    })
                     .ok_or(ContractError::Forbidden)?;
 
                 if state_bytes.is_empty() {
@@ -300,7 +303,10 @@ impl<'a> FfiCall<'a> {
                     return Err(ContractError::Forbidden);
                 }
 
-                let slot_key = (contract, Address::SYSTEM_STATE);
+                let slot_key = SlotKey {
+                    owner: contract,
+                    contract: Address::SYSTEM_STATE,
+                };
                 let (slot_index, state_bytes) = slots_guard
                     .use_rw(slot_key, recommended_state_capacity)
                     .ok_or(ContractError::Forbidden)?;
@@ -394,7 +400,10 @@ impl<'a> FfiCall<'a> {
 
                     // Null contact is used implicitly for `#[tmp]` since it is not possible for
                     // this contract to write something there directly
-                    let slot_key = (contract, Address::NULL);
+                    let slot_key = SlotKey {
+                        owner: contract,
+                        contract: Address::NULL,
+                    };
                     let tmp_bytes = slots_guard
                         .use_ro(slot_key)
                         .ok_or(ContractError::Forbidden)?;
@@ -421,7 +430,10 @@ impl<'a> FfiCall<'a> {
 
                     // Null contact is used implicitly for `#[tmp]` since it is not possible for
                     // this contract to write something there directly
-                    let slot_key = (contract, Address::NULL);
+                    let slot_key = SlotKey {
+                        owner: contract,
+                        contract: Address::NULL,
+                    };
                     let (slot_index, tmp_bytes) = slots_guard
                         .use_rw(slot_key, recommended_tmp_capacity)
                         .ok_or(ContractError::Forbidden)?;
@@ -458,7 +470,10 @@ impl<'a> FfiCall<'a> {
                     // moving right past that is safe
                     let address = unsafe { &*read_ptr!(external_args_cursor as *const Address) };
 
-                    let slot_key = (*address, contract);
+                    let slot_key = SlotKey {
+                        owner: *address,
+                        contract,
+                    };
                     let slot_bytes = slots_guard
                         .use_ro(slot_key)
                         .ok_or(ContractError::Forbidden)?;
@@ -488,7 +503,10 @@ impl<'a> FfiCall<'a> {
                     // moving right past that is safe
                     let address = unsafe { &*read_ptr!(external_args_cursor as *const Address) };
 
-                    let slot_key = (*address, contract);
+                    let slot_key = SlotKey {
+                        owner: *address,
+                        contract,
+                    };
                     let (slot_index, slot_bytes) = slots_guard
                         .use_rw(slot_key, recommended_slot_capacity)
                         .ok_or(ContractError::Forbidden)?;
@@ -560,7 +578,10 @@ impl<'a> FfiCall<'a> {
                             return Err(ContractError::Forbidden);
                         }
 
-                        let slot_key = (contract, Address::SYSTEM_STATE);
+                        let slot_key = SlotKey {
+                            owner: contract,
+                            contract: Address::SYSTEM_STATE,
+                        };
                         let (slot_index, state_bytes) = slots_guard
                             .use_rw(slot_key, recommended_state_capacity)
                             .ok_or(ContractError::Forbidden)?;

--- a/crates/contracts/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/ab-contracts-executor/src/lib.rs
@@ -6,7 +6,7 @@ mod slots;
 
 use crate::aligned_buffer::SharedAlignedBuffer;
 use crate::context::{MethodDetails, NativeExecutorContext};
-use crate::slots::Slots;
+use crate::slots::{SlotKey, Slots};
 use ab_contracts_common::env::{Env, EnvState, MethodContext};
 use ab_contracts_common::metadata::decode::{MetadataDecoder, MetadataDecodingError, MetadataItem};
 use ab_contracts_common::method::MethodFingerprint;
@@ -118,7 +118,10 @@ impl NativeExecutor {
 
         // Manually deploy code of system code contract
         let slots = [(
-            (Address::SYSTEM_CODE, Address::SYSTEM_CODE),
+            SlotKey {
+                owner: Address::SYSTEM_CODE,
+                contract: Address::SYSTEM_CODE,
+            },
             SharedAlignedBuffer::from_bytes(Code::code().get_initialized()),
         )];
 
@@ -167,7 +170,7 @@ impl NativeExecutor {
     // TODO: Remove this once there is a better way to do this
     /// Mark slot as used, such that execution environment can read/write from/to it
     pub fn use_slot(&mut self, owner: Address, contract: Address) {
-        self.slots.lock().use_slot((owner, contract));
+        self.slots.lock().use_slot(SlotKey { owner, contract });
     }
 
     /// Run a function under fresh execution environment

--- a/crates/contracts/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/ab-contracts-executor/src/lib.rs
@@ -173,6 +173,7 @@ impl NativeExecutor {
     pub fn env(&mut self, context: Address, caller: Address) -> Env<'_> {
         let env_state = EnvState {
             shard_index: self.shard_index,
+            padding_0: Default::default(),
             own_address: caller,
             context,
             caller,

--- a/crates/contracts/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/ab-contracts-executor/src/lib.rs
@@ -6,7 +6,7 @@ mod slots;
 
 use crate::aligned_buffer::SharedAlignedBuffer;
 use crate::context::{MethodDetails, NativeExecutorContext};
-use crate::slots::{HashMap, Slots};
+use crate::slots::Slots;
 use ab_contracts_common::env::{Env, EnvState, MethodContext};
 use ab_contracts_common::metadata::decode::{MetadataDecoder, MetadataDecodingError, MetadataItem};
 use ab_contracts_common::method::MethodFingerprint;
@@ -16,6 +16,7 @@ use ab_contracts_common::{
 use ab_system_contract_address_allocator::{AddressAllocator, AddressAllocatorExt};
 use ab_system_contract_code::{Code, CodeExt};
 use ab_system_contract_state::State;
+use halfbrown::HashMap;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tracing::error;
@@ -116,10 +117,10 @@ impl NativeExecutor {
         }
 
         // Manually deploy code of system code contract
-        let slots = HashMap::from_iter([(
+        let slots = [(
             (Address::SYSTEM_CODE, Address::SYSTEM_CODE),
             SharedAlignedBuffer::from_bytes(Code::code().get_initialized()),
-        )]);
+        )];
 
         let address_allocator_address = Address::system_address_allocator(shard_index);
         let slots = Slots::new(slots);

--- a/crates/contracts/ab-contracts-executor/src/slots.rs
+++ b/crates/contracts/ab-contracts-executor/src/slots.rs
@@ -1,6 +1,5 @@
 use crate::aligned_buffer::{OwnedAlignedBuffer, SharedAlignedBuffer};
 use ab_contracts_common::Address;
-use halfbrown::{DefaultHashBuilder, Entry, SizedHashMap};
 use parking_lot::Mutex;
 use smallvec::SmallVec;
 use std::mem;
@@ -12,12 +11,20 @@ use tracing::debug;
 /// This is both large enough for many practical use cases and small enough to bring significant
 /// performance improvement.
 const INLINE_SIZE: usize = 8;
-pub(super) type HashMap<K, V, S = DefaultHashBuilder> = SizedHashMap<K, V, S, INLINE_SIZE>;
 /// It should be rare that more than 2 contracts are created in the same transaction
 const NEW_CONTRACTS_INLINE: usize = 2;
 
 /// A tuple of `(owner, contract)` that corresponds to a slot
 pub(super) type SlotKey = (Address, Address);
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub(super) struct SlotIndex(usize);
+
+impl From<SlotIndex> for usize {
+    #[inline]
+    fn from(value: SlotIndex) -> Self {
+        value.0
+    }
+}
 
 #[derive(Debug)]
 enum Slot {
@@ -35,19 +42,9 @@ enum Slot {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 struct SlotAccess {
-    slot_key: SlotKey,
+    slot_index: SlotIndex,
     /// `false` for read-only and `true` for read-write
     read_write: bool,
-}
-
-impl SlotAccess {
-    fn owner(&self) -> &Address {
-        &self.slot_key.0
-    }
-
-    fn contract(&self) -> &Address {
-        &self.slot_key.1
-    }
 }
 
 #[derive(Debug)]
@@ -58,7 +55,7 @@ struct SlotsParent {
 
 #[derive(Debug)]
 pub(super) struct Slots {
-    slots: HashMap<SlotKey, Slot>,
+    slots: SmallVec<[(SlotKey, Slot); INLINE_SIZE]>,
     slot_access: SmallVec<[SlotAccess; INLINE_SIZE]>,
     /// The list of new addresses that were created during transaction processing and couldn't be
     /// known beforehand.
@@ -87,15 +84,17 @@ impl Drop for Slots {
         if self.access_violation {
             return;
         }
-        mem::swap(&mut parent.new_contracts, &mut self.new_contracts);
         mem::swap(&mut parent.slots, &mut self.slots);
+        mem::swap(&mut parent.slot_access, &mut self.slot_access);
+        mem::swap(&mut parent.new_contracts, &mut self.new_contracts);
 
         // Fix-up slots that were modified during access
-        for slot_access in self.slot_access.drain(parent_slot_access_len..) {
-            let slot = parent
+        for slot_access in parent.slot_access.drain(parent_slot_access_len..) {
+            let slot = &mut parent
                 .slots
-                .get_mut(&slot_access.slot_key)
-                .expect("Accessed slot exists; qed");
+                .get_mut(usize::from(slot_access.slot_index))
+                .expect("Accessed slot exists; qed")
+                .1;
             match slot {
                 Slot::Original(_buffer) => {
                     unreachable!("Slot can't be in Original state after being accessed")
@@ -128,7 +127,10 @@ impl Slots {
     /// owners created during runtime and initialized with [`Self::add_new_contract()`].
     ///
     /// "Empty" slots must still have a value in the form of an empty [`SharedAlignedBuffer`].
-    pub(super) fn new(slots: HashMap<SlotKey, SharedAlignedBuffer>) -> Arc<Mutex<Self>> {
+    pub(super) fn new<I>(slots: I) -> Arc<Mutex<Self>>
+    where
+        I: IntoIterator<Item = (SlotKey, SharedAlignedBuffer)>,
+    {
         let slots = slots
             .into_iter()
             .filter_map(|((owner, contract), slot)| {
@@ -193,9 +195,14 @@ impl Slots {
     }
 
     pub(super) fn use_slot(&mut self, slot_key: SlotKey) {
-        self.slots
-            .entry(slot_key)
-            .or_insert(Slot::Original(SharedAlignedBuffer::default()));
+        if !self
+            .slots
+            .iter()
+            .any(|(slot_key_candidate, _slot)| slot_key_candidate == &slot_key)
+        {
+            self.slots
+                .push((slot_key, Slot::Original(SharedAlignedBuffer::default())));
+        }
     }
 
     /// Add a new account that didn't exist before.
@@ -236,31 +243,42 @@ impl Slots {
 
     fn get_code_internal(
         owner: Address,
-        slots: &HashMap<SlotKey, Slot>,
+        slots: &SmallVec<[(SlotKey, Slot); INLINE_SIZE]>,
         slot_access: &[SlotAccess],
     ) -> Option<SharedAlignedBuffer> {
         let contract = Address::SYSTEM_CODE;
 
-        // Ensure code is not currently being written to
-        if slot_access.iter().any(|slot_access| {
-            slot_access.owner() == owner
-                && slot_access.contract() == contract
-                && slot_access.read_write
-        }) {
-            return None;
-        }
+        let slot_index =
+            slots
+                .iter()
+                .position(|((slot_key_owner, slot_key_contract), _slot)| {
+                    slot_key_owner == owner && slot_key_contract == contract
+                })?;
+        let slot_index = SlotIndex(slot_index);
 
-        let slot = match slots.get(&(owner, contract))? {
-            Slot::Original(slot)
-            | Slot::ReadOnlyAccessed(slot)
-            | Slot::ReadOnlyModified(slot)
-            | Slot::ReadOnlyModifiedAccessed(slot) => slot,
-            Slot::ReadWrite(_slot) => {
+        // Ensure code is not currently being written to
+        if slot_access
+            .iter()
+            .any(|slot_access| slot_access.slot_index == slot_index && slot_access.read_write)
+        {
+            return None;
+        };
+
+        let buffer = match &slots
+            .get(usize::from(slot_index))
+            .expect("Just found; qed")
+            .1
+        {
+            Slot::Original(buffer)
+            | Slot::ReadOnlyAccessed(buffer)
+            | Slot::ReadOnlyModified(buffer)
+            | Slot::ReadOnlyModifiedAccessed(buffer) => buffer,
+            Slot::ReadWrite(_buffer) => {
                 return None;
             }
         };
 
-        Some(slot.clone())
+        Some(buffer.clone())
     }
 
     /// Read-only access to a slot with specified owner and contract, marks it as used.
@@ -284,30 +302,38 @@ impl Slots {
 
     fn use_ro_internal<'a>(
         slot_key: SlotKey,
-        slots: &'a mut HashMap<SlotKey, Slot>,
+        slots: &'a mut SmallVec<[(SlotKey, Slot); INLINE_SIZE]>,
         slot_access: &mut SmallVec<[SlotAccess; INLINE_SIZE]>,
         new_contracts: &[Address],
     ) -> Option<&'a SharedAlignedBuffer> {
         let (owner, contract) = &slot_key;
-        // Ensure that slot is not currently being written to
-        if let Some(read_write) = slot_access.iter().find_map(|slot_access| {
-            (slot_access.owner() == owner && slot_access.contract() == contract)
-                .then_some(slot_access.read_write)
-        }) {
-            if read_write {
-                return None;
-            }
-        } else {
-            slot_access.push(SlotAccess {
-                slot_key,
-                read_write: false,
-            });
-        }
+        let maybe_slot_index = slots
+            .iter()
+            .position(|((slot_key_owner, slot_key_contract), _slot)| {
+                slot_key_owner == owner && slot_key_contract == contract
+            })
+            .map(SlotIndex);
 
-        // Get a slot or create an empty one if new address
-        match slots.entry(slot_key) {
-            Entry::Occupied(slot_entry) => {
-                let slot = slot_entry.into_mut();
+        match maybe_slot_index {
+            Some(slot_index) => {
+                // Ensure that slot is not currently being written to
+                if let Some(read_write) = slot_access.iter().find_map(|slot_access| {
+                    (slot_access.slot_index == slot_index).then_some(slot_access.read_write)
+                }) {
+                    if read_write {
+                        return None;
+                    }
+                } else {
+                    slot_access.push(SlotAccess {
+                        slot_index,
+                        read_write: false,
+                    });
+                }
+
+                let slot = &mut slots
+                    .get_mut(usize::from(slot_index))
+                    .expect("Just found; qed")
+                    .1;
 
                 // The slot that is currently being written to is not allowed for read access
                 match slot {
@@ -333,7 +359,7 @@ impl Slots {
                     Slot::ReadWrite(_buffer) => None,
                 }
             }
-            Entry::Vacant(slot_entry) => {
+            None => {
                 // `Address::NULL` is used for `#[tmp]` and is ephemeral. Reads and writes are
                 // allowed for any owner, and they will all be thrown away after transaction
                 // processing if finished.
@@ -345,8 +371,15 @@ impl Slots {
                     return None;
                 }
 
+                slot_access.push(SlotAccess {
+                    slot_index: SlotIndex(slots.len()),
+                    read_write: false,
+                });
+
                 let slot = Slot::ReadOnlyAccessed(SharedAlignedBuffer::default());
-                let Slot::ReadOnlyAccessed(buffer) = slot_entry.insert(slot) else {
+                slots.push((slot_key, slot));
+                let slot = &slots.last().expect("Just inserted; qed").1;
+                let Slot::ReadOnlyAccessed(buffer) = slot else {
                     unreachable!("Just inserted; qed");
                 };
 
@@ -362,7 +395,7 @@ impl Slots {
         &mut self,
         slot_key: SlotKey,
         capacity: u32,
-    ) -> Option<&mut OwnedAlignedBuffer> {
+    ) -> Option<(SlotIndex, &mut OwnedAlignedBuffer)> {
         let result = Self::use_rw_internal(
             slot_key,
             capacity,
@@ -382,27 +415,37 @@ impl Slots {
     fn use_rw_internal<'a>(
         slot_key: SlotKey,
         capacity: u32,
-        slots: &'a mut HashMap<SlotKey, Slot>,
+        slots: &'a mut SmallVec<[(SlotKey, Slot); INLINE_SIZE]>,
         slot_access: &mut SmallVec<[SlotAccess; INLINE_SIZE]>,
         new_contracts: &[Address],
-    ) -> Option<&'a mut OwnedAlignedBuffer> {
+    ) -> Option<(SlotIndex, &'a mut OwnedAlignedBuffer)> {
         let (owner, contract) = &slot_key;
-        // Ensure that slot is not accessed right now
-        if slot_access
+        let maybe_slot_index = slots
             .iter()
-            .any(|slot_access| slot_access.owner() == owner && slot_access.contract() == contract)
-        {
-            return None;
-        }
+            .position(|((slot_key_owner, slot_key_contract), _slot)| {
+                slot_key_owner == owner && slot_key_contract == contract
+            })
+            .map(SlotIndex);
 
-        slot_access.push(SlotAccess {
-            slot_key,
-            read_write: true,
-        });
+        match maybe_slot_index {
+            Some(slot_index) => {
+                // Ensure that slot is not accessed right now
+                if slot_access
+                    .iter()
+                    .any(|slot_access| slot_access.slot_index == slot_index)
+                {
+                    return None;
+                }
 
-        match slots.entry(slot_key) {
-            Entry::Occupied(slot_entry) => {
-                let slot = slot_entry.into_mut();
+                slot_access.push(SlotAccess {
+                    slot_index,
+                    read_write: true,
+                });
+
+                let slot = &mut slots
+                    .get_mut(usize::from(slot_index))
+                    .expect("Just found; qed")
+                    .1;
 
                 // The slot that is currently being accessed to is not allowed for writing
                 let buffer = match slot {
@@ -421,9 +464,9 @@ impl Slots {
                 };
 
                 buffer.ensure_capacity(capacity);
-                Some(buffer)
+                Some((slot_index, buffer))
             }
-            Entry::Vacant(slot_entry) => {
+            None => {
                 // `Address::NULL` is used for `#[tmp]` and is ephemeral. Reads and writes are
                 // allowed for any owner, and they will all be thrown away after transaction
                 // processing if finished.
@@ -435,12 +478,20 @@ impl Slots {
                     return None;
                 }
 
+                let slot_index = SlotIndex(slots.len());
+                slot_access.push(SlotAccess {
+                    slot_index,
+                    read_write: true,
+                });
+
                 let slot = Slot::ReadWrite(OwnedAlignedBuffer::with_capacity(capacity));
-                let Slot::ReadWrite(buffer) = slot_entry.insert(slot) else {
+                slots.push((slot_key, slot));
+                let slot = &mut slots.last_mut().expect("Just inserted; qed").1;
+                let Slot::ReadWrite(buffer) = slot else {
                     unreachable!("Just inserted; qed");
                 };
 
-                Some(buffer)
+                Some((slot_index, buffer))
             }
         }
     }
@@ -449,10 +500,18 @@ impl Slots {
     /// used due to earlier call to [`Self::use_rw()`].
     ///
     /// Returns `None` in case of access violation.
-    pub(super) fn access_used_rw(&mut self, slot_key: &SlotKey) -> Option<&mut OwnedAlignedBuffer> {
-        let Some(slot) = self.slots.get_mut(slot_key) else {
+    pub(super) fn access_used_rw(
+        &mut self,
+        slot_index: SlotIndex,
+    ) -> Option<&mut OwnedAlignedBuffer> {
+        let maybe_slot = self
+            .slots
+            .get_mut(usize::from(slot_index))
+            .map(|(_slot_key, slot)| slot);
+
+        let Some(slot) = maybe_slot else {
             debug!(
-                ?slot_key,
+                ?slot_index,
                 "`access_used_rw` state access violation (not found)"
             );
             self.access_violation = true;
@@ -466,7 +525,7 @@ impl Slots {
             | Slot::ReadOnlyModified(_buffer)
             | Slot::ReadOnlyModifiedAccessed(_buffer) => {
                 debug!(
-                    ?slot_key,
+                    ?slot_index,
                     "`access_used_rw` state access violation (read only)"
                 );
                 self.access_violation = true;


### PR DESCRIPTION
This increases address size to `u128` and keeps it as a number. While number requires larger alignment, it also generates much more compact RISC-V code. Also fixed address allocation.

With larger address type code became less efficient, so `Slots` was refactored to not use maps at all (given small expected number of slots used per transaction), which reduced memory usage and improved performance to almost the level it was prior.