### PR TITLE
Arguments handling refactoring

### DIFF
--- a/crates/contracts/ab-contracts-macros-impl/src/contract/init.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/init.rs
@@ -14,8 +14,6 @@ pub(super) fn process_init_fn(
 ) -> Result<MethodOutput, Error> {
     let mut methods_details = MethodDetails::new(MethodType::Init, self_type);
 
-    methods_details.process_output(&fn_sig.output)?;
-
     for input in fn_sig.inputs.iter_mut() {
         let input_span = input.span();
         // TODO: Moving this outside of the loop causes confusing lifetime issues
@@ -83,6 +81,8 @@ pub(super) fn process_init_fn(
             }
         }
     }
+
+    methods_details.process_return(&fn_sig.output)?;
 
     let guest_ffi = methods_details.generate_guest_ffi(fn_sig, None)?;
     let trait_ext_components = methods_details.generate_trait_ext_components(fn_sig, None)?;

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/update.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/update.rs
@@ -14,8 +14,6 @@ pub(super) fn process_update_fn(
 ) -> Result<MethodOutput, Error> {
     let mut methods_details = MethodDetails::new(MethodType::Update, self_type);
 
-    methods_details.process_output(&fn_sig.output)?;
-
     for input in fn_sig.inputs.iter_mut() {
         let input_span = input.span();
         // TODO: Moving this outside of the loop causes confusing lifetime issues
@@ -90,6 +88,8 @@ pub(super) fn process_update_fn(
         }
     }
 
+    methods_details.process_return(&fn_sig.output)?;
+
     let guest_ffi = methods_details.generate_guest_ffi(fn_sig, trait_name)?;
     let trait_ext_components = methods_details.generate_trait_ext_components(fn_sig, trait_name)?;
 
@@ -111,8 +111,6 @@ pub(super) fn process_update_fn_definition(
 ) -> Result<MethodOutput, Error> {
     let mut methods_details =
         MethodDetails::new(MethodType::Update, Type::Path(parse_quote! { #trait_name }));
-
-    methods_details.process_output(&fn_sig.output)?;
 
     for input in fn_sig.inputs.iter_mut() {
         let input_span = input.span();
@@ -177,6 +175,8 @@ pub(super) fn process_update_fn_definition(
             }
         }
     }
+
+    methods_details.process_return(&fn_sig.output)?;
 
     let guest_ffi = methods_details.generate_guest_trait_ffi(fn_sig, Some(trait_name))?;
     let trait_ext_components =

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/view.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/view.rs
@@ -14,8 +14,6 @@ pub(super) fn process_view_fn(
 ) -> Result<MethodOutput, Error> {
     let mut methods_details = MethodDetails::new(MethodType::View, self_type);
 
-    methods_details.process_output(&fn_sig.output)?;
-
     for input in fn_sig.inputs.iter_mut() {
         let input_span = input.span();
         // TODO: Moving this outside of the loop causes confusing lifetime issues
@@ -89,6 +87,8 @@ pub(super) fn process_view_fn(
         }
     }
 
+    methods_details.process_return(&fn_sig.output)?;
+
     let guest_ffi = methods_details.generate_guest_ffi(fn_sig, trait_name)?;
     let trait_ext_components = methods_details.generate_trait_ext_components(fn_sig, trait_name)?;
 
@@ -110,8 +110,6 @@ pub(super) fn process_view_fn_definition(
 ) -> Result<MethodOutput, Error> {
     let mut methods_details =
         MethodDetails::new(MethodType::View, Type::Path(parse_quote! { #trait_name }));
-
-    methods_details.process_output(&fn_sig.output)?;
 
     for input in fn_sig.inputs.iter_mut() {
         let input_span = input.span();
@@ -176,6 +174,8 @@ pub(super) fn process_view_fn_definition(
             }
         }
     }
+
+    methods_details.process_return(&fn_sig.output)?;
 
     let guest_ffi = methods_details.generate_guest_trait_ffi(fn_sig, Some(trait_name))?;
     let trait_ext_components =


### PR DESCRIPTION
This is an equivalent refactoring in preparation for the attempt to get rid of `#[result]` and unify both it and return type with `#[output]`, but that part will happen first, hence refactoring first