### PR TITLE
Initial support for `no-panic` in `ab-syse-contract-simple-wallet-base`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -136,3 +136,64 @@ jobs:
       - name: cargo miri nextest run
         run: |
           cargo -Zgitoxide -Zgit miri nextest run
+
+  no-panic:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
+          # TODO: Windows is pain, add it at some point if possible, but generally other platforms should be sufficient
+          # - windows-2025
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Ensure no panics in annotated code
+        env:
+          # Increase inlining threshold to make sure the compiler can see that some functions do not panic
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=1000
+        run: |
+          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic
+
+      - name: Ensure no panics in annotated code (various features)
+        env:
+          # Increase inlining threshold to make sure the compiler can see that some functions do not panic
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=1000
+        run: |
+          for contract_path in crates/contracts/{example,system}/*; do
+            # Not all contracts have this feature yet
+            if ! grep -q '^no-panic =' "$contract_path/Cargo.toml"; then
+              continue
+            fi
+            contract="$(basename -- $contract_path)"
+            cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p $contract --features $contract/guest
+          done
+
+          # TODO: Would be nice to have these as job matrix later
+          # TODO: Unlock commented-out crates once they have the feature
+          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/guest
+          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/alloc
+          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/executor
+
+          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-macros --features ab-contracts-common/executor
+
+          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-standards --features ab-contracts-standards/guest
+
+          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/alloc
+          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
+        if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ dependencies = [
  "ab-contracts-macros",
  "ab-contracts-standards",
  "blake3",
+ "no-panic",
  "schnorrkel",
  "thiserror",
- "tinyvec",
 ]
 
 [[package]]
@@ -659,6 +659,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-panic"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b926eaa50591fb2d593d569431833cf8fb4457754a576f47f0d0afe1be73a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,12 +948,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ criterion = { version = "0.5.1", default-features = false }
 derive_more = { version = "2.0.1", default-features = false }
 halfbrown = "0.3.0"
 ident_case = "1.0.1"
+no-panic = "0.1.34"
 proc-macro2 = "1.0.92"
 quote = "1.0.38"
 schnorrkel = { version = "0.11.4", default-features = false }
@@ -31,7 +32,6 @@ smallvec = "1.14.0"
 syn = "2.0.93"
 take_mut = "0.2.2"
 thiserror = { version = "2.0.11", default-features = false }
-tinyvec = { version = "1.8.1", default-features = false }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/Cargo.toml
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/Cargo.toml
@@ -19,9 +19,9 @@ ab-contracts-io-type = { workspace = true }
 ab-contracts-macros = { workspace = true }
 ab-contracts-standards = { workspace = true }
 blake3 = { workspace = true }
+no-panic = { workspace = true, optional = true }
 schnorrkel = { workspace = true }
 thiserror = { workspace = true }
-tinyvec = { workspace = true }
 
 [features]
 guest = [
@@ -34,4 +34,8 @@ alloc = []
 # Enables payload builder API
 payload-builder = [
     "alloc",
+]
+# Check that code can't panic under any conditions
+no-panic = [
+    "dep:no-panic",
 ]

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -12,7 +12,7 @@
 //!   followed by [`SimpleWalletBase::increase_nonce`]
 //! * [`SimpleWalletBase::change_public_key`] is used for change public key to a different one
 
-#![feature(non_null_from_ref, ptr_as_ref_unchecked, try_blocks)]
+#![feature(non_null_from_ref, ptr_as_ref_unchecked, try_blocks, unchecked_shifts)]
 #![no_std]
 
 pub mod payload;
@@ -182,7 +182,7 @@ impl SimpleWalletBase {
 
         let mut external_args_buffer = [ptr::null_mut(); EXTERNAL_ARGS_BUFFER_SIZE];
         let mut output_buffer = [MaybeUninit::uninit(); OUTPUT_BUFFER_SIZE];
-        let mut output_buffer_offsets = [(0, 0); OUTPUT_BUFFER_OFFSETS_SIZE];
+        let mut output_buffer_offsets = [MaybeUninit::uninit(); OUTPUT_BUFFER_OFFSETS_SIZE];
 
         let mut payload_decoder = TransactionPayloadDecoder::new(
             payload.get_initialized(),

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder/tests.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder/tests.rs
@@ -50,7 +50,7 @@ fn payload_encode_decode() {
 
     let mut external_args_buffer = [ptr::null_mut(); EXTERNAL_ARGS_BUFFER_SIZE];
     let mut output_buffer = [MaybeUninit::uninit(); OUTPUT_BUFFER_SIZE];
-    let mut output_buffer_offsets = [(0, 0); OUTPUT_BUFFER_OFFSETS_SIZE];
+    let mut output_buffer_offsets = [MaybeUninit::uninit(); OUTPUT_BUFFER_OFFSETS_SIZE];
 
     // Untrusted
     {

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/seal.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/seal.rs
@@ -62,6 +62,7 @@ pub fn hash_and_sign(
 ///
 /// [`hash_and_verify()`] helper function exists that combines this method with
 /// [`hash_transaction()`].
+#[cfg_attr(all(not(doc), feature = "no-panic"), no_panic::no_panic)]
 pub fn verify(
     public_key: &PublicKey,
     expected_nonce: u64,
@@ -79,6 +80,7 @@ pub fn verify(
         .map_err(|_error| ContractError::Forbidden)
 }
 
+// TODO: Add guarantees that this does not panic
 /// Combines [`hash_transaction()`] and [`verify()`]
 pub fn hash_and_verify(
     public_key: &PublicKey,


### PR DESCRIPTION
A bit more verbose, but allows to statically guarantee there will be no panics no matter the input. Also reduced the number of mathematical operations that do not have any underflow/overflow checks.

This is just for one crate, more crates will follow. Corresponding CI workflow added too.