### PR TITLE
Refactoring subspace core primitives

### DIFF
--- a/subspace/crates/pallet-subspace/Cargo.toml
+++ b/subspace/crates/pallet-subspace/Cargo.toml
@@ -57,7 +57,6 @@ std = [
     "sp-io/std",
     "sp-runtime/std",
     "sp-std/std",
-    "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",
     "subspace-verification/std"
 ]

--- a/subspace/crates/sc-proof-of-time/Cargo.toml
+++ b/subspace/crates/sc-proof-of-time/Cargo.toml
@@ -29,7 +29,7 @@ sp-consensus-slots = { workspace = true, features = ["std"] }
 sp-consensus-subspace = { workspace = true, features = ["std"] }
 sp-inherents = { workspace = true, features = ["std"] }
 sp-runtime = { workspace = true, features = ["std"] }
-subspace-core-primitives = { workspace = true, features = ["std"] }
+subspace-core-primitives = { workspace = true }
 subspace-proof-of-time.workspace = true
 thread-priority.workspace = true
 tokio = { workspace = true, features = ["sync"] }

--- a/subspace/crates/sp-consensus-subspace/Cargo.toml
+++ b/subspace/crates/sp-consensus-subspace/Cargo.toml
@@ -53,7 +53,6 @@ std = [
     "sp-runtime-interface/std",
     "sp-std/std",
     "sp-timestamp/std",
-    "subspace-core-primitives/std",
     "subspace-kzg/std",
     "subspace-verification/kzg",
     "subspace-verification/std",

--- a/subspace/crates/sp-consensus-subspace/Cargo.toml
+++ b/subspace/crates/sp-consensus-subspace/Cargo.toml
@@ -29,9 +29,9 @@ sp-runtime.workspace = true
 sp-runtime-interface.workspace = true
 sp-std.workspace = true
 sp-timestamp.workspace = true
-subspace-core-primitives.workspace = true
+subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
 subspace-kzg = { workspace = true, optional = true }
-subspace-verification.workspace = true
+subspace-verification = { workspace = true, features = ["alloc", "scale-codec"] }
 thiserror.workspace = true
 
 [features]

--- a/subspace/crates/sp-objects/Cargo.toml
+++ b/subspace/crates/sp-objects/Cargo.toml
@@ -21,6 +21,5 @@ subspace-runtime-primitives.workspace = true
 default = ["std"]
 std = [
     "sp-api/std",
-    "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",
 ]

--- a/subspace/crates/subspace-archiving/Cargo.toml
+++ b/subspace/crates/subspace-archiving/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 parity-scale-codec = { workspace = true, features = ["derive"] }
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
-subspace-core-primitives.workspace = true
+subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
 subspace-erasure-coding.workspace = true
 subspace-kzg.workspace = true
 thiserror.workspace = true

--- a/subspace/crates/subspace-archiving/Cargo.toml
+++ b/subspace/crates/subspace-archiving/Cargo.toml
@@ -50,7 +50,6 @@ std = [
     "rand?/std",
     "rand?/std_rng",
     "serde",
-    "subspace-core-primitives/std",
     "subspace-erasure-coding/std",
     "subspace-kzg/std",
     "thiserror/std",

--- a/subspace/crates/subspace-core-primitives/Cargo.toml
+++ b/subspace/crates/subspace-core-primitives/Cargo.toml
@@ -12,14 +12,14 @@ include = [
 
 [dependencies]
 blake3.workspace = true
-bytes.workspace = true
+bytes = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["full"] }
-hex = { workspace = true, features = ["alloc"] }
+hex = { workspace = true }
 num-traits.workspace = true
-parity-scale-codec = { workspace = true, features = ["bytes", "derive", "max-encoded-len"] }
+parity-scale-codec = { workspace = true, features = ["bytes", "derive", "max-encoded-len"], optional = true }
 rayon = { workspace = true, optional = true }
-scale-info = { workspace = true, features = ["derive"] }
-serde = { workspace = true, features = ["alloc", "derive"], optional = true }
+scale-info = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 serde-big-array.workspace = true
 static_assertions.workspace = true
 uint.workspace = true
@@ -28,10 +28,15 @@ uint.workspace = true
 rand = { workspace = true, features = ["min_const_gen", "std", "std_rng"] }
 
 [features]
-default = [
-    "serde",
-    "std",
-    "parallel",
+alloc = [
+    "dep:bytes",
+    "hex/alloc",
+    "serde/alloc",
+]
+scale-codec = [
+    "dep:parity-scale-codec",
+    "dep:scale-info",
+    "alloc",
 ]
 # Enables some APIs
 parallel = [
@@ -39,18 +44,20 @@ parallel = [
     "dep:rayon",
 ]
 serde = [
+    "alloc",
     "dep:serde",
     "bytes/serde",
     "hex/serde",
 ]
 std = [
+    "alloc",
     "blake3/std",
-    "bytes/std",
+    "bytes?/std",
     "derive_more/std",
     "hex/std",
     "num-traits/std",
-    "parity-scale-codec/std",
-    "scale-info/std",
+    "parity-scale-codec?/std",
+    "scale-info?/std",
     "serde?/std",
     "uint/std",
 ]

--- a/subspace/crates/subspace-core-primitives/Cargo.toml
+++ b/subspace/crates/subspace-core-primitives/Cargo.toml
@@ -49,15 +49,3 @@ serde = [
     "bytes/serde",
     "hex/serde",
 ]
-std = [
-    "alloc",
-    "blake3/std",
-    "bytes?/std",
-    "derive_more/std",
-    "hex/std",
-    "num-traits/std",
-    "parity-scale-codec?/std",
-    "scale-info?/std",
-    "serde?/std",
-    "uint/std",
-]

--- a/subspace/crates/subspace-core-primitives/src/hashes.rs
+++ b/subspace/crates/subspace-core-primitives/src/hashes.rs
@@ -4,7 +4,9 @@ use crate::ScalarBytes;
 use core::array::TryFromSliceError;
 use core::fmt;
 use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
+#[cfg(feature = "scale-codec")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+#[cfg(feature = "scale-codec")]
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -27,10 +29,10 @@ use serde::{Deserializer, Serializer};
     AsMut,
     Deref,
     DerefMut,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 pub struct Blake3Hash([u8; Blake3Hash::SIZE]);
 
@@ -76,7 +78,10 @@ impl<'de> Deserialize<'de> for Blake3Hash {
 
 impl fmt::Debug for Blake3Hash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 

--- a/subspace/crates/subspace-core-primitives/src/objects.rs
+++ b/subspace/crates/subspace-core-primitives/src/objects.rs
@@ -4,21 +4,22 @@
 //! * for objects within a block
 //! * for global objects in the global history of the blockchain (inside a piece)
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
 use crate::hashes::Blake3Hash;
 use crate::pieces::PieceIndex;
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
 use core::default::Default;
+#[cfg(feature = "scale-codec")]
 use parity_scale_codec::{Decode, Encode};
+#[cfg(feature = "scale-codec")]
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Object stored inside of the block
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct BlockObject {
@@ -29,19 +30,22 @@ pub struct BlockObject {
 }
 
 /// Mapping of objects stored inside of the block
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "serde", serde(rename_all_fields = "camelCase"))]
+#[cfg(feature = "alloc")]
 pub enum BlockObjectMapping {
     /// V0 of object mapping data structure
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "scale-codec", codec(index = 0))]
     V0 {
         /// Objects stored inside of the block
         objects: Vec<BlockObject>,
     },
 }
 
+#[cfg(feature = "alloc")]
 impl Default for BlockObjectMapping {
     fn default() -> Self {
         Self::V0 {
@@ -50,6 +54,7 @@ impl Default for BlockObjectMapping {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl BlockObjectMapping {
     /// Returns a newly created BlockObjectMapping from a list of object mappings
     #[inline]
@@ -75,7 +80,8 @@ impl BlockObjectMapping {
 }
 
 /// Object stored in the history of the blockchain
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -108,24 +114,28 @@ impl From<GlobalObject> for CompactGlobalObject {
 }
 
 /// Space-saving serialization of an object stored in the history of the blockchain
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CompactGlobalObject(Blake3Hash, PieceIndex, u32);
 
 /// Mapping of objects stored in the history of the blockchain
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "serde", serde(rename_all_fields = "camelCase"))]
+#[cfg(feature = "alloc")]
 pub enum GlobalObjectMapping {
     /// V0 of object mapping data structure.
-    #[codec(index = 0)]
+    #[cfg_attr(feature = "scale-codec", codec(index = 0))]
     V0 {
         /// Objects stored in the history of the blockchain.
         objects: Vec<GlobalObject>,
     },
 }
 
+#[cfg(feature = "alloc")]
 impl Default for GlobalObjectMapping {
     fn default() -> Self {
         Self::V0 {
@@ -134,6 +144,7 @@ impl Default for GlobalObjectMapping {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl GlobalObjectMapping {
     /// Returns a newly created GlobalObjectMapping from a list of object mappings
     #[inline]

--- a/subspace/crates/subspace-core-primitives/src/pieces.rs
+++ b/subspace/crates/subspace-core-primitives/src/pieces.rs
@@ -1,34 +1,42 @@
 //! Pieces-related data structures.
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
+#[cfg(feature = "alloc")]
+mod cow_bytes;
+#[cfg(feature = "alloc")]
+mod flat_pieces;
+#[cfg(feature = "alloc")]
+mod piece;
 
-use crate::segments::{ArchivedHistorySegment, RecordedHistorySegment, SegmentIndex};
+#[cfg(feature = "alloc")]
+pub use crate::pieces::flat_pieces::FlatPieces;
+#[cfg(feature = "alloc")]
+pub use crate::pieces::piece::Piece;
+#[cfg(feature = "alloc")]
+pub use crate::segments::ArchivedHistorySegment;
+use crate::segments::{RecordedHistorySegment, SegmentIndex};
 use crate::ScalarBytes;
 #[cfg(feature = "serde")]
 use ::serde::{Deserialize, Serialize};
 #[cfg(feature = "serde")]
 use ::serde::{Deserializer, Serializer};
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
-use alloc::format;
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use bytes::{Bytes, BytesMut};
 use core::array::TryFromSliceError;
-use core::hash::{Hash, Hasher};
+use core::hash::Hash;
 use core::iter::Step;
-use core::{fmt, mem, slice};
+#[cfg(feature = "alloc")]
+use core::slice;
+use core::{fmt, mem};
 use derive_more::{
     Add, AddAssign, AsMut, AsRef, Deref, DerefMut, Display, Div, DivAssign, From, Into, Mul,
     MulAssign, Sub, SubAssign,
 };
-use parity_scale_codec::{Decode, Encode, EncodeLike, Input, MaxEncodedLen, Output};
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
-use scale_info::build::Fields;
-use scale_info::{Path, Type, TypeInfo};
+#[cfg(feature = "scale-codec")]
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+#[cfg(feature = "scale-codec")]
+use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde_big_array::BigArray;
 
@@ -44,8 +52,6 @@ use serde_big_array::BigArray;
     Eq,
     PartialEq,
     Hash,
-    Encode,
-    Decode,
     Add,
     AddAssign,
     Sub,
@@ -54,8 +60,10 @@ use serde_big_array::BigArray;
     MulAssign,
     Div,
     DivAssign,
-    TypeInfo,
-    MaxEncodedLen,
+)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(transparent)]
@@ -121,14 +129,14 @@ impl PieceIndex {
     /// Segment index piece index corresponds to
     #[inline]
     pub const fn segment_index(&self) -> SegmentIndex {
-        SegmentIndex::new(self.0 / ArchivedHistorySegment::NUM_PIECES as u64)
+        SegmentIndex::new(self.0 / RecordedHistorySegment::NUM_PIECES as u64)
     }
 
     /// Position of a piece in a segment
     #[inline]
     pub const fn position(&self) -> u32 {
         // Position is statically guaranteed to fit into u32
-        (self.0 % ArchivedHistorySegment::NUM_PIECES as u64) as u32
+        (self.0 % RecordedHistorySegment::NUM_PIECES as u64) as u32
     }
 
     /// Position of a source piece in the source pieces for a segment.
@@ -187,8 +195,6 @@ impl PieceIndex {
     Eq,
     PartialEq,
     Hash,
-    Encode,
-    Decode,
     Add,
     AddAssign,
     Sub,
@@ -197,8 +203,10 @@ impl PieceIndex {
     MulAssign,
     Div,
     DivAssign,
-    TypeInfo,
-    MaxEncodedLen,
+)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, MaxEncodedLen, TypeInfo)
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(transparent)]
@@ -278,7 +286,10 @@ pub struct RawRecord([[u8; ScalarBytes::SAFE_BYTES]; Self::NUM_CHUNKS]);
 
 impl fmt::Debug for RawRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0.as_flattened()))
+        for byte in self.0.as_flattened() {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -382,6 +393,7 @@ impl RawRecord {
     pub const SIZE: usize = ScalarBytes::SAFE_BYTES * Self::NUM_CHUNKS;
 
     /// Create boxed value without hitting stack overflow
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn new_boxed() -> Box<Self> {
         // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
@@ -439,7 +451,10 @@ pub struct Record([[u8; ScalarBytes::FULL_BYTES]; Self::NUM_CHUNKS]);
 
 impl fmt::Debug for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0.as_flattened()))
+        for byte in self.0.as_flattened() {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -547,6 +562,7 @@ impl Record {
 
     /// Create boxed value without hitting stack overflow
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn new_boxed() -> Box<Self> {
         // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
         // SAFETY: Data structure filled with zeroes is a valid invariant
@@ -555,6 +571,7 @@ impl Record {
 
     /// Create vector filled with zeroe records without hitting stack overflow
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn new_zero_vec(length: usize) -> Vec<Self> {
         // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
         let mut records = Vec::with_capacity(length);
@@ -642,26 +659,19 @@ impl Record {
 }
 
 /// Record commitment contained within a piece.
-#[derive(
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Hash,
-    Deref,
-    DerefMut,
-    From,
-    Into,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 pub struct RecordCommitment([u8; RecordCommitment::SIZE]);
 
 impl fmt::Debug for RecordCommitment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -777,26 +787,19 @@ impl RecordCommitment {
 }
 
 /// Record witness contained within a piece.
-#[derive(
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Hash,
-    Deref,
-    DerefMut,
-    From,
-    Into,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 pub struct RecordWitness([u8; RecordWitness::SIZE]);
 
 impl fmt::Debug for RecordWitness {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -911,307 +914,6 @@ impl RecordWitness {
     pub const SIZE: usize = 48;
 }
 
-enum CowBytes {
-    Shared(Bytes),
-    Owned(BytesMut),
-}
-
-impl fmt::Debug for CowBytes {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.as_ref()))
-    }
-}
-
-impl PartialEq for CowBytes {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_ref().eq(other.as_ref())
-    }
-}
-
-impl Eq for CowBytes {}
-
-impl Hash for CowBytes {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_ref().hash(state)
-    }
-}
-
-impl Clone for CowBytes {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Shared(bytes) => Self::Shared(bytes.clone()),
-            // Always return shared clone
-            Self::Owned(bytes) => Self::Shared(Bytes::copy_from_slice(bytes)),
-        }
-    }
-}
-
-impl AsRef<[u8]> for CowBytes {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            CowBytes::Shared(bytes) => bytes.as_ref(),
-            CowBytes::Owned(bytes) => bytes.as_ref(),
-        }
-    }
-}
-
-impl AsMut<[u8]> for CowBytes {
-    #[inline]
-    fn as_mut(&mut self) -> &mut [u8] {
-        match self {
-            CowBytes::Shared(bytes) => {
-                *self = CowBytes::Owned(BytesMut::from(mem::take(bytes)));
-
-                let CowBytes::Owned(bytes) = self else {
-                    unreachable!("Just replaced; qed");
-                };
-
-                bytes.as_mut()
-            }
-            CowBytes::Owned(bytes) => bytes.as_mut(),
-        }
-    }
-}
-
-/// A piece of archival history in Subspace Network.
-///
-/// This version is allocated on the heap, for stack-allocated piece see [`PieceArray`].
-///
-/// Internally piece contains a record and corresponding witness that together with segment
-/// commitment of the segment this piece belongs to can be used to verify that a piece belongs to
-/// the actual archival history of the blockchain.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Piece(CowBytes);
-
-impl Encode for Piece {
-    #[inline]
-    fn size_hint(&self) -> usize {
-        self.as_ref().size_hint()
-    }
-
-    #[inline]
-    fn encode_to<O: Output + ?Sized>(&self, output: &mut O) {
-        self.as_ref().encode_to(output)
-    }
-
-    #[inline]
-    fn encode(&self) -> Vec<u8> {
-        self.as_ref().encode()
-    }
-
-    #[inline]
-    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-        self.as_ref().using_encoded(f)
-    }
-}
-
-impl EncodeLike for Piece {}
-
-impl Decode for Piece {
-    fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
-        let bytes =
-            Bytes::decode(input).map_err(|error| error.chain("Could not decode `Piece`"))?;
-
-        if bytes.len() != Self::SIZE {
-            return Err(
-                parity_scale_codec::Error::from("Incorrect Piece length").chain(format!(
-                    "Expected {} bytes, found {} bytes",
-                    Self::SIZE,
-                    bytes.len()
-                )),
-            );
-        }
-
-        Ok(Piece(CowBytes::Shared(bytes)))
-    }
-}
-
-impl TypeInfo for Piece {
-    type Identity = Self;
-
-    fn type_info() -> Type {
-        Type::builder()
-            .path(Path::new("Piece", module_path!()))
-            .docs(&["A piece of archival history in Subspace Network"])
-            .composite(
-                Fields::unnamed().field(|f| f.ty::<[u8; Piece::SIZE]>().type_name("PieceArray")),
-            )
-    }
-}
-
-#[cfg(feature = "serde")]
-impl Serialize for Piece {
-    #[inline]
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let bytes = match &self.0 {
-            CowBytes::Shared(bytes) => bytes.as_ref(),
-            CowBytes::Owned(bytes) => bytes.as_ref(),
-        };
-
-        if serializer.is_human_readable() {
-            hex::serde::serialize(bytes, serializer)
-        } else {
-            bytes.serialize(serializer)
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for Piece {
-    #[inline]
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bytes = if deserializer.is_human_readable() {
-            hex::serde::deserialize::<_, Vec<u8>>(deserializer).and_then(|bytes| {
-                if bytes.len() == Piece::SIZE {
-                    Ok(Bytes::from(bytes))
-                } else {
-                    Err(serde::de::Error::invalid_length(
-                        bytes.len(),
-                        &format!("Expected {} bytes", Piece::SIZE).as_str(),
-                    ))
-                }
-            })?
-        } else {
-            Bytes::deserialize(deserializer)?
-        };
-
-        Ok(Piece(CowBytes::Shared(bytes)))
-    }
-}
-
-impl Default for Piece {
-    #[inline]
-    fn default() -> Self {
-        Self(CowBytes::Owned(BytesMut::zeroed(Self::SIZE)))
-    }
-}
-
-impl From<Piece> for Vec<u8> {
-    #[inline]
-    fn from(piece: Piece) -> Self {
-        match piece.0 {
-            CowBytes::Shared(bytes) => bytes.to_vec(),
-            CowBytes::Owned(bytes) => Vec::from(bytes),
-        }
-    }
-}
-
-impl TryFrom<&[u8]> for Piece {
-    type Error = ();
-
-    #[inline]
-    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        if slice.len() != Self::SIZE {
-            return Err(());
-        }
-
-        Ok(Self(CowBytes::Shared(Bytes::copy_from_slice(slice))))
-    }
-}
-
-impl TryFrom<Vec<u8>> for Piece {
-    type Error = ();
-
-    #[inline]
-    fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
-        if vec.len() != Self::SIZE {
-            return Err(());
-        }
-
-        Ok(Self(CowBytes::Shared(Bytes::from(vec))))
-    }
-}
-
-impl TryFrom<Bytes> for Piece {
-    type Error = ();
-
-    #[inline]
-    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
-        if bytes.len() != Self::SIZE {
-            return Err(());
-        }
-
-        Ok(Self(CowBytes::Shared(bytes)))
-    }
-}
-
-impl TryFrom<BytesMut> for Piece {
-    type Error = ();
-
-    #[inline]
-    fn try_from(bytes: BytesMut) -> Result<Self, Self::Error> {
-        if bytes.len() != Self::SIZE {
-            return Err(());
-        }
-
-        Ok(Self(CowBytes::Owned(bytes)))
-    }
-}
-
-impl From<&PieceArray> for Piece {
-    #[inline]
-    fn from(value: &PieceArray) -> Self {
-        Self(CowBytes::Shared(Bytes::copy_from_slice(value.as_ref())))
-    }
-}
-
-impl Deref for Piece {
-    type Target = PieceArray;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        <&[u8; Self::SIZE]>::try_from(self.as_ref())
-            .expect("Slice of memory has correct length; qed")
-            .into()
-    }
-}
-
-impl DerefMut for Piece {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        <&mut [u8; Self::SIZE]>::try_from(self.as_mut())
-            .expect("Slice of memory has correct length; qed")
-            .into()
-    }
-}
-
-impl AsRef<[u8]> for Piece {
-    #[inline]
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl AsMut<[u8]> for Piece {
-    #[inline]
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.0.as_mut()
-    }
-}
-
-impl Piece {
-    /// Size of a piece (in bytes).
-    pub const SIZE: usize = Record::SIZE + RecordCommitment::SIZE + RecordWitness::SIZE;
-
-    /// Ensure piece contains cheaply cloneable shared data.
-    ///
-    /// Internally piece uses CoW mechanism and can store either mutable owned data or data that is
-    /// cheap to clone, calling this method will ensure further clones will not result in additional
-    /// memory allocations.
-    pub fn to_shared(self) -> Self {
-        Self(match self.0 {
-            CowBytes::Shared(bytes) => CowBytes::Shared(bytes),
-            CowBytes::Owned(bytes) => CowBytes::Shared(bytes.freeze()),
-        })
-    }
-}
-
 /// A piece of archival history in Subspace Network.
 ///
 /// This version is allocated on the stack, for heap-allocated piece see [`Piece`].
@@ -1221,18 +923,21 @@ impl Piece {
 /// the actual archival history of the blockchain.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, DerefMut, AsRef, AsMut)]
 #[repr(transparent)]
-pub struct PieceArray([u8; Piece::SIZE]);
+pub struct PieceArray([u8; Self::SIZE]);
 
 impl fmt::Debug for PieceArray {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
 impl Default for PieceArray {
     #[inline]
     fn default() -> Self {
-        Self([0u8; Piece::SIZE])
+        Self([0u8; Self::SIZE])
     }
 }
 
@@ -1250,7 +955,7 @@ impl AsMut<[u8]> for PieceArray {
     }
 }
 
-impl From<&PieceArray> for &[u8; Piece::SIZE] {
+impl From<&PieceArray> for &[u8; PieceArray::SIZE] {
     #[inline]
     fn from(value: &PieceArray) -> Self {
         // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
@@ -1259,16 +964,16 @@ impl From<&PieceArray> for &[u8; Piece::SIZE] {
     }
 }
 
-impl From<&[u8; Piece::SIZE]> for &PieceArray {
+impl From<&[u8; PieceArray::SIZE]> for &PieceArray {
     #[inline]
-    fn from(value: &[u8; Piece::SIZE]) -> Self {
+    fn from(value: &[u8; PieceArray::SIZE]) -> Self {
         // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl From<&mut PieceArray> for &mut [u8; Piece::SIZE] {
+impl From<&mut PieceArray> for &mut [u8; PieceArray::SIZE] {
     #[inline]
     fn from(value: &mut PieceArray) -> Self {
         // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
@@ -1277,9 +982,9 @@ impl From<&mut PieceArray> for &mut [u8; Piece::SIZE] {
     }
 }
 
-impl From<&mut [u8; Piece::SIZE]> for &mut PieceArray {
+impl From<&mut [u8; PieceArray::SIZE]> for &mut PieceArray {
     #[inline]
-    fn from(value: &mut [u8; Piece::SIZE]) -> Self {
+    fn from(value: &mut [u8; PieceArray::SIZE]) -> Self {
         // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
@@ -1287,8 +992,12 @@ impl From<&mut [u8; Piece::SIZE]> for &mut PieceArray {
 }
 
 impl PieceArray {
+    /// Size of a piece (in bytes).
+    pub const SIZE: usize = Record::SIZE + RecordCommitment::SIZE + RecordWitness::SIZE;
+
     /// Create boxed value without hitting stack overflow
     #[inline]
+    #[cfg(feature = "alloc")]
     pub fn new_boxed() -> Box<Self> {
         // TODO: Should have been just `::new()`, but https://github.com/rust-lang/rust/issues/53827
         // SAFETY: Data structure filled with zeroes is a valid invariant
@@ -1366,7 +1075,7 @@ impl PieceArray {
     /// Convenient conversion from slice of piece array to underlying representation for efficiency
     /// purposes.
     #[inline]
-    pub fn slice_to_repr(value: &[Self]) -> &[[u8; Piece::SIZE]] {
+    pub fn slice_to_repr(value: &[Self]) -> &[[u8; Self::SIZE]] {
         // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
@@ -1375,7 +1084,7 @@ impl PieceArray {
     /// Convenient conversion from slice of underlying representation to piece array for efficiency
     /// purposes.
     #[inline]
-    pub fn slice_from_repr(value: &[[u8; Piece::SIZE]]) -> &[Self] {
+    pub fn slice_from_repr(value: &[[u8; Self::SIZE]]) -> &[Self] {
         // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
@@ -1384,7 +1093,7 @@ impl PieceArray {
     /// Convenient conversion from mutable slice of piece array to underlying representation for
     /// efficiency purposes.
     #[inline]
-    pub fn slice_mut_to_repr(value: &mut [Self]) -> &mut [[u8; Piece::SIZE]] {
+    pub fn slice_mut_to_repr(value: &mut [Self]) -> &mut [[u8; Self::SIZE]] {
         // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
@@ -1393,169 +1102,18 @@ impl PieceArray {
     /// Convenient conversion from mutable slice of underlying representation to piece array for
     /// efficiency purposes.
     #[inline]
-    pub fn slice_mut_from_repr(value: &mut [[u8; Piece::SIZE]]) -> &mut [Self] {
+    pub fn slice_mut_from_repr(value: &mut [[u8; Self::SIZE]]) -> &mut [Self] {
         // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Box<PieceArray>> for Vec<u8> {
     fn from(value: Box<PieceArray>) -> Self {
         let mut value = mem::ManuallyDrop::new(value);
         // SAFETY: Always contains fixed allocation of bytes
-        unsafe { Vec::from_raw_parts(value.as_mut_ptr(), Piece::SIZE, Piece::SIZE) }
-    }
-}
-
-/// Flat representation of multiple pieces concatenated for more efficient for processing
-#[derive(Clone, PartialEq, Eq)]
-pub struct FlatPieces(CowBytes);
-
-impl fmt::Debug for FlatPieces {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FlatPieces").finish_non_exhaustive()
-    }
-}
-
-impl Deref for FlatPieces {
-    type Target = [PieceArray];
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        let bytes = self.0.as_ref();
-        // SAFETY: Bytes slice has length of multiples of piece size and lifetimes of returned data
-        // are preserved
-        let pieces = unsafe {
-            slice::from_raw_parts(
-                bytes.as_ptr() as *const [u8; Piece::SIZE],
-                bytes.len() / Piece::SIZE,
-            )
-        };
-        PieceArray::slice_from_repr(pieces)
-    }
-}
-
-impl DerefMut for FlatPieces {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        let bytes = self.0.as_mut();
-        // SAFETY: Bytes slice has length of multiples of piece size and lifetimes of returned data
-        // are preserved
-        let pieces = unsafe {
-            slice::from_raw_parts_mut(
-                bytes.as_mut_ptr() as *mut [u8; Piece::SIZE],
-                bytes.len() / Piece::SIZE,
-            )
-        };
-        PieceArray::slice_mut_from_repr(pieces)
-    }
-}
-
-impl FlatPieces {
-    /// Allocate `FlatPieces` that will hold `piece_count` pieces filled with zeroes
-    #[inline]
-    pub fn new(piece_count: usize) -> Self {
-        Self(CowBytes::Owned(BytesMut::zeroed(piece_count * Piece::SIZE)))
-    }
-
-    /// Iterate over all pieces.
-    ///
-    /// NOTE: Unless [`Self::to_shared`] was called first, iterator may have to allocate each piece
-    /// from scratch, which is rarely a desired behavior.
-    #[inline]
-    pub fn pieces(&self) -> Box<dyn ExactSizeIterator<Item = Piece> + '_> {
-        match &self.0 {
-            CowBytes::Shared(bytes) => Box::new(
-                bytes
-                    .chunks_exact(Piece::SIZE)
-                    .map(|slice| Piece(CowBytes::Shared(bytes.slice_ref(slice)))),
-            ),
-            CowBytes::Owned(bytes) => Box::new(
-                bytes
-                    .chunks_exact(Piece::SIZE)
-                    .map(|slice| Piece(CowBytes::Shared(Bytes::copy_from_slice(slice)))),
-            ),
-        }
-    }
-
-    /// Iterator over source pieces (even indices)
-    #[inline]
-    pub fn source_pieces(&self) -> impl ExactSizeIterator<Item = Piece> + '_ {
-        self.pieces().step_by(2)
-    }
-
-    /// Iterator over source pieces (even indices)
-    #[inline]
-    pub fn source(&self) -> impl ExactSizeIterator<Item = &'_ PieceArray> + '_ {
-        self.iter().step_by(2)
-    }
-
-    /// Mutable iterator over source pieces (even indices)
-    #[inline]
-    pub fn source_mut(&mut self) -> impl ExactSizeIterator<Item = &'_ mut PieceArray> + '_ {
-        self.iter_mut().step_by(2)
-    }
-
-    /// Iterator over parity pieces (odd indices)
-    #[inline]
-    pub fn parity_pieces(&self) -> impl ExactSizeIterator<Item = Piece> + '_ {
-        self.pieces().skip(1).step_by(2)
-    }
-
-    /// Iterator over parity pieces (odd indices)
-    #[inline]
-    pub fn parity(&self) -> impl ExactSizeIterator<Item = &'_ PieceArray> + '_ {
-        self.iter().skip(1).step_by(2)
-    }
-
-    /// Mutable iterator over parity pieces (odd indices)
-    #[inline]
-    pub fn parity_mut(&mut self) -> impl ExactSizeIterator<Item = &'_ mut PieceArray> + '_ {
-        self.iter_mut().skip(1).step_by(2)
-    }
-
-    /// Ensure flat pieces contains cheaply cloneable shared data.
-    ///
-    /// Internally flat pieces uses CoW mechanism and can store either mutable owned data or data
-    /// that is cheap to clone, calling this method will ensure further clones and returned pieces
-    /// will not result in additional memory allocations.
-    pub fn to_shared(self) -> Self {
-        Self(match self.0 {
-            CowBytes::Shared(bytes) => CowBytes::Shared(bytes),
-            CowBytes::Owned(bytes) => CowBytes::Shared(bytes.freeze()),
-        })
-    }
-}
-
-#[cfg(feature = "parallel")]
-impl FlatPieces {
-    /// Parallel iterator over source pieces (even indices)
-    #[inline]
-    pub fn par_source(&self) -> impl IndexedParallelIterator<Item = &'_ PieceArray> + '_ {
-        self.par_iter().step_by(2)
-    }
-
-    /// Mutable parallel iterator over source pieces (even indices)
-    #[inline]
-    pub fn par_source_mut(
-        &mut self,
-    ) -> impl IndexedParallelIterator<Item = &'_ mut PieceArray> + '_ {
-        self.par_iter_mut().step_by(2)
-    }
-
-    /// Parallel iterator over parity pieces (odd indices)
-    #[inline]
-    pub fn par_parity(&self) -> impl IndexedParallelIterator<Item = &'_ PieceArray> + '_ {
-        self.par_iter().skip(1).step_by(2)
-    }
-
-    /// Mutable parallel iterator over parity pieces (odd indices)
-    #[inline]
-    pub fn par_parity_mut(
-        &mut self,
-    ) -> impl IndexedParallelIterator<Item = &'_ mut PieceArray> + '_ {
-        self.par_iter_mut().skip(1).step_by(2)
+        unsafe { Vec::from_raw_parts(value.as_mut_ptr(), PieceArray::SIZE, PieceArray::SIZE) }
     }
 }

--- a/subspace/crates/subspace-core-primitives/src/pieces/cow_bytes.rs
+++ b/subspace/crates/subspace-core-primitives/src/pieces/cow_bytes.rs
@@ -1,0 +1,68 @@
+use bytes::{Bytes, BytesMut};
+use core::hash::{Hash, Hasher};
+use core::{fmt, mem};
+
+pub(super) enum CowBytes {
+    Shared(Bytes),
+    Owned(BytesMut),
+}
+
+impl fmt::Debug for CowBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.as_ref() {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl PartialEq for CowBytes {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl Eq for CowBytes {}
+
+impl Hash for CowBytes {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state)
+    }
+}
+
+impl Clone for CowBytes {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Shared(bytes) => Self::Shared(bytes.clone()),
+            // Always return shared clone
+            Self::Owned(bytes) => Self::Shared(Bytes::copy_from_slice(bytes)),
+        }
+    }
+}
+
+impl AsRef<[u8]> for CowBytes {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            CowBytes::Shared(bytes) => bytes.as_ref(),
+            CowBytes::Owned(bytes) => bytes.as_ref(),
+        }
+    }
+}
+
+impl AsMut<[u8]> for CowBytes {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        match self {
+            CowBytes::Shared(bytes) => {
+                *self = CowBytes::Owned(BytesMut::from(mem::take(bytes)));
+
+                let CowBytes::Owned(bytes) = self else {
+                    unreachable!("Just replaced; qed");
+                };
+
+                bytes.as_mut()
+            }
+            CowBytes::Owned(bytes) => bytes.as_mut(),
+        }
+    }
+}

--- a/subspace/crates/subspace-core-primitives/src/pieces/flat_pieces.rs
+++ b/subspace/crates/subspace-core-primitives/src/pieces/flat_pieces.rs
@@ -1,0 +1,160 @@
+use crate::pieces::cow_bytes::CowBytes;
+use crate::pieces::{Piece, PieceArray};
+use alloc::boxed::Box;
+use bytes::{Bytes, BytesMut};
+use core::ops::{Deref, DerefMut};
+use core::{fmt, slice};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+/// Flat representation of multiple pieces concatenated for more efficient for processing
+#[derive(Clone, PartialEq, Eq)]
+pub struct FlatPieces(CowBytes);
+
+impl fmt::Debug for FlatPieces {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlatPieces").finish_non_exhaustive()
+    }
+}
+
+impl Deref for FlatPieces {
+    type Target = [PieceArray];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        let bytes = self.0.as_ref();
+        // SAFETY: Bytes slice has length of multiples of piece size and lifetimes of returned data
+        // are preserved
+        let pieces = unsafe {
+            slice::from_raw_parts(
+                bytes.as_ptr() as *const [u8; Piece::SIZE],
+                bytes.len() / Piece::SIZE,
+            )
+        };
+        PieceArray::slice_from_repr(pieces)
+    }
+}
+
+impl DerefMut for FlatPieces {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let bytes = self.0.as_mut();
+        // SAFETY: Bytes slice has length of multiples of piece size and lifetimes of returned data
+        // are preserved
+        let pieces = unsafe {
+            slice::from_raw_parts_mut(
+                bytes.as_mut_ptr() as *mut [u8; Piece::SIZE],
+                bytes.len() / Piece::SIZE,
+            )
+        };
+        PieceArray::slice_mut_from_repr(pieces)
+    }
+}
+
+impl FlatPieces {
+    /// Allocate `FlatPieces` that will hold `piece_count` pieces filled with zeroes
+    #[inline]
+    pub fn new(piece_count: usize) -> Self {
+        Self(CowBytes::Owned(BytesMut::zeroed(piece_count * Piece::SIZE)))
+    }
+
+    /// Iterate over all pieces.
+    ///
+    /// NOTE: Unless [`Self::to_shared`] was called first, iterator may have to allocate each piece
+    /// from scratch, which is rarely a desired behavior.
+    #[inline]
+    pub fn pieces(&self) -> Box<dyn ExactSizeIterator<Item = Piece> + '_> {
+        match &self.0 {
+            CowBytes::Shared(bytes) => Box::new(
+                bytes
+                    .chunks_exact(Piece::SIZE)
+                    .map(|slice| Piece(CowBytes::Shared(bytes.slice_ref(slice)))),
+            ),
+            CowBytes::Owned(bytes) => Box::new(
+                bytes
+                    .chunks_exact(Piece::SIZE)
+                    .map(|slice| Piece(CowBytes::Shared(Bytes::copy_from_slice(slice)))),
+            ),
+        }
+    }
+
+    /// Iterator over source pieces (even indices)
+    #[inline]
+    pub fn source_pieces(&self) -> impl ExactSizeIterator<Item = Piece> + '_ {
+        self.pieces().step_by(2)
+    }
+
+    /// Iterator over source pieces (even indices)
+    #[inline]
+    pub fn source(&self) -> impl ExactSizeIterator<Item = &'_ PieceArray> + '_ {
+        self.iter().step_by(2)
+    }
+
+    /// Mutable iterator over source pieces (even indices)
+    #[inline]
+    pub fn source_mut(&mut self) -> impl ExactSizeIterator<Item = &'_ mut PieceArray> + '_ {
+        self.iter_mut().step_by(2)
+    }
+
+    /// Iterator over parity pieces (odd indices)
+    #[inline]
+    pub fn parity_pieces(&self) -> impl ExactSizeIterator<Item = Piece> + '_ {
+        self.pieces().skip(1).step_by(2)
+    }
+
+    /// Iterator over parity pieces (odd indices)
+    #[inline]
+    pub fn parity(&self) -> impl ExactSizeIterator<Item = &'_ PieceArray> + '_ {
+        self.iter().skip(1).step_by(2)
+    }
+
+    /// Mutable iterator over parity pieces (odd indices)
+    #[inline]
+    pub fn parity_mut(&mut self) -> impl ExactSizeIterator<Item = &'_ mut PieceArray> + '_ {
+        self.iter_mut().skip(1).step_by(2)
+    }
+
+    /// Ensure flat pieces contains cheaply cloneable shared data.
+    ///
+    /// Internally flat pieces uses CoW mechanism and can store either mutable owned data or data
+    /// that is cheap to clone, calling this method will ensure further clones and returned pieces
+    /// will not result in additional memory allocations.
+    pub fn to_shared(self) -> Self {
+        Self(match self.0 {
+            CowBytes::Shared(bytes) => CowBytes::Shared(bytes),
+            CowBytes::Owned(bytes) => CowBytes::Shared(bytes.freeze()),
+        })
+    }
+}
+
+#[cfg(feature = "parallel")]
+impl FlatPieces {
+    /// Parallel iterator over source pieces (even indices)
+    #[inline]
+    pub fn par_source(&self) -> impl IndexedParallelIterator<Item = &'_ PieceArray> + '_ {
+        self.par_iter().step_by(2)
+    }
+
+    /// Mutable parallel iterator over source pieces (even indices)
+    #[inline]
+    pub fn par_source_mut(
+        &mut self,
+    ) -> impl IndexedParallelIterator<Item = &'_ mut PieceArray> + '_ {
+        self.par_iter_mut().step_by(2)
+    }
+
+    /// Parallel iterator over parity pieces (odd indices)
+    #[inline]
+    pub fn par_parity(&self) -> impl IndexedParallelIterator<Item = &'_ PieceArray> + '_ {
+        self.par_iter().skip(1).step_by(2)
+    }
+
+    /// Mutable parallel iterator over parity pieces (odd indices)
+    #[inline]
+    pub fn par_parity_mut(
+        &mut self,
+    ) -> impl IndexedParallelIterator<Item = &'_ mut PieceArray> + '_ {
+        self.par_iter_mut().skip(1).step_by(2)
+    }
+}

--- a/subspace/crates/subspace-core-primitives/src/pieces/piece.rs
+++ b/subspace/crates/subspace-core-primitives/src/pieces/piece.rs
@@ -1,0 +1,257 @@
+use crate::pieces::cow_bytes::CowBytes;
+use crate::pieces::PieceArray;
+use alloc::format;
+use alloc::vec::Vec;
+use bytes::{Bytes, BytesMut};
+use core::ops::{Deref, DerefMut};
+#[cfg(feature = "scale-codec")]
+use parity_scale_codec::{Decode, Encode, EncodeLike, Input, Output};
+#[cfg(feature = "scale-codec")]
+use scale_info::build::Fields;
+#[cfg(feature = "scale-codec")]
+use scale_info::{Path, Type, TypeInfo};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A piece of archival history in Subspace Network.
+///
+/// This version is allocated on the heap, for stack-allocated piece see [`PieceArray`].
+///
+/// Internally piece contains a record and corresponding witness that together with segment
+/// commitment of the segment this piece belongs to can be used to verify that a piece belongs to
+/// the actual archival history of the blockchain.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Piece(pub(super) CowBytes);
+
+#[cfg(feature = "scale-codec")]
+impl Encode for Piece {
+    #[inline]
+    fn size_hint(&self) -> usize {
+        self.as_ref().size_hint()
+    }
+
+    #[inline]
+    fn encode_to<O: Output + ?Sized>(&self, output: &mut O) {
+        self.as_ref().encode_to(output)
+    }
+
+    #[inline]
+    fn encode(&self) -> Vec<u8> {
+        self.as_ref().encode()
+    }
+
+    #[inline]
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.as_ref().using_encoded(f)
+    }
+}
+
+#[cfg(feature = "scale-codec")]
+impl EncodeLike for Piece {}
+
+#[cfg(feature = "scale-codec")]
+impl Decode for Piece {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, parity_scale_codec::Error> {
+        let bytes =
+            Bytes::decode(input).map_err(|error| error.chain("Could not decode `Piece`"))?;
+
+        if bytes.len() != Self::SIZE {
+            return Err(
+                parity_scale_codec::Error::from("Incorrect Piece length").chain(format!(
+                    "Expected {} bytes, found {} bytes",
+                    Self::SIZE,
+                    bytes.len()
+                )),
+            );
+        }
+
+        Ok(Piece(CowBytes::Shared(bytes)))
+    }
+}
+
+#[cfg(feature = "scale-codec")]
+impl TypeInfo for Piece {
+    type Identity = Self;
+
+    fn type_info() -> Type {
+        Type::builder()
+            .path(Path::new("Piece", module_path!()))
+            .docs(&["A piece of archival history in Subspace Network"])
+            .composite(
+                Fields::unnamed().field(|f| f.ty::<[u8; Piece::SIZE]>().type_name("PieceArray")),
+            )
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Piece {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = match &self.0 {
+            CowBytes::Shared(bytes) => bytes.as_ref(),
+            CowBytes::Owned(bytes) => bytes.as_ref(),
+        };
+
+        if serializer.is_human_readable() {
+            hex::serde::serialize(bytes, serializer)
+        } else {
+            bytes.serialize(serializer)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Piece {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = if deserializer.is_human_readable() {
+            hex::serde::deserialize::<_, Vec<u8>>(deserializer).and_then(|bytes| {
+                if bytes.len() == Piece::SIZE {
+                    Ok(Bytes::from(bytes))
+                } else {
+                    Err(serde::de::Error::invalid_length(
+                        bytes.len(),
+                        &format!("Expected {} bytes", Piece::SIZE).as_str(),
+                    ))
+                }
+            })?
+        } else {
+            Bytes::deserialize(deserializer)?
+        };
+
+        Ok(Piece(CowBytes::Shared(bytes)))
+    }
+}
+
+impl Default for Piece {
+    #[inline]
+    fn default() -> Self {
+        Self(CowBytes::Owned(BytesMut::zeroed(Self::SIZE)))
+    }
+}
+
+impl From<Piece> for Vec<u8> {
+    #[inline]
+    fn from(piece: Piece) -> Self {
+        match piece.0 {
+            CowBytes::Shared(bytes) => bytes.to_vec(),
+            CowBytes::Owned(bytes) => Vec::from(bytes),
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for Piece {
+    type Error = ();
+
+    #[inline]
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        if slice.len() != Self::SIZE {
+            return Err(());
+        }
+
+        Ok(Self(CowBytes::Shared(Bytes::copy_from_slice(slice))))
+    }
+}
+
+impl TryFrom<Vec<u8>> for Piece {
+    type Error = ();
+
+    #[inline]
+    fn try_from(vec: Vec<u8>) -> Result<Self, Self::Error> {
+        if vec.len() != Self::SIZE {
+            return Err(());
+        }
+
+        Ok(Self(CowBytes::Shared(Bytes::from(vec))))
+    }
+}
+
+impl TryFrom<Bytes> for Piece {
+    type Error = ();
+
+    #[inline]
+    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
+        if bytes.len() != Self::SIZE {
+            return Err(());
+        }
+
+        Ok(Self(CowBytes::Shared(bytes)))
+    }
+}
+
+impl TryFrom<BytesMut> for Piece {
+    type Error = ();
+
+    #[inline]
+    fn try_from(bytes: BytesMut) -> Result<Self, Self::Error> {
+        if bytes.len() != Self::SIZE {
+            return Err(());
+        }
+
+        Ok(Self(CowBytes::Owned(bytes)))
+    }
+}
+
+impl From<&PieceArray> for Piece {
+    #[inline]
+    fn from(value: &PieceArray) -> Self {
+        Self(CowBytes::Shared(Bytes::copy_from_slice(value.as_ref())))
+    }
+}
+
+impl Deref for Piece {
+    type Target = PieceArray;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        <&[u8; Self::SIZE]>::try_from(self.as_ref())
+            .expect("Slice of memory has correct length; qed")
+            .into()
+    }
+}
+
+impl DerefMut for Piece {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        <&mut [u8; Self::SIZE]>::try_from(self.as_mut())
+            .expect("Slice of memory has correct length; qed")
+            .into()
+    }
+}
+
+impl AsRef<[u8]> for Piece {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for Piece {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl Piece {
+    /// Size of a piece (in bytes).
+    pub const SIZE: usize = PieceArray::SIZE;
+
+    /// Ensure piece contains cheaply cloneable shared data.
+    ///
+    /// Internally piece uses CoW mechanism and can store either mutable owned data or data that is
+    /// cheap to clone, calling this method will ensure further clones will not result in additional
+    /// memory allocations.
+    pub fn to_shared(self) -> Self {
+        Self(match self.0 {
+            CowBytes::Shared(bytes) => CowBytes::Shared(bytes),
+            CowBytes::Owned(bytes) => CowBytes::Shared(bytes.freeze()),
+        })
+    }
+}

--- a/subspace/crates/subspace-core-primitives/src/pos.rs
+++ b/subspace/crates/subspace-core-primitives/src/pos.rs
@@ -3,7 +3,9 @@
 use crate::hashes::{blake3_hash, Blake3Hash};
 use core::fmt;
 use derive_more::{Deref, DerefMut, From, Into};
+#[cfg(feature = "scale-codec")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+#[cfg(feature = "scale-codec")]
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -18,7 +20,10 @@ pub struct PosSeed([u8; PosSeed::SIZE]);
 
 impl fmt::Debug for PosSeed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -28,14 +33,19 @@ impl PosSeed {
 }
 
 /// Proof of space proof bytes.
-#[derive(
-    Copy, Clone, Eq, PartialEq, Deref, DerefMut, From, Into, Encode, Decode, TypeInfo, MaxEncodedLen,
+#[derive(Copy, Clone, Eq, PartialEq, Deref, DerefMut, From, Into)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 pub struct PosProof([u8; PosProof::SIZE]);
 
 impl fmt::Debug for PosProof {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 

--- a/subspace/crates/subspace-core-primitives/src/pot.rs
+++ b/subspace/crates/subspace-core-primitives/src/pot.rs
@@ -6,7 +6,9 @@ use core::fmt;
 use core::num::NonZeroU8;
 use core::str::FromStr;
 use derive_more::{AsMut, AsRef, Deref, DerefMut, From};
+#[cfg(feature = "scale-codec")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+#[cfg(feature = "scale-codec")]
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -14,27 +16,19 @@ use serde::{Deserialize, Serialize};
 use serde::{Deserializer, Serializer};
 
 /// Proof of time key(input to the encryption).
-#[derive(
-    Default,
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    From,
-    AsRef,
-    AsMut,
-    Deref,
-    DerefMut,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+#[derive(Default, Copy, Clone, Eq, PartialEq, From, AsRef, AsMut, Deref, DerefMut)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 pub struct PotKey([u8; Self::SIZE]);
 
 impl fmt::Debug for PotKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -80,7 +74,10 @@ impl<'de> Deserialize<'de> for PotKey {
 
 impl fmt::Display for PotKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -102,28 +99,19 @@ impl PotKey {
 }
 
 /// Proof of time seed
-#[derive(
-    Default,
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Hash,
-    From,
-    AsRef,
-    AsMut,
-    Deref,
-    DerefMut,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, From, AsRef, AsMut, Deref, DerefMut)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 pub struct PotSeed([u8; Self::SIZE]);
 
 impl fmt::Debug for PotSeed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -169,7 +157,10 @@ impl<'de> Deserialize<'de> for PotSeed {
 
 impl fmt::Display for PotSeed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -196,28 +187,19 @@ impl PotSeed {
 }
 
 /// Proof of time output, can be intermediate checkpoint or final slot output
-#[derive(
-    Default,
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Hash,
-    From,
-    AsRef,
-    AsMut,
-    Deref,
-    DerefMut,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, From, AsRef, AsMut, Deref, DerefMut)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 pub struct PotOutput([u8; Self::SIZE]);
 
 impl fmt::Debug for PotOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -263,7 +245,10 @@ impl<'de> Deserialize<'de> for PotOutput {
 
 impl fmt::Display for PotOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -295,20 +280,10 @@ impl PotOutput {
 }
 
 /// Proof of time checkpoints, result of proving
-#[derive(
-    Debug,
-    Default,
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Hash,
-    Deref,
-    DerefMut,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 pub struct PotCheckpoints([PotOutput; Self::NUM_CHECKPOINTS.get() as usize]);
 

--- a/subspace/crates/subspace-core-primitives/src/sectors.rs
+++ b/subspace/crates/subspace-core-primitives/src/sectors.rs
@@ -18,7 +18,9 @@ use derive_more::{
     Add, AddAssign, AsRef, Deref, Display, Div, DivAssign, From, Into, Mul, MulAssign, Sub,
     SubAssign,
 };
+#[cfg(feature = "scale-codec")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+#[cfg(feature = "scale-codec")]
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -43,7 +45,8 @@ impl SectorSlotChallenge {
 }
 
 /// Data structure representing sector ID in farmer's plot
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SectorId(Blake3Hash);
 
@@ -179,8 +182,6 @@ impl SectorId {
     Eq,
     PartialEq,
     Hash,
-    Encode,
-    Decode,
     Add,
     AddAssign,
     Sub,
@@ -189,8 +190,10 @@ impl SectorId {
     MulAssign,
     Div,
     DivAssign,
-    TypeInfo,
-    MaxEncodedLen,
+)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(transparent)]

--- a/subspace/crates/subspace-core-primitives/src/segments/archival_history_segment.rs
+++ b/subspace/crates/subspace-core-primitives/src/segments/archival_history_segment.rs
@@ -1,0 +1,35 @@
+use crate::pieces::{FlatPieces, Piece};
+use crate::segments::RecordedHistorySegment;
+use derive_more::{Deref, DerefMut};
+
+/// Archived history segment after archiving is applied.
+#[derive(Debug, Clone, Eq, PartialEq, Deref, DerefMut)]
+#[repr(transparent)]
+pub struct ArchivedHistorySegment(FlatPieces);
+
+impl Default for ArchivedHistorySegment {
+    #[inline]
+    fn default() -> Self {
+        Self(FlatPieces::new(Self::NUM_PIECES))
+    }
+}
+
+impl ArchivedHistorySegment {
+    /// Number of pieces in one segment of archived history.
+    pub const NUM_PIECES: usize = RecordedHistorySegment::NUM_PIECES;
+    /// Size of archived history segment in bytes.
+    ///
+    /// It includes erasure coded [`crate::pieces::PieceArray`]s (both source and parity) that are
+    /// composed of [`crate::pieces::Record`]s together with corresponding commitments and
+    /// witnesses.
+    pub const SIZE: usize = Piece::SIZE * Self::NUM_PIECES;
+
+    /// Ensure archived history segment contains cheaply cloneable shared data.
+    ///
+    /// Internally archived history segment uses CoW mechanism and can store either mutable owned
+    /// data or data that is cheap to clone, calling this method will ensure further clones and
+    /// returned pieces will not result in additional memory allocations.
+    pub fn to_shared(self) -> Self {
+        Self(self.0.to_shared())
+    }
+}

--- a/subspace/crates/subspace-core-primitives/src/solutions.rs
+++ b/subspace/crates/subspace-core-primitives/src/solutions.rs
@@ -9,7 +9,9 @@ use core::array::TryFromSliceError;
 use core::fmt;
 use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
 use num_traits::WrappingSub;
+#[cfg(feature = "scale-codec")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+#[cfg(feature = "scale-codec")]
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -64,14 +66,16 @@ const_assert!(solution_range_to_pieces(pieces_to_solution_range(3, (1, 6)), (1, 
 const_assert!(solution_range_to_pieces(pieces_to_solution_range(5, (1, 6)), (1, 6)) == 5);
 
 /// A Ristretto Schnorr signature as bytes produced by `schnorrkel` crate.
-#[derive(
-    Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, TypeInfo, Deref, From, Into,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Deref, From, Into)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 pub struct RewardSignature([u8; RewardSignature::SIZE]);
 
 impl fmt::Debug for RewardSignature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -128,27 +132,20 @@ impl RewardSignature {
 }
 
 /// Witness for chunk contained within a record.
-#[derive(
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Hash,
-    Deref,
-    DerefMut,
-    From,
-    Into,
-    Encode,
-    Decode,
-    TypeInfo,
-    MaxEncodedLen,
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 #[repr(transparent)]
 pub struct ChunkWitness([u8; ChunkWitness::SIZE]);
 
 impl fmt::Debug for ChunkWitness {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(self.0))
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
@@ -228,7 +225,8 @@ impl ChunkWitness {
 }
 
 /// Farmer solution for slot challenge.
-#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Solution<RewardAddress> {

--- a/subspace/crates/subspace-core-primitives/src/tests.rs
+++ b/subspace/crates/subspace-core-primitives/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::pieces::PieceIndex;
-use crate::segments::{ArchivedHistorySegment, RecordedHistorySegment, SegmentIndex};
+use crate::segments::{RecordedHistorySegment, SegmentIndex};
 use crate::U256;
 
 #[test]
@@ -58,10 +58,10 @@ fn source_piece_index_conversion() {
         let segment_index = SegmentIndex::new(segment_index);
         let next_source_piece_index = PieceIndex::new(next_source_piece_index);
 
-        println!(
-            "{:?} {:?} {:?} {:?} {:?}",
-            piece_index, piece_position, source_position, segment_index, next_source_piece_index
-        );
+        // println!(
+        //     "{:?} {:?} {:?} {:?} {:?}",
+        //     piece_index, piece_position, source_position, segment_index, next_source_piece_index
+        // );
 
         assert_eq!(piece_index.position(), piece_position);
 
@@ -103,14 +103,14 @@ fn parity_piece_index_conversion() {
         let piece_index = PieceIndex::new(piece_index);
         let segment_index = SegmentIndex::new(segment_index);
 
-        println!("{:?} {:?} {:?}", piece_index, piece_position, segment_index,);
+        // println!("{:?} {:?} {:?}", piece_index, piece_position, segment_index);
 
         assert_eq!(piece_index.position(), piece_position);
 
         assert_eq!(piece_index.segment_index(), segment_index);
         assert!(!piece_index.is_source(), "{:?}", piece_index);
 
-        if piece_position as usize == ArchivedHistorySegment::NUM_PIECES - 1 {
+        if piece_position as usize == RecordedHistorySegment::NUM_PIECES - 1 {
             assert_eq!(segment_index.last_piece_index(), piece_index);
         }
 
@@ -135,10 +135,10 @@ fn parity_piece_index_conversion() {
 #[test]
 #[should_panic]
 fn parity_piece_index_position_panic() {
-    for &(piece_index, piece_position, segment_index) in PARITY_PIECE_INDEX_TEST_CASES {
+    for &(piece_index, _piece_position, _segment_index) in PARITY_PIECE_INDEX_TEST_CASES {
         let piece_index = PieceIndex::new(piece_index);
 
-        println!("{:?} {:?} {:?}", piece_index, piece_position, segment_index);
+        // println!("{:?} {:?} {:?}", piece_index, piece_position, segment_index);
 
         // Always panics
         piece_index.source_position();
@@ -148,10 +148,10 @@ fn parity_piece_index_position_panic() {
 #[test]
 #[should_panic]
 fn parity_piece_index_next_source_panic() {
-    for &(piece_index, piece_position, segment_index) in PARITY_PIECE_INDEX_TEST_CASES {
+    for &(piece_index, _piece_position, _segment_index) in PARITY_PIECE_INDEX_TEST_CASES {
         let piece_index = PieceIndex::new(piece_index);
 
-        println!("{:?} {:?} {:?}", piece_index, piece_position, segment_index);
+        // println!("{:?} {:?} {:?}", piece_index, piece_position, segment_index);
 
         // Always panics
         piece_index.next_source_index();

--- a/subspace/crates/subspace-erasure-coding/Cargo.toml
+++ b/subspace/crates/subspace-erasure-coding/Cargo.toml
@@ -30,7 +30,6 @@ default = ["std", "parallel"]
 std = [
     "kzg/std",
     "rust-kzg-blst/std",
-    "subspace-core-primitives/std",
     "subspace-kzg/std",
 ]
 parallel = ["rust-kzg-blst/parallel"]

--- a/subspace/crates/subspace-erasure-coding/Cargo.toml
+++ b/subspace/crates/subspace-erasure-coding/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 [dependencies]
 kzg.workspace = true
 rust-kzg-blst.workspace = true
-subspace-core-primitives.workspace = true
+subspace-core-primitives = { workspace = true, features = ["alloc"] }
 subspace-kzg.workspace = true
 
 [dev-dependencies]

--- a/subspace/crates/subspace-networking/Cargo.toml
+++ b/subspace/crates/subspace-networking/Cargo.toml
@@ -38,7 +38,7 @@ rand.workspace = true
 schnellru.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-subspace-core-primitives.workspace = true
+subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
 subspace-logging.workspace = true
 subspace-metrics.workspace = true
 thiserror.workspace = true

--- a/subspace/crates/subspace-proof-of-space/Cargo.toml
+++ b/subspace/crates/subspace-proof-of-space/Cargo.toml
@@ -43,7 +43,6 @@ std = [
     # In no-std environment we use `spin`
     "parking_lot",
     "sha2/std",
-    "subspace-core-primitives/std",
 ]
 parallel = [
     "dep:rayon",

--- a/subspace/crates/subspace-proof-of-time/Cargo.toml
+++ b/subspace/crates/subspace-proof-of-time/Cargo.toml
@@ -38,7 +38,6 @@ harness = false
 [features]
 default = ["std"]
 std = [
-    "subspace-core-primitives/std",
     "thiserror/std",
     "rand?/std",
     "rand?/std_rng",

--- a/subspace/crates/subspace-runtime-primitives/Cargo.toml
+++ b/subspace/crates/subspace-runtime-primitives/Cargo.toml
@@ -40,7 +40,6 @@ std = [
     "serde/std",
     "sp-core/std",
     "sp-runtime/std",
-    "subspace-core-primitives/std",
 ]
 testing = [
     "sp-io"

--- a/subspace/crates/subspace-runtime/Cargo.toml
+++ b/subspace/crates/subspace-runtime/Cargo.toml
@@ -95,7 +95,6 @@ std = [
     "sp-std/std",
     "sp-transaction-pool/std",
     "sp-version/std",
-    "subspace-core-primitives/std",
     "subspace-runtime-primitives/std",
     "substrate-wasm-builder",
 ]

--- a/subspace/crates/subspace-verification/Cargo.toml
+++ b/subspace/crates/subspace-verification/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parity-scale-codec.workspace = true
+parity-scale-codec = { workspace = true, optional = true }
 schnorrkel.workspace = true
 subspace-core-primitives.workspace = true
 subspace-kzg = { workspace = true, optional = true }
@@ -24,10 +24,20 @@ subspace-proof-of-space.workspace = true
 thiserror.workspace = true
 
 [features]
-default = ["std", "kzg"]
-kzg = ["subspace-kzg"]
+alloc = [
+    "subspace-core-primitives/alloc",
+]
+scale-codec = [
+    "alloc",
+    "dep:parity-scale-codec",
+    "subspace-core-primitives/scale-codec",
+]
+kzg = [
+    "alloc",
+    "dep:subspace-kzg"
+]
 std = [
-    "parity-scale-codec/std",
+    "parity-scale-codec?/std",
     "schnorrkel/std",
     "subspace-core-primitives/std",
     "subspace-kzg?/std",

--- a/subspace/crates/subspace-verification/Cargo.toml
+++ b/subspace/crates/subspace-verification/Cargo.toml
@@ -39,7 +39,6 @@ kzg = [
 std = [
     "parity-scale-codec?/std",
     "schnorrkel/std",
-    "subspace-core-primitives/std",
     "subspace-kzg?/std",
     "thiserror/std"
 ]

--- a/subspace/crates/subspace-verification/src/lib.rs
+++ b/subspace/crates/subspace-verification/src/lib.rs
@@ -7,18 +7,19 @@
 // TODO: This feature is not actually used in this crate, but is added as a workaround for
 //  https://github.com/rust-lang/rust/issues/133199
 #![feature(generic_const_exprs)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(feature = "kzg", feature = "alloc"))]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(feature = "kzg", feature = "alloc"))]
 use alloc::string::String;
-#[cfg(all(feature = "kzg", not(feature = "std")))]
+#[cfg(all(feature = "kzg", feature = "alloc"))]
 use alloc::vec::Vec;
 use core::mem;
 #[cfg(feature = "kzg")]
 use core::simd::Simd;
+#[cfg(feature = "scale-codec")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use schnorrkel::context::SigningContext;
 use schnorrkel::SignatureError;
@@ -45,6 +46,7 @@ use subspace_proof_of_space::Table;
 
 /// Errors encountered by the Subspace consensus primitives.
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
+#[cfg(feature = "kzg")]
 pub enum Error {
     /// Invalid piece offset
     #[error("Piece verification failed")]
@@ -145,7 +147,8 @@ pub fn is_within_solution_range(
 }
 
 /// Parameters for checking piece validity
-#[derive(Debug, Clone, Encode, Decode, MaxEncodedLen)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, MaxEncodedLen))]
 pub struct PieceCheckParams {
     /// How many pieces one sector is supposed to contain (max)
     pub max_pieces_in_sector: u16,
@@ -164,7 +167,8 @@ pub struct PieceCheckParams {
 }
 
 /// Parameters for solution verification
-#[derive(Debug, Clone, Encode, Decode, MaxEncodedLen)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, MaxEncodedLen))]
 pub struct VerifySolutionParams {
     /// Proof of time for which solution is built
     pub proof_of_time: PotOutput,

--- a/subspace/shared/subspace-data-retrieval/Cargo.toml
+++ b/subspace/shared/subspace-data-retrieval/Cargo.toml
@@ -18,7 +18,7 @@ futures.workspace = true
 hex = { workspace = true, features = ["std"] }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 subspace-archiving.workspace = true
-subspace-core-primitives = { workspace = true, features = ["std"] }
+subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
 subspace-erasure-coding.workspace = true
 subspace-runtime-primitives = { workspace = true, features = ["std"] }
 thiserror.workspace = true

--- a/subspace/shared/subspace-data-retrieval/Cargo.toml
+++ b/subspace/shared/subspace-data-retrieval/Cargo.toml
@@ -20,6 +20,7 @@ parity-scale-codec = { workspace = true, features = ["derive"] }
 subspace-archiving.workspace = true
 subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
 subspace-erasure-coding.workspace = true
+# TODO: Get rid of this dependency, this is not the right place for it
 subspace-runtime-primitives = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }

--- a/subspace/shared/subspace-kzg/Cargo.toml
+++ b/subspace/shared/subspace-kzg/Cargo.toml
@@ -48,6 +48,5 @@ std = [
     # In no-std environment we use `spin`
     "parking_lot",
     "rust-kzg-blst/std",
-    "subspace-core-primitives/std",
     "tracing/std",
 ]


### PR DESCRIPTION
This removes `std` feature from `subspace-core-primitives` and adds `alloc` feature instead, which allows to use the crate in environments without any allocator at all.