### PR TITLE
`#[tmp]` automatic cleanup

### DIFF
--- a/crates/contracts/core/ab-contract-playground/src/lib.rs
+++ b/crates/contracts/core/ab-contract-playground/src/lib.rs
@@ -9,7 +9,7 @@ use ab_contracts_macros::contract;
 use ab_contracts_standards::fungible::Fungible;
 use core::cmp::Ordering;
 
-#[derive(Debug, Default, Copy, Clone, TrivialType)]
+#[derive(Debug, Default, Copy, Clone, PartialOrd, PartialEq, TrivialType)]
 #[repr(u8)]
 pub enum LastAction {
     #[default]

--- a/crates/contracts/core/ab-contracts-executor/src/context.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/context.rs
@@ -28,6 +28,7 @@ pub(super) struct NativeExecutorContext<'a> {
     /// Indexed by contract's code and method fingerprint
     methods_by_code: &'a HashMap<(&'static [u8], &'static MethodFingerprint), MethodDetails>,
     slots: UnsafeCell<Slots<'a>>,
+    tmp_owners: &'a UnsafeCell<Vec<Address>>,
     allow_env_mutation: bool,
 }
 
@@ -94,6 +95,7 @@ impl<'a> ExecutorContext for NativeExecutorContext<'a> {
             method_details,
             external_args,
             env_state,
+            self.tmp_owners,
             |slots, allow_env_mutation| self.new_nested(slots, allow_env_mutation),
         )
     }
@@ -105,6 +107,7 @@ impl<'a> NativeExecutorContext<'a> {
         shard_index: ShardIndex,
         methods_by_code: &'a HashMap<(&'static [u8], &'static MethodFingerprint), MethodDetails>,
         slots: Slots<'a>,
+        tmp_owners: &'a UnsafeCell<Vec<Address>>,
         allow_env_mutation: bool,
     ) -> Self {
         Self {
@@ -112,6 +115,7 @@ impl<'a> NativeExecutorContext<'a> {
             system_allocator_address: Address::system_address_allocator(shard_index),
             methods_by_code,
             slots: UnsafeCell::new(slots),
+            tmp_owners,
             allow_env_mutation,
         }
     }
@@ -123,6 +127,7 @@ impl<'a> NativeExecutorContext<'a> {
             system_allocator_address: self.system_allocator_address,
             methods_by_code: self.methods_by_code,
             slots: UnsafeCell::new(slots),
+            tmp_owners: self.tmp_owners,
             allow_env_mutation,
         }
     }

--- a/crates/contracts/core/ab-contracts-trivial-type-derive/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-trivial-type-derive/src/lib.rs
@@ -195,7 +195,7 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
     output.into()
 }
 
-#[allow(clippy::type_complexity, reason = "Private one-off function")]
+#[expect(clippy::type_complexity, reason = "Private one-off function")]
 fn parse_repr(
     repr_attr: &Attribute,
 ) -> Result<(bool, bool, Option<u8>, Option<usize>, Option<usize>), Error> {


### PR DESCRIPTION
Now `#[tmp]` is actually ephemeral and automatically cleaned up after transaction processing