### PR TITLE
Subspace refactoring and cleanup

### DIFF
--- a/subspace/crates/pallet-subspace/src/lib.rs
+++ b/subspace/crates/pallet-subspace/src/lib.rs
@@ -147,8 +147,6 @@ pub mod pallet {
         #[pallet::constant]
         type ConsensusConstants: Get<ConsensusConstants<BlockNumberFor<Self>>>;
 
-        type ShouldAdjustSolutionRange: Get<bool>;
-
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
 
@@ -283,8 +281,7 @@ pub mod pallet {
     /// Storage to check if the solution range is to be adjusted for next era
     #[pallet::storage]
     #[pallet::getter(fn should_adjust_solution_range)]
-    pub(super) type ShouldAdjustSolutionRange<T: Config> =
-        StorageValue<_, bool, ValueQuery, T::ShouldAdjustSolutionRange>;
+    pub(super) type ShouldAdjustSolutionRange<T: Config> = StorageValue<_, bool, ValueQuery>;
 
     /// Override solution range during next update
     #[pallet::storage]

--- a/subspace/crates/pallet-subspace/src/lib.rs
+++ b/subspace/crates/pallet-subspace/src/lib.rs
@@ -295,11 +295,6 @@ pub mod pallet {
     #[pallet::storage]
     pub(super) type DidProcessSegmentHeaders<T: Config> = StorageValue<_, bool, ValueQuery>;
 
-    /// Parent block author information.
-    #[pallet::storage]
-    pub(super) type ParentBlockAuthorInfo<T> =
-        StorageValue<_, (PublicKey, SectorIndex, PieceOffset, ScalarBytes, Slot)>;
-
     /// Block author information
     #[pallet::storage]
     pub(super) type CurrentBlockAuthorInfo<T: Config> = StorageValue<
@@ -789,14 +784,6 @@ impl<T: Config> Pallet<T> {
             frame_system::Pallet::<T>::deposit_log(DigestItem::next_solution_range(
                 next_solution_range,
             ));
-        }
-
-        if let Some((public_key, sector_index, piece_offset, scalar, slot, _reward_address)) =
-            CurrentBlockAuthorInfo::<T>::get()
-        {
-            ParentBlockAuthorInfo::<T>::put((public_key, sector_index, piece_offset, scalar, slot));
-        } else {
-            ParentBlockAuthorInfo::<T>::take();
         }
 
         DidProcessSegmentHeaders::<T>::take();

--- a/subspace/crates/pallet-subspace/src/lib.rs
+++ b/subspace/crates/pallet-subspace/src/lib.rs
@@ -83,7 +83,7 @@ pub mod pallet {
     use subspace_core_primitives::pieces::PieceOffset;
     use subspace_core_primitives::pot::PotCheckpoints;
     use subspace_core_primitives::sectors::SectorIndex;
-    use subspace_core_primitives::segments::{HistorySize, SegmentHeader, SegmentIndex};
+    use subspace_core_primitives::segments::{SegmentHeader, SegmentIndex};
     use subspace_core_primitives::solutions::SolutionRange;
     use subspace_core_primitives::{PublicKey, Randomness, ScalarBytes};
 
@@ -121,13 +121,6 @@ pub mod pallet {
         /// Origin for subspace call.
         type SubspaceOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = ()>;
 
-        /// Number of slots between slot arrival and when corresponding block can be produced.
-        ///
-        /// Practically this means future proof of time proof needs to be revealed this many slots
-        /// ahead before block can be authored even though solution is available before that.
-        #[pallet::constant]
-        type BlockAuthoringDelay: Get<Slot>;
-
         /// Interval, in blocks, between blockchain entropy injection into proof of time chain.
         #[pallet::constant]
         type PotEntropyInjectionInterval: Get<BlockNumberFor<Self>>;
@@ -157,22 +150,6 @@ pub mod pallet {
         /// represent a value between 0 and 1.
         #[pallet::constant]
         type SlotProbability: Get<(u64, u64)>;
-
-        /// Number of latest archived segments that are considered "recent history".
-        #[pallet::constant]
-        type RecentSegments: Get<HistorySize>;
-
-        /// Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
-        #[pallet::constant]
-        type RecentHistoryFraction: Get<(HistorySize, HistorySize)>;
-
-        /// Minimum lifetime of a plotted sector, measured in archived segment.
-        #[pallet::constant]
-        type MinSectorLifetime: Get<HistorySize>;
-
-        /// How many pieces one sector is supposed to contain (max)
-        #[pallet::constant]
-        type MaxPiecesInSector: Get<u16>;
 
         type ShouldAdjustSolutionRange: Get<bool>;
 

--- a/subspace/crates/pallet-subspace/src/lib.rs
+++ b/subspace/crates/pallet-subspace/src/lib.rs
@@ -176,11 +176,6 @@ pub mod pallet {
         #[pallet::constant]
         type SlotProbability: Get<(u64, u64)>;
 
-        /// Depth `K` after which a block enters the recorded history (a global constant, as opposed
-        /// to the client-dependent transaction confirmation depth `k`).
-        #[pallet::constant]
-        type ConfirmationDepthK: Get<BlockNumberFor<Self>>;
-
         /// Number of latest archived segments that are considered "recent history".
         #[pallet::constant]
         type RecentSegments: Get<HistorySize>;

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -73,17 +73,12 @@ parameter_types! {
         initial_solution_range: INITIAL_SOLUTION_RANGE,
         slot_probability: SLOT_PROBABILITY,
     };
-    pub const RecordSize: u32 = 3840;
-    pub const ReplicationFactor: u16 = 1;
-    pub const ReportLongevity: u64 = 34;
-    pub const ShouldAdjustSolutionRange: bool = false;
 }
 
 impl Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type SubspaceOrigin = pallet_subspace::EnsureSubspaceOrigin;
     type ConsensusConstants = MockConsensusConstants;
-    type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type WeightInfo = ();
     type ExtensionWeightInfo = crate::extensions::weights::SubstrateWeight<Test>;
 }

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -1,6 +1,6 @@
 //! Test utilities
 
-use crate::{self as pallet_subspace, AllowAuthoringBy, Config};
+use crate::{self as pallet_subspace, AllowAuthoringBy, Config, ConsensusConstants};
 use frame_support::traits::{ConstU128, OnInitialize};
 use frame_support::{derive_impl, parameter_types};
 use schnorrkel::Keypair;
@@ -19,7 +19,7 @@ use subspace_core_primitives::segments::{
     SegmentIndex,
 };
 use subspace_core_primitives::solutions::{Solution, SolutionRange};
-use subspace_core_primitives::{BlockNumber, PublicKey, SlotNumber};
+use subspace_core_primitives::PublicKey;
 use subspace_runtime_primitives::ConsensusEventSegmentSize;
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -60,17 +60,19 @@ impl pallet_balances::Config for Test {
 /// 1 in 6 slots (on average, not counting collisions) will have a block.
 pub const SLOT_PROBABILITY: (u64, u64) = (3, 10);
 
+// 1GB
 pub const INITIAL_SOLUTION_RANGE: SolutionRange =
     u64::MAX / (1024 * 1024 * 1024 / Piece::SIZE as u64) * SLOT_PROBABILITY.0 / SLOT_PROBABILITY.1;
 
 parameter_types! {
-    pub const PotEntropyInjectionInterval: BlockNumber = 5;
-    pub const PotEntropyInjectionLookbackDepth: u8 = 2;
-    pub const PotEntropyInjectionDelay: SlotNumber = 4;
-    pub const EraDuration: u32 = 4;
-    // 1GB
-    pub const InitialSolutionRange: SolutionRange = INITIAL_SOLUTION_RANGE;
-    pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
+    pub const MockConsensusConstants: ConsensusConstants<u64> = ConsensusConstants {
+        pot_entropy_injection_interval: 5,
+        pot_entropy_injection_lookback_depth: 2,
+        pot_entropy_injection_delay: 4,
+        era_duration: 4,
+        initial_solution_range: INITIAL_SOLUTION_RANGE,
+        slot_probability: SLOT_PROBABILITY,
+    };
     pub const RecordSize: u32 = 3840;
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
@@ -80,12 +82,7 @@ parameter_types! {
 impl Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type SubspaceOrigin = pallet_subspace::EnsureSubspaceOrigin;
-    type PotEntropyInjectionInterval = PotEntropyInjectionInterval;
-    type PotEntropyInjectionLookbackDepth = PotEntropyInjectionLookbackDepth;
-    type PotEntropyInjectionDelay = PotEntropyInjectionDelay;
-    type EraDuration = EraDuration;
-    type InitialSolutionRange = InitialSolutionRange;
-    type SlotProbability = SlotProbability;
+    type ConsensusConstants = MockConsensusConstants;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type WeightInfo = ();
     type ExtensionWeightInfo = crate::extensions::weights::SubstrateWeight<Test>;

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -1,6 +1,6 @@
 //! Test utilities
 
-use crate::{self as pallet_subspace, AllowAuthoringBy, Config, NormalEraChange};
+use crate::{self as pallet_subspace, AllowAuthoringBy, Config};
 use frame_support::traits::{ConstU128, ConstU16, OnInitialize};
 use frame_support::{derive_impl, parameter_types};
 use schnorrkel::Keypair;
@@ -101,7 +101,6 @@ impl Config for Test {
     type MinSectorLifetime = MinSectorLifetime;
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
-    type EraChangeTrigger = NormalEraChange;
     type WeightInfo = ();
     type ExtensionWeightInfo = crate::extensions::weights::SubstrateWeight<Test>;
 }

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -70,7 +70,6 @@ parameter_types! {
         pot_entropy_injection_lookback_depth: 2,
         pot_entropy_injection_delay: 4,
         era_duration: 4,
-        initial_solution_range: INITIAL_SOLUTION_RANGE,
         slot_probability: SLOT_PROBABILITY,
     };
 }
@@ -165,6 +164,7 @@ pub fn new_test_ext() -> TestExternalities {
     pallet_subspace::GenesisConfig::<Test> {
         allow_authoring_by: AllowAuthoringBy::Anyone,
         pot_slot_iterations: NonZeroU32::new(100_000).unwrap(),
+        initial_solution_range: INITIAL_SOLUTION_RANGE,
         phantom: PhantomData,
     }
     .assimilate_storage(&mut storage)

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -74,7 +74,6 @@ parameter_types! {
     // 1GB
     pub const InitialSolutionRange: SolutionRange = INITIAL_SOLUTION_RANGE;
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
-    pub const ConfirmationDepthK: u32 = 10;
     pub const RecentSegments: HistorySize = HistorySize::new(NonZeroU64::new(5).unwrap());
     pub const RecentHistoryFraction: (HistorySize, HistorySize) = (
         HistorySize::new(NonZeroU64::new(1).unwrap()),
@@ -98,7 +97,6 @@ impl Config for Test {
     type EraDuration = EraDuration;
     type InitialSolutionRange = InitialSolutionRange;
     type SlotProbability = SlotProbability;
-    type ConfirmationDepthK = ConfirmationDepthK;
     type RecentSegments = RecentSegments;
     type RecentHistoryFraction = RecentHistoryFraction;
     type MinSectorLifetime = MinSectorLifetime;

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -1,7 +1,7 @@
 //! Test utilities
 
 use crate::{self as pallet_subspace, AllowAuthoringBy, Config};
-use frame_support::traits::{ConstU128, ConstU16, OnInitialize};
+use frame_support::traits::{ConstU128, OnInitialize};
 use frame_support::{derive_impl, parameter_types};
 use schnorrkel::Keypair;
 use sp_consensus_slots::Slot;
@@ -10,7 +10,7 @@ use sp_io::TestExternalities;
 use sp_runtime::testing::{Digest, DigestItem, TestXt};
 use sp_runtime::BuildStorage;
 use std::marker::PhantomData;
-use std::num::{NonZeroU32, NonZeroU64};
+use std::num::NonZeroU32;
 use std::sync::Once;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::pieces::{Piece, PieceOffset};
@@ -24,8 +24,6 @@ use subspace_runtime_primitives::ConsensusEventSegmentSize;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 type Balance = u128;
-
-const MAX_PIECES_IN_SECTOR: u16 = 1;
 
 frame_support::construct_runtime!(
     pub struct Test {
@@ -66,7 +64,6 @@ pub const INITIAL_SOLUTION_RANGE: SolutionRange =
     u64::MAX / (1024 * 1024 * 1024 / Piece::SIZE as u64) * SLOT_PROBABILITY.0 / SLOT_PROBABILITY.1;
 
 parameter_types! {
-    pub const BlockAuthoringDelay: SlotNumber = 2;
     pub const PotEntropyInjectionInterval: BlockNumber = 5;
     pub const PotEntropyInjectionLookbackDepth: u8 = 2;
     pub const PotEntropyInjectionDelay: SlotNumber = 4;
@@ -74,12 +71,6 @@ parameter_types! {
     // 1GB
     pub const InitialSolutionRange: SolutionRange = INITIAL_SOLUTION_RANGE;
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
-    pub const RecentSegments: HistorySize = HistorySize::new(NonZeroU64::new(5).unwrap());
-    pub const RecentHistoryFraction: (HistorySize, HistorySize) = (
-        HistorySize::new(NonZeroU64::new(1).unwrap()),
-        HistorySize::new(NonZeroU64::new(10).unwrap()),
-    );
-    pub const MinSectorLifetime: HistorySize = HistorySize::new(NonZeroU64::new(4).unwrap());
     pub const RecordSize: u32 = 3840;
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
@@ -89,17 +80,12 @@ parameter_types! {
 impl Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type SubspaceOrigin = pallet_subspace::EnsureSubspaceOrigin;
-    type BlockAuthoringDelay = BlockAuthoringDelay;
     type PotEntropyInjectionInterval = PotEntropyInjectionInterval;
     type PotEntropyInjectionLookbackDepth = PotEntropyInjectionLookbackDepth;
     type PotEntropyInjectionDelay = PotEntropyInjectionDelay;
     type EraDuration = EraDuration;
     type InitialSolutionRange = InitialSolutionRange;
     type SlotProbability = SlotProbability;
-    type RecentSegments = RecentSegments;
-    type RecentHistoryFraction = RecentHistoryFraction;
-    type MinSectorLifetime = MinSectorLifetime;
-    type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type WeightInfo = ();
     type ExtensionWeightInfo = crate::extensions::weights::SubstrateWeight<Test>;

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -84,7 +84,6 @@ parameter_types! {
     pub const ReplicationFactor: u16 = 1;
     pub const ReportLongevity: u64 = 34;
     pub const ShouldAdjustSolutionRange: bool = false;
-    pub const BlockSlotCount: u32 = 6;
 }
 
 impl Config for Test {
@@ -104,7 +103,6 @@ impl Config for Test {
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type EraChangeTrigger = NormalEraChange;
     type WeightInfo = ();
-    type BlockSlotCount = BlockSlotCount;
     type ExtensionWeightInfo = crate::extensions::weights::SubstrateWeight<Test>;
 }
 

--- a/subspace/crates/pallet-subspace/src/tests.rs
+++ b/subspace/crates/pallet-subspace/src/tests.rs
@@ -27,10 +27,6 @@ fn can_update_solution_range_on_era_change() {
         let keypair = Keypair::generate();
 
         assert_eq!(<Test as Config>::ConsensusConstants::get().era_duration, 4);
-        assert_eq!(
-            <Test as Config>::ConsensusConstants::get().initial_solution_range,
-            INITIAL_SOLUTION_RANGE
-        );
         let initial_solution_ranges = SolutionRanges {
             current: INITIAL_SOLUTION_RANGE,
             next: None,
@@ -90,10 +86,6 @@ fn can_override_solution_range_update() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
 
-        assert_eq!(
-            <Test as Config>::ConsensusConstants::get().initial_solution_range,
-            INITIAL_SOLUTION_RANGE
-        );
         let initial_solution_ranges = SolutionRanges {
             current: INITIAL_SOLUTION_RANGE,
             next: None,
@@ -129,10 +121,6 @@ fn solution_range_should_not_update_when_disabled() {
         let keypair = Keypair::generate();
 
         assert_eq!(<Test as Config>::ConsensusConstants::get().era_duration, 4);
-        assert_eq!(
-            <Test as Config>::ConsensusConstants::get().initial_solution_range,
-            INITIAL_SOLUTION_RANGE
-        );
         let initial_solution_ranges = SolutionRanges {
             current: INITIAL_SOLUTION_RANGE,
             next: None,

--- a/subspace/crates/pallet-subspace/src/tests.rs
+++ b/subspace/crates/pallet-subspace/src/tests.rs
@@ -26,9 +26,9 @@ fn can_update_solution_range_on_era_change() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
 
-        assert_eq!(<Test as Config>::EraDuration::get(), 4);
+        assert_eq!(<Test as Config>::ConsensusConstants::get().era_duration, 4);
         assert_eq!(
-            <Test as Config>::InitialSolutionRange::get(),
+            <Test as Config>::ConsensusConstants::get().initial_solution_range,
             INITIAL_SOLUTION_RANGE
         );
         let initial_solution_ranges = SolutionRanges {
@@ -91,7 +91,7 @@ fn can_override_solution_range_update() {
         let keypair = Keypair::generate();
 
         assert_eq!(
-            <Test as Config>::InitialSolutionRange::get(),
+            <Test as Config>::ConsensusConstants::get().initial_solution_range,
             INITIAL_SOLUTION_RANGE
         );
         let initial_solution_ranges = SolutionRanges {
@@ -111,7 +111,11 @@ fn can_override_solution_range_update() {
         assert_eq!(updated_solution_ranges.current, random_solution_range);
 
         // Era edge
-        progress_to_block(&keypair, <Test as Config>::EraDuration::get().into(), 1);
+        progress_to_block(
+            &keypair,
+            <Test as Config>::ConsensusConstants::get().era_duration,
+            1,
+        );
         // Next solution range should be updated to the same value as current due to override
         let updated_solution_ranges = Subspace::solution_ranges();
         assert_eq!(updated_solution_ranges.current, random_solution_range);
@@ -124,9 +128,9 @@ fn solution_range_should_not_update_when_disabled() {
     new_test_ext().execute_with(|| {
         let keypair = Keypair::generate();
 
-        assert_eq!(<Test as Config>::EraDuration::get(), 4);
+        assert_eq!(<Test as Config>::ConsensusConstants::get().era_duration, 4);
         assert_eq!(
-            <Test as Config>::InitialSolutionRange::get(),
+            <Test as Config>::ConsensusConstants::get().initial_solution_range,
             INITIAL_SOLUTION_RANGE
         );
         let initial_solution_ranges = SolutionRanges {

--- a/subspace/crates/subspace-core-primitives/src/pot.rs
+++ b/subspace/crates/subspace-core-primitives/src/pot.rs
@@ -271,6 +271,7 @@ impl PotOutput {
     /// Size of proof of time proof in bytes
     pub const SIZE: usize = 16;
 
+    // TODO: The seed is only 128-bits, should it be made larger somehow?
     /// Derives the global randomness from the output
     #[inline]
     pub fn derive_global_randomness(&self) -> Randomness {

--- a/subspace/crates/subspace-node/src/chain_spec.rs
+++ b/subspace/crates/subspace-node/src/chain_spec.rs
@@ -9,14 +9,17 @@ use sp_runtime::BoundedVec;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use subspace_core_primitives::pot::PotKey;
+use subspace_core_primitives::solutions::{pieces_to_solution_range, SolutionRange};
 use subspace_core_primitives::PublicKey;
 use subspace_runtime::{
     AllowAuthoringBy, BalancesConfig, RewardPoint, RewardsConfig, RuntimeConfigsConfig,
     RuntimeGenesisConfig, SubspaceConfig, SudoConfig, SystemConfig, WASM_BINARY,
 };
-use subspace_runtime_primitives::{AccountId, Balance, SSC};
+use subspace_runtime_primitives::{AccountId, Balance, SLOT_PROBABILITY, SSC};
 
 const SUBSPACE_TELEMETRY_URL: &str = "wss://telemetry.subspace.foundation/submit/";
+// We assume initial plot size starts with a single sector.
+const INITIAL_SOLUTION_RANGE: SolutionRange = pieces_to_solution_range(1000, SLOT_PROBABILITY);
 
 /// Additional subspace specific genesis parameters.
 struct GenesisParams {
@@ -244,6 +247,7 @@ fn subspace_genesis_config(
         subspace: SubspaceConfig {
             allow_authoring_by,
             pot_slot_iterations,
+            initial_solution_range: INITIAL_SOLUTION_RANGE,
             phantom: PhantomData,
         },
         rewards: rewards_config,

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -36,6 +36,7 @@ use frame_system::limits::{BlockLength, BlockWeights};
 use frame_system::pallet_prelude::RuntimeCallFor;
 pub use pallet_rewards::RewardPoint;
 pub use pallet_subspace::AllowAuthoringBy;
+use pallet_subspace::ConsensusConstants;
 use sp_api::impl_runtime_apis;
 use sp_consensus_slots::{Slot, SlotDuration};
 use sp_consensus_subspace::{ChainConstants, PotParameters, SolutionRanges};
@@ -206,11 +207,14 @@ impl frame_system::Config for Runtime {
 }
 
 parameter_types! {
-    pub const PotEntropyInjectionInterval: BlockNumber = POT_ENTROPY_INJECTION_INTERVAL;
-    pub const PotEntropyInjectionLookbackDepth: u8 = POT_ENTROPY_INJECTION_LOOKBACK_DEPTH;
-    pub const PotEntropyInjectionDelay: SlotNumber = POT_ENTROPY_INJECTION_DELAY;
-    pub const EraDuration: u32 = ERA_DURATION_IN_BLOCKS;
-    pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
+    pub const RuntimeConsensusConstants: ConsensusConstants<BlockNumber> = ConsensusConstants {
+        pot_entropy_injection_interval: POT_ENTROPY_INJECTION_INTERVAL,
+        pot_entropy_injection_lookback_depth: POT_ENTROPY_INJECTION_LOOKBACK_DEPTH,
+        pot_entropy_injection_delay: POT_ENTROPY_INJECTION_DELAY,
+        era_duration: ERA_DURATION_IN_BLOCKS,
+        initial_solution_range: INITIAL_SOLUTION_RANGE,
+        slot_probability: SLOT_PROBABILITY,
+    };
     // Disable solution range adjustment at the start of chain.
     // Root origin must enable later
     pub const ShouldAdjustSolutionRange: bool = false;
@@ -219,12 +223,7 @@ parameter_types! {
 impl pallet_subspace::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SubspaceOrigin = pallet_subspace::EnsureSubspaceOrigin;
-    type PotEntropyInjectionInterval = PotEntropyInjectionInterval;
-    type PotEntropyInjectionLookbackDepth = PotEntropyInjectionLookbackDepth;
-    type PotEntropyInjectionDelay = PotEntropyInjectionDelay;
-    type EraDuration = EraDuration;
-    type InitialSolutionRange = ConstU64<INITIAL_SOLUTION_RANGE>;
-    type SlotProbability = SlotProbability;
+    type ConsensusConstants = RuntimeConsensusConstants;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type WeightInfo = pallet_subspace::weights::SubstrateWeight<Runtime>;
     type ExtensionWeightInfo = pallet_subspace::extensions::weights::SubstrateWeight<Runtime>;
@@ -630,8 +629,8 @@ impl_runtime_apis! {
             ChainConstants::V0 {
                 confirmation_depth_k: pallet_runtime_configs::ConfirmationDepthK::<Runtime>::get(),
                 block_authoring_delay: Slot::from(BLOCK_AUTHORING_DELAY),
-                era_duration: EraDuration::get(),
-                slot_probability: SlotProbability::get(),
+                era_duration: ERA_DURATION_IN_BLOCKS,
+                slot_probability: SLOT_PROBABILITY,
                 slot_duration: SlotDuration::from_millis(SLOT_DURATION),
                 recent_segments: RECENT_SEGMENTS,
                 recent_history_fraction: RECENT_HISTORY_FRACTION,

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -215,16 +215,12 @@ parameter_types! {
         initial_solution_range: INITIAL_SOLUTION_RANGE,
         slot_probability: SLOT_PROBABILITY,
     };
-    // Disable solution range adjustment at the start of chain.
-    // Root origin must enable later
-    pub const ShouldAdjustSolutionRange: bool = false;
 }
 
 impl pallet_subspace::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SubspaceOrigin = pallet_subspace::EnsureSubspaceOrigin;
     type ConsensusConstants = RuntimeConsensusConstants;
-    type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type WeightInfo = pallet_subspace::weights::SubstrateWeight<Runtime>;
     type ExtensionWeightInfo = pallet_subspace::extensions::weights::SubstrateWeight<Runtime>;
 }

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -54,9 +54,7 @@ use subspace_core_primitives::pieces::Piece;
 use subspace_core_primitives::segments::{
     HistorySize, SegmentCommitment, SegmentHeader, SegmentIndex,
 };
-use subspace_core_primitives::solutions::{
-    pieces_to_solution_range, solution_range_to_pieces, SolutionRange,
-};
+use subspace_core_primitives::solutions::solution_range_to_pieces;
 use subspace_core_primitives::{PublicKey, SlotNumber};
 use subspace_runtime_primitives::utility::{
     DefaultNonceProvider, MaybeNestedCall, MaybeUtilityCall,
@@ -118,10 +116,6 @@ const_assert!(POT_ENTROPY_INJECTION_DELAY > BLOCK_AUTHORING_DELAY + 1);
 
 /// Era duration in blocks.
 const ERA_DURATION_IN_BLOCKS: BlockNumber = 2016;
-
-// We assume initial plot size starts with a single sector.
-const INITIAL_SOLUTION_RANGE: SolutionRange =
-    pieces_to_solution_range(MAX_PIECES_IN_SECTOR as u64, SLOT_PROBABILITY);
 
 /// Number of latest archived segments that are considered "recent history".
 const RECENT_SEGMENTS: HistorySize = HistorySize::new(NonZeroU64::new(5).expect("Not zero; qed"));
@@ -212,7 +206,6 @@ parameter_types! {
         pot_entropy_injection_lookback_depth: POT_ENTROPY_INJECTION_LOOKBACK_DEPTH,
         pot_entropy_injection_delay: POT_ENTROPY_INJECTION_DELAY,
         era_duration: ERA_DURATION_IN_BLOCKS,
-        initial_solution_range: INITIAL_SOLUTION_RANGE,
         slot_probability: SLOT_PROBABILITY,
     };
 }

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -28,7 +28,7 @@ use alloc::borrow::Cow;
 use core::num::NonZeroU64;
 use frame_support::genesis_builder_helper::{build_state, get_preset};
 use frame_support::inherent::ProvideInherent;
-use frame_support::traits::{ConstU16, ConstU32, ConstU64, ConstU8, Everything, Get};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64, ConstU8, Everything};
 use frame_support::weights::constants::ParityDbWeight;
 use frame_support::weights::{ConstantMultiplier, Weight};
 use frame_support::{construct_runtime, parameter_types};
@@ -218,7 +218,6 @@ parameter_types! {
     // Disable solution range adjustment at the start of chain.
     // Root origin must enable later
     pub const ShouldAdjustSolutionRange: bool = false;
-    pub const BlockSlotCount: u32 = 6;
 }
 
 impl pallet_subspace::Config for Runtime {
@@ -238,7 +237,6 @@ impl pallet_subspace::Config for Runtime {
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type EraChangeTrigger = pallet_subspace::NormalEraChange;
     type WeightInfo = pallet_subspace::weights::SubstrateWeight<Runtime>;
-    type BlockSlotCount = BlockSlotCount;
     type ExtensionWeightInfo = pallet_subspace::extensions::weights::SubstrateWeight<Runtime>;
 }
 

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -221,14 +221,6 @@ parameter_types! {
     pub const BlockSlotCount: u32 = 6;
 }
 
-pub struct ConfirmationDepthK;
-
-impl Get<BlockNumber> for ConfirmationDepthK {
-    fn get() -> BlockNumber {
-        pallet_runtime_configs::ConfirmationDepthK::<Runtime>::get()
-    }
-}
-
 impl pallet_subspace::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SubspaceOrigin = pallet_subspace::EnsureSubspaceOrigin;
@@ -239,7 +231,6 @@ impl pallet_subspace::Config for Runtime {
     type EraDuration = EraDuration;
     type InitialSolutionRange = ConstU64<INITIAL_SOLUTION_RANGE>;
     type SlotProbability = SlotProbability;
-    type ConfirmationDepthK = ConfirmationDepthK;
     type RecentSegments = RecentSegments;
     type RecentHistoryFraction = RecentHistoryFraction;
     type MinSectorLifetime = MinSectorLifetime;
@@ -649,7 +640,7 @@ impl_runtime_apis! {
 
         fn chain_constants() -> ChainConstants {
             ChainConstants::V0 {
-                confirmation_depth_k: ConfirmationDepthK::get(),
+                confirmation_depth_k: pallet_runtime_configs::ConfirmationDepthK::<Runtime>::get(),
                 block_authoring_delay: Slot::from(BlockAuthoringDelay::get()),
                 era_duration: EraDuration::get(),
                 slot_probability: SlotProbability::get(),

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -235,7 +235,6 @@ impl pallet_subspace::Config for Runtime {
     type MinSectorLifetime = MinSectorLifetime;
     type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
-    type EraChangeTrigger = pallet_subspace::NormalEraChange;
     type WeightInfo = pallet_subspace::weights::SubstrateWeight<Runtime>;
     type ExtensionWeightInfo = pallet_subspace::extensions::weights::SubstrateWeight<Runtime>;
 }

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -206,15 +206,11 @@ impl frame_system::Config for Runtime {
 }
 
 parameter_types! {
-    pub const BlockAuthoringDelay: SlotNumber = BLOCK_AUTHORING_DELAY;
     pub const PotEntropyInjectionInterval: BlockNumber = POT_ENTROPY_INJECTION_INTERVAL;
     pub const PotEntropyInjectionLookbackDepth: u8 = POT_ENTROPY_INJECTION_LOOKBACK_DEPTH;
     pub const PotEntropyInjectionDelay: SlotNumber = POT_ENTROPY_INJECTION_DELAY;
     pub const EraDuration: u32 = ERA_DURATION_IN_BLOCKS;
     pub const SlotProbability: (u64, u64) = SLOT_PROBABILITY;
-    pub const RecentSegments: HistorySize = RECENT_SEGMENTS;
-    pub const RecentHistoryFraction: (HistorySize, HistorySize) = RECENT_HISTORY_FRACTION;
-    pub const MinSectorLifetime: HistorySize = MIN_SECTOR_LIFETIME;
     // Disable solution range adjustment at the start of chain.
     // Root origin must enable later
     pub const ShouldAdjustSolutionRange: bool = false;
@@ -223,17 +219,12 @@ parameter_types! {
 impl pallet_subspace::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type SubspaceOrigin = pallet_subspace::EnsureSubspaceOrigin;
-    type BlockAuthoringDelay = BlockAuthoringDelay;
     type PotEntropyInjectionInterval = PotEntropyInjectionInterval;
     type PotEntropyInjectionLookbackDepth = PotEntropyInjectionLookbackDepth;
     type PotEntropyInjectionDelay = PotEntropyInjectionDelay;
     type EraDuration = EraDuration;
     type InitialSolutionRange = ConstU64<INITIAL_SOLUTION_RANGE>;
     type SlotProbability = SlotProbability;
-    type RecentSegments = RecentSegments;
-    type RecentHistoryFraction = RecentHistoryFraction;
-    type MinSectorLifetime = MinSectorLifetime;
-    type MaxPiecesInSector = ConstU16<{ MAX_PIECES_IN_SECTOR }>;
     type ShouldAdjustSolutionRange = ShouldAdjustSolutionRange;
     type WeightInfo = pallet_subspace::weights::SubstrateWeight<Runtime>;
     type ExtensionWeightInfo = pallet_subspace::extensions::weights::SubstrateWeight<Runtime>;
@@ -638,13 +629,13 @@ impl_runtime_apis! {
         fn chain_constants() -> ChainConstants {
             ChainConstants::V0 {
                 confirmation_depth_k: pallet_runtime_configs::ConfirmationDepthK::<Runtime>::get(),
-                block_authoring_delay: Slot::from(BlockAuthoringDelay::get()),
+                block_authoring_delay: Slot::from(BLOCK_AUTHORING_DELAY),
                 era_duration: EraDuration::get(),
                 slot_probability: SlotProbability::get(),
                 slot_duration: SlotDuration::from_millis(SLOT_DURATION),
-                recent_segments: RecentSegments::get(),
-                recent_history_fraction: RecentHistoryFraction::get(),
-                min_sector_lifetime: MinSectorLifetime::get(),
+                recent_segments: RECENT_SEGMENTS,
+                recent_history_fraction: RECENT_HISTORY_FRACTION,
+                min_sector_lifetime: MIN_SECTOR_LIFETIME,
             }
         }
     }


### PR DESCRIPTION
This refactors constants (removes from `pallet-subspace` those that are not used there) and cleans up a bunch of stuff that is no longer relevant in reduced implementation.

This should make it easier to extract things out of the pallet later.

@adlrocha FYI