### PR TITLE
Add various tweaks needed for `no_std` contracts without OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ab-system-contract-code = { version = "0.0.1", path = "crates/contracts/system/a
 ab-system-contract-simple-wallet-base = { version = "0.0.1", path = "crates/contracts/system/ab-system-contract-simple-wallet-base" }
 ab-system-contract-state = { version = "0.0.1", path = "crates/contracts/system/ab-system-contract-state" }
 blake3 = { version = "1.6.0", default-features = false }
-const-sha1 = "0.3.0"
+const-sha1 = { version = "0.3.0", default-features = false }
 const_format = "0.2.34"
 criterion = { version = "0.5.1", default-features = false }
 derive_more = { version = "2.0.1", default-features = false }

--- a/crates/contracts/core/ab-contracts-macros-impl/src/contract.rs
+++ b/crates/contracts/core/ab-contracts-macros-impl/src/contract.rs
@@ -445,6 +445,13 @@ fn process_struct_impl(mut item_impl: ItemImpl) -> Result<TokenStream, Error> {
 
     let struct_name_str = struct_name_ident.to_string();
     Ok(quote! {
+        #[cfg(all(feature = "guest", not(any(unix, windows))))]
+        #[panic_handler]
+        fn panic(_info: &::core::panic::PanicInfo<'_>) -> ! {
+            // TODO: Might need something different than this in practice
+            loop {}
+        }
+
         /// Main contract metadata
         ///
         /// Enabled with `guest` feature to appear in the final binary, also prevents from

--- a/crates/contracts/core/ab-contracts-macros/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-macros/src/lib.rs
@@ -1,4 +1,6 @@
 //! Macros for contracts
+#![no_std]
+
 #[doc(hidden)]
 pub mod __private;
 


### PR DESCRIPTION
Once I figure out what target it'll be compiled to, will add corresponding tests