### PR TITLE
Wallet/flipper benchmark

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,8 +80,11 @@ jobs:
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-common --features ab-contracts-common/guest -- -D warnings
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-common --features ab-contracts-common/alloc -- -D warnings
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-common --features ab-contracts-common/executor -- -D warnings
+
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-macros --features ab-contracts-common/executor -- -D warnings
+
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-standards --features ab-contracts-standards/guest -- -D warnings
+
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/alloc -- -D warnings
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder -- -D warnings
         if: runner.os == 'Linux'
@@ -119,12 +122,14 @@ jobs:
         run: |
           cargo -Zgitoxide -Zgit nextest run --locked
 
-      - name: cargo test (guest feature)
+      - name: cargo test (various features)
         working-directory: crates/contracts
         run: |
           for contract in {ab-contract-example-,ab-system-contract-}*; do  
             cargo -Zgitoxide -Zgit test -p $contract --features $contract/guest
           done
+
+          cargo -Zgitoxide -Zgit test -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
         if: runner.os == 'Linux'
 
       - name: cargo miri nextest run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,11 +31,15 @@ name = "ab-contract-example-wallet"
 version = "0.0.1"
 dependencies = [
  "ab-contracts-common",
+ "ab-contracts-executor",
  "ab-contracts-io-type",
  "ab-contracts-macros",
  "ab-contracts-standards",
+ "ab-system-contract-code",
  "ab-system-contract-simple-wallet-base",
  "ab-system-contract-state",
+ "criterion",
+ "schnorrkel",
 ]
 
 [[package]]
@@ -180,6 +184,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +213,18 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "arrayref"
@@ -244,6 +279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +298,58 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "const-sha1"
@@ -300,12 +393,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -368,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,12 +536,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom_or_panic"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -427,10 +588,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "keccak"
@@ -470,6 +663,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,10 +691,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "overload"
@@ -555,6 +769,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -564,6 +781,35 @@ checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
@@ -581,11 +827,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schnorrkel"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de18f6d8ba0aad7045f5feae07ec29899c1112584a38509a84ad7b04451eaa0"
 dependencies = [
+ "aead",
  "arrayref",
  "arrayvec",
  "curve25519-dalek",
@@ -608,6 +870,38 @@ name = "semver"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+
+[[package]]
+name = "serde"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha2"
@@ -686,6 +980,16 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -782,6 +1086,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,10 +1118,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ aliasable = "0.1.3"
 blake3 = { version = "1.6.0", default-features = false }
 const-sha1 = "0.3.0"
 const_format = "0.2.34"
+criterion = { version = "0.5.1", default-features = false }
 derive_more = { version = "2.0.1", default-features = false }
 halfbrown = "0.3.0"
 ident_case = "1.0.1"

--- a/crates/contracts/ab-contract-example-wallet/Cargo.toml
+++ b/crates/contracts/ab-contract-example-wallet/Cargo.toml
@@ -13,6 +13,14 @@ include = [
 [package.metadata.docs.rs]
 all-features = true
 
+[lib]
+# Necessary for CLI options to work on benches
+bench = false
+
+[[bench]]
+name = "flip"
+harness = false
+
 [dependencies]
 ab-contracts-common = { workspace = true }
 ab-contracts-io-type = { workspace = true }
@@ -20,6 +28,13 @@ ab-contracts-macros = { workspace = true }
 ab-contracts-standards = { workspace = true }
 ab-system-contract-simple-wallet-base = { workspace = true }
 ab-system-contract-state = { workspace = true }
+
+[dev-dependencies]
+ab-contracts-executor = { workspace = true }
+ab-system-contract-code = { workspace = true }
+ab-system-contract-simple-wallet-base = { workspace = true, features = ["payload-builder"] }
+criterion = { workspace = true }
+schnorrkel = { workspace = true, features = ["getrandom"] }
 
 [features]
 guest = [

--- a/crates/contracts/ab-contract-example-wallet/benches/flip.rs
+++ b/crates/contracts/ab-contract-example-wallet/benches/flip.rs
@@ -1,0 +1,144 @@
+use crate::ffi::flip::FlipperFlipArgs;
+use ab_contract_example_wallet::{ExampleWallet, ExampleWalletExt};
+use ab_contracts_common::env::{Blake3Hash, MethodContext, TransactionHeader, TransactionRef};
+use ab_contracts_common::{Address, Contract, ShardIndex};
+use ab_contracts_executor::NativeExecutor;
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_macros::contract;
+use ab_contracts_standards::tx_handler::TxHandler;
+use ab_system_contract_code::CodeExt;
+use ab_system_contract_simple_wallet_base::payload::TransactionMethodContext;
+use ab_system_contract_simple_wallet_base::payload::builder::TransactionPayloadBuilder;
+use ab_system_contract_simple_wallet_base::seal::hash_and_sign;
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use schnorrkel::Keypair;
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct Flipper {
+    pub value: bool,
+}
+
+#[contract]
+impl Flipper {
+    #[init]
+    pub fn new(#[input] &init_value: &bool) -> Self {
+        Self { value: init_value }
+    }
+
+    #[update]
+    pub fn flip(&mut self) {
+        self.value = !self.value;
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let shard_index = ShardIndex::from_u32(1).unwrap();
+    let executor = NativeExecutor::builder(shard_index)
+        .with_contract::<ExampleWallet>()
+        .with_contract_trait::<ExampleWallet, dyn TxHandler>()
+        .with_contract::<Flipper>()
+        .build()
+        .unwrap();
+
+    let storage = &mut executor.new_storage().unwrap();
+
+    let keypair = Keypair::generate();
+
+    let wallet_address = executor.transaction_emulate(Address::NULL, storage, |env| {
+        // Deploy
+        let wallet_address = env
+            .code_deploy(
+                MethodContext::Keep,
+                Address::SYSTEM_CODE,
+                &ExampleWallet::code(),
+            )
+            .unwrap();
+
+        // Initialize state
+        env.example_wallet_initialize(
+            MethodContext::Keep,
+            wallet_address,
+            &keypair.public.to_bytes(),
+        )
+        .unwrap();
+
+        wallet_address
+    });
+
+    let flipper_address = executor.transaction_emulate(Address::NULL, storage, |env| {
+        // Deploy
+        let flipper_address = env
+            .code_deploy(MethodContext::Keep, Address::SYSTEM_CODE, &Flipper::code())
+            .unwrap();
+
+        // Initialize state
+        env.flipper_new(MethodContext::Keep, flipper_address, &true)
+            .unwrap();
+
+        flipper_address
+    });
+
+    let header = TransactionHeader {
+        genesis_hash: Blake3Hash::default(),
+        block_hash: Blake3Hash::default(),
+        gas_limit: Default::default(),
+        contract: wallet_address,
+    };
+    let payload = {
+        let mut builder = TransactionPayloadBuilder::default();
+        builder
+            .with_method_call(
+                &flipper_address,
+                &FlipperFlipArgs::new(),
+                TransactionMethodContext::Null,
+                &[],
+            )
+            .unwrap();
+        builder.into_aligned_bytes()
+    };
+    let mut nonce = 0;
+
+    c.bench_function("verify", |b| {
+        let seal = hash_and_sign(&keypair, &header, &payload, nonce);
+
+        b.iter(|| {
+            executor
+                .transaction_verify(
+                    black_box(TransactionRef {
+                        header: &header,
+                        payload: &payload,
+                        seal: seal.as_bytes(),
+                    }),
+                    black_box(storage),
+                )
+                .unwrap();
+        })
+    });
+
+    c.bench_function("execute", |b| {
+        b.iter_batched(
+            || {
+                let seal = hash_and_sign(&keypair, &header, &payload, nonce);
+                nonce += 1;
+                seal
+            },
+            |seal| {
+                executor
+                    .transaction_execute(
+                        black_box(TransactionRef {
+                            header: &header,
+                            payload: &payload,
+                            seal: seal.as_bytes(),
+                        }),
+                        black_box(storage),
+                    )
+                    .unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/contracts/ab-contract-example-wallet/tests/flip.rs
+++ b/crates/contracts/ab-contract-example-wallet/tests/flip.rs
@@ -1,0 +1,133 @@
+// Auto-generated constants will conflict with the main crate when `guest` feature is enabled
+#![cfg(not(feature = "guest"))]
+
+use crate::ffi::flip::FlipperFlipArgs;
+use ab_contract_example_wallet::{ExampleWallet, ExampleWalletExt};
+use ab_contracts_common::env::{Blake3Hash, MethodContext, TransactionHeader, TransactionRef};
+use ab_contracts_common::{Address, Contract, ShardIndex};
+use ab_contracts_executor::NativeExecutor;
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_macros::contract;
+use ab_contracts_standards::tx_handler::TxHandler;
+use ab_system_contract_code::CodeExt;
+use ab_system_contract_simple_wallet_base::payload::TransactionMethodContext;
+use ab_system_contract_simple_wallet_base::payload::builder::TransactionPayloadBuilder;
+use ab_system_contract_simple_wallet_base::seal::hash_and_sign;
+use schnorrkel::Keypair;
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct Flipper {
+    pub value: bool,
+}
+
+#[contract]
+impl Flipper {
+    #[init]
+    pub fn new(#[input] &init_value: &bool) -> Self {
+        Self { value: init_value }
+    }
+
+    #[update]
+    pub fn flip(&mut self) {
+        self.value = !self.value;
+    }
+}
+
+#[test]
+fn flip() {
+    let shard_index = ShardIndex::from_u32(1).unwrap();
+    let executor = NativeExecutor::builder(shard_index)
+        .with_contract::<ExampleWallet>()
+        .with_contract_trait::<ExampleWallet, dyn TxHandler>()
+        .with_contract::<Flipper>()
+        .build()
+        .unwrap();
+
+    let storage = &mut executor.new_storage().unwrap();
+
+    let keypair = Keypair::generate();
+
+    let wallet_address = executor.transaction_emulate(Address::NULL, storage, |env| {
+        // Deploy
+        let wallet_address = env
+            .code_deploy(
+                MethodContext::Keep,
+                Address::SYSTEM_CODE,
+                &ExampleWallet::code(),
+            )
+            .unwrap();
+
+        // Initialize state
+        env.example_wallet_initialize(
+            MethodContext::Keep,
+            wallet_address,
+            &keypair.public.to_bytes(),
+        )
+        .unwrap();
+
+        wallet_address
+    });
+
+    let flipper_address = executor.transaction_emulate(Address::NULL, storage, |env| {
+        // Deploy
+        let flipper_address = env
+            .code_deploy(MethodContext::Keep, Address::SYSTEM_CODE, &Flipper::code())
+            .unwrap();
+
+        // Initialize state
+        env.flipper_new(MethodContext::Keep, flipper_address, &true)
+            .unwrap();
+
+        flipper_address
+    });
+
+    let header = TransactionHeader {
+        genesis_hash: Blake3Hash::default(),
+        block_hash: Blake3Hash::default(),
+        gas_limit: Default::default(),
+        contract: wallet_address,
+    };
+    let payload = {
+        let mut builder = TransactionPayloadBuilder::default();
+        builder
+            .with_method_call(
+                &flipper_address,
+                &FlipperFlipArgs::new(),
+                TransactionMethodContext::Null,
+                &[],
+            )
+            .unwrap();
+        builder.into_aligned_bytes()
+    };
+    let nonce = 0;
+
+    {
+        let seal = hash_and_sign(&keypair, &header, &payload, nonce);
+        executor
+            .transaction_verify(
+                TransactionRef {
+                    header: &header,
+                    payload: &payload,
+                    seal: seal.as_bytes(),
+                },
+                storage,
+            )
+            .unwrap();
+    }
+
+    for nonce in (nonce..).take(5) {
+        let seal = hash_and_sign(&keypair, &header, &payload, nonce);
+
+        executor
+            .transaction_execute(
+                TransactionRef {
+                    header: &header,
+                    payload: &payload,
+                    seal: seal.as_bytes(),
+                },
+                storage,
+            )
+            .unwrap();
+    }
+}

--- a/crates/contracts/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/ab-contracts-executor/src/context.rs
@@ -84,8 +84,8 @@ impl NativeExecutorContext {
             // context
             self.slots.lock().new_nested()
         } else {
-            // If mutation wasn't allowed on higher level, then reuse existing slots instance
-            Arc::clone(&self.slots)
+            // TODO: For read-only nested slots do not track anything at all
+            self.slots.lock().new_nested()
         }
     }
 

--- a/crates/contracts/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/ab-contracts-executor/src/lib.rs
@@ -99,6 +99,11 @@ impl NativeExecutorBuilder {
                     main_contract_metadata: State::MAIN_CONTRACT_METADATA,
                     native_executor_methods: State::NATIVE_EXECUTOR_METHODS,
                 },
+                MethodsEntry {
+                    contact_code: SimpleWalletBase::CODE,
+                    main_contract_metadata: SimpleWalletBase::MAIN_CONTRACT_METADATA,
+                    native_executor_methods: SimpleWalletBase::NATIVE_EXECUTOR_METHODS,
+                },
             ],
         }
     }

--- a/crates/contracts/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/ab-contracts-executor/src/lib.rs
@@ -297,7 +297,7 @@ impl NativeExecutor {
     /// For transaction execution [`Self::transaction_verify()`] can be used.
     pub fn transaction_verify(
         &self,
-        transaction: &TransactionRef<'_>,
+        transaction: TransactionRef<'_>,
         storage: &Storage,
     ) -> Result<(), ContractError> {
         let env_state = EnvState {

--- a/crates/contracts/ab-contracts-io-type/src/metadata/compact.rs
+++ b/crates/contracts/ab-contracts-io-type/src/metadata/compact.rs
@@ -234,15 +234,15 @@ pub(super) const fn compact_metadata<'i, 'o>(
             (input, output) = forward_option!(copy_n_bytes(input, output, 1));
             compact_enum(input, output, Some(10), false)
         }
-        IoTypeMetadataKind::Array8b => {
+        IoTypeMetadataKind::Array8b | IoTypeMetadataKind::VariableElements8b => {
             (input, output) = forward_option!(copy_n_bytes(input, output, 1 + 1));
             compact_metadata(input, output)
         }
-        IoTypeMetadataKind::Array16b => {
+        IoTypeMetadataKind::Array16b | IoTypeMetadataKind::VariableElements16b => {
             (input, output) = forward_option!(copy_n_bytes(input, output, 1 + 2));
             compact_metadata(input, output)
         }
-        IoTypeMetadataKind::Array32b => {
+        IoTypeMetadataKind::Array32b | IoTypeMetadataKind::VariableElements32b => {
             (input, output) = forward_option!(copy_n_bytes(input, output, 1 + 4));
             compact_metadata(input, output)
         }
@@ -271,13 +271,12 @@ pub(super) const fn compact_metadata<'i, 'o>(
         | IoTypeMetadataKind::VariableBytes131072
         | IoTypeMetadataKind::VariableBytes262144
         | IoTypeMetadataKind::VariableBytes524288
-        | IoTypeMetadataKind::VariableBytes1048576
-        | IoTypeMetadataKind::VariableElements8b
-        | IoTypeMetadataKind::VariableElements16b
-        | IoTypeMetadataKind::VariableElements32b
-        | IoTypeMetadataKind::VariableElements0
-        | IoTypeMetadataKind::Address
-        | IoTypeMetadataKind::Balance => copy_n_bytes(input, output, 1),
+        | IoTypeMetadataKind::VariableBytes1048576 => copy_n_bytes(input, output, 1),
+        IoTypeMetadataKind::VariableElements0 => {
+            (input, output) = forward_option!(copy_n_bytes(input, output, 1));
+            compact_metadata(input, output)
+        }
+        IoTypeMetadataKind::Address | IoTypeMetadataKind::Balance => copy_n_bytes(input, output, 1),
     }
 }
 

--- a/crates/contracts/ab-contracts-io-type/src/metadata/type_details.rs
+++ b/crates/contracts/ab-contracts-io-type/src/metadata/type_details.rs
@@ -129,6 +129,10 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
             ))
         }
         IoTypeMetadataKind::Array16b | IoTypeMetadataKind::VariableElements16b => {
+            if metadata.is_empty() {
+                return None;
+            }
+
             let mut num_elements = [0; size_of::<u16>()];
             (metadata, _) =
                 forward_option!(copy_n_bytes(metadata, &mut num_elements, size_of::<u16>()));
@@ -147,6 +151,10 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
             ))
         }
         IoTypeMetadataKind::Array32b | IoTypeMetadataKind::VariableElements32b => {
+            if metadata.is_empty() {
+                return None;
+            }
+
             let mut num_elements = [0; size_of::<u32>()];
             (metadata, _) =
                 forward_option!(copy_n_bytes(metadata, &mut num_elements, size_of::<u32>()));
@@ -185,6 +193,10 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
             Some((IoTypeDetails::bytes(num_bytes), metadata))
         }
         IoTypeMetadataKind::VariableBytes16b => {
+            if metadata.is_empty() {
+                return None;
+            }
+
             let mut num_bytes = [0; size_of::<u16>()];
             (metadata, _) =
                 forward_option!(copy_n_bytes(metadata, &mut num_bytes, size_of::<u16>()));
@@ -193,6 +205,10 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
             Some((IoTypeDetails::bytes(num_bytes), metadata))
         }
         IoTypeMetadataKind::VariableBytes32b => {
+            if metadata.is_empty() {
+                return None;
+            }
+
             let mut num_bytes = [0; size_of::<u32>()];
             (metadata, _) =
                 forward_option!(copy_n_bytes(metadata, &mut num_bytes, size_of::<u32>()));

--- a/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
@@ -29,9 +29,15 @@ where
     Element: TrivialType,
 {
     const METADATA: &[u8] = {
-        const fn metadata(recommended_allocation: u32) -> ([u8; MAX_METADATA_CAPACITY], usize) {
+        const fn metadata(
+            recommended_allocation: u32,
+            inner_metadata: &[u8],
+        ) -> ([u8; MAX_METADATA_CAPACITY], usize) {
             if recommended_allocation == 0 {
-                return concat_metadata_sources(&[&[IoTypeMetadataKind::VariableElements0 as u8]]);
+                return concat_metadata_sources(&[
+                    &[IoTypeMetadataKind::VariableElements0 as u8],
+                    inner_metadata,
+                ]);
             }
 
             let (io_type, size_bytes) = if recommended_allocation < 2u32.pow(8) {
@@ -45,13 +51,14 @@ where
             concat_metadata_sources(&[
                 &[io_type as u8],
                 recommended_allocation.to_le_bytes().split_at(size_bytes).0,
+                inner_metadata,
             ])
         }
 
         // Strange syntax to allow Rust to extend the lifetime of metadata scratch automatically
-        metadata(RECOMMENDED_ALLOCATION)
+        metadata(RECOMMENDED_ALLOCATION, Element::METADATA)
             .0
-            .split_at(metadata(RECOMMENDED_ALLOCATION).1)
+            .split_at(metadata(RECOMMENDED_ALLOCATION, Element::METADATA).1)
             .0
     };
 

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/payload.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/payload.rs
@@ -188,7 +188,7 @@ impl<'a> TransactionPayloadDecoder<'a> {
     pub fn decode_next_method(
         &mut self,
     ) -> Result<Option<PreparedMethod<'a>>, TransactionPayloadDecoderError> {
-        if self.payload.is_empty() {
+        if self.payload.len() <= usize::from(MAX_ALIGNMENT) {
             return Ok(None);
         }
 
@@ -323,7 +323,7 @@ impl<'a> TransactionPayloadDecoder<'a> {
         let bytes;
         (bytes, self.payload) = self
             .payload
-            .split_at_checked(align_of::<T>())
+            .split_at_checked(size_of::<T>())
             .ok_or(TransactionPayloadDecoderError::PayloadTooSmall)?;
 
         // SAFETY: Correctly aligned bytes of correct size

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/payload/builder.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/payload/builder.rs
@@ -1,5 +1,8 @@
 //! Transaction payload creation utilities
 
+#[cfg(test)]
+mod tests;
+
 extern crate alloc;
 
 use crate::payload::{TransactionInput, TransactionMethodContext};
@@ -107,7 +110,7 @@ impl TransactionPayloadBuilder {
         self.extend_payload_with_alignment(contract.as_bytes(), align_of_val(contract));
         self.extend_payload_with_alignment(
             method_fingerprint.as_bytes(),
-            align_of_val(&method_fingerprint),
+            align_of_val(method_fingerprint),
         );
         self.payload.push(method_context as u8);
 

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/payload/builder/tests.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/payload/builder/tests.rs
@@ -1,0 +1,85 @@
+use crate::payload::builder::TransactionPayloadBuilder;
+use crate::payload::builder::tests::ffi::set::DemoContractSetArgs;
+use crate::payload::{TransactionMethodContext, TransactionPayloadDecoder};
+use crate::{EXTERNAL_ARGS_BUFFER_SIZE, OUTPUT_BUFFER_OFFSETS_SIZE, OUTPUT_BUFFER_SIZE};
+use ab_contracts_common::Address;
+use ab_contracts_common::env::{MethodContext, PreparedMethod};
+use ab_contracts_common::method::ExternalArgs;
+use ab_contracts_io_type::trivial_type::TrivialType;
+use ab_contracts_macros::contract;
+use core::mem::MaybeUninit;
+use core::ptr;
+
+#[derive(Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct DemoContract {
+    pub value: u8,
+}
+
+#[contract]
+impl DemoContract {
+    #[init]
+    pub fn new(#[input] &init_value: &u8) -> Self {
+        Self { value: init_value }
+    }
+
+    #[update]
+    pub fn set(&mut self, #[input] &new_value: &u8) {
+        self.value = new_value;
+    }
+}
+
+// TODO: Test output indices and more complex types
+#[test]
+fn payload_encode_decode() {
+    let expected_contract = Address::SYSTEM_SIMPLE_WALLET_BASE;
+    let new_value = 42;
+
+    let payload = {
+        let mut builder = TransactionPayloadBuilder::default();
+        builder
+            .with_method_call(
+                &expected_contract,
+                &DemoContractSetArgs::new(&new_value),
+                TransactionMethodContext::Wallet,
+                &[],
+            )
+            .unwrap();
+        builder.into_aligned_bytes()
+    };
+
+    let mut external_args_buffer = [ptr::null_mut(); EXTERNAL_ARGS_BUFFER_SIZE];
+    let mut output_buffer = [MaybeUninit::uninit(); OUTPUT_BUFFER_SIZE];
+    let mut output_buffer_offsets = [(0, 0); OUTPUT_BUFFER_OFFSETS_SIZE];
+
+    let mut decoder = TransactionPayloadDecoder::new(
+        &payload,
+        &mut external_args_buffer,
+        &mut output_buffer,
+        &mut output_buffer_offsets,
+        |method_context| match method_context {
+            TransactionMethodContext::Null => MethodContext::Reset,
+            TransactionMethodContext::Wallet => MethodContext::Keep,
+        },
+    );
+
+    let PreparedMethod {
+        contract,
+        fingerprint,
+        external_args,
+        method_context,
+        phantom: _,
+    } = decoder.decode_next_method().unwrap().unwrap();
+
+    assert_eq!(contract, expected_contract);
+    assert_eq!(fingerprint, DemoContractSetArgs::FINGERPRINT);
+    assert_eq!(
+        unsafe { external_args.read().cast::<u8>().read() },
+        new_value
+    );
+    assert_eq!(method_context, MethodContext::Keep);
+
+    // There is some padding, but it is correctly determined that there is no payload anymore
+    assert!(!decoder.payload.is_empty());
+    assert!(decoder.decode_next_method().unwrap().is_none());
+}

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/seal.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/seal.rs
@@ -1,0 +1,87 @@
+//! Utilities for [`Seal`] creation and verification
+
+use crate::{SIGNING_CONTEXT, Seal};
+use ab_contracts_common::ContractError;
+use ab_contracts_common::env::{Blake3Hash, TransactionHeader};
+use ab_contracts_io_type::trivial_type::TrivialType;
+use core::slice;
+use schnorrkel::context::SigningContext;
+use schnorrkel::{Keypair, PublicKey, Signature};
+
+/// Create transaction hash used for signing with [`sign()`].
+///
+/// [`hash_and_sign()`] helper function exists that combines this method with [`sign()`].
+pub fn hash_transaction(header: &TransactionHeader, payload: &[u128], nonce: u64) -> Blake3Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(header.as_bytes());
+    // SAFETY: Valid memory of correct size
+    let payload_bytes =
+        unsafe { slice::from_raw_parts(payload.as_ptr().cast::<u8>(), size_of_val(payload)) };
+    hasher.update(payload_bytes);
+    hasher.update(&nonce.to_le_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+/// Sign transaction hash created with [`hash_transaction()`].
+///
+/// [`hash_and_sign()`] helper function exists that combines this method with
+/// [`hash_transaction()`].
+pub fn sign(keypair: &Keypair, tx_hash: &Blake3Hash) -> Signature {
+    let signing_context = SigningContext::new(SIGNING_CONTEXT);
+    keypair.sign(signing_context.bytes(tx_hash))
+}
+
+/// Combines [`hash_transaction()`] and [`sign()`] and returns [`Seal`]
+pub fn hash_and_sign(
+    keypair: &Keypair,
+    header: &TransactionHeader,
+    payload: &[u128],
+    nonce: u64,
+) -> Seal {
+    let tx_hash = hash_transaction(header, payload, nonce);
+    let signature = sign(keypair, &tx_hash).to_bytes();
+
+    Seal { signature, nonce }
+}
+
+/// Verify seal created by [`hash_and_sign()`].
+///
+/// [`hash_and_verify()`] helper function exists that combines this method with
+/// [`hash_transaction()`].
+pub fn verify(
+    public_key: &PublicKey,
+    expected_nonce: u64,
+    tx_hash: &Blake3Hash,
+    signature: &Signature,
+    nonce: u64,
+) -> Result<(), ContractError> {
+    if nonce != expected_nonce {
+        return Err(ContractError::BadInput);
+    }
+
+    let signing_context = SigningContext::new(SIGNING_CONTEXT);
+    public_key
+        .verify(signing_context.bytes(tx_hash.as_bytes()), signature)
+        .map_err(|_error| ContractError::Forbidden)
+}
+
+/// Combines [`hash_transaction()`] and [`verify()`]
+pub fn hash_and_verify(
+    public_key: &PublicKey,
+    expected_nonce: u64,
+    header: &TransactionHeader,
+    payload: &[u128],
+    seal: &Seal,
+) -> Result<(), ContractError> {
+    if seal.nonce != expected_nonce {
+        return Err(ContractError::BadInput);
+    }
+
+    let tx_hash = hash_transaction(header, payload, seal.nonce);
+    let signature =
+        Signature::from_bytes(&seal.signature).map_err(|_error| ContractError::BadInput)?;
+    let signing_context = SigningContext::new(SIGNING_CONTEXT);
+    public_key
+        .verify(signing_context.bytes(tx_hash.as_bytes()), &signature)
+        .map_err(|_error| ContractError::Forbidden)
+}


### PR DESCRIPTION
This fixes a bunch of small issues (and adds a couple of relevant basic tests).

The example wallet gained both test and benchmark, allowing to test end-to-end workflow where a signed transaction is verified by the wallet contract, decoded and executed.

A lot of cross-contract calls of different kinds is happening in the process, currently benchmarks look like this:
```
verify                  time:   [18.661 µs 18.685 µs 18.712 µs]
execute                 time:   [23.280 µs 23.309 µs 23.343 µs]
```

This is about 2 orders of magnitude slower than direct flipper calls without a transaction.

The majority of the cost comes from signature verification, while just hashing of the transaction is quite fast:
```
hash                    time:   [181.66 ns 181.76 ns 181.88 ns]
hash_verify             time:   [14.672 µs 14.702 µs 14.735 µs]
```

Looks like I'll have to look into performance of `schnorrkel` library at some point. Picking another crypto is also always an option.