### PR TITLE
Small improvements

### DIFF
--- a/crates/contracts/ab-contracts-common/src/metadata.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata.rs
@@ -181,6 +181,20 @@ impl ContractMetadataKind {
     ///
     /// Returns `None` if input is invalid or too long.
     pub const fn compact(metadata: &[u8]) -> Option<([u8; MAX_METADATA_CAPACITY], usize)> {
-        compact_metadata(metadata)
+        compact_metadata(metadata, false)
+    }
+
+    // TODO: Create wrapper type for metadata bytes and move this method there
+    /// Produce compact metadata for `ExternalArgs`.
+    ///
+    /// Similar to [`Self::compact()`] arguments that are not reflected in `ExternalArgs` will be
+    /// skipped since they don't impact `ExternalArgs` API. This is used for `MethodFingerprint`
+    /// derivation.
+    ///
+    /// Returns `None` if input is invalid or too long.
+    pub const fn compact_external_args(
+        metadata: &[u8],
+    ) -> Option<([u8; MAX_METADATA_CAPACITY], usize)> {
+        compact_metadata(metadata, true)
     }
 }

--- a/crates/contracts/ab-contracts-common/src/metadata/compact.rs
+++ b/crates/contracts/ab-contracts-common/src/metadata/compact.rs
@@ -4,10 +4,12 @@ use core::ptr;
 
 pub(super) const fn compact_metadata(
     metadata: &[u8],
+    for_external_args: bool,
 ) -> Option<([u8; MAX_METADATA_CAPACITY], usize)> {
     let mut metadata_scratch = [0; MAX_METADATA_CAPACITY];
 
-    let Some((metadata, remainder)) = compact_metadata_inner(metadata, &mut metadata_scratch)
+    let Some((metadata, remainder)) =
+        compact_metadata_inner(metadata, &mut metadata_scratch, for_external_args)
     else {
         return None;
     };
@@ -34,20 +36,22 @@ macro_rules! forward_option {
 const fn compact_metadata_inner<'i, 'o>(
     mut input: &'i [u8],
     mut output: &'o mut [u8],
+    for_external_args: bool,
 ) -> Option<(&'i [u8], &'o mut [u8])> {
     if input.is_empty() || output.is_empty() {
         return None;
     }
 
     let kind = forward_option!(ContractMetadataKind::try_from_u8(input[0]));
-    (input, output) = forward_option!(copy_n_bytes(input, output, 1));
-
-    if input.is_empty() || output.is_empty() {
-        return None;
-    }
 
     match kind {
         ContractMetadataKind::Contract => {
+            (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+
+            if input.is_empty() || output.is_empty() {
+                return None;
+            }
+
             // Compact contract state type
             (input, output) = forward_option!(IoTypeMetadataKind::compact(input, output));
             // Compact contract `#[slot]` type
@@ -68,12 +72,19 @@ const fn compact_metadata_inner<'i, 'o>(
                     return None;
                 }
 
-                (input, output) = forward_option!(compact_metadata_inner(input, output));
+                (input, output) =
+                    forward_option!(compact_metadata_inner(input, output, for_external_args));
 
                 num_methods -= 1;
             }
         }
         ContractMetadataKind::Trait => {
+            (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+
+            if input.is_empty() || output.is_empty() {
+                return None;
+            }
+
             // Remove trait name
             let trait_name_length = input[0] as usize;
             output[0] = 0;
@@ -93,7 +104,8 @@ const fn compact_metadata_inner<'i, 'o>(
                     return None;
                 }
 
-                (input, output) = forward_option!(compact_metadata_inner(input, output));
+                (input, output) =
+                    forward_option!(compact_metadata_inner(input, output, for_external_args));
 
                 num_methods -= 1;
             }
@@ -104,6 +116,40 @@ const fn compact_metadata_inner<'i, 'o>(
         | ContractMetadataKind::UpdateStatefulRw
         | ContractMetadataKind::ViewStateless
         | ContractMetadataKind::ViewStateful => {
+            match kind {
+                ContractMetadataKind::Init => {
+                    (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+                }
+                ContractMetadataKind::UpdateStateless
+                | ContractMetadataKind::UpdateStatefulRo
+                | ContractMetadataKind::UpdateStatefulRw => {
+                    if for_external_args {
+                        // For `ExternalArgs` the kind of `#[update]` doesn't matter
+                        output[0] = ContractMetadataKind::UpdateStateless as u8;
+                        (input, output) = forward_option!(skip_n_bytes_io(input, output, 1));
+                    } else {
+                        (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+                    }
+                }
+                ContractMetadataKind::ViewStateless | ContractMetadataKind::ViewStateful => {
+                    if for_external_args {
+                        // For `ExternalArgs` the kind of `#[view]` doesn't matter
+                        output[0] = ContractMetadataKind::ViewStateless as u8;
+                        (input, output) = forward_option!(skip_n_bytes_io(input, output, 1));
+                    } else {
+                        (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+                    }
+                }
+                _ => {
+                    // Just matched above
+                    unreachable!();
+                }
+            }
+
+            if input.is_empty() || output.is_empty() {
+                return None;
+            }
+
             // Copy method name
             let method_name_length = input[0] as usize;
             (input, output) = forward_option!(copy_n_bytes(input, output, 1 + method_name_length));
@@ -127,7 +173,8 @@ const fn compact_metadata_inner<'i, 'o>(
                     input,
                     output,
                     kind,
-                    num_arguments == 0
+                    num_arguments == 0,
+                    for_external_args
                 ));
             }
         }
@@ -152,13 +199,13 @@ const fn compact_method_argument<'i, 'o>(
     mut output: &'o mut [u8],
     method_kind: ContractMetadataKind,
     last_argument: bool,
+    for_external_args: bool,
 ) -> Option<(&'i [u8], &'o mut [u8])> {
     if input.is_empty() || output.is_empty() {
         return None;
     }
 
     let kind = forward_option!(ContractMetadataKind::try_from_u8(input[0]));
-    (input, output) = forward_option!(copy_n_bytes(input, output, 1));
 
     match kind {
         ContractMetadataKind::Contract
@@ -173,12 +220,42 @@ const fn compact_method_argument<'i, 'o>(
             return None;
         }
         ContractMetadataKind::EnvRo | ContractMetadataKind::EnvRw => {
+            if for_external_args {
+                // For `ExternalArgs` `#[env]` doesn't matter
+                input = forward_option!(skip_n_bytes(input, 1));
+            } else {
+                (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+            }
             // Nothing else to do here, `#[env]` doesn't include metadata of its type
         }
         ContractMetadataKind::TmpRo
         | ContractMetadataKind::TmpRw
         | ContractMetadataKind::SlotRo
         | ContractMetadataKind::SlotRw => {
+            match kind {
+                ContractMetadataKind::TmpRo | ContractMetadataKind::TmpRw => {
+                    if for_external_args {
+                        // For `ExternalArgs` `#[tmp]` doesn't matter
+                        input = forward_option!(skip_n_bytes(input, 1));
+                    } else {
+                        (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+                    }
+                }
+                ContractMetadataKind::SlotRo | ContractMetadataKind::SlotRw => {
+                    if for_external_args {
+                        // For `ExternalArgs` the kind of `#[slot]` doesn't matter
+                        output[0] = ContractMetadataKind::SlotRo as u8;
+                        (input, output) = forward_option!(skip_n_bytes_io(input, output, 1));
+                    } else {
+                        (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+                    }
+                }
+                _ => {
+                    // Just matched above
+                    unreachable!()
+                }
+            }
+
             if input.is_empty() || output.is_empty() {
                 return None;
             }
@@ -190,6 +267,8 @@ const fn compact_method_argument<'i, 'o>(
             input = forward_option!(skip_n_bytes(input, argument_name_length));
         }
         ContractMetadataKind::Input | ContractMetadataKind::Output => {
+            (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+
             if input.is_empty() || output.is_empty() {
                 return None;
             }

--- a/crates/contracts/ab-contracts-common/src/method.rs
+++ b/crates/contracts/ab-contracts-common/src/method.rs
@@ -25,11 +25,12 @@ impl fmt::Display for MethodFingerprint {
 impl MethodFingerprint {
     /// Create a new method fingerprint from its metadata.
     ///
-    /// `None` is returned for invalid metadata (see [`ContractMetadataKind::compact`] for details).
+    /// `None` is returned for invalid metadata (see
+    /// [`ContractMetadataKind::compact_external_args()`] for details).
     pub const fn new(method_metadata: &[u8]) -> Option<Self> {
         // `?` is not supported in `const` environment
         let Some((compact_metadata_scratch, compact_metadata_size)) =
-            ContractMetadataKind::compact(method_metadata)
+            ContractMetadataKind::compact_external_args(method_metadata)
         else {
             return None;
         };

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -161,10 +161,13 @@ impl SimpleWalletBase {
     #[update]
     pub fn execute(
         #[env] env: &mut Env,
-        #[input] _header: &TransactionHeader,
+        #[input] header: &TransactionHeader,
         #[input] payload: &TxHandlerPayload,
-        #[input] _seal: &TxHandlerSeal,
+        #[input] seal: &TxHandlerSeal,
     ) -> Result<(), ContractError> {
+        let _ = header;
+        let _ = seal;
+
         // Only allow direct calls by context owner
         if env.caller() != env.context() {
             return Err(ContractError::Forbidden);
@@ -199,9 +202,11 @@ impl SimpleWalletBase {
     #[view]
     pub fn increase_nonce(
         #[input] state: &VariableBytes<0>,
-        #[input] _seal: &TxHandlerSeal,
+        #[input] seal: &TxHandlerSeal,
         #[output] new_state: &mut VariableBytes<0>,
     ) -> Result<(), ContractError> {
+        let _ = seal;
+
         let Some(mut state) = state.read_trivial_type::<WalletState>() else {
             return Err(ContractError::BadInput);
         };


### PR DESCRIPTION
The second commit is especially useful since it allows to add/remove `#[env]`, `#[tmp]`, change statefullness of the method or mutability of `#[slot]` without affecting public API. Previously those changes still affected method fingerprint, but not anymore.