### PR TITLE
Improve `ab-system-contract-simple-wallet-base` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,6 @@ dependencies = [
  "ab-contracts-io-type",
  "ab-contracts-macros",
  "ab-contracts-standards",
- "ab-system-contract-state",
  "blake3",
  "schnorrkel",
  "thiserror",

--- a/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
@@ -13,6 +13,7 @@ use core::{ptr, slice};
 /// on other circumstances, like when called from another contract with specific allocation
 /// specified.
 #[derive(Debug)]
+#[repr(C)]
 pub struct VariableElements<const RECOMMENDED_ALLOCATION: u32, Element>
 where
     Element: TrivialType,
@@ -386,6 +387,36 @@ where
     #[inline]
     pub fn as_mut_ptr(&mut self) -> &mut NonNull<Element> {
         &mut self.elements
+    }
+
+    /// Cast a shared reference to this instance into a reference to an instance of a different
+    /// recommended allocation
+    #[inline]
+    pub fn cast_ref<const DIFFERENT_RECOMMENDED_ALLOCATION: u32>(
+        &self,
+    ) -> &VariableElements<DIFFERENT_RECOMMENDED_ALLOCATION, Element> {
+        // SAFETY: `VariableElements` has a fixed layout due to `#[repr(C)]`, which doesn't depend
+        // on recommended allocation
+        unsafe {
+            NonNull::from_ref(self)
+                .cast::<VariableElements<DIFFERENT_RECOMMENDED_ALLOCATION, Element>>()
+                .as_ref()
+        }
+    }
+
+    /// Cast an exclusive reference to this instance into a reference to an instance of a different
+    /// recommended allocation
+    #[inline]
+    pub fn cast_mut<const DIFFERENT_RECOMMENDED_ALLOCATION: u32>(
+        &mut self,
+    ) -> &mut VariableElements<DIFFERENT_RECOMMENDED_ALLOCATION, Element> {
+        // SAFETY: `VariableElements` has a fixed layout due to `#[repr(C)]`, which doesn't depend
+        // on recommended allocation
+        unsafe {
+            NonNull::from_mut(self)
+                .cast::<VariableElements<DIFFERENT_RECOMMENDED_ALLOCATION, Element>>()
+                .as_mut()
+        }
     }
 
     /// Assume that the first `size` are initialized and can be read.

--- a/crates/contracts/ab-system-contract-simple-wallet-base/Cargo.toml
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/Cargo.toml
@@ -18,7 +18,6 @@ ab-contracts-common = { version = "0.0.1", path = "../ab-contracts-common" }
 ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
 ab-contracts-macros = { version = "0.0.1", path = "../ab-contracts-macros" }
 ab-contracts-standards = { version = "0.0.1", path = "../ab-contracts-standards" }
-ab-system-contract-state = { version = "0.0.1", path = "../ab-system-contract-state" }
 blake3 = { version = "1.6.0", default-features = false }
 schnorrkel = { version = "0.11.4", default-features = false }
 thiserror = { version = "2.0.11", default-features = false }

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -122,9 +122,7 @@ impl SimpleWalletBase {
         #[input] seal: &TxHandlerSeal,
     ) -> Result<(), ContractError> {
         let state = Self::read_state(env, owner)?;
-        // SAFETY: Any set of bytes is valid and will be verified
-        let maybe_seal = unsafe { Seal::from_bytes(seal.get_initialized()) };
-        let Some(seal) = maybe_seal else {
+        let Some(seal) = seal.read_trivial_type::<Seal>() else {
             return Err(ContractError::BadInput);
         };
 

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -18,13 +18,12 @@
 pub mod payload;
 
 use crate::payload::{TransactionMethodContext, TransactionPayloadDecoder};
+use ab_contracts_common::ContractError;
 use ab_contracts_common::env::{Env, MethodContext, TransactionHeader};
-use ab_contracts_common::{Address, ContractError};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_macros::contract;
 use ab_contracts_standards::tx_handler::{TxHandlerPayload, TxHandlerSeal};
-use ab_system_contract_state::{RECOMMENDED_STATE_CAPACITY, StateExt};
 use core::mem::MaybeUninit;
 use core::{ptr, slice};
 use schnorrkel::context::SigningContext;
@@ -95,7 +94,7 @@ impl SimpleWalletBase {
     #[view]
     pub fn initialize(
         #[input] &public_key: &[u8; 32],
-        #[output] state: &mut VariableBytes<RECOMMENDED_STATE_CAPACITY>,
+        #[output] state: &mut VariableBytes<0>,
     ) -> Result<(), ContractError> {
         // TODO: Storing some lower-level representation of the public key might reduce the cost of
         //  verification in `Self::authorize()` method
@@ -115,13 +114,14 @@ impl SimpleWalletBase {
     /// Reads state of `owner` and returns `Ok(())` if authorization succeeds
     #[view]
     pub fn authorize(
-        #[env] env: &Env,
-        #[input] owner: &Address,
+        #[input] state: &VariableBytes<0>,
         #[input] header: &TransactionHeader,
         #[input] payload: &TxHandlerPayload,
         #[input] seal: &TxHandlerSeal,
     ) -> Result<(), ContractError> {
-        let state = Self::read_state(env, owner)?;
+        let Some(state) = state.read_trivial_type::<WalletState>() else {
+            return Err(ContractError::BadInput);
+        };
         let Some(seal) = seal.read_trivial_type::<Seal>() else {
             return Err(ContractError::BadInput);
         };
@@ -198,12 +198,13 @@ impl SimpleWalletBase {
     /// Returns state with increased nonce
     #[view]
     pub fn increase_nonce(
-        #[env] env: &Env,
-        #[input] owner: &Address,
+        #[input] state: &VariableBytes<0>,
         #[input] _seal: &TxHandlerSeal,
-        #[output] new_state: &mut VariableBytes<RECOMMENDED_STATE_CAPACITY>,
+        #[output] new_state: &mut VariableBytes<0>,
     ) -> Result<(), ContractError> {
-        let mut state = Self::read_state(env, owner)?;
+        let Some(mut state) = state.read_trivial_type::<WalletState>() else {
+            return Err(ContractError::BadInput);
+        };
 
         state.nonce = state.nonce.checked_add(1).ok_or(ContractError::Forbidden)?;
 
@@ -217,12 +218,13 @@ impl SimpleWalletBase {
     /// Returns state with a changed public key
     #[view]
     pub fn change_public_key(
-        #[env] env: &Env,
-        #[input] owner: &Address,
+        #[input] state: &VariableBytes<0>,
         #[input] &public_key: &[u8; 32],
-        #[output] new_state: &mut VariableBytes<RECOMMENDED_STATE_CAPACITY>,
+        #[output] new_state: &mut VariableBytes<0>,
     ) -> Result<(), ContractError> {
-        let mut state = Self::read_state(env, owner)?;
+        let Some(mut state) = state.read_trivial_type::<WalletState>() else {
+            return Err(ContractError::BadInput);
+        };
         // Ensure public key is valid
         schnorrkel::PublicKey::from_bytes(&public_key).map_err(|_error| ContractError::BadInput)?;
 
@@ -233,27 +235,5 @@ impl SimpleWalletBase {
         }
 
         Ok(())
-    }
-
-    /// Read state of the owner
-    fn read_state(env: &Env, owner: &Address) -> Result<WalletState, ContractError> {
-        let mut state = WalletState {
-            public_key: [0; 32],
-            nonce: 0,
-        };
-
-        let mut size = 0;
-        // SAFETY: All bytes are valid for `WalletState`, size doesn't matter since it
-        let mut bytes = VariableBytes::from_buffer_mut(unsafe { state.as_bytes_mut() }, &mut size);
-
-        env.state_read(Address::SYSTEM_STATE, owner, &mut bytes)?;
-
-        drop(bytes);
-
-        if size != WalletState::SIZE {
-            return Err(ContractError::InternalError);
-        }
-
-        Ok(state)
     }
 }


### PR DESCRIPTION
Reading of the state internally was not flexible enough for some use cases like when a wallet might have several nonces/keypairs stored in its state.

Also a few utility methods introduced on `VariableBytes` and `VariableElements` that make it easier to compose larger apps with safe APIs.