### PR TITLE
Do not use unchecked payload parsing

### DIFF
--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -195,8 +195,9 @@ impl SimpleWalletBase {
             },
         );
 
-        // SAFETY: Verified in `Self::authorize()`
-        while let Some(prepared_method) = unsafe { payload_decoder.decode_next_method_unchecked() }
+        while let Some(prepared_method) = payload_decoder
+            .decode_next_method()
+            .map_err(|_error| ContractError::BadInput)?
         {
             env.call_prepared(prepared_method)?;
         }


### PR DESCRIPTION
This would have been fine in the contract of end user, but potential memory corruption from user input is problematic for system contract