### PR TITLE
Transaction interface and simple wallet implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "ab-contracts-common",
  "ab-system-contract-address-allocator",
  "ab-system-contract-code",
+ "ab-system-contract-simple-wallet-base",
  "ab-system-contract-state",
  "aliasable",
  "halfbrown",
@@ -129,6 +130,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-system-contract-simple-wallet-base"
+version = "0.0.1"
+dependencies = [
+ "ab-contracts-common",
+ "ab-contracts-io-type",
+ "ab-contracts-macros",
+ "ab-contracts-standards",
+ "ab-system-contract-state",
+ "blake3",
+ "schnorrkel",
+ "thiserror",
+ "tinyvec",
+]
+
+[[package]]
 name = "ab-system-contract-state"
 version = "0.0.1"
 dependencies = [
@@ -150,6 +166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +188,43 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
+name = "blake3"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -200,6 +259,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,16 +332,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom_or_panic"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "halfbrown"
@@ -261,6 +407,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +442,18 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core",
+ "zeroize",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -358,6 +525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,10 +546,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "schnorrkel"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de18f6d8ba0aad7045f5feae07ec29899c1112584a38509a84ad7b04451eaa0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "curve25519-dalek",
+ "getrandom_or_panic",
+ "merlin",
+ "rand_core",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -388,10 +604,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -433,6 +661,12 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 
 [[package]]
 name = "tracing"
@@ -492,6 +726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +748,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "winapi"
@@ -594,3 +840,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-contract-example-wallet"
+version = "0.0.1"
+dependencies = [
+ "ab-contracts-common",
+ "ab-contracts-io-type",
+ "ab-contracts-macros",
+ "ab-contracts-standards",
+ "ab-system-contract-simple-wallet-base",
+ "ab-system-contract-state",
+]
+
+[[package]]
 name = "ab-contract-playground"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ name = "ab-contracts-standards"
 version = "0.0.1"
 dependencies = [
  "ab-contracts-common",
+ "ab-contracts-io-type",
  "ab-contracts-macros",
 ]
 

--- a/crates/contracts/ab-contract-example-wallet/Cargo.toml
+++ b/crates/contracts/ab-contract-example-wallet/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ab-contract-example-wallet"
+description = ""
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
+ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
+ab-contracts-standards = { version = "0.0.1", path = "../ab-contracts-standards" }
+ab-system-contract-simple-wallet-base = { version = "0.0.1", path = "../ab-system-contract-simple-wallet-base" }
+ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state" }
+
+[features]
+guest = [
+    "ab-contracts-common/guest",
+    "ab-contracts-macros/guest",
+    "ab-contracts-standards/guest",
+]

--- a/crates/contracts/ab-contract-example-wallet/src/lib.rs
+++ b/crates/contracts/ab-contract-example-wallet/src/lib.rs
@@ -1,0 +1,131 @@
+#![no_std]
+
+use ab_contracts_common::env::{Env, MethodContext, TransactionHeader};
+use ab_contracts_common::{Address, ContractError};
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_macros::contract;
+use ab_contracts_standards::tx_handler::{TxHandler, TxHandlerPayload, TxHandlerSeal};
+use ab_system_contract_simple_wallet_base::SimpleWalletBaseExt;
+use ab_system_contract_state::{StateExt, with_state_buffer};
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct ExampleWallet;
+
+#[contract]
+impl TxHandler for ExampleWallet {
+    #[view]
+    fn authorize(
+        #[env] env: &Env,
+        #[input] header: &TransactionHeader,
+        #[input] payload: &TxHandlerPayload,
+        #[input] seal: &TxHandlerSeal,
+    ) -> Result<(), ContractError> {
+        env.simple_wallet_base_authorize(
+            Address::SYSTEM_SIMPLE_WALLET_BASE,
+            &env.own_address(),
+            header,
+            payload,
+            seal,
+        )
+    }
+
+    #[update]
+    fn execute(
+        #[env] env: &mut Env,
+        #[input] header: &TransactionHeader,
+        #[input] payload: &TxHandlerPayload,
+        #[input] seal: &TxHandlerSeal,
+    ) -> Result<(), ContractError> {
+        // Only execution environment is allowed to make this call
+        if env.caller() != Address::NULL {
+            return Err(ContractError::Forbidden);
+        }
+
+        env.simple_wallet_base_execute(
+            MethodContext::Replace,
+            Address::SYSTEM_SIMPLE_WALLET_BASE,
+            header,
+            payload,
+            seal,
+        )?;
+
+        // Manual state management due to the possibility that one of the calls during execution
+        // above may update the state.
+        with_state_buffer(|state| {
+            // Fill `state` with updated state containing increased nonce
+            env.simple_wallet_base_increase_nonce(
+                Address::SYSTEM_SIMPLE_WALLET_BASE,
+                &env.own_address(),
+                seal,
+                state,
+            )?;
+            // Write new state of the contract, this can only be done by the direct owner
+            env.state_write(
+                MethodContext::Reset,
+                Address::SYSTEM_STATE,
+                &env.own_address(),
+                state,
+            )
+        })
+    }
+}
+
+/// TODO: Support upgrading wallet to a different implementation
+#[contract]
+impl ExampleWallet {
+    /// Initialize a wallet with specified public key
+    #[update]
+    pub fn initialize(
+        #[env] env: &mut Env,
+        #[input] public_key: &[u8; 32],
+    ) -> Result<(), ContractError> {
+        with_state_buffer(|state| {
+            // Fill `state` with initialized wallet state
+            env.simple_wallet_base_initialize(
+                Address::SYSTEM_SIMPLE_WALLET_BASE,
+                public_key,
+                state,
+            )?;
+            // Initialize state of the contract, this can only be done by the direct owner
+            env.state_initialize(
+                MethodContext::Reset,
+                Address::SYSTEM_STATE,
+                &env.own_address(),
+                state,
+            )
+        })
+    }
+
+    /// Change public key to a different one
+    #[update]
+    pub fn change_public_key(
+        #[env] env: &mut Env,
+        #[input] public_key: &[u8; 32],
+    ) -> Result<(), ContractError> {
+        // Only the system simple wallet base contract under the context of this contract is allowed
+        // to change public key
+        if !(env.context() == env.own_address()
+            && env.caller() == Address::SYSTEM_SIMPLE_WALLET_BASE)
+        {
+            return Err(ContractError::Forbidden);
+        }
+
+        with_state_buffer(|state| {
+            // Fill `state` with updated state containing changed public key
+            env.simple_wallet_base_change_public_key(
+                Address::SYSTEM_SIMPLE_WALLET_BASE,
+                &env.own_address(),
+                public_key,
+                state,
+            )?;
+            // Write new state of the contract, this can only be done by the direct owner
+            env.state_write(
+                MethodContext::Reset,
+                Address::SYSTEM_STATE,
+                &env.own_address(),
+                state,
+            )
+        })
+    }
+}

--- a/crates/contracts/ab-contracts-common/Cargo.toml
+++ b/crates/contracts/ab-contracts-common/Cargo.toml
@@ -23,5 +23,7 @@ thiserror = "2.0.11"
 
 [features]
 guest = []
+# APIs that require `alloc` crate
 alloc = []
+# APIs needed for native executor
 executor = ["alloc"]

--- a/crates/contracts/ab-contracts-common/src/address.rs
+++ b/crates/contracts/ab-contracts-common/src/address.rs
@@ -91,6 +91,8 @@ impl Address {
     pub const SYSTEM_CODE: Self = Self::from_u128(1);
     /// System contract for managing state of other contracts
     pub const SYSTEM_STATE: Self = Self::from_u128(2);
+    /// System simple wallet base contract that can be used by end user wallets
+    pub const SYSTEM_SIMPLE_WALLET_BASE: Self = Self::from_u128(3);
 
     /// Turn value into `u128`
     #[inline]

--- a/crates/contracts/ab-contracts-common/src/address.rs
+++ b/crates/contracts/ab-contracts-common/src/address.rs
@@ -21,7 +21,7 @@ const _: () = {
     let (type_details, _metadata) = IoTypeMetadataKind::type_details(Address::METADATA)
         .expect("Statically correct metadata; qed");
     assert!(size_of::<Address>() == type_details.recommended_capacity as usize);
-    assert!(align_of::<Address>() == type_details.alignment as usize);
+    assert!(align_of::<Address>() == type_details.alignment.get() as usize);
 };
 
 impl fmt::Debug for Address {

--- a/crates/contracts/ab-contracts-common/src/balance.rs
+++ b/crates/contracts/ab-contracts-common/src/balance.rs
@@ -21,7 +21,7 @@ const _: () = {
     let (type_details, _metadata) = IoTypeMetadataKind::type_details(Balance::METADATA)
         .expect("Statically correct metadata; qed");
     assert!(size_of::<Balance>() == type_details.recommended_capacity as usize);
-    assert!(align_of::<Balance>() == type_details.alignment as usize);
+    assert!(align_of::<Balance>() == type_details.alignment.get() as usize);
 };
 
 impl fmt::Debug for Balance {

--- a/crates/contracts/ab-contracts-common/src/method.rs
+++ b/crates/contracts/ab-contracts-common/src/method.rs
@@ -1,4 +1,6 @@
+use crate::env::Blake3Hash;
 use crate::metadata::ContractMetadataKind;
+use ab_contracts_io_type::trivial_type::TrivialType;
 use const_sha1::sha1;
 use core::fmt;
 
@@ -7,9 +9,9 @@ use core::fmt;
 /// While nothing can be said about method implementation, matching method fingerprint means method
 /// name, inputs and outputs are what they are expected to be (struct and field names are ignored as
 /// explained in [`ContractMetadataKind::compact`].
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, TrivialType)]
 #[repr(C)]
-pub struct MethodFingerprint([u8; 32]);
+pub struct MethodFingerprint(Blake3Hash);
 
 impl fmt::Display for MethodFingerprint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -21,7 +23,7 @@ impl fmt::Display for MethodFingerprint {
 }
 
 impl MethodFingerprint {
-    /// Create new method fingerprint from its metadata.
+    /// Create a new method fingerprint from its metadata.
     ///
     /// `None` is returned for invalid metadata (see [`ContractMetadataKind::compact`] for details).
     pub const fn new(method_metadata: &[u8]) -> Option<Self> {
@@ -45,7 +47,7 @@ impl MethodFingerprint {
     }
 
     #[inline]
-    pub const fn to_bytes(&self) -> &[u8; 32] {
+    pub const fn to_bytes(&self) -> &Blake3Hash {
         &self.0
     }
 }

--- a/crates/contracts/ab-contracts-common/src/method.rs
+++ b/crates/contracts/ab-contracts-common/src/method.rs
@@ -61,4 +61,6 @@ impl MethodFingerprint {
 pub unsafe trait ExternalArgs {
     /// Fingerprint of the method being called
     const FINGERPRINT: MethodFingerprint;
+    /// Metadata that corresponds to a method being called
+    const METADATA: &[u8];
 }

--- a/crates/contracts/ab-contracts-executor/Cargo.toml
+++ b/crates/contracts/ab-contracts-executor/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common", features = ["executor"] }
 ab-system-contract-address-allocator = { version = "0.0.1", path = "../ab-system-contract-address-allocator" }
 ab-system-contract-code = { version = "0.0.1", path = "../ab-system-contract-code" }
+ab-system-contract-simple-wallet-base = { version = "0.0.1", path = "../ab-system-contract-simple-wallet-base" }
 ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state" }
 aliasable = "0.1.3"
 halfbrown = { version = "0.3.0", features = ["arraybackend", "fxhash"] }
@@ -24,5 +25,3 @@ parking_lot = { version = "0.12.3", features = ["arc_lock"] }
 smallvec = "1.14.0"
 thiserror = "2.0.11"
 tracing = "0.1.41"
-
-[features]

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(non_null_from_ref)]
+#![feature(maybe_uninit_slice, non_null_from_ref)]
 #![no_std]
 
 pub mod maybe_data;

--- a/crates/contracts/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/ab-contracts-io-type/src/lib.rs
@@ -11,6 +11,10 @@ use crate::trivial_type::TrivialType;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
+/// The maximum alignment supported by [`IoType`] types (16 bytes, corresponds to alignment of
+/// `u128`)
+pub const MAX_ALIGNMENT: u8 = 16;
+
 const _: () = {
     assert!(
         size_of::<usize>() >= size_of::<u32>(),
@@ -23,6 +27,12 @@ const _: () = {
     assert!(
         u16::from_ne_bytes(1u16.to_le_bytes()) == 1u16,
         "Only little-endian platform supported"
+    );
+
+    // Max alignment is expected to match that of `u128`
+    assert!(
+        align_of::<u128>() == MAX_ALIGNMENT as usize,
+        "Max alignment mismatch"
     );
 
     // Only support targets with expected alignment and refuse to compile on other targets
@@ -160,7 +170,7 @@ pub unsafe trait IoType {
     /// Create a mutable reference to a type, which is represented by provided memory.
     ///
     /// Memory must be correctly aligned and sufficient in size or else `None` will be returned, but
-    /// padding beyond the size of the type is allowed. Memory behind pointer must not be read or
+    /// padding beyond the size of the type is allowed. Memory behind a pointer must not be read or
     /// written to in the meantime either.
     ///
     /// `size` indicates how many bytes are used within larger allocation for types that can

--- a/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
+++ b/crates/contracts/ab-contracts-io-type/src/maybe_data.rs
@@ -205,7 +205,7 @@ where
     pub fn from_uninit<'a>(
         uninit: &'a mut MaybeUninit<Data>,
         size: &'a mut u32,
-    ) -> impl Deref<Target = Self> + 'a {
+    ) -> impl DerefMut<Target = Self> + 'a {
         debug_assert_eq!(*size, 0, "Invalid size");
 
         DerefWrapper(Self {

--- a/crates/contracts/ab-contracts-io-type/src/metadata.rs
+++ b/crates/contracts/ab-contracts-io-type/src/metadata.rs
@@ -7,6 +7,7 @@ mod type_name;
 use crate::metadata::compact::compact_metadata;
 use crate::metadata::type_details::decode_type_details;
 use crate::metadata::type_name::type_name;
+use core::num::NonZeroU8;
 use core::ptr;
 
 /// Max capacity for metadata bytes used in fixed size buffers
@@ -52,14 +53,14 @@ pub struct IoTypeDetails {
     /// must allocate the recommended capacity for guest anyway.
     pub recommended_capacity: u32,
     /// Alignment of the type
-    pub alignment: u8,
+    pub alignment: NonZeroU8,
 }
 
 impl IoTypeDetails {
     const fn bytes(recommended_capacity: u32) -> Self {
         Self {
             recommended_capacity,
-            alignment: 1,
+            alignment: NonZeroU8::new(1).expect("Not zero; qed"),
         }
     }
 }

--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -199,7 +199,7 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         // debug_assert_eq!(buffer.len(), *size as usize, "Invalid size");
 
         DerefWrapper(Self {
-            bytes: NonNull::from_ref(buffer).cast::<<Self as IoType>::PointerType>(),
+            bytes: NonNull::new(buffer.as_ptr().cast_mut()).expect("Not null; qed"),
             size: NonNull::from_ref(size),
             capacity: *size,
         })
@@ -220,7 +220,7 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         debug_assert_eq!(buffer.len(), *size as usize, "Invalid size");
 
         DerefWrapper(Self {
-            bytes: NonNull::from_mut(buffer).cast::<<Self as IoType>::PointerType>(),
+            bytes: NonNull::new(buffer.as_mut_ptr()).expect("Not null; qed"),
             size: NonNull::from_mut(size),
             capacity: *size,
         })
@@ -237,7 +237,7 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
     //  `CAPACITY as usize`
     #[track_caller]
     pub fn from_uninit<'a, const CAPACITY: usize>(
-        uninit: &'a mut MaybeUninit<[<Self as IoType>::PointerType; CAPACITY]>,
+        uninit: &'a mut [MaybeUninit<<Self as IoType>::PointerType>; CAPACITY],
         size: &'a mut u32,
     ) -> impl Deref<Target = Self> + 'a {
         debug_assert!(
@@ -247,7 +247,7 @@ impl<const RECOMMENDED_ALLOCATION: u32> VariableBytes<RECOMMENDED_ALLOCATION> {
         let capacity = CAPACITY as u32;
 
         DerefWrapper(Self {
-            bytes: NonNull::from_mut(uninit).cast::<<Self as IoType>::PointerType>(),
+            bytes: NonNull::new(MaybeUninit::slice_as_mut_ptr(uninit)).expect("Not null; qed"),
             size: NonNull::from_mut(size),
             capacity,
         })

--- a/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
@@ -206,7 +206,7 @@ where
         // debug_assert_eq!(buffer.len(), *size as usize, "Invalid size");
 
         DerefWrapper(Self {
-            elements: NonNull::from_ref(buffer).cast::<<Self as IoType>::PointerType>(),
+            elements: NonNull::new(buffer.as_ptr().cast_mut()).expect("Not null; qed"),
             size: NonNull::from_ref(size),
             capacity: *size,
         })
@@ -231,7 +231,7 @@ where
         );
 
         DerefWrapper(Self {
-            elements: NonNull::from_mut(buffer).cast::<<Self as IoType>::PointerType>(),
+            elements: NonNull::new(buffer.as_mut_ptr()).expect("Not null; qed"),
             size: NonNull::from_mut(size),
             capacity: *size,
         })
@@ -250,7 +250,7 @@ where
     //  `CAPACITY as usize`
     #[track_caller]
     pub fn from_uninit<'a, const CAPACITY: usize>(
-        uninit: &'a mut MaybeUninit<[<Self as IoType>::PointerType; CAPACITY]>,
+        uninit: &'a mut [MaybeUninit<<Self as IoType>::PointerType>; CAPACITY],
         size: &'a mut u32,
     ) -> impl Deref<Target = Self> + 'a {
         debug_assert!(
@@ -266,7 +266,7 @@ where
         let capacity = CAPACITY as u32;
 
         DerefWrapper(Self {
-            elements: NonNull::from_mut(uninit).cast::<<Self as IoType>::PointerType>(),
+            elements: NonNull::new(MaybeUninit::slice_as_mut_ptr(uninit)).expect("Not null; qed"),
             size: NonNull::from_mut(size),
             capacity,
         })

--- a/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
@@ -252,7 +252,7 @@ where
     pub fn from_uninit<'a, const CAPACITY: usize>(
         uninit: &'a mut [MaybeUninit<<Self as IoType>::PointerType>; CAPACITY],
         size: &'a mut u32,
-    ) -> impl Deref<Target = Self> + 'a {
+    ) -> impl DerefMut<Target = Self> + 'a {
         debug_assert!(
             *size as usize <= CAPACITY,
             "Size {size} must not exceed capacity {CAPACITY}"

--- a/crates/contracts/ab-contracts-macros-impl/src/contract.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract.rs
@@ -217,7 +217,7 @@ fn process_trait_impl(mut item_impl: ItemImpl, trait_name: &Ident) -> Result<Tok
         #[used]
         #[unsafe(no_mangle)]
         #[unsafe(link_section = "CONTRACT_METADATA")]
-        static #static_name: [u8; <dyn #trait_name as ::ab_contracts_macros::__private::ContractTraitDefinition>::METADATA.len()] = unsafe {
+        static #static_name: [::core::primitive::u8; <dyn #trait_name as ::ab_contracts_macros::__private::ContractTraitDefinition>::METADATA.len()] = unsafe {
             *<dyn #trait_name as ::ab_contracts_macros::__private::ContractTraitDefinition>::METADATA.as_ptr().cast()
         };
 
@@ -304,7 +304,7 @@ fn generate_trait_metadata(
         /// [`ContractMetadataKind`]: ::ab_contracts_macros::__private::ContractMetadataKind
         const METADATA: &[::core::primitive::u8] = {
             const fn metadata()
-                -> ([u8; ::ab_contracts_macros::__private::MAX_METADATA_CAPACITY], usize)
+                -> ([::core::primitive::u8; ::ab_contracts_macros::__private::MAX_METADATA_CAPACITY], usize)
             {
                 ::ab_contracts_macros::__private::concat_metadata_sources(&[
                     &[::ab_contracts_macros::__private::ContractMetadataKind::Trait as ::core::primitive::u8],
@@ -399,7 +399,7 @@ fn process_struct_impl(mut item_impl: ItemImpl) -> Result<TokenStream, Error> {
         quote! {
             const MAIN_CONTRACT_METADATA: &[::core::primitive::u8] = {
                 const fn metadata()
-                    -> ([u8; ::ab_contracts_macros::__private::MAX_METADATA_CAPACITY], usize)
+                    -> ([::core::primitive::u8; ::ab_contracts_macros::__private::MAX_METADATA_CAPACITY], usize)
                 {
                     ::ab_contracts_macros::__private::concat_metadata_sources(&[
                         &[::ab_contracts_macros::__private::ContractMetadataKind::Contract as ::core::primitive::u8],
@@ -459,7 +459,7 @@ fn process_struct_impl(mut item_impl: ItemImpl) -> Result<TokenStream, Error> {
         #[unsafe(no_mangle)]
         #[unsafe(link_section = "CONTRACT_METADATA")]
         static MAIN_CONTRACT_METADATA: [
-            u8;
+            ::core::primitive::u8;
             <#struct_name as ::ab_contracts_macros::__private::Contract>::MAIN_CONTRACT_METADATA
                 .len()
         ] = unsafe {

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
@@ -1468,6 +1468,7 @@ impl MethodDetails {
                 const FINGERPRINT: ::ab_contracts_macros::__private::MethodFingerprint =
                     ::ab_contracts_macros::__private::MethodFingerprint::new(METADATA)
                         .expect("Metadata is statically correct; qed");
+                const METADATA: &[::core::primitive::u8] = METADATA;
             }
 
             impl #args_struct_name {
@@ -1634,7 +1635,7 @@ impl MethodDetails {
         let method_name_metadata = derive_ident_metadata(&ffi_fn_name)?;
         Ok(quote_spanned! {fn_sig.span() =>
             const fn metadata()
-                -> ([u8; ::ab_contracts_macros::__private::MAX_METADATA_CAPACITY], usize)
+                -> ([::core::primitive::u8; ::ab_contracts_macros::__private::MAX_METADATA_CAPACITY], usize)
             {
                 ::ab_contracts_macros::__private::concat_metadata_sources(&[
                     &[::ab_contracts_macros::__private::ContractMetadataKind::#method_type as ::core::primitive::u8],

--- a/crates/contracts/ab-contracts-standards/Cargo.toml
+++ b/crates/contracts/ab-contracts-standards/Cargo.toml
@@ -15,6 +15,7 @@ all-features = true
 
 [dependencies]
 ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
 ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
 
 [features]

--- a/crates/contracts/ab-contracts-standards/src/lib.rs
+++ b/crates/contracts/ab-contracts-standards/src/lib.rs
@@ -1,3 +1,4 @@
 #![no_std]
 
 pub mod fungible;
+pub mod tx_handler;

--- a/crates/contracts/ab-contracts-standards/src/tx_handler.rs
+++ b/crates/contracts/ab-contracts-standards/src/tx_handler.rs
@@ -4,6 +4,9 @@ use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_io_type::variable_elements::VariableElements;
 use ab_contracts_macros::contract;
 
+pub type TxHandlerPayload = VariableElements<0, u128>;
+pub type TxHandlerSeal = VariableBytes<0>;
+
 /// A transaction handler interface prototype
 #[contract]
 pub trait TxHandler {
@@ -35,8 +38,8 @@ pub trait TxHandler {
     fn authorize(
         #[env] env: &Env,
         #[input] header: &TransactionHeader,
-        #[input] payload: &VariableElements<0, u128>,
-        #[input] seal: &VariableBytes<0>,
+        #[input] payload: &TxHandlerPayload,
+        #[input] seal: &TxHandlerSeal,
     ) -> Result<(), ContractError>;
 
     /// Execute previously verified transaction.
@@ -54,7 +57,7 @@ pub trait TxHandler {
     fn execute(
         #[env] env: &mut Env,
         #[input] header: &TransactionHeader,
-        #[input] payload: &VariableElements<0, u128>,
-        #[input] seal: &VariableBytes<0>,
+        #[input] payload: &TxHandlerPayload,
+        #[input] seal: &TxHandlerSeal,
     ) -> Result<(), ContractError>;
 }

--- a/crates/contracts/ab-contracts-standards/src/tx_handler.rs
+++ b/crates/contracts/ab-contracts-standards/src/tx_handler.rs
@@ -1,0 +1,60 @@
+use ab_contracts_common::ContractError;
+use ab_contracts_common::env::{Env, TransactionHeader};
+use ab_contracts_io_type::variable_bytes::VariableBytes;
+use ab_contracts_io_type::variable_elements::VariableElements;
+use ab_contracts_macros::contract;
+
+/// A transaction handler interface prototype
+#[contract]
+pub trait TxHandler {
+    /// Verify a transaction.
+    ///
+    /// Each transaction consists of a header, payload and a seal.
+    ///
+    /// Payload contains 16-byte aligned bytes, which typically represent method calls to be
+    /// executed, but the serialization format for it is contract-specific.
+    ///
+    /// Seal typically contains nonce and a signature over transaction header and payload, used for
+    /// checking whether to allow execution of methods in the payload argument.
+    ///
+    /// In the end, it is up to the contract implementing this trait to interpret both payload and
+    /// seal in any way desired.
+    ///
+    /// This method is called by execution environment is used for transaction authorization. It is
+    /// expected to do a limited amount of work before deciding whether execution is allowed or not.
+    /// Once authorization is granted (by returning a non-error result), execution environment will
+    /// deduct gas from the contract's balance and call [`TxHandler::execute()`] for actual
+    /// transaction execution.
+    ///
+    /// It is up to the host environment to decide how much work is allowed here when verifying
+    /// transaction in the transaction pool as for DoS protection. As a result, requiring too much
+    /// work may prevent transaction from being included in the block at all (unless user authors
+    /// the block and include the transaction themselves). Once a transaction is in the block, there
+    /// are no limits to the amount of work here except the ability to pay for gas.
+    #[view]
+    fn authorize(
+        #[env] env: &Env,
+        #[input] header: &TransactionHeader,
+        #[input] payload: &VariableElements<0, u128>,
+        #[input] seal: &VariableBytes<0>,
+    ) -> Result<(), ContractError>;
+
+    /// Execute previously verified transaction.
+    ///
+    /// *Execution environment will call this method with `env.caller()` set to `Address::NULL`,
+    /// which is very important to check!* Since there is no code deployed at `Address::NULL`, only
+    /// (trusted) execution environment is able to make such a call.
+    ///
+    /// Getting to this stage means that verification succeeded and except charging for gas, no
+    /// other state changes were made since then. If necessary, it is still possible to do
+    /// additional checks that would be too expensive or not possible to do in
+    /// [`TxHandler::authorize()`]. It is also important to implement a transaction replay
+    /// protection mechanism such as nonce increase or similar.
+    #[update]
+    fn execute(
+        #[env] env: &mut Env,
+        #[input] header: &TransactionHeader,
+        #[input] payload: &VariableElements<0, u128>,
+        #[input] seal: &VariableBytes<0>,
+    ) -> Result<(), ContractError>;
+}

--- a/crates/contracts/ab-contracts-trivial-type-derive/src/lib.rs
+++ b/crates/contracts/ab-contracts-trivial-type-derive/src/lib.rs
@@ -96,7 +96,7 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
                         )
                             .expect("Statically correct metadata; qed");
                     assert!(size_of::<#type_name>() == type_details.recommended_capacity as ::core::primitive::usize);
-                    assert!(align_of::<#type_name>() == type_details.alignment as ::core::primitive::usize);
+                    assert!(align_of::<#type_name>() == type_details.alignment.get() as ::core::primitive::usize);
                 };
 
                 #[automatically_derived]
@@ -168,7 +168,7 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
                         )
                             .expect("Statically correct metadata; qed");
                     assert!(size_of::<#type_name>() == type_details.recommended_capacity as ::core::primitive::usize);
-                    assert!(align_of::<#type_name>() == type_details.alignment as ::core::primitive::usize);
+                    assert!(align_of::<#type_name>() == type_details.alignment.get() as ::core::primitive::usize);
 
                     #( #padding_assertions )*;
                 };

--- a/crates/contracts/ab-system-contract-simple-wallet-base/Cargo.toml
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "ab-system-contract-simple-wallet-base"
+description = ""
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
+ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
+ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
+ab-contracts-standards = { version = "0.0.1", path = "../ab-contracts-standards" }
+ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state" }
+blake3 = { version = "1.6.0", default-features = false }
+schnorrkel = { version = "0.11.4", default-features = false }
+thiserror = { version = "2.0.11", default-features = false }
+tinyvec = { version = "1.8.1", default-features = false }
+
+[features]
+guest = [
+    "ab-contracts-common/guest",
+    "ab-contracts-macros/guest",
+    "ab-contracts-standards/guest",
+]
+# APIs that require `alloc` crate
+alloc = []
+# Enables payload builder API
+payload-builder = [
+    "alloc",
+]

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -1,0 +1,261 @@
+//! A simple wallet contract base contract to be used by other contracts
+//!
+//! It includes the core logic, making contracts using it much more compact. The implementation is
+//! based on [`schnorrkel`] crate and its SR25519 signature scheme.
+//!
+//! It abstracts away its inner types in the public API to allow it to evolve over time.
+//!
+//! The general workflow is:
+//! * [`SimpleWalletBase::initialize`] is used for wallet initialization
+//! * [`SimpleWalletBase::authorize`] is used for authorization
+//! * [`SimpleWalletBase::execute`] is used for executing method calls contained in the payload,
+//!   followed by [`SimpleWalletBase::increase_nonce`]
+//! * [`SimpleWalletBase::change_public_key`] is used for change public key to a different one
+
+#![feature(non_null_from_ref, try_blocks)]
+#![no_std]
+
+pub mod payload;
+
+use crate::payload::{TransactionMethodContext, TransactionPayloadDecoder};
+use ab_contracts_common::env::{Env, MethodContext, TransactionHeader};
+use ab_contracts_common::{Address, ContractError};
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_io_type::variable_bytes::VariableBytes;
+use ab_contracts_macros::contract;
+use ab_contracts_standards::tx_handler::{TxHandlerPayload, TxHandlerSeal};
+use ab_system_contract_state::{RECOMMENDED_STATE_CAPACITY, StateExt};
+use core::mem::MaybeUninit;
+use core::{ptr, slice};
+use schnorrkel::context::SigningContext;
+
+/// Context for transaction signatures, see [`SigningContext`].
+///
+/// This constant is helpful for frontend/hardware wallet implementations.
+pub const SIGNING_CONTEXT: &[u8] = b"system-simple-wallet";
+/// Size of the buffer in pointers that is used for `ExternalArgs` pointers.
+///
+/// This constant is helpful for transaction generation to check whether a created transaction
+/// doesn't exceed this limit.
+///
+/// `#[slot]` argument using one pointer, `#[input]` two pointers and `#[output]`/`#[result]` three
+/// pointers each.
+pub const EXTERNAL_ARGS_BUFFER_SIZE: usize = 32 * 1024;
+/// Size of the buffer in bytes that is used as a stack for storing outputs.
+///
+/// This constant is helpful for transaction generation to check whether a created transaction
+/// doesn't exceed this limit.
+///
+/// This defines how big the total sum of `#[output]` and `#[result]` could be in all methods of the
+/// payload together.
+///
+/// Overflow will result in an error.
+pub const OUTPUT_BUFFER_SIZE: usize = 32 * 1024;
+/// Size of the buffer in entries that is used to store buffer offsets.
+///
+/// This constant is helpful for transaction generation to check whether a created transaction
+/// doesn't exceed this limit.
+///
+/// This defines how many `#[output]` and `#[result]` arguments could exist in all methods of the
+/// payload together.
+///
+/// Overflow will result in an error.
+pub const OUTPUT_BUFFER_OFFSETS_SIZE: usize = 16;
+
+/// Transaction seal.
+///
+/// Contains signature and nonce, this is necessary to produce a correctly sealed transaction.
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct Seal {
+    pub signature: [u8; 64],
+    pub nonce: u64,
+}
+
+/// State of the wallet.
+///
+/// Shouldn't be necessary to use directly.
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct WalletState {
+    pub public_key: [u8; 32],
+    pub nonce: u64,
+}
+
+/// A simple wallet contract base contract to be used by other contracts.
+///
+/// See the module description for details.
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct SimpleWalletBase;
+
+#[contract]
+impl SimpleWalletBase {
+    /// Returns initial state with a provided public key
+    #[view]
+    pub fn initialize(
+        #[input] &public_key: &[u8; 32],
+        #[output] state: &mut VariableBytes<RECOMMENDED_STATE_CAPACITY>,
+    ) -> Result<(), ContractError> {
+        // TODO: Storing some lower-level representation of the public key might reduce the cost of
+        //  verification in `Self::authorize()` method
+        // Ensure public key is valid
+        schnorrkel::PublicKey::from_bytes(&public_key).map_err(|_error| ContractError::BadInput)?;
+
+        if !state.copy_from(&WalletState {
+            public_key,
+            nonce: 0,
+        }) {
+            return Err(ContractError::BadInput);
+        }
+
+        Ok(())
+    }
+
+    /// Reads state of `owner` and returns `Ok(())` if authorization succeeds
+    #[view]
+    pub fn authorize(
+        #[env] env: &Env,
+        #[input] owner: &Address,
+        #[input] header: &TransactionHeader,
+        #[input] payload: &TxHandlerPayload,
+        #[input] seal: &TxHandlerSeal,
+    ) -> Result<(), ContractError> {
+        let state = Self::read_state(env, owner)?;
+        // SAFETY: Any set of bytes is valid and will be verified
+        let maybe_seal = unsafe { Seal::from_bytes(seal.get_initialized()) };
+        let Some(seal) = maybe_seal else {
+            return Err(ContractError::BadInput);
+        };
+
+        let tx_hash = {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(header.as_bytes());
+            let payload = payload.get_initialized();
+            // SAFETY: Valid memory of correct size
+            let payload_bytes = unsafe {
+                slice::from_raw_parts(payload.as_ptr().cast::<u8>(), size_of_val(payload))
+            };
+            hasher.update(payload_bytes);
+            hasher.update(&seal.nonce.to_le_bytes());
+            hasher.finalize()
+        };
+
+        if Some(seal.nonce) == state.nonce.checked_add(1) {
+            return Err(ContractError::BadInput);
+        }
+
+        let public_key = schnorrkel::PublicKey::from_bytes(state.public_key.as_ref())
+            .expect("Guaranteed by constructor; qed");
+        let signature = schnorrkel::Signature::from_bytes(&seal.signature)
+            .map_err(|_error| ContractError::BadInput)?;
+        let signing_context = SigningContext::new(SIGNING_CONTEXT);
+        public_key
+            .verify(signing_context.bytes(tx_hash.as_bytes()), &signature)
+            .map_err(|_error| ContractError::Forbidden)
+    }
+
+    /// Executes provided transactions in the payload, *remember to also [`Self::increase_nonce()`]
+    /// afterward* unless there is a very good reason not to (like when wallet was replaced with
+    /// another implementation containing a different state).
+    ///
+    /// Caller must set themselves as a context or else error will be returned.
+    #[update]
+    pub fn execute(
+        #[env] env: &mut Env,
+        #[input] _header: &TransactionHeader,
+        #[input] payload: &TxHandlerPayload,
+        #[input] _seal: &TxHandlerSeal,
+    ) -> Result<(), ContractError> {
+        // Only allow direct calls by context owner
+        if env.caller() != env.context() {
+            return Err(ContractError::Forbidden);
+        }
+
+        let mut external_args_buffer = [ptr::null_mut(); EXTERNAL_ARGS_BUFFER_SIZE];
+        let mut output_buffer = [MaybeUninit::uninit(); OUTPUT_BUFFER_SIZE];
+        let mut output_buffer_offsets = [(0, 0); OUTPUT_BUFFER_OFFSETS_SIZE];
+
+        let mut payload_decoder = TransactionPayloadDecoder::new(
+            payload.get_initialized(),
+            &mut external_args_buffer,
+            &mut output_buffer,
+            &mut output_buffer_offsets,
+            |method_context| match method_context {
+                TransactionMethodContext::Null => MethodContext::Reset,
+                TransactionMethodContext::Wallet => MethodContext::Keep,
+            },
+        );
+
+        while let Some(prepared_method) = payload_decoder
+            .decode_next_method()
+            .map_err(|_error| ContractError::BadInput)?
+        {
+            env.call_many([prepared_method])?;
+        }
+
+        Ok(())
+    }
+
+    /// Returns state with increased nonce
+    #[view]
+    pub fn increase_nonce(
+        #[env] env: &Env,
+        #[input] owner: &Address,
+        #[input] _seal: &TxHandlerSeal,
+        #[output] new_state: &mut VariableBytes<RECOMMENDED_STATE_CAPACITY>,
+    ) -> Result<(), ContractError> {
+        let mut state = Self::read_state(env, owner)?;
+
+        state.nonce = state.nonce.checked_add(1).ok_or(ContractError::Forbidden)?;
+
+        if !new_state.copy_from(&state) {
+            return Err(ContractError::BadInput);
+        }
+
+        Ok(())
+    }
+
+    /// Returns state with a changed public key
+    #[view]
+    pub fn change_public_key(
+        #[env] env: &Env,
+        #[input] owner: &Address,
+        #[input] &public_key: &[u8; 32],
+        #[output] new_state: &mut VariableBytes<RECOMMENDED_STATE_CAPACITY>,
+    ) -> Result<(), ContractError> {
+        let mut state = Self::read_state(env, owner)?;
+        // Ensure public key is valid
+        schnorrkel::PublicKey::from_bytes(&public_key).map_err(|_error| ContractError::BadInput)?;
+
+        state.public_key = public_key;
+
+        if !new_state.copy_from(&state) {
+            return Err(ContractError::BadInput);
+        }
+
+        Ok(())
+    }
+
+    /// Read state of the owner
+    fn read_state(env: &Env, owner: &Address) -> Result<WalletState, ContractError> {
+        let mut state = WalletState {
+            public_key: [0; 32],
+            nonce: 0,
+        };
+
+        let mut size = 0;
+        // SAFETY: All bytes are valid for `WalletState`, size doesn't matter since it
+        let mut bytes = VariableBytes::from_buffer_mut(unsafe { state.as_bytes_mut() }, &mut size);
+
+        env.state_read(Address::SYSTEM_STATE, owner, &mut bytes)?;
+
+        drop(bytes);
+
+        if size != WalletState::SIZE {
+            return Err(ContractError::InternalError);
+        }
+
+        Ok(state)
+    }
+}

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/payload.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/payload.rs
@@ -1,0 +1,419 @@
+//! This module contains generic utilities for serializing and deserializing method calls to/from
+//! payload bytes.
+//!
+//! It can be reused to implement a different wallet implementation as well as read and verify the
+//! contents of the transaction (for example, to display it on the screen of the hardware wallet).
+//!
+//! Builder interface requires heap allocations and can be enabled with `payload-builder` feature,
+//! while the rest works in `no_std` environment without a global allocator.
+
+#[cfg(feature = "payload-builder")]
+pub mod builder;
+
+use ab_contracts_common::Address;
+use ab_contracts_common::env::{MethodContext, PreparedMethod};
+use ab_contracts_common::method::MethodFingerprint;
+use ab_contracts_io_type::MAX_ALIGNMENT;
+use ab_contracts_io_type::trivial_type::TrivialType;
+use core::ffi::c_void;
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::num::NonZeroU8;
+use core::ptr::NonNull;
+use core::slice;
+use tinyvec::SliceVec;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, TrivialType)]
+#[repr(u8)]
+pub enum TransactionMethodContext {
+    /// Call contract under [`Address::NULL`] context (corresponds to [`MethodContext::Reset`])
+    Null,
+    /// Call contract under context of the wallet (corresponds to [`MethodContext::Replace`])
+    Wallet,
+}
+
+impl TransactionMethodContext {
+    // TODO: Implement `TryFrom` once it is available in const environment
+    /// Try to create an instance from its `u8` representation
+    pub const fn try_from_u8(n: u8) -> Option<Self> {
+        Some(match n {
+            0 => Self::Null,
+            1 => Self::Wallet,
+            _ => {
+                return None;
+            }
+        })
+    }
+}
+
+#[derive(Debug, Copy, Eq, PartialEq, Clone)]
+pub enum TransactionInputType {
+    Value { alignment_power: u8 },
+    OutputIndex { output_index: u8 },
+}
+
+/// The type of transaction input could be either explicit value or output index.
+///
+/// Specifically, if the previous method has `#[output]` or `#[result]`, those values are collected
+/// and pushed into a virtual "stack". Then, if [`Self::input_type()`] returns
+/// [`TransactionInputType::OutputIndex`]`, then the corresponding input will use the value at
+/// `output_index` of this stack instead of what was specified in `external_args`. This allows
+/// composing calls to multiple methods into more sophisticated workflows without writing special
+/// contracts for this.
+#[derive(Debug, Copy, Clone)]
+pub struct TransactionInput(TransactionInputType);
+
+impl TransactionInput {
+    /// Regular input value with specified alignment.
+    ///
+    /// Valid alignment values are: 1, 2, 4, 8, 16.
+    pub const fn new_value(alignment: NonZeroU8) -> Option<Self> {
+        match alignment.get() {
+            1 | 2 | 4 | 8 | 16 => Some(Self(TransactionInputType::Value {
+                alignment_power: alignment.ilog2() as u8,
+            })),
+            _ => None,
+        }
+    }
+
+    /// Output index value.
+    ///
+    /// Valid index values are 0..=127.
+    pub const fn new_output_index(output_index: u8) -> Option<Self> {
+        if output_index > 0b0111_1111 {
+            return None;
+        }
+
+        Some(Self(TransactionInputType::OutputIndex { output_index }))
+    }
+
+    /// Create an instance from `u8`
+    pub const fn from_u8(n: u8) -> Self {
+        // The first bit is set to 1 for value and 0 for output index
+        if n & 0b1000_0000 == 0 {
+            Self(TransactionInputType::OutputIndex { output_index: n })
+        } else {
+            Self(TransactionInputType::Value {
+                alignment_power: n & 0b0111_1111,
+            })
+        }
+    }
+
+    /// Convert instance into `u8`
+    pub const fn into_u8(self) -> u8 {
+        // The first bit is set to 1 for value and 0 for output index
+        match self.0 {
+            TransactionInputType::Value { alignment_power } => 0b1000_0000 | alignment_power,
+            TransactionInputType::OutputIndex { output_index } => output_index,
+        }
+    }
+
+    /// Returns `Some(output_index)` or `None` if regular input value
+    pub const fn input_type(self) -> TransactionInputType {
+        self.0
+    }
+}
+
+/// Errors for [`TransactionPayloadDecoder`]
+#[derive(Debug, thiserror::Error)]
+pub enum TransactionPayloadDecoderError {
+    /// Payload too small
+    #[error("Payload too small")]
+    PayloadTooSmall,
+    /// `ExternalArgs` buffer too small
+    #[error("`ExternalArgs` buffer too small")]
+    ExternalArgsBufferTooSmall,
+    /// Output index not found
+    #[error("Output index not found: {0}")]
+    OutputIndexNotFound(u8),
+    /// Output buffer too small
+    #[error("Output buffer too small")]
+    OutputBufferTooSmall,
+    /// Output buffer offsets too small
+    #[error("Output buffer offsets too small")]
+    OutputBufferOffsetsTooSmall,
+}
+
+/// Decoder for transaction payload created using `TransactionPayloadBuilder`.
+pub struct TransactionPayloadDecoder<'a> {
+    payload: &'a [u8],
+    external_args_buffer: &'a mut [*mut c_void],
+    output_buffer: &'a mut [MaybeUninit<u8>],
+    output_buffer_cursor: usize,
+    output_buffer_offsets: SliceVec<'a, (u32, u32)>,
+    map_context: fn(TransactionMethodContext) -> MethodContext,
+}
+
+impl<'a> TransactionPayloadDecoder<'a> {
+    /// Create new instance.
+    ///
+    /// The size of `external_args_buffer` defines max number of bytes allocated for `ExternalArgs`,
+    /// which impacts the number of arguments that can be represented by `ExternalArgs`. The size is
+    /// specified in pointers with `#[slot]` argument using one pointer, `#[input]` two pointers and
+    /// `#[output]`/`#[result]` three pointers each.
+    ///
+    /// The size of `output_buffer` defines how big the total sum of `#[output]` and `#[result]`
+    /// could be in all methods of the payload together.
+    ///
+    /// The size of `output_buffer_offsets` defines how many `#[output]` and `#[result]` arguments
+    /// could exist in all methods of the payload together.
+    #[inline]
+    pub fn new(
+        payload: &'a [u128],
+        external_args_buffer: &'a mut [*mut c_void],
+        output_buffer: &'a mut [MaybeUninit<u128>],
+        output_buffer_offsets: &'a mut [(u32, u32)],
+        map_context: fn(TransactionMethodContext) -> MethodContext,
+    ) -> Self {
+        debug_assert_eq!(align_of_val(payload), usize::from(MAX_ALIGNMENT));
+        debug_assert_eq!(align_of_val(output_buffer), usize::from(MAX_ALIGNMENT));
+
+        // SAFETY: Memory is valid and bound by argument's lifetime
+        let payload =
+            unsafe { slice::from_raw_parts(payload.as_ptr().cast::<u8>(), size_of_val(payload)) };
+
+        // SAFETY: Memory is valid and bound by argument's lifetime
+        let output_buffer = unsafe {
+            slice::from_raw_parts_mut(
+                output_buffer.as_mut_ptr().cast::<MaybeUninit<u8>>(),
+                size_of_val(output_buffer),
+            )
+        };
+
+        let mut output_buffer_offsets = SliceVec::from(output_buffer_offsets);
+        output_buffer_offsets.clear();
+
+        Self {
+            payload,
+            external_args_buffer,
+            output_buffer,
+            output_buffer_cursor: 0,
+            output_buffer_offsets,
+            map_context,
+        }
+    }
+
+    pub fn decode_next_method(
+        &mut self,
+    ) -> Result<Option<PreparedMethod<'a>>, TransactionPayloadDecoderError> {
+        if self.payload.is_empty() {
+            return Ok(None);
+        }
+
+        let contract = self.get_trivial_type::<Address>()?;
+        let method_fingerprint = self.get_trivial_type::<MethodFingerprint>()?;
+        let method_context =
+            (self.map_context)(*self.get_trivial_type::<TransactionMethodContext>()?);
+        let num_slot_arguments = self.read_u8()?;
+        let num_input_arguments = self.read_u8()?;
+        let num_output_arguments = self.read_u8()?;
+
+        // Slot needs one address pointer, input needs pointers to data and size, output needs
+        // pointers to data, size and capacity
+        let expected_external_args_buffer_size = usize::from(num_slot_arguments)
+            + usize::from(num_input_arguments) * 2
+            + usize::from(num_output_arguments) * 3;
+        if expected_external_args_buffer_size > self.external_args_buffer.len() {
+            return Err(TransactionPayloadDecoderError::ExternalArgsBufferTooSmall);
+        }
+
+        let external_args =
+            NonNull::new(self.external_args_buffer.as_mut_ptr()).expect("Not null; qed");
+        {
+            let mut external_args_cursor = external_args;
+
+            for _ in 0..num_slot_arguments {
+                let slot = self.get_trivial_type::<Address>()?;
+                // SAFETY: Size of `self.external_args_buffer` checked above, buffer is correctly
+                // aligned
+                unsafe {
+                    external_args_cursor.cast::<*const Address>().write(slot);
+                    external_args_cursor = external_args_cursor.offset(1);
+                }
+            }
+
+            for _ in 0..num_input_arguments {
+                let (bytes, size) = match TransactionInput::from_u8(self.read_u8()?).input_type() {
+                    TransactionInputType::Value { alignment_power } => {
+                        let alignment = 2usize.pow(u32::from(alignment_power));
+
+                        let size = self.get_trivial_type::<u32>()?;
+                        let bytes = self.get_bytes(*size, alignment)?;
+
+                        (bytes, size)
+                    }
+                    TransactionInputType::OutputIndex { output_index } => {
+                        let (size_offset, output_offset) = *self
+                            .output_buffer_offsets
+                            .get(usize::from(output_index))
+                            .ok_or(TransactionPayloadDecoderError::OutputIndexNotFound(
+                                output_index,
+                            ))?;
+
+                        // SAFETY: Offset was created as the result of writing value at the correct
+                        // offset
+                        let size = unsafe {
+                            self.output_buffer
+                                .as_ptr()
+                                .add(size_offset as usize)
+                                .cast::<u32>()
+                                .as_ref()
+                                .expect("Pointer is not null; qed")
+                        };
+                        // SAFETY: Offset was created as the result of writing value at the correct
+                        // offset
+                        let bytes = unsafe {
+                            let bytes_ptr = self.output_buffer.as_ptr().add(output_offset as usize);
+
+                            slice::from_raw_parts(bytes_ptr.cast::<u8>(), *size as usize)
+                        };
+
+                        (bytes, size)
+                    }
+                };
+
+                // SAFETY: Size of `self.external_args_buffer` checked above, buffer is correctly
+                // aligned
+                unsafe {
+                    external_args_cursor
+                        .cast::<*const u8>()
+                        .write(bytes.as_ptr());
+                    external_args_cursor = external_args_cursor.offset(1);
+
+                    external_args_cursor.cast::<*const u32>().write(size);
+                    external_args_cursor = external_args_cursor.offset(1);
+                }
+            }
+
+            for _ in 0..num_output_arguments {
+                let recommended_capacity = self.get_trivial_type::<u32>()?;
+                let alignment_power = *self.get_trivial_type::<u8>()?;
+                let alignment = 2usize.pow(u32::from(alignment_power));
+
+                let (size, data) = self.allocate_output_buffer(*recommended_capacity, alignment)?;
+
+                // SAFETY: Size of `self.external_args_buffer` checked above, buffer is correctly
+                // aligned
+                unsafe {
+                    external_args_cursor.cast::<*mut u8>().write(data.as_ptr());
+                    external_args_cursor = external_args_cursor.offset(1);
+
+                    external_args_cursor.cast::<*mut u32>().write(size.as_ptr());
+                    external_args_cursor = external_args_cursor.offset(1);
+
+                    external_args_cursor
+                        .cast::<*const u32>()
+                        .write(recommended_capacity);
+                    external_args_cursor = external_args_cursor.offset(1);
+                }
+            }
+        }
+
+        Ok(Some(PreparedMethod {
+            contract: *contract,
+            fingerprint: *method_fingerprint,
+            external_args: external_args.cast::<NonNull<c_void>>(),
+            method_context,
+            phantom: PhantomData,
+        }))
+    }
+
+    fn get_trivial_type<T>(&mut self) -> Result<&'a T, TransactionPayloadDecoderError>
+    where
+        T: TrivialType,
+    {
+        self.ensure_alignment(align_of::<T>());
+
+        let bytes;
+        (bytes, self.payload) = self
+            .payload
+            .split_at_checked(align_of::<T>())
+            .ok_or(TransactionPayloadDecoderError::PayloadTooSmall)?;
+
+        // SAFETY: Correctly aligned bytes of correct size
+        let value_ref = unsafe { bytes.as_ptr().cast::<T>().as_ref().expect("Not null; qed") };
+
+        Ok(value_ref)
+    }
+
+    fn get_bytes(
+        &mut self,
+        size: u32,
+        alignment: usize,
+    ) -> Result<&'a [u8], TransactionPayloadDecoderError> {
+        self.ensure_alignment(alignment);
+
+        let bytes;
+        (bytes, self.payload) = self
+            .payload
+            .split_at_checked(size as usize)
+            .ok_or(TransactionPayloadDecoderError::PayloadTooSmall)?;
+
+        Ok(bytes)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, TransactionPayloadDecoderError> {
+        let value;
+        (value, self.payload) = self
+            .payload
+            .split_at_checked(1)
+            .ok_or(TransactionPayloadDecoderError::PayloadTooSmall)?;
+
+        Ok(value[0])
+    }
+
+    fn ensure_alignment(&mut self, alignment: usize) {
+        let unaligned_by = self.payload.len() % alignment;
+        self.payload = &self.payload[unaligned_by..];
+    }
+
+    fn allocate_output_buffer(
+        &mut self,
+        capacity: u32,
+        output_alignment: usize,
+    ) -> Result<(NonNull<u32>, NonNull<u8>), TransactionPayloadDecoderError> {
+        if self.output_buffer_offsets.len() == self.output_buffer_offsets.capacity() {
+            return Err(TransactionPayloadDecoderError::OutputBufferOffsetsTooSmall);
+        }
+
+        let (size_offset, size_ptr) = self
+            .allocate_output_buffer_ptr::<u32>(align_of::<u32>(), size_of::<u32>())
+            .ok_or(TransactionPayloadDecoderError::OutputBufferTooSmall)?;
+        let (output_offset, output_ptr) = self
+            .allocate_output_buffer_ptr(output_alignment, capacity as usize)
+            .ok_or(TransactionPayloadDecoderError::OutputBufferTooSmall)?;
+
+        self.output_buffer_offsets
+            .push((size_offset as u32, output_offset as u32));
+
+        Ok((size_ptr, output_ptr))
+    }
+
+    /// Returns `None` if output buffer is not large enough
+    fn allocate_output_buffer_ptr<T>(
+        &mut self,
+        alignment: usize,
+        size: usize,
+    ) -> Option<(usize, NonNull<T>)> {
+        debug_assert!(alignment <= usize::from(MAX_ALIGNMENT));
+
+        let unaligned_by = self.output_buffer_cursor % alignment;
+        if self.output_buffer_cursor + unaligned_by + size > self.output_buffer.len() {
+            return None;
+        }
+
+        // SAFETY: Bounds and alignment checks are done above
+        let buffer_ptr = unsafe {
+            NonNull::new_unchecked(
+                self.output_buffer
+                    .as_mut_ptr()
+                    .add(self.output_buffer_cursor + unaligned_by)
+                    .cast::<T>(),
+            )
+        };
+        let offset = self.output_buffer_cursor + unaligned_by;
+        self.output_buffer_cursor += unaligned_by + size;
+
+        Some((offset, buffer_ptr))
+    }
+}

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/payload/builder.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/payload/builder.rs
@@ -1,0 +1,275 @@
+//! Transaction payload creation utilities
+
+extern crate alloc;
+
+use crate::payload::{TransactionInput, TransactionMethodContext};
+use ab_contracts_common::Address;
+use ab_contracts_common::metadata::decode::{
+    ArgumentKind, MetadataDecodingError, MethodMetadataDecoder, MethodsContainerKind,
+};
+use ab_contracts_common::method::{ExternalArgs, MethodFingerprint};
+use ab_contracts_io_type::MAX_ALIGNMENT;
+use ab_contracts_io_type::trivial_type::TrivialType;
+use alloc::vec::Vec;
+use core::ffi::c_void;
+use core::num::NonZeroU8;
+use core::ptr::NonNull;
+use core::{ptr, slice};
+
+/// Errors for [`TransactionPayloadBuilder`]
+#[derive(Debug, thiserror::Error)]
+pub enum TransactionPayloadBuilderError<'a> {
+    /// Metadata decoding error
+    #[error("Metadata decoding error: {0}")]
+    MetadataDecodingError(MetadataDecodingError<'a>),
+    /// Invalid alignment
+    #[error("Invalid alignment: {0}")]
+    InvalidAlignment(NonZeroU8),
+    /// Invalid output index
+    #[error("Invalid output index: {0}")]
+    InvalidOutputIndex(u8),
+}
+
+/// Builder for payload to be used with [`TxHandler`] (primarily for [`SimpleWallet`]).
+///
+/// Decoding can be done with [`TransactionPayloadDecoder`]
+///
+/// [`TxHandler`]: ab_contracts_standards::tx_handler::TxHandler
+/// [`SimpleWallet`]: crate::SimpleWalletBase
+/// [`TransactionPayloadDecoder`]: crate::payload::TransactionPayloadDecoder
+#[derive(Debug, Clone)]
+pub struct TransactionPayloadBuilder {
+    payload: Vec<u8>,
+}
+
+impl Default for TransactionPayloadBuilder {
+    fn default() -> Self {
+        Self {
+            payload: Vec::with_capacity(1024),
+        }
+    }
+}
+
+impl TransactionPayloadBuilder {
+    /// Add method call to the payload.
+    ///
+    /// The wallet will call this method in addition order.
+    ///
+    /// `input_output_index` is used for referencing earlier outputs as inputs of this method,
+    /// its values are optional, see [`TransactionInput`] for more details.
+    pub fn with_method_call<Args>(
+        self,
+        contract: &Address,
+        external_args: &Args,
+        method_context: TransactionMethodContext,
+        input_output_index: &[Option<u8>],
+    ) -> Result<Self, TransactionPayloadBuilderError<'static>>
+    where
+        Args: ExternalArgs,
+    {
+        let external_args = NonNull::from_ref(external_args).cast::<*const c_void>();
+
+        // SAFETY: Called with statically valid data
+        unsafe {
+            self.with_method_call_untyped(
+                contract,
+                &external_args,
+                Args::METADATA,
+                &Args::FINGERPRINT,
+                method_context,
+                input_output_index,
+            )
+        }
+    }
+
+    /// Other than unsafe API, this method is identical to [`Self::with_method_call()`].
+    ///
+    /// # Safety
+    /// `external_args` must correspond to `method_metadata` and `method_fingerprint`. Outputs are
+    /// never read from `external_args` and inputs that have corresponding `input_output_index`
+    /// are not read either.
+    pub unsafe fn with_method_call_untyped<'a>(
+        mut self,
+        contract: &Address,
+        external_args: &NonNull<*const c_void>,
+        mut method_metadata: &'a [u8],
+        method_fingerprint: &MethodFingerprint,
+        method_context: TransactionMethodContext,
+        input_output_index: &[Option<u8>],
+    ) -> Result<Self, TransactionPayloadBuilderError<'a>> {
+        let mut external_args = *external_args;
+
+        let (mut metadata_decoder, _method_metadata_item) =
+            MethodMetadataDecoder::new(&mut method_metadata, MethodsContainerKind::Unknown)
+                .decode_next()
+                .map_err(TransactionPayloadBuilderError::MetadataDecodingError)?;
+
+        self.extend_payload_with_alignment(contract.as_bytes(), align_of_val(contract));
+        self.extend_payload_with_alignment(
+            method_fingerprint.as_bytes(),
+            align_of_val(&method_fingerprint),
+        );
+        self.payload.push(method_context as u8);
+
+        // Remember the position to update later
+        let num_slots_index = self.payload.len();
+        self.payload.push(0);
+        // Remember the position to update later
+        let num_inputs_index = self.payload.len();
+        self.payload.push(0);
+        // Remember the position to update later
+        let num_outputs_index = self.payload.len();
+        self.payload.push(0);
+
+        while let Some(item) = metadata_decoder
+            .decode_next()
+            .transpose()
+            .map_err(TransactionPayloadBuilderError::MetadataDecodingError)?
+        {
+            match item.argument_kind {
+                ArgumentKind::EnvRo
+                | ArgumentKind::EnvRw
+                | ArgumentKind::TmpRo
+                | ArgumentKind::TmpRw => {
+                    // Not represented in external args
+                }
+                ArgumentKind::SlotRo | ArgumentKind::SlotRw => {
+                    self.payload[num_slots_index] += 1;
+
+                    // SAFETY: Method description requires the layout to correspond to metadata
+                    let address = unsafe {
+                        let address = external_args.cast::<NonNull<Address>>().read().as_ref();
+                        external_args = external_args.offset(1);
+                        address
+                    };
+                    self.extend_payload_with_alignment(address.as_bytes(), align_of_val(address));
+                }
+                ArgumentKind::Input => {
+                    let input_offset = usize::from(self.payload[num_inputs_index]);
+                    self.payload[num_inputs_index] += 1;
+
+                    let type_details = &item
+                        .type_details
+                        .expect("Always present for `#[input]`; qed");
+
+                    let maybe_output_index =
+                        input_output_index.get(input_offset).copied().flatten();
+                    let input_type = match maybe_output_index {
+                        Some(output_index) => TransactionInput::new_output_index(output_index)
+                            .ok_or(TransactionPayloadBuilderError::InvalidOutputIndex(
+                                output_index,
+                            ))?,
+                        None => TransactionInput::new_value(type_details.alignment).ok_or(
+                            TransactionPayloadBuilderError::InvalidAlignment(
+                                type_details.alignment,
+                            ),
+                        )?,
+                    };
+                    self.payload.push(input_type.into_u8());
+
+                    if maybe_output_index.is_none() {
+                        // SAFETY: Method description requires the layout to correspond to metadata
+                        let (size, data) = unsafe {
+                            let data = external_args.cast::<NonNull<u8>>().read();
+                            external_args = external_args.offset(1);
+                            let size = external_args.cast::<NonNull<u32>>().read().read();
+                            external_args = external_args.offset(1);
+
+                            let data =
+                                slice::from_raw_parts(data.as_ptr().cast_const(), size as usize);
+
+                            (size, data)
+                        };
+
+                        self.extend_payload_with_alignment(
+                            &size.to_le_bytes(),
+                            align_of_val(&size),
+                        );
+                        self.extend_payload_with_alignment(
+                            data,
+                            type_details.alignment.get() as usize,
+                        );
+                    }
+                }
+                ArgumentKind::Output | ArgumentKind::Result => {
+                    self.payload[num_outputs_index] += 1;
+
+                    let type_details = &item
+                        .type_details
+                        .expect("Always present for `#[output]`/`#[result]`; qed");
+
+                    self.extend_payload_with_alignment(
+                        &type_details.recommended_capacity.to_le_bytes(),
+                        align_of_val(&type_details.recommended_capacity),
+                    );
+                    self.extend_payload_with_alignment(
+                        &[type_details.alignment.ilog2() as u8],
+                        align_of::<u8>(),
+                    );
+                }
+            }
+        }
+
+        Ok(self)
+    }
+
+    /// Returns 16-byte aligned bytes.
+    ///
+    /// The contents is a concatenated sequence of method calls with their arguments. All data
+    /// structures are correctly aligned in the returned byte buffer with `0` used as padding when
+    /// necessary.
+    ///
+    /// Each method is serialized in the following way:
+    /// * Contract to call: [`Address`]
+    /// * Fingerprint of the method to call: [`MethodFingerprint`]
+    /// * Method context: [`TransactionMethodContext`]
+    /// * Number of slot arguments: `u8`
+    /// * Number of `#[input]` arguments: `u8`
+    /// * Number of `#[output]` or `#[result]` arguments: `u8`
+    /// * Concatenated sequence of arguments
+    ///
+    /// Each argument is serialized in the following way (others are skipped):
+    /// * `#[slot]`: [`Address`]
+    /// * `#[input]`: [`TransactionInput`] as `u8`
+    ///     * If [`TransactionInput::new_value()`] then input size as little-endian `u32`
+    ///       followed by the input itself
+    /// * `#[output]` or `#[result]`: recommended capacity as little-endian `u32` followed by
+    ///   alignment power as `u8` (`NonZeroU8::ilog2(alignment)`)
+    pub fn into_aligned_bytes(mut self) -> Vec<u128> {
+        // Fill bytes to make it multiple of `u128` before creating `u128`-based vector
+        self.ensure_alignment(usize::from(MAX_ALIGNMENT));
+
+        let output_len = self.payload.len() / size_of::<u128>();
+        let mut output = Vec::<u128>::with_capacity(output_len);
+
+        // SAFETY: Pointers are valid for reads/writes, aligned and not overlapping
+        unsafe {
+            ptr::copy_nonoverlapping(
+                self.payload.as_ptr(),
+                output.as_mut_ptr().cast::<u8>(),
+                self.payload.len(),
+            );
+            output.set_len(output_len);
+        }
+
+        debug_assert_eq!(align_of_val(output.as_slice()), usize::from(MAX_ALIGNMENT));
+
+        output
+    }
+
+    fn extend_payload_with_alignment(&mut self, bytes: &[u8], alignment: usize) {
+        self.ensure_alignment(alignment);
+
+        self.payload.extend_from_slice(bytes);
+    }
+
+    fn ensure_alignment(&mut self, alignment: usize) {
+        debug_assert!(alignment <= usize::from(MAX_ALIGNMENT));
+
+        let unaligned_by = self.payload.len() % alignment;
+        if unaligned_by > 0 {
+            self.payload
+                .resize(self.payload.len() + (alignment - unaligned_by), 0);
+        }
+    }
+}

--- a/crates/contracts/ab-system-contract-state/src/lib.rs
+++ b/crates/contracts/ab-system-contract-state/src/lib.rs
@@ -5,9 +5,22 @@ use ab_contracts_common::{Address, ContractError};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_macros::contract;
+use core::mem::MaybeUninit;
 
 // TODO: How/where should this limit be defined?
 pub const RECOMMENDED_STATE_CAPACITY: u32 = 1024;
+
+/// Helper function that calls provided function with new empty state buffer
+#[inline(always)]
+pub fn with_state_buffer<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut VariableBytes<RECOMMENDED_STATE_CAPACITY>) -> R,
+{
+    let mut state_bytes = [MaybeUninit::uninit(); RECOMMENDED_STATE_CAPACITY as usize];
+    let mut state_size = 0;
+    let mut new_state = VariableBytes::from_uninit(&mut state_bytes, &mut state_size);
+    f(&mut new_state)
+}
 
 #[derive(Copy, Clone, TrivialType)]
 #[repr(C)]
@@ -15,6 +28,25 @@ pub struct State;
 
 #[contract]
 impl State {
+    /// Initialize state.
+    ///
+    /// Similar to [`Self::write()`], but returns error if the state is not empty.
+    #[update]
+    pub fn initialize(
+        #[env] env: &mut Env,
+        #[slot] (address, contract_state): (
+            &Address,
+            &mut VariableBytes<RECOMMENDED_STATE_CAPACITY>,
+        ),
+        #[input] state: &VariableBytes<RECOMMENDED_STATE_CAPACITY>,
+    ) -> Result<(), ContractError> {
+        if !Self::is_empty(contract_state) {
+            return Err(ContractError::Conflict);
+        }
+
+        Self::write(env, (address, contract_state), state)
+    }
+
     /// Write state.
     ///
     /// Only direct caller is allowed to write its own state for security reasons.


### PR DESCRIPTION
This introduces `TxHandler` trait in `ab-contracts-standards` that will be used by the execution environment to process transactions. The interface is super generic to not make too many assumptions about what transactions look like. This allows to make wallets as simple or as complex as necessary. It also facilitates zero-copy APIs and doesn't require heap allocations.

The execution environment itself will be made aware of this interface in the future with a separate PR.

To demonstrate what the wallet might potentially look like two new crates were added.

`ab-system-contract-simple-wallet-base` includes modules for serializing/deserializing method calls to/from payload as well as a contract that uses SR25519 signature scheme to facilitate implementation of `TxHandler`. It is not a wallet on its own and doesn't implement `TxHandler` directly because that will make wallet of the end user unnecessarily large.

For the actual wallet there is `ab-contract-example-wallet`, which is small and simple, calling into `ab-system-contract-simple-wallet-base` to do the heavy lifting.

Overall this should be a decent start for supporting transactions in one of the upcoming PRs.