### PR TITLE
Refactor transaction types

### DIFF
--- a/crates/contracts/ab-contract-example-wallet/benches/flip.rs
+++ b/crates/contracts/ab-contract-example-wallet/benches/flip.rs
@@ -1,6 +1,6 @@
 use crate::ffi::flip::FlipperFlipArgs;
 use ab_contract_example_wallet::{ExampleWallet, ExampleWalletExt};
-use ab_contracts_common::env::{Blake3Hash, MethodContext, TransactionHeader, TransactionRef};
+use ab_contracts_common::env::{Blake3Hash, MethodContext, Transaction, TransactionHeader};
 use ab_contracts_common::{Address, Contract, ShardIndex};
 use ab_contracts_executor::NativeExecutor;
 use ab_contracts_io_type::trivial_type::TrivialType;
@@ -105,7 +105,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             executor
                 .transaction_verify(
-                    black_box(TransactionRef {
+                    black_box(Transaction {
                         header: &header,
                         payload: &payload,
                         seal: seal.as_bytes(),
@@ -126,7 +126,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             |seal| {
                 executor
                     .transaction_execute(
-                        black_box(TransactionRef {
+                        black_box(Transaction {
                             header: &header,
                             payload: &payload,
                             seal: seal.as_bytes(),

--- a/crates/contracts/ab-contract-example-wallet/tests/flip.rs
+++ b/crates/contracts/ab-contract-example-wallet/tests/flip.rs
@@ -3,7 +3,7 @@
 
 use crate::ffi::flip::FlipperFlipArgs;
 use ab_contract_example_wallet::{ExampleWallet, ExampleWalletExt};
-use ab_contracts_common::env::{Blake3Hash, MethodContext, TransactionHeader, TransactionRef};
+use ab_contracts_common::env::{Blake3Hash, MethodContext, Transaction, TransactionHeader};
 use ab_contracts_common::{Address, Contract, ShardIndex};
 use ab_contracts_executor::NativeExecutor;
 use ab_contracts_io_type::trivial_type::TrivialType;
@@ -106,7 +106,7 @@ fn flip() {
         let seal = hash_and_sign(&keypair, &header, &payload, nonce);
         executor
             .transaction_verify(
-                TransactionRef {
+                Transaction {
                     header: &header,
                     payload: &payload,
                     seal: seal.as_bytes(),
@@ -121,7 +121,7 @@ fn flip() {
 
         executor
             .transaction_execute(
-                TransactionRef {
+                Transaction {
                     header: &header,
                     payload: &payload,
                     seal: seal.as_bytes(),

--- a/crates/contracts/ab-contracts-common/src/env.rs
+++ b/crates/contracts/ab-contracts-common/src/env.rs
@@ -6,8 +6,6 @@ use crate::{Address, ContractError, ShardIndex};
 use ab_contracts_io_type::trivial_type::TrivialType;
 #[cfg(feature = "executor")]
 use alloc::boxed::Box;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
@@ -30,31 +28,11 @@ pub struct TransactionHeader {
     pub contract: Address,
 }
 
-#[derive(Debug)]
-#[cfg(feature = "alloc")]
-pub struct Transaction {
-    pub header: TransactionHeader,
-    pub payload: Vec<u128>,
-    pub seal: Vec<u8>,
-}
-
-#[cfg(feature = "alloc")]
-impl Transaction {
-    /// Get [`TransactionRef`] out of transaction
-    pub fn as_ref(&self) -> TransactionRef<'_> {
-        TransactionRef {
-            header: &self.header,
-            payload: &self.payload,
-            seal: &self.seal,
-        }
-    }
-}
-
 /// Similar to `Transaction`, but doesn't require `allow` or data ownership.
 ///
 /// Can be created with `Transaction::as_ref()` call.
-#[derive(Debug)]
-pub struct TransactionRef<'a> {
+#[derive(Debug, Copy, Clone)]
+pub struct Transaction<'a> {
     pub header: &'a TransactionHeader,
     pub payload: &'a [u128],
     pub seal: &'a [u8],
@@ -117,7 +95,7 @@ pub struct EnvState {
 
 /// Executor context that can be used to interact with executor
 #[cfg(feature = "executor")]
-pub trait ExecutorContext: alloc::fmt::Debug {
+pub trait ExecutorContext: core::fmt::Debug {
     /// Call multiple methods
     fn call_many(
         &self,

--- a/crates/contracts/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/ab-contracts-executor/src/lib.rs
@@ -7,7 +7,7 @@ mod slots;
 use crate::aligned_buffer::SharedAlignedBuffer;
 use crate::context::{MethodDetails, NativeExecutorContext};
 use crate::slots::{SlotKey, Slots};
-use ab_contracts_common::env::{Env, EnvState, MethodContext, TransactionRef};
+use ab_contracts_common::env::{Env, EnvState, MethodContext, Transaction};
 use ab_contracts_common::metadata::decode::{MetadataDecoder, MetadataDecodingError, MetadataItem};
 use ab_contracts_common::method::MethodFingerprint;
 use ab_contracts_common::{
@@ -297,7 +297,7 @@ impl NativeExecutor {
     /// For transaction execution [`Self::transaction_verify()`] can be used.
     pub fn transaction_verify(
         &self,
-        transaction: TransactionRef<'_>,
+        transaction: Transaction<'_>,
         storage: &Storage,
     ) -> Result<(), ContractError> {
         let env_state = EnvState {
@@ -338,7 +338,7 @@ impl NativeExecutor {
     /// If only verification is needed, [`Self::transaction_verify()`] can be used instead.
     pub fn transaction_execute(
         &self,
-        transaction: TransactionRef<'_>,
+        transaction: Transaction<'_>,
         storage: &mut Storage,
     ) -> Result<(), ContractError> {
         // TODO: This is a pretty large data structure to copy around, try to make it a reference

--- a/crates/contracts/ab-contracts-test-utils/src/transaction_builder.rs
+++ b/crates/contracts/ab-contracts-test-utils/src/transaction_builder.rs
@@ -9,6 +9,24 @@ use ab_system_contract_simple_wallet_base::payload::builder::{
 };
 use alloc::vec::Vec;
 
+#[derive(Debug, Clone)]
+pub struct OwnedTransaction {
+    pub header: TransactionHeader,
+    pub payload: Vec<u128>,
+    pub seal: Vec<u8>,
+}
+
+impl OwnedTransaction {
+    /// Get [`Transaction`] out of owned transaction
+    pub fn as_ref(&self) -> Transaction<'_> {
+        Transaction {
+            header: &self.header,
+            payload: &self.payload,
+            seal: &self.seal,
+        }
+    }
+}
+
 pub struct TransactionBuilder {
     contract: Address,
     transaction_payload_builder: TransactionPayloadBuilder,
@@ -44,8 +62,8 @@ impl TransactionBuilder {
         )
     }
 
-    pub fn build(self) -> Transaction {
-        Transaction {
+    pub fn build(self) -> OwnedTransaction {
+        OwnedTransaction {
             header: TransactionHeader {
                 genesis_hash: Blake3Hash::default(),
                 block_hash: Blake3Hash::default(),


### PR DESCRIPTION
I expect `Transaction` to be much more popular in APIs, but its contents will come from various sources (like network stack, RPC, etc.) and in all of those cases allocation avoidance will be desirable