### PR TITLE
Remove `genesis_hash` from the transaction header

### DIFF
--- a/crates/contracts/core/ab-contracts-common/src/env.rs
+++ b/crates/contracts/core/ab-contracts-common/src/env.rs
@@ -21,7 +21,6 @@ pub struct Gas(u64);
 #[derive(Debug, Copy, Clone, TrivialType)]
 #[repr(C)]
 pub struct TransactionHeader {
-    pub genesis_hash: Blake3Hash,
     pub block_hash: Blake3Hash,
     pub gas_limit: Gas,
     /// Contract implementing `TxHandler` trait to use for transaction verification and execution

--- a/crates/contracts/core/ab-contracts-test-utils/src/transaction_builder.rs
+++ b/crates/contracts/core/ab-contracts-test-utils/src/transaction_builder.rs
@@ -65,7 +65,6 @@ impl TransactionBuilder {
     pub fn build(self) -> OwnedTransaction {
         OwnedTransaction {
             header: TransactionHeader {
-                genesis_hash: Blake3Hash::default(),
                 block_hash: Blake3Hash::default(),
                 gas_limit: Gas::default(),
                 contract: self.contract,

--- a/crates/contracts/example/ab-example-contract-wallet/benches/flip.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/benches/flip.rs
@@ -80,7 +80,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     let header = TransactionHeader {
-        genesis_hash: Blake3Hash::default(),
         block_hash: Blake3Hash::default(),
         gas_limit: Default::default(),
         contract: wallet_address,

--- a/crates/contracts/example/ab-example-contract-wallet/tests/flip.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/tests/flip.rs
@@ -83,7 +83,6 @@ fn flip() {
     });
 
     let header = TransactionHeader {
-        genesis_hash: Blake3Hash::default(),
         block_hash: Blake3Hash::default(),
         gas_limit: Default::default(),
         contract: wallet_address,


### PR DESCRIPTION
Shouldn't be needed most of the time and when it is needed, can be proven from the block hash anyway