### PR TITLE
Make a bunch of methods in `ab-contracts-common` `no-panic`, remove UTF-8 parsing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -186,7 +186,7 @@ jobs:
           # TODO: Would be nice to have these as job matrix later
           # TODO: Unlock commented-out crates once they have the feature
           # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/guest
-          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/executor
+          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/executor
 
           # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-macros --features ab-contracts-common/executor
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "ab-contracts-io-type",
  "const-sha1",
  "derive_more",
+ "no-panic",
  "thiserror",
 ]
 

--- a/crates/contracts/core/ab-contracts-common/Cargo.toml
+++ b/crates/contracts/core/ab-contracts-common/Cargo.toml
@@ -19,12 +19,17 @@ ab-contracts-io-type = { workspace = true }
 #  exposed
 const-sha1 = { workspace = true }
 derive_more = { workspace = true, features = ["display"] }
+no-panic = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [features]
 guest = []
 # APIs needed for native executor
 executor = []
+# Check that code can't panic under any conditions
+no-panic = [
+    "dep:no-panic",
+]
 
 [lints]
 workspace = true

--- a/crates/contracts/core/ab-contracts-common/src/address.rs
+++ b/crates/contracts/core/ab-contracts-common/src/address.rs
@@ -25,14 +25,12 @@ const _: () = {
 };
 
 impl fmt::Debug for Address {
-    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Address").field(&self.into_u128()).finish()
     }
 }
 
 impl fmt::Display for Address {
-    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: Human-readable formatting rather than a huge number
         self.into_u128().fmt(f)

--- a/crates/contracts/core/ab-contracts-common/src/balance.rs
+++ b/crates/contracts/core/ab-contracts-common/src/balance.rs
@@ -25,14 +25,12 @@ const _: () = {
 };
 
 impl fmt::Debug for Balance {
-    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Balance").field(&self.into_u128()).finish()
     }
 }
 
 impl fmt::Display for Balance {
-    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.into_u128().fmt(f)
     }

--- a/crates/contracts/core/ab-contracts-common/src/env.rs
+++ b/crates/contracts/core/ab-contracts-common/src/env.rs
@@ -138,6 +138,7 @@ impl<'a> Env<'a> {
     /// Instantiate environment with executor context
     #[cfg(feature = "executor")]
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn with_executor_context(
         state: EnvState,
         executor_context: &'a mut dyn ExecutorContext,
@@ -152,30 +153,35 @@ impl<'a> Env<'a> {
     /// Instantiate environment with executor context
     #[cfg(feature = "executor")]
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn get_mut_executor_context(&mut self) -> &mut dyn ExecutorContext {
         self.executor_context
     }
 
     /// Shard index where execution is happening
     #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn shard_index(&self) -> ShardIndex {
         self.state.shard_index
     }
 
     /// Own address of the contract
     #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn own_address(&self) -> Address {
         self.state.own_address
     }
 
     /// Context of the execution
     #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn context<'b>(self: &'b &'b mut Self) -> Address {
         self.state.context
     }
 
     /// Caller of this contract
     #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn caller<'b>(self: &'b &'b mut Self) -> Address {
         self.state.caller
     }
@@ -201,6 +207,7 @@ impl<'a> Env<'a> {
     ///
     /// The result is to be used with [`Self::call_prepared()`] afterward.
     #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn prepare_method_call<Args>(
         contract: Address,
         args: &mut Args,

--- a/crates/contracts/core/ab-contracts-common/src/error.rs
+++ b/crates/contracts/core/ab-contracts-common/src/error.rs
@@ -121,7 +121,7 @@ impl From<ExitCode> for Result<(), ContractError> {
 impl ExitCode {
     /// Exit code indicating success
     #[inline(always)]
-    pub fn ok() -> Self {
+    pub const fn ok() -> Self {
         Self(0)
     }
 

--- a/crates/contracts/core/ab-contracts-common/src/metadata/compact.rs
+++ b/crates/contracts/core/ab-contracts-common/src/metadata/compact.rs
@@ -1,6 +1,7 @@
 use crate::metadata::ContractMetadataKind;
 use ab_contracts_io_type::metadata::{IoTypeMetadataKind, MAX_METADATA_CAPACITY};
 
+#[inline(always)]
 pub(super) const fn compact_metadata(
     metadata: &[u8],
     for_external_args: bool,
@@ -32,6 +33,7 @@ macro_rules! forward_option {
     }};
 }
 
+#[inline(always)]
 const fn compact_metadata_inner<'i, 'o>(
     mut input: &'i [u8],
     mut output: &'o mut [u8],
@@ -193,6 +195,7 @@ const fn compact_metadata_inner<'i, 'o>(
     Some((input, output))
 }
 
+#[inline(always)]
 const fn compact_method_argument<'i, 'o>(
     mut input: &'i [u8],
     mut output: &'o mut [u8],
@@ -298,6 +301,7 @@ const fn compact_method_argument<'i, 'o>(
 }
 
 /// Copies `n` bytes from input to output and returns both input and output after `n` bytes offset
+#[inline(always)]
 const fn copy_n_bytes<'i, 'o>(
     input: &'i [u8],
     output: &'o mut [u8],
@@ -315,6 +319,7 @@ const fn copy_n_bytes<'i, 'o>(
 }
 
 /// Skips `n` bytes and return remainder
+#[inline(always)]
 const fn skip_n_bytes(input: &[u8], n: usize) -> Option<&[u8]> {
     if n > input.len() {
         return None;
@@ -325,6 +330,7 @@ const fn skip_n_bytes(input: &[u8], n: usize) -> Option<&[u8]> {
 }
 
 /// Skips `n` bytes in input and output
+#[inline(always)]
 const fn skip_n_bytes_io<'i, 'o>(
     mut input: &'i [u8],
     mut output: &'o mut [u8],

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
@@ -366,6 +366,7 @@ pub enum IoTypeMetadataKind {
 impl IoTypeMetadataKind {
     // TODO: Implement `TryFrom` once it is available in const environment
     /// Try to create an instance from its `u8` representation
+    #[inline]
     pub const fn try_from_u8(byte: u8) -> Option<Self> {
         Some(match byte {
             0 => Self::Unit,
@@ -483,6 +484,7 @@ impl IoTypeMetadataKind {
     /// caller.
     ///
     /// Unexpected metadata kind results in `None` being returned.
+    #[inline]
     pub const fn compact<'i, 'o>(
         input: &'i [u8],
         output: &'o mut [u8],
@@ -491,8 +493,11 @@ impl IoTypeMetadataKind {
     }
 
     // TODO: Create wrapper type for metadata bytes and move this method there
-    /// Decode type name
-    pub const fn type_name(metadata: &[u8]) -> Option<&str> {
+    /// Decode type name.
+    ///
+    /// Expected to be UTF-8, but must be parsed before printed as text, which is somewhat costly.
+    #[inline]
+    pub const fn type_name(metadata: &[u8]) -> Option<&[u8]> {
         type_name(metadata)
     }
 
@@ -504,7 +509,7 @@ impl IoTypeMetadataKind {
     ///
     /// Returns type details and whatever slice of bytes from `input` that is left after
     /// type decoding.
-    #[inline(always)]
+    #[inline]
     pub const fn type_details(metadata: &[u8]) -> Option<(IoTypeDetails, &[u8])> {
         decode_type_details(metadata)
     }

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/type_name.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/type_name.rs
@@ -10,7 +10,8 @@ macro_rules! forward_option {
     }};
 }
 
-pub(super) const fn type_name(mut metadata: &[u8]) -> Option<&str> {
+#[inline(always)]
+pub(super) const fn type_name(mut metadata: &[u8]) -> Option<&[u8]> {
     if metadata.is_empty() {
         return None;
     }
@@ -19,18 +20,18 @@ pub(super) const fn type_name(mut metadata: &[u8]) -> Option<&str> {
     metadata = forward_option!(skip_n_bytes(metadata, 1));
 
     Some(match kind {
-        IoTypeMetadataKind::Unit => "()",
-        IoTypeMetadataKind::Bool => "bool",
-        IoTypeMetadataKind::U8 => "u8",
-        IoTypeMetadataKind::U16 => "u16",
-        IoTypeMetadataKind::U32 => "u32",
-        IoTypeMetadataKind::U64 => "u64",
-        IoTypeMetadataKind::U128 => "u128",
-        IoTypeMetadataKind::I8 => "i8",
-        IoTypeMetadataKind::I16 => "i16",
-        IoTypeMetadataKind::I32 => "i32",
-        IoTypeMetadataKind::I64 => "i64",
-        IoTypeMetadataKind::I128 => "i128",
+        IoTypeMetadataKind::Unit => b"()",
+        IoTypeMetadataKind::Bool => b"bool",
+        IoTypeMetadataKind::U8 => b"u8",
+        IoTypeMetadataKind::U16 => b"u16",
+        IoTypeMetadataKind::U32 => b"u32",
+        IoTypeMetadataKind::U64 => b"u64",
+        IoTypeMetadataKind::U128 => b"u128",
+        IoTypeMetadataKind::I8 => b"i8",
+        IoTypeMetadataKind::I16 => b"i16",
+        IoTypeMetadataKind::I32 => b"i32",
+        IoTypeMetadataKind::I64 => b"i64",
+        IoTypeMetadataKind::I128 => b"i128",
         IoTypeMetadataKind::Struct
         | IoTypeMetadataKind::Struct0
         | IoTypeMetadataKind::Struct1
@@ -88,26 +89,21 @@ pub(super) const fn type_name(mut metadata: &[u8]) -> Option<&str> {
             }
 
             let (type_name, _) = metadata.split_at(type_name_length);
-            match str::from_utf8(type_name) {
-                Ok(type_name) => type_name,
-                Err(_error) => {
-                    return None;
-                }
-            }
+            type_name
         }
         IoTypeMetadataKind::Array8b
         | IoTypeMetadataKind::Array16b
-        | IoTypeMetadataKind::Array32b => "[T; N]",
-        IoTypeMetadataKind::ArrayU8x8 => "[u8; 8]",
-        IoTypeMetadataKind::ArrayU8x16 => "[u8; 16]",
-        IoTypeMetadataKind::ArrayU8x32 => "[u8; 32]",
-        IoTypeMetadataKind::ArrayU8x64 => "[u8; 64]",
-        IoTypeMetadataKind::ArrayU8x128 => "[u8; 128]",
-        IoTypeMetadataKind::ArrayU8x256 => "[u8; 256]",
-        IoTypeMetadataKind::ArrayU8x512 => "[u8; 512]",
-        IoTypeMetadataKind::ArrayU8x1024 => "[u8; 1024]",
-        IoTypeMetadataKind::ArrayU8x2028 => "[u8; 2028]",
-        IoTypeMetadataKind::ArrayU8x4096 => "[u8; 4096]",
+        | IoTypeMetadataKind::Array32b => b"[T; N]",
+        IoTypeMetadataKind::ArrayU8x8 => b"[u8; 8]",
+        IoTypeMetadataKind::ArrayU8x16 => b"[u8; 16]",
+        IoTypeMetadataKind::ArrayU8x32 => b"[u8; 32]",
+        IoTypeMetadataKind::ArrayU8x64 => b"[u8; 64]",
+        IoTypeMetadataKind::ArrayU8x128 => b"[u8; 128]",
+        IoTypeMetadataKind::ArrayU8x256 => b"[u8; 256]",
+        IoTypeMetadataKind::ArrayU8x512 => b"[u8; 512]",
+        IoTypeMetadataKind::ArrayU8x1024 => b"[u8; 1024]",
+        IoTypeMetadataKind::ArrayU8x2028 => b"[u8; 2028]",
+        IoTypeMetadataKind::ArrayU8x4096 => b"[u8; 4096]",
         IoTypeMetadataKind::VariableBytes8b
         | IoTypeMetadataKind::VariableBytes16b
         | IoTypeMetadataKind::VariableBytes32b
@@ -123,22 +119,18 @@ pub(super) const fn type_name(mut metadata: &[u8]) -> Option<&str> {
         | IoTypeMetadataKind::VariableBytes131072
         | IoTypeMetadataKind::VariableBytes262144
         | IoTypeMetadataKind::VariableBytes524288
-        | IoTypeMetadataKind::VariableBytes1048576 => "VariableBytes",
+        | IoTypeMetadataKind::VariableBytes1048576 => b"VariableBytes",
         IoTypeMetadataKind::VariableElements8b
         | IoTypeMetadataKind::VariableElements16b
         | IoTypeMetadataKind::VariableElements32b
-        | IoTypeMetadataKind::VariableElements0 => "VariableElements",
-        IoTypeMetadataKind::Address => "Address",
-        IoTypeMetadataKind::Balance => "Balance",
+        | IoTypeMetadataKind::VariableElements0 => b"VariableElements",
+        IoTypeMetadataKind::Address => b"Address",
+        IoTypeMetadataKind::Balance => b"Balance",
     })
 }
 
 /// Skips `n` bytes and return remainder
+#[inline(always)]
 const fn skip_n_bytes(input: &[u8], n: usize) -> Option<&[u8]> {
-    if n > input.len() {
-        return None;
-    }
-
-    // `&input[n..]` not supported in const yet
-    Some(input.split_at(n).1)
+    Some(forward_option!(input.split_at_checked(n)).1)
 }

--- a/crates/contracts/system/ab-system-contract-state/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-state/src/lib.rs
@@ -11,7 +11,7 @@ use core::mem::MaybeUninit;
 pub const RECOMMENDED_STATE_CAPACITY: u32 = 1024;
 
 /// Helper function that calls provided function with new empty state buffer
-#[inline(always)]
+#[inline]
 pub fn with_state_buffer<F, R>(f: F) -> R
 where
     F: FnOnce(&mut VariableBytes<RECOMMENDED_STATE_CAPACITY>) -> R,


### PR DESCRIPTION
UTF-8 parsing had to go because it prevented compiler from proving that panic can't happen, it also was non-negligible amount of compute, which resulted in a substantial speed-up:
```
flipper/direct          time:   [61.179 ns 61.433 ns 61.735 ns]
                        thrpt:  [16.198 Melem/s 16.278 Melem/s 16.345 Melem/s]
flipper/transaction     time:   [64.810 ns 65.026 ns 65.281 ns]
                        thrpt:  [15.318 Melem/s 15.378 Melem/s 15.430 Melem/s]
example-wallet/execute-only
                        time:   [3.0185 µs 3.0249 µs 3.0321 µs]
                        thrpt:  [329.81 Kelem/s 330.59 Kelem/s 331.29 Kelem/s]
```

Also tweaked inlining attributes, removing `always` from some of them and adding `#[inline]` to others to help compiler prove where panics can't happen.

`const fn` methods are not supported yet (can't have `Drop` trait in const), so those are skipped, also skipped method calls in `env` module and `fmt` module impls. The rest is now `no-panic` :tada: 