### PR TITLE
Refacor `AlignedBuffer`

### DIFF
--- a/crates/contracts/core/ab-contracts-executor/src/context/ffi_call.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/context/ffi_call.rs
@@ -77,7 +77,9 @@ struct DelayedProcessingSlotReadWrite {
     must_be_not_empty: bool,
 }
 
-/// Stores details about arguments that need to be processed after FFI call
+/// Stores details about arguments that need to be processed after FFI call.
+///
+/// It is also more efficient to store length and capacities compactly next to each other in memory.
 enum DelayedProcessing {
     SlotReadOnly(DelayedProcessingSlotReadOnly),
     SlotReadWrite(DelayedProcessingSlotReadWrite),


### PR DESCRIPTION
This is probably the last optimization there for now:
```
flipper/direct          time:   [66.476 ns 66.701 ns 66.967 ns]
                        thrpt:  [14.933 Melem/s 14.992 Melem/s 15.043 Melem/s]
flipper/transaction     time:   [70.278 ns 70.571 ns 70.911 ns]
                        thrpt:  [14.102 Melem/s 14.170 Melem/s 14.229 Melem/s]
```