### PR TITLE
Transaction refactoring

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -165,14 +165,14 @@ jobs:
       - name: Ensure no panics in annotated code
         env:
           # Increase inlining threshold to make sure the compiler can see that some functions do not panic
-          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=1000
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=1500
         run: |
           cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic
 
       - name: Ensure no panics in annotated code (various features)
         env:
           # Increase inlining threshold to make sure the compiler can see that some functions do not panic
-          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=1000
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=1500
         run: |
           for contract_path in crates/contracts/{example,system}/*; do
             # Not all contracts have this feature yet

--- a/crates/contracts/core/ab-contracts-common/src/env.rs
+++ b/crates/contracts/core/ab-contracts-common/src/env.rs
@@ -8,45 +8,6 @@ use core::ptr::NonNull;
 // TODO: New type
 pub type Blake3Hash = [u8; 32];
 
-/// A measure of compute resources, 1 Gas == 1 ns of compute on reference hardware
-#[derive(Debug, Default, Copy, Clone, TrivialType)]
-#[repr(C)]
-pub struct Gas(u64);
-
-#[derive(Debug, Copy, Clone, TrivialType)]
-#[repr(C)]
-pub struct TransactionHeader {
-    pub block_hash: Blake3Hash,
-    pub gas_limit: Gas,
-    /// Contract implementing `TxHandler` trait to use for transaction verification and execution
-    pub contract: Address,
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, TrivialType)]
-#[repr(C)]
-pub struct TransactionSlot {
-    pub owner: Address,
-    pub contract: Address,
-}
-
-/// Similar to `Transaction`, but doesn't require `allow` or data ownership.
-///
-/// Can be created with `Transaction::as_ref()` call.
-#[derive(Debug, Copy, Clone)]
-pub struct Transaction<'a> {
-    pub header: &'a TransactionHeader,
-    /// Slots in the form of [`TransactionSlot`] that may be read during transaction processing.
-    ///
-    /// The code slot of the contract that is being executed is implicitly included and doesn't need
-    /// to be repeated. Also slots that may also be written to do not need to be repeated in the
-    /// read slots.
-    pub read_slots: &'a [TransactionSlot],
-    /// Slots in the form of [`TransactionSlot`] that may be written during transaction processing
-    pub write_slots: &'a [TransactionSlot],
-    pub payload: &'a [u128],
-    pub seal: &'a [u8],
-}
-
 /// Context for method call.
 ///
 /// The correct mental model for context is "user of the child process", where "process" is a method

--- a/crates/contracts/core/ab-contracts-common/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod env;
 mod error;
 pub mod metadata;
 pub mod method;
+pub mod transaction;
 
 use crate::method::MethodFingerprint;
 use ab_contracts_io_type::IoType;

--- a/crates/contracts/core/ab-contracts-common/src/transaction.rs
+++ b/crates/contracts/core/ab-contracts-common/src/transaction.rs
@@ -1,0 +1,42 @@
+use crate::Address;
+use crate::env::Blake3Hash;
+use ab_contracts_io_type::trivial_type::TrivialType;
+
+/// A measure of compute resources, 1 Gas == 1 ns of compute on reference hardware
+#[derive(Debug, Default, Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct Gas(u64);
+
+#[derive(Debug, Copy, Clone, TrivialType)]
+#[repr(C)]
+pub struct TransactionHeader {
+    pub block_hash: Blake3Hash,
+    pub gas_limit: Gas,
+    /// Contract implementing `TxHandler` trait to use for transaction verification and execution
+    pub contract: Address,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, TrivialType)]
+#[repr(C)]
+pub struct TransactionSlot {
+    pub owner: Address,
+    pub contract: Address,
+}
+
+/// Similar to `Transaction`, but doesn't require `allow` or data ownership.
+///
+/// Can be created with `Transaction::as_ref()` call.
+#[derive(Debug, Copy, Clone)]
+pub struct Transaction<'a> {
+    pub header: &'a TransactionHeader,
+    /// Slots in the form of [`TransactionSlot`] that may be read during transaction processing.
+    ///
+    /// The code slot of the contract that is being executed is implicitly included and doesn't need
+    /// to be repeated. Also slots that may also be written to do not need to be repeated in the
+    /// read slots.
+    pub read_slots: &'a [TransactionSlot],
+    /// Slots in the form of [`TransactionSlot`] that may be written during transaction processing
+    pub write_slots: &'a [TransactionSlot],
+    pub payload: &'a [u128],
+    pub seal: &'a [u8],
+}

--- a/crates/contracts/core/ab-contracts-executor/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/lib.rs
@@ -3,9 +3,10 @@
 mod context;
 
 use crate::context::{MethodDetails, NativeExecutorContext};
-use ab_contracts_common::env::{Env, EnvState, MethodContext, Transaction, TransactionSlot};
+use ab_contracts_common::env::{Env, EnvState, MethodContext};
 use ab_contracts_common::metadata::decode::{MetadataDecoder, MetadataDecodingError, MetadataItem};
 use ab_contracts_common::method::MethodFingerprint;
+use ab_contracts_common::transaction::{Transaction, TransactionSlot};
 use ab_contracts_common::{
     Address, Contract, ContractError, ContractTrait, ContractTraitDefinition,
     NativeExecutorContactMethod, ShardIndex,

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
@@ -47,8 +47,9 @@ pub struct IoTypeDetails {
 }
 
 impl IoTypeDetails {
+    /// Create an instance for regular bytes (alignment 1)
     #[inline(always)]
-    const fn bytes(recommended_capacity: u32) -> Self {
+    pub const fn bytes(recommended_capacity: u32) -> Self {
         Self {
             recommended_capacity,
             alignment: NonZeroU8::new(1).expect("Not zero; qed"),

--- a/crates/contracts/core/ab-contracts-standards/src/tx_handler.rs
+++ b/crates/contracts/core/ab-contracts-standards/src/tx_handler.rs
@@ -1,5 +1,6 @@
 use ab_contracts_common::ContractError;
-use ab_contracts_common::env::{Env, TransactionHeader, TransactionSlot};
+use ab_contracts_common::env::Env;
+use ab_contracts_common::transaction::{TransactionHeader, TransactionSlot};
 use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_io_type::variable_elements::VariableElements;
 use ab_contracts_macros::contract;

--- a/crates/contracts/core/ab-contracts-test-utils/src/dummy_wallet.rs
+++ b/crates/contracts/core/ab-contracts-test-utils/src/dummy_wallet.rs
@@ -3,7 +3,8 @@
     reason = "Intentionally not adding `guest` feature, this is a test utility not to be deployed"
 )]
 
-use ab_contracts_common::env::{Env, MethodContext, TransactionHeader};
+use ab_contracts_common::env::{Env, MethodContext};
+use ab_contracts_common::transaction::TransactionHeader;
 use ab_contracts_common::{Address, ContractError};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_macros::contract;

--- a/crates/contracts/core/ab-contracts-test-utils/src/transaction_builder.rs
+++ b/crates/contracts/core/ab-contracts-test-utils/src/transaction_builder.rs
@@ -53,6 +53,7 @@ impl TransactionBuilder {
         contract: &Address,
         external_args: &Args,
         method_context: TransactionMethodContext,
+        slot_output_index: &[Option<u8>],
         input_output_index: &[Option<u8>],
     ) -> Result<(), TransactionPayloadBuilderError<'static>>
     where
@@ -62,6 +63,7 @@ impl TransactionBuilder {
             contract,
             external_args,
             method_context,
+            slot_output_index,
             input_output_index,
         )
     }

--- a/crates/contracts/core/ab-contracts-test-utils/src/transaction_builder.rs
+++ b/crates/contracts/core/ab-contracts-test-utils/src/transaction_builder.rs
@@ -1,6 +1,7 @@
 use ab_contracts_common::Address;
-use ab_contracts_common::env::{Blake3Hash, Gas, Transaction, TransactionHeader, TransactionSlot};
+use ab_contracts_common::env::Blake3Hash;
 use ab_contracts_common::method::ExternalArgs;
+use ab_contracts_common::transaction::{Gas, Transaction, TransactionHeader, TransactionSlot};
 use ab_system_contract_simple_wallet_base::payload::TransactionMethodContext;
 use ab_system_contract_simple_wallet_base::payload::builder::{
     TransactionPayloadBuilder, TransactionPayloadBuilderError,

--- a/crates/contracts/example/ab-example-contract-wallet/benches/example-contract-wallet.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/benches/example-contract-wallet.rs
@@ -97,6 +97,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 &FlipperFlipArgs::new(),
                 TransactionMethodContext::Null,
                 &[],
+                &[],
             )
             .unwrap();
         builder.into_aligned_bytes()

--- a/crates/contracts/example/ab-example-contract-wallet/benches/example-contract-wallet.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/benches/example-contract-wallet.rs
@@ -1,7 +1,6 @@
 use crate::ffi::flip::FlipperFlipArgs;
-use ab_contracts_common::env::{
-    Blake3Hash, MethodContext, Transaction, TransactionHeader, TransactionSlot,
-};
+use ab_contracts_common::env::{Blake3Hash, MethodContext};
+use ab_contracts_common::transaction::{Transaction, TransactionHeader, TransactionSlot};
 use ab_contracts_common::{Address, Contract, ShardIndex};
 use ab_contracts_executor::NativeExecutor;
 use ab_contracts_io_type::trivial_type::TrivialType;

--- a/crates/contracts/example/ab-example-contract-wallet/src/lib.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
-use ab_contracts_common::env::{Env, MethodContext, TransactionHeader};
+use ab_contracts_common::env::{Env, MethodContext};
+use ab_contracts_common::transaction::TransactionHeader;
 use ab_contracts_common::{Address, ContractError};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_macros::contract;

--- a/crates/contracts/example/ab-example-contract-wallet/tests/flip.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/tests/flip.rs
@@ -100,6 +100,7 @@ fn flip() {
                 &FlipperFlipArgs::new(),
                 TransactionMethodContext::Null,
                 &[],
+                &[],
             )
             .unwrap();
         builder.into_aligned_bytes()

--- a/crates/contracts/example/ab-example-contract-wallet/tests/flip.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/tests/flip.rs
@@ -2,9 +2,8 @@
 #![cfg(not(feature = "guest"))]
 
 use crate::ffi::flip::FlipperFlipArgs;
-use ab_contracts_common::env::{
-    Blake3Hash, MethodContext, Transaction, TransactionHeader, TransactionSlot,
-};
+use ab_contracts_common::env::{Blake3Hash, MethodContext};
+use ab_contracts_common::transaction::{Transaction, TransactionHeader, TransactionSlot};
 use ab_contracts_common::{Address, Contract, ShardIndex};
 use ab_contracts_executor::NativeExecutor;
 use ab_contracts_io_type::trivial_type::TrivialType;

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -20,7 +20,8 @@ pub mod seal;
 
 use crate::payload::{TransactionMethodContext, TransactionPayloadDecoder};
 use crate::seal::hash_and_verify;
-use ab_contracts_common::env::{Env, MethodContext, TransactionHeader};
+use ab_contracts_common::env::{Env, MethodContext};
+use ab_contracts_common::transaction::TransactionHeader;
 use ab_contracts_common::{ContractError, MAX_TOTAL_METHOD_ARGS};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_io_type::variable_bytes::VariableBytes;

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -12,7 +12,13 @@
 //!   followed by [`SimpleWalletBase::increase_nonce`]
 //! * [`SimpleWalletBase::change_public_key`] is used for change public key to a different one
 
-#![feature(non_null_from_ref, ptr_as_ref_unchecked, try_blocks, unchecked_shifts)]
+#![feature(
+    maybe_uninit_slice,
+    non_null_from_ref,
+    ptr_as_ref_unchecked,
+    try_blocks,
+    unchecked_shifts
+)]
 #![no_std]
 
 pub mod payload;

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder.rs
@@ -145,7 +145,7 @@ impl TransactionPayloadBuilder {
             method_fingerprint.as_bytes(),
             align_of_val(method_fingerprint),
         );
-        self.payload.push(method_context as u8);
+        self.push_payload_byte(method_context as u8);
 
         let mut num_slot_arguments = 0u8;
         let mut num_input_arguments = 0u8;
@@ -196,7 +196,7 @@ impl TransactionPayloadBuilder {
         };
 
         // Store number of slots and `TransactionSlot` for each slot
-        self.payload.push(num_slot_arguments);
+        self.push_payload_byte(num_slot_arguments);
         for slot_offset in 0..usize::from(num_slot_arguments) {
             let slot_type = if let Some(&Some(output_index)) = slot_output_index.get(slot_offset) {
                 TransactionSlot::new_output_index(output_index).ok_or(
@@ -205,11 +205,11 @@ impl TransactionPayloadBuilder {
             } else {
                 TransactionSlot::new_address()
             };
-            self.payload.push(slot_type.into_u8());
+            self.push_payload_byte(slot_type.into_u8());
         }
 
         // Store number of inputs and `TransactionInput` for each input
-        self.payload.push(num_input_arguments);
+        self.push_payload_byte(num_input_arguments);
         for (input_offset, type_details) in input_type_details.iter().enumerate() {
             let input_type = if let Some(&Some(output_index)) = input_output_index.get(input_offset)
             {
@@ -221,11 +221,11 @@ impl TransactionPayloadBuilder {
                     TransactionPayloadBuilderError::InvalidAlignment(type_details.alignment),
                 )?
             };
-            self.payload.push(input_type.into_u8());
+            self.push_payload_byte(input_type.into_u8());
         }
 
         // Store number of outputs
-        self.payload.push(num_output_arguments);
+        self.push_payload_byte(num_output_arguments);
 
         for slot_offset in 0..usize::from(num_slot_arguments) {
             // SAFETY: Method description requires the layout to correspond to metadata
@@ -348,5 +348,9 @@ impl TransactionPayloadBuilder {
             self.payload
                 .resize(self.payload.len() + (alignment - unaligned_by), 0);
         }
+    }
+
+    fn push_payload_byte(&mut self, byte: u8) {
+        self.payload.push(byte);
     }
 }

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder.rs
@@ -5,7 +5,7 @@ mod tests;
 
 extern crate alloc;
 
-use crate::payload::{TransactionInput, TransactionMethodContext};
+use crate::payload::{TransactionInput, TransactionMethodContext, TransactionSlot};
 use ab_contracts_common::metadata::decode::{
     ArgumentKind, MetadataDecodingError, MethodMetadataDecoder, MethodMetadataItem,
     MethodsContainerKind,
@@ -13,12 +13,19 @@ use ab_contracts_common::metadata::decode::{
 use ab_contracts_common::method::{ExternalArgs, MethodFingerprint};
 use ab_contracts_common::{Address, MAX_TOTAL_METHOD_ARGS};
 use ab_contracts_io_type::MAX_ALIGNMENT;
+use ab_contracts_io_type::metadata::IoTypeDetails;
 use ab_contracts_io_type::trivial_type::TrivialType;
 use alloc::vec::Vec;
 use core::ffi::c_void;
+use core::mem::MaybeUninit;
 use core::num::NonZeroU8;
 use core::ptr::NonNull;
 use core::{ptr, slice};
+
+const _: () = {
+    // Make sure bit flags for all arguments will fit into a single u8 below
+    assert!(MAX_TOTAL_METHOD_ARGS as u32 == u8::BITS);
+};
 
 /// Errors for [`TransactionPayloadBuilder`]
 #[derive(Debug, thiserror::Error)]
@@ -62,13 +69,15 @@ impl TransactionPayloadBuilder {
     ///
     /// The wallet will call this method in addition order.
     ///
-    /// `input_output_index` is used for referencing earlier outputs as inputs of this method,
-    /// its values are optional, see [`TransactionInput`] for more details.
+    /// `slot_output_index` and `input_output_index` are used for referencing earlier outputs as
+    /// slots or inputs of this method, its values are optional, see [`TransactionInput`] for more
+    /// details.
     pub fn with_method_call<Args>(
         &mut self,
         contract: &Address,
         external_args: &Args,
         method_context: TransactionMethodContext,
+        slot_output_index: &[Option<u8>],
         input_output_index: &[Option<u8>],
     ) -> Result<(), TransactionPayloadBuilderError<'static>>
     where
@@ -84,6 +93,7 @@ impl TransactionPayloadBuilder {
                 Args::METADATA,
                 &Args::FINGERPRINT,
                 method_context,
+                slot_output_index,
                 input_output_index,
             )
         }
@@ -95,6 +105,10 @@ impl TransactionPayloadBuilder {
     /// `external_args` must correspond to `method_metadata` and `method_fingerprint`. Outputs are
     /// never read from `external_args` and inputs that have corresponding `input_output_index`
     /// are not read either.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Only exceeds the limit due to being untyped, while above typed version is not"
+    )]
     pub unsafe fn with_method_call_untyped<'a>(
         &mut self,
         contract: &Address,
@@ -102,6 +116,7 @@ impl TransactionPayloadBuilder {
         mut method_metadata: &'a [u8],
         method_fingerprint: &MethodFingerprint,
         method_context: TransactionMethodContext,
+        slot_output_index: &[Option<u8>],
         input_output_index: &[Option<u8>],
     ) -> Result<(), TransactionPayloadBuilderError<'a>> {
         let mut external_args = *external_args;
@@ -132,16 +147,13 @@ impl TransactionPayloadBuilder {
         );
         self.payload.push(method_context as u8);
 
-        // Remember the position to update later
-        let num_slots_index = self.payload.len();
-        self.payload.push(0);
-        // Remember the position to update later
-        let num_inputs_index = self.payload.len();
-        self.payload.push(0);
-        // Remember the position to update later
-        let num_outputs_index = self.payload.len();
-        self.payload.push(0);
+        let mut num_slot_arguments = 0u8;
+        let mut num_input_arguments = 0u8;
+        let mut num_output_arguments = 0u8;
 
+        let mut input_output_type_details =
+            [MaybeUninit::<IoTypeDetails>::uninit(); MAX_TOTAL_METHOD_ARGS as usize];
+        // Collect information about all arguments so everything below is able to be purely additive
         while let Some(item) = metadata_decoder
             .decode_next()
             .transpose()
@@ -155,79 +167,117 @@ impl TransactionPayloadBuilder {
                     // Not represented in external args
                 }
                 ArgumentKind::SlotRo | ArgumentKind::SlotRw => {
-                    self.payload[num_slots_index] += 1;
-
-                    // SAFETY: Method description requires the layout to correspond to metadata
-                    let address = unsafe {
-                        let address = external_args.cast::<NonNull<Address>>().read().as_ref();
-                        external_args = external_args.offset(1);
-                        address
-                    };
-                    self.extend_payload_with_alignment(address.as_bytes(), align_of_val(address));
+                    num_slot_arguments += 1;
                 }
                 ArgumentKind::Input => {
-                    let input_offset = usize::from(self.payload[num_inputs_index]);
-                    self.payload[num_inputs_index] += 1;
-
-                    let type_details = &item
-                        .type_details
-                        .expect("Always present for `#[input]`; qed");
-
-                    let maybe_output_index =
-                        input_output_index.get(input_offset).copied().flatten();
-                    let input_type = match maybe_output_index {
-                        Some(output_index) => TransactionInput::new_output_index(output_index)
-                            .ok_or(TransactionPayloadBuilderError::InvalidOutputIndex(
-                                output_index,
-                            ))?,
-                        None => TransactionInput::new_value(type_details.alignment).ok_or(
-                            TransactionPayloadBuilderError::InvalidAlignment(
-                                type_details.alignment,
-                            ),
-                        )?,
-                    };
-                    self.payload.push(input_type.into_u8());
-
-                    if maybe_output_index.is_none() {
-                        // SAFETY: Method description requires the layout to correspond to metadata
-                        let (size, data) = unsafe {
-                            let data = external_args.cast::<NonNull<u8>>().read();
-                            external_args = external_args.offset(1);
-                            let size = external_args.cast::<NonNull<u32>>().read().read();
-                            external_args = external_args.offset(1);
-
-                            let data =
-                                slice::from_raw_parts(data.as_ptr().cast_const(), size as usize);
-
-                            (size, data)
-                        };
-
-                        self.extend_payload_with_alignment(
-                            &size.to_le_bytes(),
-                            align_of_val(&size),
-                        );
-                        self.extend_payload_with_alignment(
-                            data,
-                            type_details.alignment.get() as usize,
-                        );
-                    }
+                    input_output_type_details[usize::from(num_input_arguments)]
+                        .write(item.type_details.unwrap_or(IoTypeDetails::bytes(0)));
+                    num_input_arguments += 1;
                 }
                 ArgumentKind::Output => {
-                    self.payload[num_outputs_index] += 1;
-
-                    // May be skipped for `#[init]`, see `ContractMetadataKind::Init` for details
-                    if let Some(type_details) = &item.type_details {
-                        self.extend_payload_with_alignment(
-                            &type_details.recommended_capacity.to_le_bytes(),
-                            align_of_val(&type_details.recommended_capacity),
-                        );
-                        self.extend_payload_with_alignment(
-                            &[type_details.alignment.ilog2() as u8],
-                            align_of::<u8>(),
-                        );
-                    }
+                    input_output_type_details
+                        [usize::from(num_input_arguments + num_output_arguments)]
+                    .write(item.type_details.unwrap_or(IoTypeDetails::bytes(0)));
+                    num_output_arguments += 1;
                 }
             }
+        }
+        // SAFETY: Just initialized elements above
+        let (input_type_details, output_type_details) = unsafe {
+            let (input_type_details, output_type_details) =
+                input_output_type_details.split_at_unchecked(usize::from(num_input_arguments));
+            let (output_type_details, _) =
+                output_type_details.split_at_unchecked(usize::from(num_output_arguments));
+
+            (
+                input_type_details.assume_init_ref(),
+                output_type_details.assume_init_ref(),
+            )
+        };
+
+        // Store number of slots and `TransactionSlot` for each slot
+        self.payload.push(num_slot_arguments);
+        for slot_offset in 0..usize::from(num_slot_arguments) {
+            let slot_type = if let Some(&Some(output_index)) = slot_output_index.get(slot_offset) {
+                TransactionSlot::new_output_index(output_index).ok_or(
+                    TransactionPayloadBuilderError::InvalidOutputIndex(output_index),
+                )?
+            } else {
+                TransactionSlot::new_address()
+            };
+            self.payload.push(slot_type.into_u8());
+        }
+
+        // Store number of inputs and `TransactionInput` for each input
+        self.payload.push(num_input_arguments);
+        for (input_offset, type_details) in input_type_details.iter().enumerate() {
+            let input_type = if let Some(&Some(output_index)) = input_output_index.get(input_offset)
+            {
+                TransactionInput::new_output_index(output_index).ok_or(
+                    TransactionPayloadBuilderError::InvalidOutputIndex(output_index),
+                )?
+            } else {
+                TransactionInput::new_value(type_details.alignment).ok_or(
+                    TransactionPayloadBuilderError::InvalidAlignment(type_details.alignment),
+                )?
+            };
+            self.payload.push(input_type.into_u8());
+        }
+
+        // Store number of outputs
+        self.payload.push(num_output_arguments);
+
+        for slot_offset in 0..usize::from(num_slot_arguments) {
+            // SAFETY: Method description requires the layout to correspond to metadata
+            let address = unsafe {
+                let address = external_args.cast::<NonNull<Address>>().read().as_ref();
+                external_args = external_args.offset(1);
+                address
+            };
+
+            if slot_output_index
+                .get(slot_offset)
+                .copied()
+                .flatten()
+                .is_none()
+            {
+                self.extend_payload_with_alignment(address.as_bytes(), align_of_val(address));
+            }
+        }
+
+        for (input_offset, type_details) in input_type_details.iter().enumerate() {
+            // SAFETY: Method description requires the layout to correspond to metadata
+            let (size, data) = unsafe {
+                let data = external_args.cast::<NonNull<u8>>().read();
+                external_args = external_args.offset(1);
+                let size = external_args.cast::<NonNull<u32>>().read().read();
+                external_args = external_args.offset(1);
+
+                let data = slice::from_raw_parts(data.as_ptr().cast_const(), size as usize);
+
+                (size, data)
+            };
+
+            if input_output_index
+                .get(input_offset)
+                .copied()
+                .flatten()
+                .is_none()
+            {
+                self.extend_payload_with_alignment(&size.to_le_bytes(), align_of_val(&size));
+                self.extend_payload_with_alignment(data, type_details.alignment.get() as usize);
+            }
+        }
+
+        for type_details in output_type_details {
+            self.extend_payload_with_alignment(
+                &type_details.recommended_capacity.to_le_bytes(),
+                align_of_val(&type_details.recommended_capacity),
+            );
+            self.extend_payload_with_alignment(
+                &[type_details.alignment.ilog2() as u8],
+                align_of::<u8>(),
+            );
         }
 
         Ok(())
@@ -243,18 +293,23 @@ impl TransactionPayloadBuilder {
     /// * Contract to call: [`Address`]
     /// * Fingerprint of the method to call: [`MethodFingerprint`]
     /// * Method context: [`TransactionMethodContext`]
-    /// * Number of slot arguments: `u8`
+    /// * Number of `#[slot]` arguments: `u8`
+    /// * For each `#[slot]` argument:
+    ///     * [`TransactionSlot`]  as `u8`
     /// * Number of `#[input]` arguments: `u8`
+    /// * For each `#[input]` argument:
+    ///     * [`TransactionInput`] for each `#[input]` argument as `u8`
     /// * Number of `#[output]` arguments: `u8`
-    /// * Concatenated sequence of arguments
+    /// * For each [`TransactionSlot`], whose type is [`TransactionSlotType::Address`]:
+    ///     * [`Address`]
+    /// * For each [`TransactionInput`], whose type is [`TransactionInputType::Value`]:
+    ///     * Input size as little-endian `u32` followed by the input itself
+    /// * For each `#[output]`:
+    ///     * recommended capacity as little-endian `u32` followed by alignment power as `u8`
+    ///       (`NonZeroU8::ilog2(alignment)`)
     ///
-    /// Each argument is serialized in the following way (others are skipped):
-    /// * `#[slot]`: [`Address`]
-    /// * `#[input]`: [`TransactionInput`] as `u8`
-    ///     * If [`TransactionInput::new_value()`] then input size as little-endian `u32`
-    ///       followed by the input itself
-    /// * `#[output]`: recommended capacity as little-endian `u32` followed by alignment power as
-    ///   `u8` (`NonZeroU8::ilog2(alignment)`)
+    /// [`TransactionSlotType::Address`]: crate::payload::TransactionSlotType::Address
+    /// [`TransactionInputType::Value`]: crate::payload::TransactionInputType::Value
     pub fn into_aligned_bytes(mut self) -> Vec<u128> {
         // Fill bytes to make it multiple of `u128` before creating `u128`-based vector
         self.ensure_alignment(usize::from(MAX_ALIGNMENT));

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder/tests.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder/tests.rs
@@ -43,6 +43,7 @@ fn payload_encode_decode() {
                 &DemoContractSetArgs::new(&new_value),
                 TransactionMethodContext::Wallet,
                 &[],
+                &[],
             )
             .unwrap();
         builder.into_aligned_bytes()

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/seal.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/seal.rs
@@ -2,7 +2,8 @@
 
 use crate::{SIGNING_CONTEXT, Seal};
 use ab_contracts_common::ContractError;
-use ab_contracts_common::env::{Blake3Hash, TransactionHeader, TransactionSlot};
+use ab_contracts_common::env::Blake3Hash;
+use ab_contracts_common::transaction::{TransactionHeader, TransactionSlot};
 use ab_contracts_io_type::trivial_type::TrivialType;
 use core::slice;
 use schnorrkel::context::SigningContext;


### PR DESCRIPTION
The biggest change here is transaction payload encoding/decoding rewrite. Not only it now supports using outputs of previous method calls for slots (only inputs were supported before), it also builds payload incrementally. Incremental building means it will be possible to make it work in `no_std` environment with little effort if needed, which might be useful.

There were also a few bugs in not yet tested code paths that were fixed, for example outputs have optional `TypeDetails` (for `#[init]`'s last `#[output]`), but encoding wasn't aware of this distinction, resulting in invalid encoding in some cases.

And lastly, the encoding of transactions should generally be more compact than before due to better alignment.