### PR TITLE
Revert slot modifications on failed call

### DIFF
--- a/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
+++ b/crates/contracts/ab-contracts-executor/src/aligned_buffer.rs
@@ -26,7 +26,7 @@ const _: () = {
 ///
 /// Data is aligned to 16 bytes (128 bits), which is the largest alignment required by primitive
 /// types and by extension any type that implements `TrivialType`/`IoType`.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(super) struct OwnedAlignedBuffer {
     buffer: Arc<[MaybeUninit<AlignedBytes>]>,
     len: u32,
@@ -175,6 +175,7 @@ impl SharedAlignedBuffer {
     /// allocation will be created.
     ///
     /// Returns `None` if there exit other shared instances.
+    #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
     pub(super) fn into_owned(mut self) -> OwnedAlignedBuffer {
         // Check if this is the last instance of the buffer
         if Arc::get_mut(&mut self.buffer).is_some() {

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -348,6 +348,8 @@ pub mod __private;
 /// updated value from. This is helpful in case increase of the value size beyond allocated capacity
 /// is needed.
 ///
+/// Slot changes done by the method call will not be persisted if it returns an error.
+///
 /// ### `#[input] input: &InputValue`
 ///
 /// `#[input] input: &InputValue` is a read-only input to the contract call and generates two

--- a/crates/contracts/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros/src/lib.rs
@@ -385,6 +385,8 @@ pub mod __private;
 /// host will not follow it to the new address, the output size is fully constrained by capacity
 /// specified in `output_capacity`.
 ///
+/// NOTE: Even in case the method call fails, the host may modify the contents of the output.
+///
 /// ### `#[result] result: &mut MaybeData<ResultValue>` and `-> Result<ResultValue, ContractError>`
 ///
 /// `#[result] result: &mut MaybeData<ResultValue>` and regular return type (only one of those can


### PR DESCRIPTION
Slot changes must not be persisted if call fails.

Also potential changes of `#[output]` and `#[result]` are documented. explicitly.