### PR TITLE
Improve `make_ffi_call` performance (part 2)

### DIFF
--- a/crates/contracts/core/ab-contracts-executor/src/context/ffi_call.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/context/ffi_call.rs
@@ -394,13 +394,11 @@ where
         return Err(ContractError::BadInput);
     }
 
+    let internal_args = NonNull::new(internal_args.get().cast::<MaybeUninit<*mut c_void>>())
+        .expect("Taken from non-null instance; qed");
     // This pointer will be moving as the data structure is being constructed, while `internal_args`
     // will keep pointing to the beginning
-    let mut internal_args_cursor = NonNull::<MaybeUninit<*mut c_void>>::new(
-        internal_args.get().cast::<MaybeUninit<*mut c_void>>(),
-    )
-    .expect("Taken from non-null instance; qed")
-    .cast::<*mut c_void>();
+    let mut internal_args_cursor = internal_args.cast::<*mut c_void>();
     // This pointer will be moving as the data structure is being read, while `external_args` will
     // keep pointing to the beginning
     let mut external_args_cursor = *external_args;
@@ -742,10 +740,7 @@ where
 
     // Will only read initialized number of pointers, hence `NonNull<c_void>` even though there is
     // likely slack capacity with uninitialized data
-    let internal_args =
-        NonNull::<MaybeUninit<*mut c_void>>::new(internal_args.get_mut().as_mut_ptr())
-            .expect("Taken from non-null instance; qed")
-            .cast::<NonNull<c_void>>();
+    let internal_args = internal_args.cast::<NonNull<c_void>>();
 
     // SAFETY: FFI function was generated at the same time as corresponding `Args` and must match
     // ABI of the fingerprint or else it wouldn't compile

--- a/crates/contracts/core/ab-contracts-executor/src/context/ffi_call.rs
+++ b/crates/contracts/core/ab-contracts-executor/src/context/ffi_call.rs
@@ -338,15 +338,10 @@ where
 
     // Allocate a buffer that will contain incrementally built `InternalArgs` that method expects,
     // according to its metadata.
-    // `* 4` is due to slots having 2 pointers (detecting this accurately is more code, so this
-    // just assumes the worst case), otherwise it would be 3 pointers: data + size + capacity.
-    let internal_args = Box::<[*mut c_void]>::new_uninit_slice(number_of_arguments * 4);
-    // SAFETY: `UnsafeCell` has the same memory layout as its inner value
-    let mut internal_args = unsafe {
-        mem::transmute::<Box<[MaybeUninit<*mut c_void>]>, Box<UnsafeCell<[MaybeUninit<*mut c_void>]>>>(
-            internal_args,
-        )
-    };
+    // `* 4` is due the worst case being to have a slot with 4 pointers: address + data + size +
+    // capacity.
+    let mut internal_args =
+        UnsafeCell::new([MaybeUninit::<*mut c_void>::uninit(); MAX_TOTAL_METHOD_ARGS as usize * 4]);
 
     // This pointer will be moving as the data structure is being constructed, while `internal_args`
     // will keep pointing to the beginning


### PR DESCRIPTION
This further improves performance:
```
flipper/direct          time:   [48.326 ns 48.469 ns 48.638 ns]
                        thrpt:  [20.560 Melem/s 20.632 Melem/s 20.693 Melem/s]
flipper/transaction     time:   [57.682 ns 57.933 ns 58.219 ns]
                        thrpt:  [17.177 Melem/s 17.261 Melem/s 17.336 Melem/s]
example-wallet/execute-only
                        time:   [535.60 ns 537.22 ns 539.44 ns]
                        thrpt:  [1.8538 Melem/s 1.8614 Melem/s 1.8671 Melem/s]
```