### PR TITLE
Improved error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,18 +323,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/contracts/ab-contracts-common/Cargo.toml
+++ b/crates/contracts/ab-contracts-common/Cargo.toml
@@ -18,7 +18,7 @@ ab-contracts-io-type = { version = "0.0.1", path = "../ab-contracts-io-type" }
 # TODO: Switch to blake3 once https://github.com/BLAKE3-team/BLAKE3/pull/439 is upstreamed and const hashing version is
 #  exposed
 const-sha1 = "0.3.0"
-derive_more = { version = "1.0.0", default-features = false, features = ["add", "add_assign", "display", "from", "into", "mul", "mul_assign"] }
+derive_more = { version = "2.0.1", default-features = false, features = ["display"] }
 thiserror = "2.0.11"
 
 [features]

--- a/crates/contracts/ab-contracts-common/src/error.rs
+++ b/crates/contracts/ab-contracts-common/src/error.rs
@@ -1,0 +1,118 @@
+use derive_more::Display;
+
+#[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct CustomContractErrorCode(u64);
+
+impl CustomContractErrorCode {
+    /// Get the inner error code
+    #[inline]
+    pub const fn code(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub enum ContractError {
+    BadInput,
+    BadOutput,
+    Forbidden,
+    NotFound,
+    Conflict,
+    InternalError,
+    NotImplemented,
+    Custom(CustomContractErrorCode),
+}
+
+impl From<CustomContractErrorCode> for ContractError {
+    #[inline]
+    fn from(error: CustomContractErrorCode) -> Self {
+        Self::Custom(error)
+    }
+}
+
+impl ContractError {
+    /// Create contract error with a custom error code.
+    ///
+    /// Code must be larger than `u8::MAX` or `None` will be returned.
+    #[inline]
+    pub const fn new_custom_code(code: u64) -> Option<Self> {
+        if code > u8::MAX as u64 {
+            Some(Self::Custom(CustomContractErrorCode(code)))
+        } else {
+            None
+        }
+    }
+
+    /// Convert contact error into contract exit code.
+    ///
+    /// Mosty useful for low-level code.
+    #[inline]
+    pub const fn exit_code(self) -> ExitCode {
+        ExitCode(match self {
+            Self::BadInput => 1,
+            Self::BadOutput => 2,
+            Self::Forbidden => 3,
+            Self::NotFound => 4,
+            Self::Conflict => 5,
+            Self::InternalError => 6,
+            Self::NotImplemented => 7,
+            Self::Custom(custom) => custom.code(),
+        })
+    }
+}
+
+#[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+#[repr(C)]
+#[must_use = "Code can be Ok or one of the errors, consider converting to Result<(), ContractCode>"]
+pub struct ExitCode(u64);
+
+impl From<ContractError> for ExitCode {
+    #[inline]
+    fn from(error: ContractError) -> Self {
+        error.exit_code()
+    }
+}
+
+impl From<Result<(), ContractError>> for ExitCode {
+    #[inline]
+    fn from(error: Result<(), ContractError>) -> Self {
+        match error {
+            Ok(()) => Self(0),
+            Err(error) => error.exit_code(),
+        }
+    }
+}
+
+impl From<ExitCode> for Result<(), ContractError> {
+    #[inline]
+    fn from(value: ExitCode) -> Self {
+        Err(match value.0 {
+            0 => {
+                return Ok(());
+            }
+            1 => ContractError::BadInput,
+            2 => ContractError::BadOutput,
+            3 => ContractError::Forbidden,
+            4 => ContractError::NotFound,
+            5 => ContractError::Conflict,
+            6 => ContractError::InternalError,
+            7 => ContractError::NotImplemented,
+            8..=255 => unreachable!(),
+            code => ContractError::Custom(CustomContractErrorCode(code)),
+        })
+    }
+}
+
+impl ExitCode {
+    /// Exit code indicating success
+    #[inline]
+    pub fn ok() -> Self {
+        Self(0)
+    }
+
+    /// Convert into `u64`
+    #[inline]
+    pub const fn into_u64(self) -> u64 {
+        self.0
+    }
+}

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -125,48 +125,70 @@ pub trait ContractTraitDefinition {
 }
 
 #[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
-#[repr(u8)]
+pub struct CustomContractErrorCode(u64);
+
+impl CustomContractErrorCode {
+    /// Get the inner error code
+    #[inline]
+    pub const fn code(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub enum ContractError {
-    BadInput = 1,
+    BadInput,
     BadOutput,
     Forbidden,
     NotFound,
     Conflict,
     InternalError,
     NotImplemented,
+    Custom(CustomContractErrorCode),
+}
+
+impl From<CustomContractErrorCode> for ContractError {
+    #[inline]
+    fn from(error: CustomContractErrorCode) -> Self {
+        Self::Custom(error)
+    }
 }
 
 impl ContractError {
+    /// Create contract error with a custom error code.
+    ///
+    /// Code must be larger than `u8::MAX` or `None` will be returned.
+    #[inline]
+    pub const fn new_custom_code(code: u64) -> Option<Self> {
+        if code > u8::MAX as u64 {
+            Some(Self::Custom(CustomContractErrorCode(code)))
+        } else {
+            None
+        }
+    }
+
     /// Convert contact error into contract exit code.
     ///
     /// Mosty useful for low-level code.
     #[inline]
     pub const fn exit_code(self) -> ExitCode {
-        match self {
-            Self::BadInput => ExitCode::BadInput,
-            Self::BadOutput => ExitCode::BadOutput,
-            Self::Forbidden => ExitCode::Forbidden,
-            Self::NotFound => ExitCode::NotFound,
-            Self::Conflict => ExitCode::Conflict,
-            Self::InternalError => ExitCode::InternalError,
-            Self::NotImplemented => ExitCode::NotImplemented,
-        }
+        ExitCode(match self {
+            Self::BadInput => 1,
+            Self::BadOutput => 2,
+            Self::Forbidden => 3,
+            Self::NotFound => 4,
+            Self::Conflict => 5,
+            Self::InternalError => 6,
+            Self::NotImplemented => 7,
+            Self::Custom(custom) => custom.code(),
+        })
     }
 }
 
 #[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
-#[repr(u8)]
+#[repr(C)]
 #[must_use = "Code can be Ok or one of the errors, consider converting to Result<(), ContractCode>"]
-pub enum ExitCode {
-    Ok = 0,
-    BadInput = 1,
-    BadOutput,
-    Forbidden,
-    NotFound,
-    Conflict,
-    InternalError,
-    NotImplemented,
-}
+pub struct ExitCode(u64);
 
 impl From<ContractError> for ExitCode {
     #[inline]
@@ -179,7 +201,7 @@ impl From<Result<(), ContractError>> for ExitCode {
     #[inline]
     fn from(error: Result<(), ContractError>) -> Self {
         match error {
-            Ok(()) => Self::Ok,
+            Ok(()) => Self(0),
             Err(error) => error.exit_code(),
         }
     }
@@ -188,16 +210,34 @@ impl From<Result<(), ContractError>> for ExitCode {
 impl From<ExitCode> for Result<(), ContractError> {
     #[inline]
     fn from(value: ExitCode) -> Self {
-        match value {
-            ExitCode::Ok => Ok(()),
-            ExitCode::BadInput => Err(ContractError::BadInput),
-            ExitCode::BadOutput => Err(ContractError::BadOutput),
-            ExitCode::Forbidden => Err(ContractError::Forbidden),
-            ExitCode::NotFound => Err(ContractError::NotFound),
-            ExitCode::Conflict => Err(ContractError::Conflict),
-            ExitCode::InternalError => Err(ContractError::InternalError),
-            ExitCode::NotImplemented => Err(ContractError::NotImplemented),
-        }
+        Err(match value.0 {
+            0 => {
+                return Ok(());
+            }
+            1 => ContractError::BadInput,
+            2 => ContractError::BadOutput,
+            3 => ContractError::Forbidden,
+            4 => ContractError::NotFound,
+            5 => ContractError::Conflict,
+            6 => ContractError::InternalError,
+            7 => ContractError::NotImplemented,
+            8..=255 => unreachable!(),
+            code => ContractError::Custom(CustomContractErrorCode(code)),
+        })
+    }
+}
+
+impl ExitCode {
+    /// Exit code indicating success
+    #[inline]
+    pub fn ok() -> Self {
+        Self(0)
+    }
+
+    /// Convert into `u64`
+    #[inline]
+    pub const fn into_u64(self) -> u64 {
+        self.0
     }
 }
 

--- a/crates/contracts/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/ab-contracts-common/src/lib.rs
@@ -4,6 +4,7 @@
 mod address;
 mod balance;
 pub mod env;
+mod error;
 pub mod metadata;
 pub mod method;
 
@@ -17,7 +18,8 @@ use core::ffi::c_void;
 use core::num::{NonZeroU32, NonZeroU128};
 use core::ops::Deref;
 use core::ptr::NonNull;
-use derive_more::{Display, From};
+use derive_more::Display;
+pub use error::{ContractError, CustomContractErrorCode, ExitCode};
 
 /// Max allowed size of the contract code
 pub const MAX_CODE_SIZE: u32 = 1024 * 1024;
@@ -122,123 +124,6 @@ pub trait ContractTraitDefinition {
     ///
     /// [`ContractMetadataKind`]: crate::metadata::ContractMetadataKind
     const METADATA: &[::core::primitive::u8];
-}
-
-#[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
-pub struct CustomContractErrorCode(u64);
-
-impl CustomContractErrorCode {
-    /// Get the inner error code
-    #[inline]
-    pub const fn code(self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
-pub enum ContractError {
-    BadInput,
-    BadOutput,
-    Forbidden,
-    NotFound,
-    Conflict,
-    InternalError,
-    NotImplemented,
-    Custom(CustomContractErrorCode),
-}
-
-impl From<CustomContractErrorCode> for ContractError {
-    #[inline]
-    fn from(error: CustomContractErrorCode) -> Self {
-        Self::Custom(error)
-    }
-}
-
-impl ContractError {
-    /// Create contract error with a custom error code.
-    ///
-    /// Code must be larger than `u8::MAX` or `None` will be returned.
-    #[inline]
-    pub const fn new_custom_code(code: u64) -> Option<Self> {
-        if code > u8::MAX as u64 {
-            Some(Self::Custom(CustomContractErrorCode(code)))
-        } else {
-            None
-        }
-    }
-
-    /// Convert contact error into contract exit code.
-    ///
-    /// Mosty useful for low-level code.
-    #[inline]
-    pub const fn exit_code(self) -> ExitCode {
-        ExitCode(match self {
-            Self::BadInput => 1,
-            Self::BadOutput => 2,
-            Self::Forbidden => 3,
-            Self::NotFound => 4,
-            Self::Conflict => 5,
-            Self::InternalError => 6,
-            Self::NotImplemented => 7,
-            Self::Custom(custom) => custom.code(),
-        })
-    }
-}
-
-#[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
-#[repr(C)]
-#[must_use = "Code can be Ok or one of the errors, consider converting to Result<(), ContractCode>"]
-pub struct ExitCode(u64);
-
-impl From<ContractError> for ExitCode {
-    #[inline]
-    fn from(error: ContractError) -> Self {
-        error.exit_code()
-    }
-}
-
-impl From<Result<(), ContractError>> for ExitCode {
-    #[inline]
-    fn from(error: Result<(), ContractError>) -> Self {
-        match error {
-            Ok(()) => Self(0),
-            Err(error) => error.exit_code(),
-        }
-    }
-}
-
-impl From<ExitCode> for Result<(), ContractError> {
-    #[inline]
-    fn from(value: ExitCode) -> Self {
-        Err(match value.0 {
-            0 => {
-                return Ok(());
-            }
-            1 => ContractError::BadInput,
-            2 => ContractError::BadOutput,
-            3 => ContractError::Forbidden,
-            4 => ContractError::NotFound,
-            5 => ContractError::Conflict,
-            6 => ContractError::InternalError,
-            7 => ContractError::NotImplemented,
-            8..=255 => unreachable!(),
-            code => ContractError::Custom(CustomContractErrorCode(code)),
-        })
-    }
-}
-
-impl ExitCode {
-    /// Exit code indicating success
-    #[inline]
-    pub fn ok() -> Self {
-        Self(0)
-    }
-
-    /// Convert into `u64`
-    #[inline]
-    pub const fn into_u64(self) -> u64 {
-        self.0
-    }
 }
 
 /// Shard index

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/method.rs
@@ -1128,7 +1128,7 @@ impl MethodDetails {
                 MethodResultType::Unit(_) => {
                     quote! {
                         // Return exit code
-                        ::ab_contracts_macros::__private::ExitCode::Ok
+                        ::ab_contracts_macros::__private::ExitCode::ok()
                     }
                 }
                 MethodResultType::Regular(_) => {
@@ -1141,14 +1141,14 @@ impl MethodDetails {
                         }
                         args.ok_result_ptr.write(#result_var_name);
                         // Return exit code
-                        ::ab_contracts_macros::__private::ExitCode::Ok
+                        ::ab_contracts_macros::__private::ExitCode::ok()
                     }
                 }
                 MethodResultType::ResultUnit(_) => {
                     quote! {
                         // Return exit code
                         match #result_var_name {
-                            Ok(()) => ::ab_contracts_macros::__private::ExitCode::Ok,
+                            Ok(()) => ::ab_contracts_macros::__private::ExitCode::ok(),
                             Err(error) => error.exit_code(),
                         }
                     }
@@ -1166,7 +1166,7 @@ impl MethodDetails {
                                 }
                                 args.ok_result_ptr.write(result);
                                 // Return exit code
-                                ::ab_contracts_macros::__private::ExitCode::Ok
+                                ::ab_contracts_macros::__private::ExitCode::ok()
                             }
                             Err(error) => error.exit_code(),
                         }


### PR DESCRIPTION
This allows to have custom error codes for contracts rather than being constrained to the enum variants offered by `ContractError`