### PR TITLE
Faster `AlignedBuffer`

### DIFF
--- a/crates/contracts/core/ab-contracts-executor/src/aligned_buffer.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/aligned_buffer.rs
@@ -2,16 +2,14 @@
 mod tests;
 
 use ab_contracts_io_type::MAX_ALIGNMENT;
-use std::mem::MaybeUninit;
-use std::sync::{Arc, LazyLock};
-use std::{mem, slice};
+use std::mem::{ManuallyDrop, MaybeUninit};
+use std::ptr::NonNull;
+use std::slice;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 #[repr(C, align(16))]
-struct AlignedBytes([u8; Self::SIZE]);
-
-impl AlignedBytes {
-    const SIZE: usize = MAX_ALIGNMENT as usize;
-}
+struct AlignedBytes([u8; MAX_ALIGNMENT as usize]);
 
 const _: () = {
     assert!(
@@ -27,10 +25,33 @@ const _: () = {
 ///
 /// Data is aligned to 16 bytes (128 bits), which is the largest alignment required by primitive
 /// types and by extension any type that implements `TrivialType`/`IoType`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug)]
 pub(super) struct OwnedAlignedBuffer {
-    buffer: Arc<[MaybeUninit<AlignedBytes>]>,
+    /// Last 4 bytes reserved for [`SharedAlignedBuffer::strong_count()`]
+    buffer: NonNull<[MaybeUninit<AlignedBytes>]>,
     len: u32,
+}
+
+// SAFETY: Heap-allocated memory buffer can be used from any thread
+unsafe impl Send for OwnedAlignedBuffer {}
+// SAFETY: Heap-allocated memory buffer can be used from any thread
+unsafe impl Sync for OwnedAlignedBuffer {}
+
+impl Clone for OwnedAlignedBuffer {
+    #[inline]
+    fn clone(&self) -> Self {
+        let mut buffer = Self::with_capacity(self.capacity());
+        buffer.copy_from_slice(self.as_slice());
+        buffer
+    }
+}
+
+impl Drop for OwnedAlignedBuffer {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: Created from `Box` in constructor
+        let _ = unsafe { Box::from_non_null(self.buffer) };
+    }
 }
 
 impl OwnedAlignedBuffer {
@@ -40,9 +61,18 @@ impl OwnedAlignedBuffer {
     #[inline(always)]
     pub(super) fn with_capacity(capacity: u32) -> Self {
         Self {
-            buffer: Arc::new_uninit_slice((capacity as usize).div_ceil(AlignedBytes::SIZE)),
+            buffer: Self::allocate_buffer(capacity),
             len: 0,
         }
+    }
+
+    /// Allocates a new buffer + one [`AlignedBytes`] worth of memory at the beginning for the
+    /// `strong_count` in case it is later converted to [`SharedAlignedBuffer`]
+    #[inline(always)]
+    fn allocate_buffer(capacity: u32) -> NonNull<[MaybeUninit<AlignedBytes>]> {
+        Box::into_non_null(Box::new_uninit_slice(
+            1 + (capacity as usize).div_ceil(size_of::<AlignedBytes>()),
+        ))
     }
 
     /// Create a new instance from provided bytes.
@@ -73,25 +103,22 @@ impl OwnedAlignedBuffer {
 
     #[inline(always)]
     pub(super) fn as_ptr(&self) -> *const u8 {
-        self.buffer.as_ptr().cast::<u8>()
+        let buffer_ptr = self.buffer.as_ptr().cast_const().cast::<u8>();
+        // SAFETY: Constructor allocates the first element for `strong_count`
+        unsafe { buffer_ptr.add(size_of::<AlignedBytes>()) }
     }
 
     #[inline(always)]
     pub(super) fn as_mut_ptr(&mut self) -> *mut u8 {
-        // SAFETY: `Arc` is owned by this data structure and neither exposed externally nor supports
-        // shared references in case of `OwnedAlignedBuffer`, hence `&mut self` implies exclusive
-        // access
-        unsafe { Arc::get_mut_unchecked(&mut self.buffer) }
-            .as_mut_ptr()
-            .cast::<u8>()
+        let buffer_ptr = self.buffer.as_ptr().cast::<u8>();
+        // SAFETY: Constructor allocates the first element for `strong_count`
+        unsafe { buffer_ptr.add(size_of::<AlignedBytes>()) }
     }
 
     #[inline(always)]
     pub(super) fn into_shared(self) -> SharedAlignedBuffer {
-        SharedAlignedBuffer {
-            buffer: self.buffer,
-            len: self.len,
-        }
+        let instance = ManuallyDrop::new(self);
+        SharedAlignedBuffer::new_from_buffer_with_len(instance.buffer, instance.len)
     }
 
     /// Ensure capacity of the buffer is at least `capacity`.
@@ -99,6 +126,7 @@ impl OwnedAlignedBuffer {
     /// Will re-allocate if necessary.
     #[inline(always)]
     pub(super) fn ensure_capacity(&mut self, capacity: u32) {
+        // `+ size_of::<AlignedBytes>()` for `strong_count`
         if capacity > self.capacity() {
             let mut new_buffer = Self::with_capacity(capacity);
             new_buffer.copy_from_slice(self.as_slice());
@@ -118,9 +146,10 @@ impl OwnedAlignedBuffer {
 
         if len > self.capacity() {
             // Drop old buffer
-            mem::take(&mut self.buffer);
+            // SAFETY: Created from `Box` in constructor
+            let _ = unsafe { Box::from_non_null(self.buffer) };
             // Allocate new buffer
-            self.buffer = Self::with_capacity(len).buffer;
+            self.buffer = Self::allocate_buffer(len);
         }
 
         // SAFETY: Sufficient capacity guaranteed above, natural alignment of bytes is 1 for input
@@ -143,10 +172,12 @@ impl OwnedAlignedBuffer {
         self.len
     }
 
+    // TODO: Store precomputed capacity and expose pointer to it
     #[inline(always)]
     pub(super) fn capacity(&self) -> u32 {
-        // API constraints capacity to `u32`, hence this never truncates
-        (self.buffer.len() * AlignedBytes::SIZE) as u32
+        // API constraints capacity to `u32`, hence this never truncates, `- 1` due to
+        // `strong_count` stored at the beginning of the buffer
+        ((self.buffer.len() - 1) * size_of::<AlignedBytes>()) as u32
     }
 
     /// Set the length of the useful data to specified value.
@@ -174,13 +205,59 @@ impl OwnedAlignedBuffer {
 ///
 /// Data is aligned to 16 bytes (128 bits), which is the largest alignment required by primitive
 /// types and by extension any type that implements `TrivialType`/`IoType`.
-#[derive(Debug, Default, Clone)]
+///
+/// NOTE: Counter for number of shared instances is `u32` and will wrap around if exceeded breaking
+/// internal invariants (which is extremely unlikely, but still).
+#[derive(Debug)]
 pub(super) struct SharedAlignedBuffer {
-    buffer: Arc<[MaybeUninit<AlignedBytes>]>,
+    buffer: NonNull<[MaybeUninit<AlignedBytes>]>,
     len: u32,
 }
 
+impl Default for SharedAlignedBuffer {
+    #[inline]
+    fn default() -> Self {
+        OwnedAlignedBuffer::with_capacity(0).into_shared()
+    }
+}
+
+impl Clone for SharedAlignedBuffer {
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        self.strong_count().fetch_add(1, Ordering::AcqRel);
+
+        Self {
+            buffer: self.buffer,
+            len: self.len,
+        }
+    }
+}
+
+impl Drop for SharedAlignedBuffer {
+    #[inline]
+    fn drop(&mut self) {
+        if self.strong_count().fetch_sub(1, Ordering::AcqRel) == 1 {
+            // SAFETY: Created from `Box` in constructor
+            let _ = unsafe { Box::from_non_null(self.buffer) };
+        }
+    }
+}
+
+// SAFETY: Heap-allocated memory buffer and atomic can be used from any thread
+unsafe impl Send for SharedAlignedBuffer {}
+// SAFETY: Heap-allocated memory buffer and atomic can be used from any thread
+unsafe impl Sync for SharedAlignedBuffer {}
+
 impl SharedAlignedBuffer {
+    /// # Safety
+    /// Must only be called with First bytes are allocated to be `strong_count`
+    fn new_from_buffer_with_len(buffer: NonNull<[MaybeUninit<AlignedBytes>]>, len: u32) -> Self {
+        // SAFETY: The first bytes are allocated for strong count, which is a correctly aligned copy
+        // type
+        unsafe { buffer.as_ptr().cast::<AtomicU32>().write(AtomicU32::new(1)) };
+        Self { buffer, len }
+    }
+
     /// Static reference to an empty buffer
     #[inline(always)]
     pub(super) fn empty_ref() -> &'static Self {
@@ -205,29 +282,31 @@ impl SharedAlignedBuffer {
     /// Returns `None` if there exit other shared instances.
     #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
     #[inline(always)]
-    pub(super) fn into_owned(mut self) -> OwnedAlignedBuffer {
-        // Check if this is the last instance of the buffer
-        if Arc::get_mut(&mut self.buffer).is_some() {
+    pub(super) fn into_owned(self) -> OwnedAlignedBuffer {
+        let instance = ManuallyDrop::new(self);
+        if instance.strong_count().fetch_sub(1, Ordering::AcqRel) == 1 {
             OwnedAlignedBuffer {
-                buffer: self.buffer,
-                len: self.len,
+                buffer: instance.buffer,
+                len: instance.len,
             }
         } else {
-            let mut instance = OwnedAlignedBuffer::with_capacity(self.capacity());
-            instance.copy_from_slice(self.as_slice());
-            instance
+            let mut owned_instance = OwnedAlignedBuffer::with_capacity(0);
+            owned_instance.copy_from_slice(instance.as_slice());
+            owned_instance
         }
     }
 
     #[inline(always)]
     pub(super) fn as_slice(&self) -> &[u8] {
         // SAFETY: Not null and size is a protected invariant of the implementation
-        unsafe { slice::from_raw_parts(self.buffer.as_ptr().cast::<u8>(), self.len as usize) }
+        unsafe { slice::from_raw_parts(self.as_ptr(), self.len as usize) }
     }
 
     #[inline(always)]
     pub(super) fn as_ptr(&self) -> *const u8 {
-        self.buffer.as_ptr().cast::<u8>()
+        let buffer_ptr = self.buffer.as_ptr().cast_const().cast::<u8>();
+        // SAFETY: Constructor allocates the first element for `strong_count`
+        unsafe { buffer_ptr.add(size_of::<AlignedBytes>()) }
     }
 
     #[inline(always)]
@@ -241,8 +320,9 @@ impl SharedAlignedBuffer {
     }
 
     #[inline(always)]
-    pub(super) fn capacity(&self) -> u32 {
-        // API constraints capacity to `u32`, hence this never truncates
-        (self.buffer.len() * AlignedBytes::SIZE) as u32
+    fn strong_count(&self) -> &AtomicU32 {
+        // SAFETY: The first bytes are allocated for strong count, which is a correctly aligned copy
+        // type initialized in constructor if `true`
+        unsafe { self.buffer.as_ptr().cast::<AtomicU32>().as_ref_unchecked() }
     }
 }

--- a/crates/contracts/core/ab-contracts-executor/src/aligned_buffer/tests.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/aligned_buffer/tests.rs
@@ -161,8 +161,6 @@ fn basic() {
 
         assert_eq!(shared.len(), shared2.len(), "Capacity {capacity}");
         assert_eq!(shared.len(), owned.len(), "Capacity {capacity}");
-        assert_eq!(shared.capacity(), shared2.capacity(), "Capacity {capacity}");
-        assert_eq!(shared.capacity(), owned.capacity(), "Capacity {capacity}");
         assert_eq!(shared.is_empty(), shared2.is_empty(), "Capacity {capacity}");
         assert_eq!(shared.is_empty(), owned.is_empty(), "Capacity {capacity}");
         assert_eq!(shared.as_ptr(), shared2.as_ptr(), "Capacity {capacity}");

--- a/crates/contracts/core/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(
+    box_vec_non_null,
     get_mut_unchecked,
     pointer_is_aligned_to,
     ptr_as_ref_unchecked,

--- a/crates/contracts/core/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(
     box_vec_non_null,
     get_mut_unchecked,
+    non_null_from_ref,
     pointer_is_aligned_to,
     ptr_as_ref_unchecked,
     try_blocks

--- a/crates/contracts/core/ab-contracts-test-utils/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-test-utils/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-extern crate alloc;
 
 pub mod dummy_wallet;
 pub mod transaction_builder;


### PR DESCRIPTION
This replaced `Arc` with a more efficient and internally simpler implementation, also `LazyLock` usage was replaced with a static unconditionally available instance.

As the result performance improved even further:
```
flipper/direct          time:   [68.005 ns 68.284 ns 68.600 ns]
                        thrpt:  [14.577 Melem/s 14.645 Melem/s 14.705 Melem/s]
flipper/transaction     time:   [71.065 ns 71.352 ns 71.711 ns]
                        thrpt:  [13.945 Melem/s 14.015 Melem/s 14.072 Melem/s]

example-wallet/execute-only
                        time:   [3.0973 µs 3.1050 µs 3.1141 µs]
                        thrpt:  [321.12 Kelem/s 322.07 Kelem/s 322.86 Kelem/s]
```

The only thing preventing `NativeExecutor` from being usable in `no_std` environment with `alloc` is `HashMap` usage, which can be replaced with `BTreeMap`, but will be slower. Once there is a need for that, a new feature can be added to make it work in `no_std` environment.