### PR TITLE
Optimize native execution context, remove useless `#[inline]`

### DIFF
--- a/crates/contracts/ab-contracts-executor/src/aligned_buffer/tests.rs
+++ b/crates/contracts/ab-contracts-executor/src/aligned_buffer/tests.rs
@@ -139,7 +139,7 @@ fn basic() {
             let shorter_len = owned2.len() - 1;
             // SAFETY: length is guaranteed to be within stored bytes
             unsafe { owned2.set_len(shorter_len) };
-            assert_eq!(&owned[..shorter_len as usize], owned2.as_slice());
+            assert_eq!(&owned.as_slice()[..shorter_len as usize], owned2.as_slice());
         }
 
         // Create a shared instance

--- a/crates/contracts/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/ab-contracts-executor/src/context.rs
@@ -38,78 +38,160 @@ impl ExecutorContext for NativeExecutorContext {
         previous_env_state: &EnvState,
         prepared_methods: &mut [PreparedMethod<'_>],
     ) -> Result<(), ContractError> {
-        let ffi_calls = {
-            // For call to multiple methods only read-only `#[view]` is allowed
-            let force_view_only = prepared_methods.len() > 1;
-            let nested_slots = if self.allow_env_mutation {
-                // Create nested slots instance to avoid persisting any access in slots owned by the
-                // context
-                self.slots.lock().new_nested()
-            } else {
-                // If mutation wasn't allowed on higher level, then reuse existing slots instance
-                Arc::clone(&self.slots)
-            };
+        if prepared_methods.len() == 1 {
+            self.call_single_method(previous_env_state, &mut prepared_methods[0])?;
+        } else {
+            self.call_many_methods(previous_env_state, prepared_methods)?;
+        }
 
-            prepared_methods
-                .iter_mut()
-                .map(|prepared_method| {
-                    let PreparedMethod {
-                        contract,
-                        fingerprint,
-                        external_args,
-                        method_context,
-                        ..
-                    } = prepared_method;
+        if self.slots.lock().access_violation() {
+            return Err(ContractError::Forbidden);
+        }
 
-                    let env_state = EnvState {
-                        shard_index: self.shard_index,
-                        padding_0: Default::default(),
-                        own_address: *contract,
-                        context: match method_context {
-                            MethodContext::Keep => previous_env_state.context,
-                            MethodContext::Reset => Address::NULL,
-                            MethodContext::Replace => previous_env_state.own_address,
-                        },
-                        caller: previous_env_state.own_address,
-                    };
+        Ok(())
+    }
+}
 
-                    let span = info_span!("NativeExecutorContext", %contract);
-                    let _span_guard = span.enter();
+impl NativeExecutorContext {
+    pub(super) fn new(
+        shard_index: ShardIndex,
+        methods_by_code: Arc<HashMap<(&'static [u8], &'static MethodFingerprint), MethodDetails>>,
+        slots: Arc<Mutex<Slots>>,
+    ) -> Self {
+        Self {
+            shard_index,
+            system_allocator_address: Address::system_address_allocator(shard_index),
+            methods_by_code,
+            slots,
+            allow_env_mutation: true,
+        }
+    }
 
-                    let method_details = {
-                        let code = nested_slots.lock().get_code(*contract).ok_or_else(|| {
-                            error!("Contract or its code not found");
-                            ContractError::NotFound
-                        })?;
-                        *self
-                            .methods_by_code
-                            .get(&(code.as_slice(), fingerprint))
-                            .ok_or_else(|| {
-                                let code = String::from_utf8_lossy(&code);
-                                error!(
-                                    %code,
-                                    %fingerprint,
-                                    "Contract's code or fingerprint not found in methods map"
-                                );
-                                ContractError::NotImplemented
-                            })?
-                    };
-                    let is_allocate_new_address_method = contract == &self.system_allocator_address
-                        && fingerprint == &AddressAllocatorAllocateAddressArgs::FINGERPRINT;
+    fn new_nested(&self, slots: Arc<Mutex<Slots>>, allow_env_mutation: bool) -> Self {
+        Self {
+            shard_index: self.shard_index,
+            system_allocator_address: self.system_allocator_address,
+            methods_by_code: Arc::clone(&self.methods_by_code),
+            slots,
+            allow_env_mutation,
+        }
+    }
 
-                    FfiCall::new(
-                        self,
-                        force_view_only,
-                        is_allocate_new_address_method,
-                        Arc::clone(&nested_slots),
-                        *contract,
-                        method_details,
-                        external_args,
-                        env_state,
-                    )
-                })
-                .collect::<Result<Vec<FfiCall>, _>>()?
+    fn nested_slots(&self) -> Arc<Mutex<Slots>> {
+        if self.allow_env_mutation {
+            // Create nested slots instance to avoid persisting any access in slots owned by the
+            // context
+            self.slots.lock().new_nested()
+        } else {
+            // If mutation wasn't allowed on higher level, then reuse existing slots instance
+            Arc::clone(&self.slots)
+        }
+    }
+
+    fn prepare_ffi_call<'a>(
+        &self,
+        previous_env_state: &EnvState,
+        prepared_method: &'a mut PreparedMethod<'_>,
+        force_view_only: bool,
+        nested_slots: Arc<Mutex<Slots>>,
+    ) -> Result<FfiCall<'a>, ContractError> {
+        let PreparedMethod {
+            contract,
+            fingerprint,
+            external_args,
+            method_context,
+            ..
+        } = prepared_method;
+
+        let env_state = EnvState {
+            shard_index: self.shard_index,
+            padding_0: Default::default(),
+            own_address: *contract,
+            context: match method_context {
+                MethodContext::Keep => previous_env_state.context,
+                MethodContext::Reset => Address::NULL,
+                MethodContext::Replace => previous_env_state.own_address,
+            },
+            caller: previous_env_state.own_address,
         };
+
+        let span = info_span!("NativeExecutorContext", %contract);
+        let _span_guard = span.enter();
+
+        let method_details = {
+            let code = nested_slots.lock().get_code(*contract).ok_or_else(|| {
+                error!("Contract or its code not found");
+                ContractError::NotFound
+            })?;
+            *self
+                .methods_by_code
+                .get(&(code.as_slice(), fingerprint))
+                .ok_or_else(|| {
+                    let code = String::from_utf8_lossy(code.as_slice());
+                    error!(
+                        %code,
+                        %fingerprint,
+                        "Contract's code or fingerprint not found in methods map"
+                    );
+                    ContractError::NotImplemented
+                })?
+        };
+        let is_allocate_new_address_method = contract == &self.system_allocator_address
+            && fingerprint == &AddressAllocatorAllocateAddressArgs::FINGERPRINT;
+
+        FfiCall::new(
+            self,
+            force_view_only,
+            is_allocate_new_address_method,
+            nested_slots,
+            *contract,
+            method_details,
+            external_args,
+            env_state,
+        )
+    }
+
+    fn call_single_method(
+        &self,
+        previous_env_state: &EnvState,
+        prepared_method: &mut PreparedMethod<'_>,
+    ) -> Result<(), ContractError> {
+        let nested_slots = self.nested_slots();
+
+        self.prepare_ffi_call(
+            previous_env_state,
+            prepared_method,
+            // For call to multiple methods only read-only `#[view]` is allowed
+            false,
+            Arc::clone(&nested_slots),
+        )?
+        .dispatch()?
+        .persist()
+    }
+
+    fn call_many_methods(
+        &self,
+        previous_env_state: &EnvState,
+        prepared_methods: &mut [PreparedMethod<'_>],
+    ) -> Result<(), ContractError> {
+        if prepared_methods.is_empty() {
+            return Ok(());
+        }
+
+        let nested_slots = self.nested_slots();
+
+        let ffi_calls = prepared_methods
+            .iter_mut()
+            .map(|prepared_method| {
+                self.prepare_ffi_call(
+                    previous_env_state,
+                    prepared_method,
+                    // For call to multiple methods only read-only `#[view]` is allowed
+                    true,
+                    Arc::clone(&nested_slots),
+                )
+            })
+            .collect::<Result<Vec<FfiCall>, _>>()?;
 
         // TODO: Parallelism, but with panic unwinding it'll require to catch panics, which is
         //  really annoying
@@ -126,38 +208,6 @@ impl ExecutorContext for NativeExecutorContext {
             let () = result?;
         }
 
-        if self.slots.lock().access_violation() {
-            return Err(ContractError::Forbidden);
-        }
-
         Ok(())
-    }
-}
-
-impl NativeExecutorContext {
-    #[inline]
-    pub(super) fn new(
-        shard_index: ShardIndex,
-        methods_by_code: Arc<HashMap<(&'static [u8], &'static MethodFingerprint), MethodDetails>>,
-        slots: Arc<Mutex<Slots>>,
-    ) -> Self {
-        Self {
-            shard_index,
-            system_allocator_address: Address::system_address_allocator(shard_index),
-            methods_by_code,
-            slots,
-            allow_env_mutation: true,
-        }
-    }
-
-    #[inline]
-    fn new_nested(&self, slots: Arc<Mutex<Slots>>, allow_env_mutation: bool) -> Self {
-        Self {
-            shard_index: self.shard_index,
-            system_allocator_address: self.system_allocator_address,
-            methods_by_code: Arc::clone(&self.methods_by_code),
-            slots,
-            allow_env_mutation,
-        }
     }
 }

--- a/crates/contracts/ab-contracts-executor/src/slots.rs
+++ b/crates/contracts/ab-contracts-executor/src/slots.rs
@@ -24,7 +24,6 @@ pub(super) struct SlotKey {
 pub(super) struct SlotIndex(usize);
 
 impl From<SlotIndex> for usize {
-    #[inline]
     fn from(value: SlotIndex) -> Self {
         value.0
     }


### PR DESCRIPTION
This allows to increase number of flips from ~4M/s to ~5M/s!

The primary reason is extracting the most common special case with a single method call into a separate method that doesn't need to deal with iteration and heap allocation for method call.

`#[inline]` on private methods does nothing.