### PR TITLE
Allow to not specify `0` explicitly in `VariableBytes` and `VariableElements`

### DIFF
--- a/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_bytes.rs
@@ -14,7 +14,7 @@ use core::{ptr, slice};
 /// specified.
 #[derive(Debug)]
 #[repr(C)]
-pub struct VariableBytes<const RECOMMENDED_ALLOCATION: u32> {
+pub struct VariableBytes<const RECOMMENDED_ALLOCATION: u32 = 0> {
     bytes: NonNull<u8>,
     size: NonNull<u32>,
     capacity: u32,

--- a/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
+++ b/crates/contracts/ab-contracts-io-type/src/variable_elements.rs
@@ -14,7 +14,7 @@ use core::{ptr, slice};
 /// specified.
 #[derive(Debug)]
 #[repr(C)]
-pub struct VariableElements<const RECOMMENDED_ALLOCATION: u32, Element>
+pub struct VariableElements<Element, const RECOMMENDED_ALLOCATION: u32 = 0>
 where
     Element: TrivialType,
 {
@@ -23,8 +23,8 @@ where
     capacity: u32,
 }
 
-unsafe impl<const RECOMMENDED_ALLOCATION: u32, Element> IoType
-    for VariableElements<RECOMMENDED_ALLOCATION, Element>
+unsafe impl<Element, const RECOMMENDED_ALLOCATION: u32> IoType
+    for VariableElements<Element, RECOMMENDED_ALLOCATION>
 where
     Element: TrivialType,
 {
@@ -181,14 +181,14 @@ where
     }
 }
 
-impl<const RECOMMENDED_ALLOCATION: u32, Element> IoTypeOptional
-    for VariableElements<RECOMMENDED_ALLOCATION, Element>
+impl<Element, const RECOMMENDED_ALLOCATION: u32> IoTypeOptional
+    for VariableElements<Element, RECOMMENDED_ALLOCATION>
 where
     Element: TrivialType,
 {
 }
 
-impl<const RECOMMENDED_ALLOCATION: u32, Element> VariableElements<RECOMMENDED_ALLOCATION, Element>
+impl<Element, const RECOMMENDED_ALLOCATION: u32> VariableElements<Element, RECOMMENDED_ALLOCATION>
 where
     Element: TrivialType,
 {
@@ -401,12 +401,12 @@ where
     #[inline]
     pub fn cast_ref<const DIFFERENT_RECOMMENDED_ALLOCATION: u32>(
         &self,
-    ) -> &VariableElements<DIFFERENT_RECOMMENDED_ALLOCATION, Element> {
+    ) -> &VariableElements<Element, DIFFERENT_RECOMMENDED_ALLOCATION> {
         // SAFETY: `VariableElements` has a fixed layout due to `#[repr(C)]`, which doesn't depend
         // on recommended allocation
         unsafe {
             NonNull::from_ref(self)
-                .cast::<VariableElements<DIFFERENT_RECOMMENDED_ALLOCATION, Element>>()
+                .cast::<VariableElements<Element, DIFFERENT_RECOMMENDED_ALLOCATION>>()
                 .as_ref()
         }
     }
@@ -416,12 +416,12 @@ where
     #[inline]
     pub fn cast_mut<const DIFFERENT_RECOMMENDED_ALLOCATION: u32>(
         &mut self,
-    ) -> &mut VariableElements<DIFFERENT_RECOMMENDED_ALLOCATION, Element> {
+    ) -> &mut VariableElements<Element, DIFFERENT_RECOMMENDED_ALLOCATION> {
         // SAFETY: `VariableElements` has a fixed layout due to `#[repr(C)]`, which doesn't depend
         // on recommended allocation
         unsafe {
             NonNull::from_mut(self)
-                .cast::<VariableElements<DIFFERENT_RECOMMENDED_ALLOCATION, Element>>()
+                .cast::<VariableElements<Element, DIFFERENT_RECOMMENDED_ALLOCATION>>()
                 .as_mut()
         }
     }

--- a/crates/contracts/ab-contracts-standards/src/tx_handler.rs
+++ b/crates/contracts/ab-contracts-standards/src/tx_handler.rs
@@ -4,8 +4,8 @@ use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_io_type::variable_elements::VariableElements;
 use ab_contracts_macros::contract;
 
-pub type TxHandlerPayload = VariableElements<0, u128>;
-pub type TxHandlerSeal = VariableBytes<0>;
+pub type TxHandlerPayload = VariableElements<u128>;
+pub type TxHandlerSeal = VariableBytes;
 
 /// A transaction handler interface prototype
 #[contract]

--- a/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -98,7 +98,7 @@ impl SimpleWalletBase {
     #[view]
     pub fn initialize(
         #[input] &public_key: &[u8; 32],
-        #[output] state: &mut VariableBytes<0>,
+        #[output] state: &mut VariableBytes,
     ) -> Result<(), ContractError> {
         // TODO: Storing some lower-level representation of the public key might reduce the cost of
         //  verification in `Self::authorize()` method
@@ -118,7 +118,7 @@ impl SimpleWalletBase {
     /// Reads state of `owner` and returns `Ok(())` if authorization succeeds
     #[view]
     pub fn authorize(
-        #[input] state: &VariableBytes<0>,
+        #[input] state: &VariableBytes,
         #[input] header: &TransactionHeader,
         #[input] payload: &TxHandlerPayload,
         #[input] seal: &TxHandlerSeal,
@@ -195,9 +195,9 @@ impl SimpleWalletBase {
     /// Returns state with increased nonce
     #[view]
     pub fn increase_nonce(
-        #[input] state: &VariableBytes<0>,
+        #[input] state: &VariableBytes,
         #[input] seal: &TxHandlerSeal,
-        #[output] new_state: &mut VariableBytes<0>,
+        #[output] new_state: &mut VariableBytes,
     ) -> Result<(), ContractError> {
         let _ = seal;
 
@@ -217,9 +217,9 @@ impl SimpleWalletBase {
     /// Returns state with a changed public key
     #[view]
     pub fn change_public_key(
-        #[input] state: &VariableBytes<0>,
+        #[input] state: &VariableBytes,
         #[input] &public_key: &[u8; 32],
-        #[output] new_state: &mut VariableBytes<0>,
+        #[output] new_state: &mut VariableBytes,
     ) -> Result<(), ContractError> {
         let Some(mut state) = state.read_trivial_type::<WalletState>() else {
             return Err(ContractError::BadInput);


### PR DESCRIPTION
This makes thing a bit more readable in a simple case