### PR TITLE
Remove `#[result]`

### DIFF
--- a/crates/contracts/ab-contract-playground/src/lib.rs
+++ b/crates/contracts/ab-contract-playground/src/lib.rs
@@ -70,10 +70,17 @@ impl Playground {
     }
 
     #[init]
-    pub fn new_result(#[env] env: &mut Env, #[result] result: &mut MaybeData<Self>) {
+    pub fn new_result(
+        #[slot] (owner_addr, owner): (&Address, &mut MaybeData<Slot>),
+        #[input] total_supply: &Balance,
+        #[output] result: &mut MaybeData<Self>,
+    ) {
+        owner.replace(Slot {
+            balance: *total_supply,
+        });
         result.replace(Self {
-            total_supply: Balance::MIN,
-            owner: env.context(),
+            total_supply: *total_supply,
+            owner: *owner_addr,
         });
     }
 
@@ -126,7 +133,7 @@ impl Playground {
     }
 
     #[view]
-    pub fn balance3(#[slot] target: &MaybeData<Slot>, #[result] result: &mut MaybeData<Balance>) {
+    pub fn balance3(#[slot] target: &MaybeData<Slot>, #[output] result: &mut MaybeData<Balance>) {
         result.replace(
             target
                 .get()

--- a/crates/contracts/ab-contract-playground/tests/basic.rs
+++ b/crates/contracts/ab-contract-playground/tests/basic.rs
@@ -25,7 +25,7 @@ fn basic() {
                 &Playground::code(),
             )
             .unwrap();
-        env.playground_new(
+        env.playground_new_result(
             MethodContext::Keep,
             playground_address,
             &playground_address,

--- a/crates/contracts/ab-contracts-common/src/metadata.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata.rs
@@ -61,19 +61,19 @@ pub enum ContractMetadataKind {
     ///   * [`Self::SlotRw`]
     ///   * [`Self::Input`]
     ///   * [`Self::Output`]
-    ///   * [`Self::Result`]
     /// * Length of the argument name in bytes (u8, except for [`Self::EnvRo`] and [`Self::EnvRw`])
     /// * Argument name as UTF-8 bytes (except for [`Self::EnvRo`] and [`Self::EnvRw`])
-    /// * Only for [`Self::Input`], [`Self::Output`] and [`Self::Result`] recursive metadata of
-    ///   argument's type as described in [`IoTypeMetadataKind`] with following exceptions:
-    ///   * For [`Self::Result`] this is skipped if method is [`Self::Init`] and present otherwise
+    /// * Only for [`Self::Input`] and [`Self::Output`] recursive metadata of argument's type as
+    ///   described in [`IoTypeMetadataKind`] with following exception:
+    ///   * For last [`Self::Output`] this is skipped if method is [`Self::Init`] (since it is
+    ///     statically known to be `Self`) and present otherwise
     ///
     /// [`IoTypeMetadataKind`]: ab_contracts_io_type::metadata::IoTypeMetadataKind
     ///
-    /// NOTE: Result, regardless of whether it is a return type or explicit `#[result]` argument is
-    /// encoded as a separate argument and counts towards number of arguments. At the same time,
-    /// `self` doesn't count towards the number of arguments as it is implicitly defined by the
-    /// variant of this struct.
+    /// NOTE: [`Self::Output`], regardless of whether it is a return type or explicit `#[output]`
+    /// argument is encoded as a separate argument and counts towards number of arguments. At the
+    /// same time, `self` doesn't count towards the number of arguments as it is implicitly defined
+    /// by the variant of this struct.
     Init,
     /// Stateless `#[update]` method (doesn't have `self` in its arguments).
     ///
@@ -127,20 +127,13 @@ pub enum ContractMetadataKind {
     ///
     /// Example: `#[input] balance: &Balance,`
     Input,
-    /// `#[output]` argument.
-    ///
-    /// Example: `#[output] out: &mut VariableBytes<1024>,`
-    Output,
-    // TODO: Is explicit result needed? If not then `#[input]` and `#[output]` can be made implicit
-    /// Explicit `#[result`] argument or `T` of [`Result<T, ContractError>`] return type or simply
+    /// Explicit `#[output]` argument or `T` of [`Result<T, ContractError>`] return type or simply
     /// return type if it is not fallible.
     ///
     /// NOTE: Skipped if return type's `T` is `().
     ///
-    /// Example: `#[result] result: &mut MaybeData<Balance>,`
-    ///
-    /// NOTE: There is always exactly one result in a method.
-    Result,
+    /// Example: `#[output] out: &mut VariableBytes<1024>,`
+    Output,
 }
 
 impl ContractMetadataKind {
@@ -164,7 +157,6 @@ impl ContractMetadataKind {
             13 => Self::SlotRw,
             14 => Self::Input,
             15 => Self::Output,
-            16 => Self::Result,
             _ => {
                 return None;
             }

--- a/crates/contracts/ab-contracts-common/src/metadata/tests.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata/tests.rs
@@ -19,7 +19,6 @@ fn check_repr() {
         (ContractMetadataKind::SlotRw, 13),
         (ContractMetadataKind::Input, 14),
         (ContractMetadataKind::Output, 15),
-        (ContractMetadataKind::Result, 16),
     ];
 
     for (kind, repr_byte) in known_variants {

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/init.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/init.rs
@@ -33,10 +33,6 @@ pub(super) fn process_init_fn(
                 format_ident!("output"),
                 MethodDetails::process_output_arg as _,
             ),
-            (
-                format_ident!("result"),
-                MethodDetails::process_result_arg as _,
-            ),
         ]);
 
         match input {

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/update.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/update.rs
@@ -33,10 +33,6 @@ pub(super) fn process_update_fn(
                 format_ident!("output"),
                 MethodDetails::process_output_arg as _,
             ),
-            (
-                format_ident!("result"),
-                MethodDetails::process_result_arg as _,
-            ),
         ]);
 
         match input {
@@ -125,10 +121,6 @@ pub(super) fn process_update_fn_definition(
             (
                 format_ident!("output"),
                 MethodDetails::process_output_arg as _,
-            ),
-            (
-                format_ident!("result"),
-                MethodDetails::process_result_arg as _,
             ),
         ]);
 

--- a/crates/contracts/ab-contracts-macros-impl/src/contract/view.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/contract/view.rs
@@ -32,10 +32,6 @@ pub(super) fn process_view_fn(
                 format_ident!("output"),
                 MethodDetails::process_output_arg as _,
             ),
-            (
-                format_ident!("result"),
-                MethodDetails::process_result_arg as _,
-            ),
         ]);
 
         match input {
@@ -124,10 +120,6 @@ pub(super) fn process_view_fn_definition(
             (
                 format_ident!("output"),
                 MethodDetails::process_output_arg as _,
-            ),
-            (
-                format_ident!("result"),
-                MethodDetails::process_result_arg as _,
             ),
         ]);
 

--- a/crates/contracts/ab-contracts-macros-impl/src/lib.rs
+++ b/crates/contracts/ab-contracts-macros-impl/src/lib.rs
@@ -1,6 +1,6 @@
-#![feature(extract_if, iter_map_windows, let_chains)]
-
 //! See and use `ab-contracts-macros` crate instead, this is its implementation detail
+
+#![feature(extract_if, exact_size_is_empty, iter_map_windows, let_chains)]
 
 mod contract;
 

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -37,16 +37,16 @@ pub const SIGNING_CONTEXT: &[u8] = b"system-simple-wallet";
 /// This constant is helpful for transaction generation to check whether a created transaction
 /// doesn't exceed this limit.
 ///
-/// `#[slot]` argument using one pointer, `#[input]` two pointers and `#[output]`/`#[result]` three
-/// pointers each.
+/// `#[slot]` argument using one pointer, `#[input]` two pointers and `#[output]` three pointers
+/// each.
 pub const EXTERNAL_ARGS_BUFFER_SIZE: usize = 32 * 1024;
 /// Size of the buffer in bytes that is used as a stack for storing outputs.
 ///
 /// This constant is helpful for transaction generation to check whether a created transaction
 /// doesn't exceed this limit.
 ///
-/// This defines how big the total sum of `#[output]` and `#[result]` could be in all methods of the
-/// payload together.
+/// This defines how big the total size of `#[output]` arguments and return values could be in all
+/// methods of the payload together.
 ///
 /// Overflow will result in an error.
 pub const OUTPUT_BUFFER_SIZE: usize = 32 * 1024;
@@ -55,7 +55,7 @@ pub const OUTPUT_BUFFER_SIZE: usize = 32 * 1024;
 /// This constant is helpful for transaction generation to check whether a created transaction
 /// doesn't exceed this limit.
 ///
-/// This defines how many `#[output]` and `#[result]` arguments could exist in all methods of the
+/// This defines how many `#[output]` arguments and return values could exist in all methods of the
 /// payload together.
 ///
 /// Overflow will result in an error.

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/payload.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/payload.rs
@@ -54,7 +54,7 @@ pub enum TransactionInputType {
 
 /// The type of transaction input could be either explicit value or output index.
 ///
-/// Specifically, if the previous method has `#[output]` or `#[result]`, those values are collected
+/// Specifically, if the previous method has `#[output]` or return value, those values are collected
 /// and pushed into a virtual "stack". Then, if [`Self::input_type()`] returns
 /// [`TransactionInputType::OutputIndex`]`, then the corresponding input will use the value at
 /// `output_index` of this stack instead of what was specified in `external_args`. This allows
@@ -150,12 +150,12 @@ impl<'a> TransactionPayloadDecoder<'a> {
     /// The size of `external_args_buffer` defines max number of bytes allocated for `ExternalArgs`,
     /// which impacts the number of arguments that can be represented by `ExternalArgs`. The size is
     /// specified in pointers with `#[slot]` argument using one pointer, `#[input]` two pointers and
-    /// `#[output]`/`#[result]` three pointers each.
+    /// `#[output]` three pointers each.
     ///
-    /// The size of `output_buffer` defines how big the total sum of `#[output]` and `#[result]`
+    /// The size of `output_buffer` defines how big the total size of `#[output]` and return values
     /// could be in all methods of the payload together.
     ///
-    /// The size of `output_buffer_offsets` defines how many `#[output]` and `#[result]` arguments
+    /// The size of `output_buffer_offsets` defines how many `#[output]` arguments and return values
     /// could exist in all methods of the payload together.
     #[inline]
     pub fn new(


### PR DESCRIPTION
This finally replaces `#[result]` with `#[output]` and unifies a few things, while also removing a bunch of code.

It is a bit tricky that last `#[output]` can now be used an an alternative for result, but hopefully that is not too confusing. If it is, that behavior can be removed, forcing developers to use `#[update]` instead of `#[init]` and calling state contract directly.