### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,6 +132,36 @@ jobs:
           cargo -Zgitoxide -Zgit test -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
         if: runner.os == 'Linux'
 
+  cargo-miri-test:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
+          - windows-2025
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # 2.47.0
+        with:
+          tool: cargo-nextest
+
       - name: cargo miri nextest run
         run: |
           cargo -Zgitoxide -Zgit miri nextest run

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -225,3 +225,29 @@ jobs:
           cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/alloc
           cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
         if: runner.os == 'Linux'
+
+  contracts:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Ensure contracts compile for a custom target
+        run: |
+          for contract_path in crates/contracts/{example,system}/*; do
+            contract="$(basename -- $contract_path)"
+            # TODO: This uses x86-64-based target, but will have to change to riscv64e-based target eventually
+            cargo -Zgitoxide -Zgit rustc -Z build-std=core --crate-type cdylib --profile production --target crates/contracts/x86_64-unknown-none-abundance.json -p $contract --features $contract/guest
+          done
+        if: runner.os == 'Linux'

--- a/crates/contracts/x86_64-unknown-none-abundance.json
+++ b/crates/contracts/x86_64-unknown-none-abundance.json
@@ -1,0 +1,30 @@
+{
+  "arch": "x86_64",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  "dynamic-linking": true,
+  "only-cdylib": true,
+  "executables": false,
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "disable-redzone": true,
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
+  "llvm-target": "x86_64-unknown-none-elf",
+  "max-atomic-width": 64,
+  "panic-strategy": "abort",
+  "plt-by-default": false,
+  "position-independent-executables": true,
+  "relro-level": "full",
+  "static-position-independent-executables": true,
+  "target-pointer-width": "64",
+  "relocation-model": "pie",
+  "singlethread": true,
+  "pre-link-args": {
+    "ld": [
+      "--hash-style=gnu"
+    ]
+  },
+  "dll-prefix": "",
+  "dll-suffix": ".contract",
+  "env": "abundance"
+}


### PR DESCRIPTION
This splits Miri into a separate job for better concurrency and add `contracts` job that builds contracts for a custom `no_std` target