### PR TITLE
Faster transaction processing

### DIFF
--- a/crates/contracts/core/ab-contracts-common/src/env.rs
+++ b/crates/contracts/core/ab-contracts-common/src/env.rs
@@ -159,28 +159,28 @@ impl<'a> Env<'a> {
     }
 
     /// Shard index where execution is happening
-    #[inline]
+    #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn shard_index(&self) -> ShardIndex {
         self.state.shard_index
     }
 
     /// Own address of the contract
-    #[inline]
+    #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn own_address(&self) -> Address {
         self.state.own_address
     }
 
     /// Context of the execution
-    #[inline]
+    #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn context<'b>(self: &'b &'b mut Self) -> Address {
         self.state.context
     }
 
     /// Caller of this contract
-    #[inline]
+    #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn caller<'b>(self: &'b &'b mut Self) -> Address {
         self.state.caller
@@ -189,7 +189,7 @@ impl<'a> Env<'a> {
     /// Call a method at specified address and with specified arguments.
     ///
     /// This is a shortcut for [`Self::prepare_method_call()`] + [`Self::call_prepared()`].
-    #[inline]
+    #[inline(always)]
     pub fn call<Args>(
         &self,
         contract: Address,
@@ -206,7 +206,7 @@ impl<'a> Env<'a> {
     /// Prepare a single method for calling at specified address and with specified arguments.
     ///
     /// The result is to be used with [`Self::call_prepared()`] afterward.
-    #[inline]
+    #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn prepare_method_call<Args>(
         contract: Address,

--- a/crates/contracts/core/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-common/src/lib.rs
@@ -23,6 +23,11 @@ pub use error::{ContractError, CustomContractErrorCode, ExitCode};
 
 /// Max allowed size of the contract code
 pub const MAX_CODE_SIZE: u32 = 1024 * 1024;
+/// Max number of arguments in a method.
+///
+/// NOTE: Both `self` and return type that is not `()` or `Result<(), ContractError>` count towards
+/// the total number of method arguments.
+pub const MAX_TOTAL_METHOD_ARGS: u8 = 8;
 
 /// Method details used by native execution environment.
 ///

--- a/crates/contracts/core/ab-contracts-common/src/metadata.rs
+++ b/crates/contracts/core/ab-contracts-common/src/metadata.rs
@@ -49,7 +49,8 @@ pub enum ContractMetadataKind {
     /// Initializers are encoded af follows:
     /// * Length of method name in bytes (u8)
     /// * Method name as UTF-8 bytes
-    /// * Number of named arguments (u8, excluding state argument `&self` or `&mut self`)
+    /// * Number of named arguments (u8, excluding state argument `&self` or `&mut self`, but
+    ///   including return type that is not `()` or `Result<(), ContactError>`)
     ///
     /// Each argument is encoded as follows:
     /// * Argument type as u8, one of:

--- a/crates/contracts/core/ab-contracts-macros/src/__private.rs
+++ b/crates/contracts/core/ab-contracts-macros/src/__private.rs
@@ -3,7 +3,7 @@ pub use ab_contracts_common::metadata::ContractMetadataKind;
 pub use ab_contracts_common::method::{ExternalArgs, MethodFingerprint};
 pub use ab_contracts_common::{
     Address, Contract, ContractError, ContractTrait, ContractTraitDefinition, ExitCode,
-    MAX_CODE_SIZE, NativeExecutorContactMethod,
+    MAX_CODE_SIZE, MAX_TOTAL_METHOD_ARGS, NativeExecutorContactMethod,
 };
 pub use ab_contracts_io_type::metadata::{MAX_METADATA_CAPACITY, concat_metadata_sources};
 pub use ab_contracts_io_type::trivial_type::TrivialType;

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -20,8 +20,8 @@ pub mod seal;
 
 use crate::payload::{TransactionMethodContext, TransactionPayloadDecoder};
 use crate::seal::hash_and_verify;
-use ab_contracts_common::ContractError;
 use ab_contracts_common::env::{Env, MethodContext, TransactionHeader};
+use ab_contracts_common::{ContractError, MAX_TOTAL_METHOD_ARGS};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_macros::contract;
@@ -43,7 +43,7 @@ pub const SIGNING_CONTEXT: &[u8] = b"system-simple-wallet";
 ///
 /// `#[slot]` argument using one pointer, `#[input]` two pointers and `#[output]` three pointers
 /// each.
-pub const EXTERNAL_ARGS_BUFFER_SIZE: usize = 32 * 1024;
+pub const EXTERNAL_ARGS_BUFFER_SIZE: usize = 3 * MAX_TOTAL_METHOD_ARGS as usize;
 /// Size of the buffer in bytes that is used as a stack for storing outputs.
 ///
 /// This constant is helpful for transaction generation to check whether a created transaction

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -44,7 +44,7 @@ pub const SIGNING_CONTEXT: &[u8] = b"system-simple-wallet";
 /// `#[slot]` argument using one pointer, `#[input]` two pointers and `#[output]` three pointers
 /// each.
 pub const EXTERNAL_ARGS_BUFFER_SIZE: usize = 3 * MAX_TOTAL_METHOD_ARGS as usize;
-/// Size of the buffer in bytes that is used as a stack for storing outputs.
+/// Size of the buffer in `u128` elements that is used as a stack for storing outputs.
 ///
 /// This constant is helpful for transaction generation to check whether a created transaction
 /// doesn't exceed this limit.
@@ -53,7 +53,7 @@ pub const EXTERNAL_ARGS_BUFFER_SIZE: usize = 3 * MAX_TOTAL_METHOD_ARGS as usize;
 /// methods of the payload together.
 ///
 /// Overflow will result in an error.
-pub const OUTPUT_BUFFER_SIZE: usize = 32 * 1024;
+pub const OUTPUT_BUFFER_SIZE: usize = 32 * 1024 / size_of::<u128>();
 /// Size of the buffer in entries that is used to store buffer offsets.
 ///
 /// This constant is helpful for transaction generation to check whether a created transaction


### PR DESCRIPTION
This makes transaction execution A LOT faster:
```
example-wallet/execute-only
                        time:   [611.07 ns 613.71 ns 616.75 ns]
                        thrpt:  [1.6214 Melem/s 1.6294 Melem/s 1.6365 Melem/s]
```

Explicit limit for number of arguments will be leveraged to further improve performance and to allow easier and more compact implementation of more advanced transaction payload encoding (with ability to reference outputs for slots, not just inputs).