### PR TITLE
Add `executor` and `alloc` features to `ab-contracts-common` crate

### DIFF
--- a/crates/contracts/ab-contracts-common/Cargo.toml
+++ b/crates/contracts/ab-contracts-common/Cargo.toml
@@ -20,3 +20,5 @@ thiserror = "2.0.11"
 
 [features]
 guest = []
+alloc = []
+executor = ["alloc"]

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -29,7 +29,6 @@ pub const MAX_CODE_SIZE: u32 = 1024 * 1024;
 ///
 /// NOTE: It is unlikely to be necessary to interact with this directly.
 #[derive(Debug, Copy, Clone)]
-#[cfg(any(unix, windows))]
 #[doc(hidden)]
 pub struct NativeExecutorContactMethod {
     pub method_fingerprint: &'static MethodFingerprint,
@@ -52,13 +51,11 @@ pub trait Contract: IoType {
     /// Something that can be used as "code" in native execution environment.
     ///
     /// NOTE: It is unlikely to be necessary to interact with this directly.
-    #[cfg(any(unix, windows))]
     #[doc(hidden)]
     const CODE: &str;
     /// Methods of a contract used in native execution environment.
     ///
     /// NOTE: It is unlikely to be necessary to interact with this directly.
-    #[cfg(any(unix, windows))]
     #[doc(hidden)]
     const NATIVE_EXECUTOR_METHODS: &[NativeExecutorContactMethod];
     // Default value is provided to only fail to compile when contract that uses
@@ -72,9 +69,11 @@ pub trait Contract: IoType {
     type Slot: IoType;
     /// Tmp type used by this contract
     type Tmp: IoType;
-    /// Something that can be used as "code" in native execution environment
+    /// Something that can be used as "code" in native execution environment and primarily used for
+    /// testing.
+    ///
+    /// This is NOT the code compiled for guest architecture!
     // TODO: Make `const` when possible
-    #[cfg(any(unix, windows))]
     fn code() -> impl Deref<Target = VariableBytes<MAX_CODE_SIZE>>;
 }
 
@@ -93,7 +92,6 @@ where
     DynTrait: ?Sized,
 {
     /// Methods of a trait used in native execution environment
-    #[cfg(any(unix, windows))]
     #[doc(hidden)]
     const NATIVE_EXECUTOR_METHODS: &[NativeExecutorContactMethod];
 }

--- a/crates/contracts/ab-contracts-executor/Cargo.toml
+++ b/crates/contracts/ab-contracts-executor/Cargo.toml
@@ -11,7 +11,7 @@ include = [
 ]
 
 [dependencies]
-ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common", features = ["executor"] }
 ab-system-contract-address-allocator = { version = "0.0.1", path = "../ab-system-contract-address-allocator" }
 ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
 ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state" }

--- a/crates/contracts/ab-contracts-macros-impl/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract.rs
@@ -198,7 +198,6 @@ fn process_trait_impl(mut item_impl: ItemImpl, trait_name: &Ident) -> Result<Tok
             .map(|method| &method.original_ident);
 
         quote! {
-            #[cfg(any(unix, windows))]
             #[doc(hidden)]
             const NATIVE_EXECUTOR_METHODS: &[::ab_contracts_macros::__private::NativeExecutorContactMethod] = &[
                 #( #ffi_mod_ident::#methods::fn_pointer::METHOD_FN_POINTER, )*
@@ -421,7 +420,6 @@ fn process_struct_impl(mut item_impl: ItemImpl) -> Result<TokenStream, Error> {
             .map(|method| &method.original_ident);
 
         quote! {
-            #[cfg(any(unix, windows))]
             #[doc(hidden)]
             const NATIVE_EXECUTOR_METHODS: &[::ab_contracts_macros::__private::NativeExecutorContactMethod] = &[
                 #( ffi::#methods::fn_pointer::METHOD_FN_POINTER, )*
@@ -466,7 +464,6 @@ fn process_struct_impl(mut item_impl: ItemImpl) -> Result<TokenStream, Error> {
         impl ::ab_contracts_macros::__private::Contract for #struct_name {
             #metadata_const
             #method_fn_pointers_const
-            #[cfg(any(unix, windows))]
             #[doc(hidden)]
             const CODE: &::core::primitive::str = ::ab_contracts_macros::__private::concatcp!(
                 #struct_name_str,
@@ -487,7 +484,6 @@ fn process_struct_impl(mut item_impl: ItemImpl) -> Result<TokenStream, Error> {
             type Slot = #slot_type;
             type Tmp = #tmp_type;
 
-            #[cfg(any(unix, windows))]
             fn code() -> impl ::core::ops::Deref<
                 Target = ::ab_contracts_macros::__private::VariableBytes<
                     { ::ab_contracts_macros::__private::MAX_CODE_SIZE },

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
@@ -1230,7 +1230,6 @@ impl MethodDetails {
             )?;
 
             quote! {
-                #[cfg(any(unix, windows))]
                 #[doc(hidden)]
                 pub mod fn_pointer {
                     use super::*;

--- a/crates/contracts/ab-contracts-macros/Cargo.toml
+++ b/crates/contracts/ab-contracts-macros/Cargo.toml
@@ -14,8 +14,6 @@ include = [
 ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
 ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
 ab-contracts-macros-impl = { version = "0.0.1", path = "../ab-contracts-macros-impl" }
-
-[target.'cfg(any(unix, windows))'.dependencies]
 const_format = "0.2.34"
 
 [features]

--- a/crates/contracts/ab-contracts-macros/src/__private.rs
+++ b/crates/contracts/ab-contracts-macros/src/__private.rs
@@ -3,15 +3,10 @@ pub use ab_contracts_common::metadata::ContractMetadataKind;
 pub use ab_contracts_common::method::{ExternalArgs, MethodFingerprint};
 pub use ab_contracts_common::{
     Address, Contract, ContractError, ContractTrait, ContractTraitDefinition, ExitCode,
+    MAX_CODE_SIZE, NativeExecutorContactMethod,
 };
 pub use ab_contracts_io_type::metadata::{MAX_METADATA_CAPACITY, concat_metadata_sources};
 pub use ab_contracts_io_type::trivial_type::TrivialType;
-pub use ab_contracts_io_type::{IoType, IoTypeOptional};
-
-// This bunch is only needed for native execution environment
-#[cfg(any(unix, windows))]
-pub use ab_contracts_common::{MAX_CODE_SIZE, NativeExecutorContactMethod};
-#[cfg(any(unix, windows))]
 pub use ab_contracts_io_type::variable_bytes::VariableBytes;
-#[cfg(any(unix, windows))]
+pub use ab_contracts_io_type::{IoType, IoTypeOptional};
 pub use const_format::concatcp;


### PR DESCRIPTION
With minor changes to executor (switching from `std` to `alloc`/`core`) this makes it possible to run contracts inside of contracts.

`alloc` feature will also be used for other things soon.