### PR TITLE
Remove the need for `alloc` in `Env` by taking a reference to the executor context

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,6 @@ jobs:
 
           # TODO: Would be nice to have these as job matrix later
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-common --features ab-contracts-common/guest -- -D warnings
-          cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-common --features ab-contracts-common/alloc -- -D warnings
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-common --features ab-contracts-common/executor -- -D warnings
 
           cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-macros --features ab-contracts-common/executor -- -D warnings
@@ -187,7 +186,6 @@ jobs:
           # TODO: Would be nice to have these as job matrix later
           # TODO: Unlock commented-out crates once they have the feature
           # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/guest
-          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/alloc
           # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/executor
 
           # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-macros --features ab-contracts-common/executor

--- a/crates/contracts/core/ab-contracts-common/Cargo.toml
+++ b/crates/contracts/core/ab-contracts-common/Cargo.toml
@@ -23,7 +23,5 @@ thiserror = { workspace = true }
 
 [features]
 guest = []
-# APIs that require `alloc` crate
-alloc = []
 # APIs needed for native executor
-executor = ["alloc"]
+executor = []

--- a/crates/contracts/core/ab-contracts-common/src/address.rs
+++ b/crates/contracts/core/ab-contracts-common/src/address.rs
@@ -25,14 +25,14 @@ const _: () = {
 };
 
 impl fmt::Debug for Address {
-    #[inline]
+    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Address").field(&self.into_u128()).finish()
     }
 }
 
 impl fmt::Display for Address {
-    #[inline]
+    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: Human-readable formatting rather than a huge number
         self.into_u128().fmt(f)
@@ -40,42 +40,42 @@ impl fmt::Display for Address {
 }
 
 impl PartialEq<&Address> for Address {
-    #[inline]
+    #[inline(always)]
     fn eq(&self, other: &&Address) -> bool {
         self.0 == other.0
     }
 }
 
 impl PartialEq<Address> for &Address {
-    #[inline]
+    #[inline(always)]
     fn eq(&self, other: &Address) -> bool {
         self.0 == other.0
     }
 }
 
 impl Ord for Address {
-    #[inline]
+    #[inline(always)]
     fn cmp(&self, other: &Address) -> Ordering {
         self.into_u128().cmp(&other.into_u128())
     }
 }
 
 impl PartialOrd for Address {
-    #[inline]
+    #[inline(always)]
     fn partial_cmp(&self, other: &Address) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl From<u128> for Address {
-    #[inline]
+    #[inline(always)]
     fn from(value: u128) -> Self {
         Self::from_u128(value)
     }
 }
 
 impl From<Address> for u128 {
-    #[inline]
+    #[inline(always)]
     fn from(value: Address) -> Self {
         value.into_u128()
     }
@@ -95,14 +95,14 @@ impl Address {
     pub const SYSTEM_SIMPLE_WALLET_BASE: Self = Self::from_u128(3);
 
     /// Turn value into `u128`
-    #[inline]
+    #[inline(always)]
     const fn into_u128(self) -> u128 {
         // SAFETY: correct size, valid pointer, and all bits are valid
         unsafe { ptr::from_ref(&self).cast::<u128>().read_unaligned() }
     }
 
     /// Create a value from `u128`
-    #[inline]
+    #[inline(always)]
     const fn from_u128(n: u128) -> Self {
         let mut result = MaybeUninit::<Self>::uninit();
         // SAFETY: correct size, valid pointer, and all bits are valid
@@ -113,7 +113,7 @@ impl Address {
     }
 
     /// System contract for address allocation on a particular shard index
-    #[inline]
+    #[inline(always)]
     pub const fn system_address_allocator(shard_index: ShardIndex) -> Self {
         // Shard `0` doesn't have its own allocator because there are no user-deployable contracts
         // there, so address `0` is `NULL`, the rest up to `ShardIndex::MAX_SHARD_INDEX` correspond

--- a/crates/contracts/core/ab-contracts-common/src/balance.rs
+++ b/crates/contracts/core/ab-contracts-common/src/balance.rs
@@ -25,28 +25,28 @@ const _: () = {
 };
 
 impl fmt::Debug for Balance {
-    #[inline]
+    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Balance").field(&self.into_u128()).finish()
     }
 }
 
 impl fmt::Display for Balance {
-    #[inline]
+    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.into_u128().fmt(f)
     }
 }
 
 impl Ord for Balance {
-    #[inline]
+    #[inline(always)]
     fn cmp(&self, other: &Balance) -> Ordering {
         self.into_u128().cmp(&other.into_u128())
     }
 }
 
 impl PartialOrd for Balance {
-    #[inline]
+    #[inline(always)]
     fn partial_cmp(&self, other: &Balance) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -55,7 +55,7 @@ impl PartialOrd for Balance {
 impl Add for Balance {
     type Output = Balance;
 
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn add(self, rhs: Balance) -> Balance {
         Self::from_u128(self.into_u128().add(rhs.into_u128()))
@@ -63,7 +63,7 @@ impl Add for Balance {
 }
 
 impl AddAssign for Balance {
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn add_assign(&mut self, rhs: Balance) {
         *self = *self + rhs;
@@ -73,7 +73,7 @@ impl AddAssign for Balance {
 impl Sub for Balance {
     type Output = Balance;
 
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn sub(self, rhs: Balance) -> Balance {
         Self::from_u128(self.into_u128().sub(rhs.into_u128()))
@@ -81,7 +81,7 @@ impl Sub for Balance {
 }
 
 impl SubAssign for Balance {
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn sub_assign(&mut self, rhs: Balance) {
         *self = *self - rhs;
@@ -94,7 +94,7 @@ where
 {
     type Output = Balance;
 
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn mul(self, rhs: Rhs) -> Balance {
         Self::from_u128(<u128 as Mul<Rhs>>::mul(self.into_u128(), rhs))
@@ -105,7 +105,7 @@ impl<Rhs> MulAssign<Rhs> for Balance
 where
     u128: Mul<Rhs, Output = u128>,
 {
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn mul_assign(&mut self, rhs: Rhs) {
         *self = *self * rhs;
@@ -118,7 +118,7 @@ where
 {
     type Output = Balance;
 
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn div(self, rhs: Rhs) -> Balance {
         Self::from_u128(<u128 as Div<Rhs>>::div(self.into_u128(), rhs))
@@ -129,7 +129,7 @@ impl<Rhs> DivAssign<Rhs> for Balance
 where
     u128: Div<Rhs, Output = u128>,
 {
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn div_assign(&mut self, rhs: Rhs) {
         *self = *self / rhs;
@@ -137,14 +137,14 @@ where
 }
 
 impl From<u128> for Balance {
-    #[inline]
+    #[inline(always)]
     fn from(value: u128) -> Self {
         Self::from_u128(value)
     }
 }
 
 impl From<Balance> for u128 {
-    #[inline]
+    #[inline(always)]
     fn from(value: Balance) -> Self {
         value.into_u128()
     }
@@ -155,14 +155,14 @@ impl Balance {
     pub const MAX: Self = Self::from_u128(u128::MAX);
 
     /// Turn value into `u128`
-    #[inline]
+    #[inline(always)]
     pub const fn into_u128(self) -> u128 {
         // SAFETY: correct size, valid pointer, and all bits are valid
         unsafe { ptr::from_ref(&self).cast::<u128>().read_unaligned() }
     }
 
     /// Create a value from `u128`
-    #[inline]
+    #[inline(always)]
     pub const fn from_u128(n: u128) -> Self {
         let mut result = MaybeUninit::<Self>::uninit();
         // SAFETY: correct size, valid pointer, and all bits are valid

--- a/crates/contracts/core/ab-contracts-common/src/env.rs
+++ b/crates/contracts/core/ab-contracts-common/src/env.rs
@@ -142,7 +142,7 @@ pub struct Env<'a> {
 impl<'a> Env<'a> {
     /// Instantiate environment with executor context
     #[cfg(feature = "executor")]
-    #[inline]
+    #[inline(always)]
     pub fn with_executor_context(
         state: EnvState,
         executor_context: Box<dyn ExecutorContext + 'a>,
@@ -156,7 +156,7 @@ impl<'a> Env<'a> {
 
     /// Instantiate environment with executor context
     #[cfg(feature = "executor")]
-    #[inline]
+    #[inline(always)]
     pub fn get_mut_executor_context(&mut self) -> &mut (dyn ExecutorContext + 'a) {
         self.executor_context.as_mut()
     }

--- a/crates/contracts/core/ab-contracts-common/src/env.rs
+++ b/crates/contracts/core/ab-contracts-common/src/env.rs
@@ -1,11 +1,6 @@
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
 use crate::method::{ExternalArgs, MethodFingerprint};
 use crate::{Address, ContractError, ShardIndex};
 use ab_contracts_io_type::trivial_type::TrivialType;
-#[cfg(feature = "executor")]
-use alloc::boxed::Box;
 use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
@@ -132,7 +127,7 @@ compile_error!(
 pub struct Env<'a> {
     state: EnvState,
     #[cfg(feature = "executor")]
-    executor_context: Box<dyn ExecutorContext + 'a>,
+    executor_context: &'a mut dyn ExecutorContext,
     phantom_data: PhantomData<&'a ()>,
 }
 
@@ -145,7 +140,7 @@ impl<'a> Env<'a> {
     #[inline(always)]
     pub fn with_executor_context(
         state: EnvState,
-        executor_context: Box<dyn ExecutorContext + 'a>,
+        executor_context: &'a mut dyn ExecutorContext,
     ) -> Self {
         Self {
             state,
@@ -157,8 +152,8 @@ impl<'a> Env<'a> {
     /// Instantiate environment with executor context
     #[cfg(feature = "executor")]
     #[inline(always)]
-    pub fn get_mut_executor_context(&mut self) -> &mut (dyn ExecutorContext + 'a) {
-        self.executor_context.as_mut()
+    pub fn get_mut_executor_context(&mut self) -> &mut dyn ExecutorContext {
+        self.executor_context
     }
 
     /// Shard index where execution is happening

--- a/crates/contracts/core/ab-contracts-common/src/error.rs
+++ b/crates/contracts/core/ab-contracts-common/src/error.rs
@@ -5,7 +5,7 @@ pub struct UnknownContractErrorCode(u8);
 
 impl UnknownContractErrorCode {
     /// Get the inner error code
-    #[inline]
+    #[inline(always)]
     pub const fn code(self) -> u8 {
         self.0
     }
@@ -16,7 +16,7 @@ pub struct CustomContractErrorCode(u64);
 
 impl CustomContractErrorCode {
     /// Get the inner error code
-    #[inline]
+    #[inline(always)]
     pub const fn code(self) -> u64 {
         self.0
     }
@@ -36,7 +36,7 @@ pub enum ContractError {
 }
 
 impl From<CustomContractErrorCode> for ContractError {
-    #[inline]
+    #[inline(always)]
     fn from(error: CustomContractErrorCode) -> Self {
         Self::Custom(error)
     }
@@ -46,7 +46,7 @@ impl ContractError {
     /// Create contract error with a custom error code.
     ///
     /// Code must be larger than `u8::MAX` or `None` will be returned.
-    #[inline]
+    #[inline(always)]
     pub const fn new_custom_code(code: u64) -> Option<Self> {
         if code > u8::MAX as u64 {
             Some(Self::Custom(CustomContractErrorCode(code)))
@@ -58,7 +58,7 @@ impl ContractError {
     /// Convert contact error into contract exit code.
     ///
     /// Mosty useful for low-level code.
-    #[inline]
+    #[inline(always)]
     pub const fn exit_code(self) -> ExitCode {
         ExitCode(match self {
             Self::BadInput => 1,
@@ -80,14 +80,14 @@ impl ContractError {
 pub struct ExitCode(u64);
 
 impl From<ContractError> for ExitCode {
-    #[inline]
+    #[inline(always)]
     fn from(error: ContractError) -> Self {
         error.exit_code()
     }
 }
 
 impl From<Result<(), ContractError>> for ExitCode {
-    #[inline]
+    #[inline(always)]
     fn from(error: Result<(), ContractError>) -> Self {
         match error {
             Ok(()) => Self(0),
@@ -97,7 +97,7 @@ impl From<Result<(), ContractError>> for ExitCode {
 }
 
 impl From<ExitCode> for Result<(), ContractError> {
-    #[inline]
+    #[inline(always)]
     fn from(value: ExitCode) -> Self {
         Err(match value.0 {
             0 => {
@@ -120,13 +120,13 @@ impl From<ExitCode> for Result<(), ContractError> {
 
 impl ExitCode {
     /// Exit code indicating success
-    #[inline]
+    #[inline(always)]
     pub fn ok() -> Self {
         Self(0)
     }
 
     /// Convert into `u64`
-    #[inline]
+    #[inline(always)]
     pub const fn into_u64(self) -> u64 {
         self.0
     }

--- a/crates/contracts/core/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-common/src/lib.rs
@@ -145,6 +145,7 @@ impl ShardIndex {
     /// Convert shard index to `u32`.
     ///
     /// This is typically only necessary for low-level code.
+    #[inline(always)]
     pub const fn to_u32(self) -> u32 {
         self.0
     }
@@ -155,6 +156,7 @@ impl ShardIndex {
     /// Returns `None` if `shard_index > ShardIndex::MAX_SHARD_INDEX`
     ///
     /// This is typically only necessary for low-level code.
+    #[inline(always)]
     pub const fn from_u32(shard_index: u32) -> Option<Self> {
         if shard_index > Self::MAX_SHARD_INDEX {
             return None;

--- a/crates/contracts/core/ab-contracts-common/src/metadata.rs
+++ b/crates/contracts/core/ab-contracts-common/src/metadata.rs
@@ -139,6 +139,7 @@ pub enum ContractMetadataKind {
 impl ContractMetadataKind {
     // TODO: Implement `TryFrom` once it is available in const environment
     /// Try to create an instance from its `u8` representation
+    #[inline(always)]
     pub const fn try_from_u8(byte: u8) -> Option<Self> {
         Some(match byte {
             0 => Self::Contract,

--- a/crates/contracts/core/ab-contracts-common/src/method.rs
+++ b/crates/contracts/core/ab-contracts-common/src/method.rs
@@ -47,7 +47,7 @@ impl MethodFingerprint {
         ]))
     }
 
-    #[inline]
+    #[inline(always)]
     pub const fn to_bytes(&self) -> &Blake3Hash {
         &self.0
     }

--- a/crates/contracts/core/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/context.rs
@@ -100,6 +100,7 @@ impl<'a> ExecutorContext for NativeExecutorContext<'a> {
 }
 
 impl<'a> NativeExecutorContext<'a> {
+    #[inline(always)]
     pub(super) fn new(
         shard_index: ShardIndex,
         methods_by_code: &'a HashMap<(&'static [u8], &'static MethodFingerprint), MethodDetails>,

--- a/crates/contracts/core/ab-contracts-test-utils/Cargo.toml
+++ b/crates/contracts/core/ab-contracts-test-utils/Cargo.toml
@@ -14,7 +14,7 @@ include = [
 all-features = true
 
 [dependencies]
-ab-contracts-common = { workspace = true, features = ["alloc"] }
+ab-contracts-common = { workspace = true }
 ab-contracts-io-type = { workspace = true }
 ab-contracts-macros = { workspace = true }
 ab-contracts-standards = { workspace = true }


### PR DESCRIPTION
It'd be nice for the contract to be able to host other contracts, but the fact that there is a single `Env` struct causes difficulties. I think `HostEnv` and `GuestEnv`/`Env` separation is needed, possibly with `EnvLike` trait that will be implemented for both and might be useful elsewhere.

But all that will be later, for now this should be fine and already provides a nice performance improvement, especially for transaction emulation, which is much closer to the direct execution now (which also got a tiny bit faster):
```
flipper/direct          time:   [75.096 ns 75.394 ns 75.737 ns]
                        thrpt:  [13.204 Melem/s 13.264 Melem/s 13.316 Melem/s]
flipper/transaction     time:   [79.468 ns 79.776 ns 80.143 ns]
                        thrpt:  [12.478 Melem/s 12.535 Melem/s 12.584 Melem/s]
```