### PR TITLE
Add `ab-merkle-tree` crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,19 +73,18 @@ jobs:
         run: |
           for contract_path in crates/contracts/{example,system}/*; do
             contract="$(basename -- $contract_path)"
-            cargo -Zgitoxide -Zgit clippy --all-targets -p $contract --features $contract/guest -- -D warnings
+            cargo -Zgitoxide -Zgit clippy --all-targets --package $contract --features $contract/guest -- -D warnings
           done
 
           # TODO: Would be nice to have these as job matrix later
-          cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-common --features ab-contracts-common/guest -- -D warnings
-          cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-common --features ab-contracts-common/executor -- -D warnings
+          cargo -Zgitoxide -Zgit clippy --all-targets --package ab-contracts-common --features ab-contracts-common/guest -- -D warnings
+          cargo -Zgitoxide -Zgit clippy --all-targets --package ab-contracts-common --features ab-contracts-common/executor -- -D warnings
 
-          cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-macros --features ab-contracts-macros/guest -- -D warnings
+          cargo -Zgitoxide -Zgit clippy --all-targets --package ab-contracts-macros --features ab-contracts-macros/guest -- -D warnings
 
-          cargo -Zgitoxide -Zgit clippy --all-targets -p ab-contracts-standards --features ab-contracts-standards/guest -- -D warnings
+          cargo -Zgitoxide -Zgit clippy --all-targets --package ab-contracts-standards --features ab-contracts-standards/guest -- -D warnings
 
-          cargo -Zgitoxide -Zgit clippy --all-targets -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/alloc -- -D warnings
-          cargo -Zgitoxide -Zgit clippy --all-targets -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder -- -D warnings
+          cargo -Zgitoxide -Zgit clippy --all-targets --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder -- -D warnings
         if: runner.os == 'Linux'
 
   cargo-test:
@@ -114,7 +113,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # 2.47.0
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # 2.47.0
         with:
           tool: cargo-nextest
 
@@ -124,12 +123,21 @@ jobs:
 
       - name: cargo test (various features)
         run: |
-          for contract_path in crates/contracts/{example,system}/*; do
-            contract="$(basename -- $contract_path)"
-            cargo -Zgitoxide -Zgit test -p $contract --features $contract/guest
+          for crate_path in crates/{execution,shared}/*; do
+            # Not all crates have this feature
+            if ! grep --no-messages --quiet '^alloc =' "$crate_path/Cargo.toml"; then
+              continue
+            fi
+            crate="$(basename -- $crate_path)"
+            cargo -Zgitoxide -Zgit nextest run --no-tests pass --package $crate --features alloc
           done
 
-          cargo -Zgitoxide -Zgit test -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
+          for contract_path in crates/contracts/{example,system}/*; do
+            contract="$(basename -- $contract_path)"
+            cargo -Zgitoxide -Zgit nextest run --no-tests pass --package $contract --features $contract/guest
+          done
+
+          cargo -Zgitoxide -Zgit nextest run --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
         if: runner.os == 'Linux'
 
   cargo-miri-test:
@@ -158,13 +166,27 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # 2.47.0
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # 2.47.0
         with:
           tool: cargo-nextest
 
       - name: cargo miri nextest run
         run: |
           cargo -Zgitoxide -Zgit miri nextest run
+
+      - name: cargo miri nextest run (various features)
+        run: |
+          for crate_path in crates/{execution,shared}/*; do
+            # Not all crates have this feature
+            if ! grep --no-messages --quiet '^alloc =' "$crate_path/Cargo.toml"; then
+              continue
+            fi
+            crate="$(basename -- $crate_path)"
+            cargo -Zgitoxide -Zgit miri nextest run --no-tests pass --package $crate --features alloc
+          done
+
+          cargo -Zgitoxide -Zgit miri nextest run --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
+        if: runner.os == 'Linux'
 
   no-panic:
     strategy:
@@ -206,24 +228,23 @@ jobs:
         run: |
           for contract_path in crates/contracts/{example,system}/*; do
             # Not all contracts have this feature yet
-            if ! grep -q '^no-panic =' "$contract_path/Cargo.toml"; then
+            if ! grep --no-messages --quiet '^no-panic =' "$contract_path/Cargo.toml"; then
               continue
             fi
             contract="$(basename -- $contract_path)"
-            cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p $contract --features $contract/guest
+            cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package $contract --features $contract/guest
           done
 
           # TODO: Would be nice to have these as job matrix later
           # TODO: Unlock commented-out crates once they have the feature
-          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/guest
-          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-common --features ab-contracts-common/executor
+          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-contracts-common --features ab-contracts-common/guest
+          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-contracts-common --features ab-contracts-common/executor
 
-          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-macros --features ab-contracts-macros/guest
+          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-contracts-macros --features ab-contracts-macros/guest
 
-          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-contracts-standards --features ab-contracts-standards/guest
+          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-contracts-standards --features ab-contracts-standards/guest
 
-          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/alloc
-          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic -p ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
+          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
         if: runner.os == 'Linux'
 
   contracts:
@@ -248,6 +269,6 @@ jobs:
           for contract_path in crates/contracts/{example,system}/*; do
             contract="$(basename -- $contract_path)"
             # TODO: This uses x86-64-based target, but will have to change to riscv64e-based target eventually
-            cargo -Zgitoxide -Zgit rustc -Z build-std=core --crate-type cdylib --profile contract --target crates/contracts/x86_64-unknown-none-abundance.json -p $contract --features $contract/guest
+            cargo -Zgitoxide -Zgit rustc -Z build-std=core --crate-type cdylib --profile contract --target crates/contracts/x86_64-unknown-none-abundance.json --package $contract --features $contract/guest
           done
         if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-merkle-tree"
+version = "0.0.1"
+dependencies = [
+ "blake3",
+ "rand_chacha",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "ab-system-contract-address-allocator"
 version = "0.0.1"
 dependencies = [
@@ -495,7 +504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -608,7 +617,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -722,7 +731,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -781,6 +790,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +817,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +834,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 
 [[package]]
 name = "regex"
@@ -878,7 +912,7 @@ dependencies = [
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "subtle",
  "zeroize",
@@ -1223,6 +1257,26 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ ident_case = "1.0.1"
 no-panic = "0.1.35"
 proc-macro2 = "1.0.94"
 quote = "1.0.40"
+rand_core = { version = "0.9.3", default-features = false }
+rand_chacha = { version = "0.9.0", default-features = false }
 schnorrkel = { version = "0.11.4", default-features = false }
 smallvec = "1.14.0"
 syn = "2.0.100"

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/Cargo.toml
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/Cargo.toml
@@ -31,12 +31,8 @@ guest = [
     "ab-contracts-macros/guest",
     "ab-contracts-standards/guest",
 ]
-# APIs that require `alloc` crate
-alloc = []
 # Enables payload builder API
-payload-builder = [
-    "alloc",
-]
+payload-builder = []
 # Check that code can't panic under any conditions
 no-panic = [
     "dep:no-panic",

--- a/crates/shared/ab-merkle-tree/Cargo.toml
+++ b/crates/shared/ab-merkle-tree/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ab-merkle-tree"
+description = ""
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+# TODO: Benches
+
+[dependencies]
+blake3 = { workspace = true }
+
+[dev-dependencies]
+rand_core = { workspace = true }
+rand_chacha = { workspace = true }
+
+[features]
+alloc = []
+
+[lints]
+workspace = true

--- a/crates/shared/ab-merkle-tree/src/balanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/src/balanced_hashed.rs
@@ -1,0 +1,268 @@
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+use blake3::OUT_LEN;
+use core::iter::TrustedLen;
+use core::mem::MaybeUninit;
+
+/// Number of hashes, including root and excluding already provided leaf hashes
+#[inline(always)]
+pub const fn num_hashes(num_leaves_log_2: u32) -> usize {
+    2_usize.pow(num_leaves_log_2) - 1
+}
+
+/// Number of leaves in a tree
+#[inline(always)]
+pub const fn num_leaves(num_leaves_log_2: u32) -> usize {
+    2_usize.pow(num_leaves_log_2)
+}
+
+/// Merkle Tree variant that has hash-sized leaves and is fully balanced according to configured
+/// generic parameter.
+///
+/// This Merkle Tree implementation is best suited for use cases when proofs for all (or most) of
+/// the elements need to be generated and the whole tree easily fits into memory. It can also be
+/// constructed and proofs can be generated efficiently without heap allocations.
+///
+/// With all parameters of the tree known statically, it results in the most efficient version of
+/// the code being generated for a given set of parameters.
+///
+/// `NUM_LEAVES_LOG_2` is base-2 logarithm of the number of leaves in a tree.
+#[derive(Debug)]
+pub struct BalancedHashedMerkleTree<'a, const NUM_LEAVES_LOG_2: u32>
+where
+    [(); num_hashes(NUM_LEAVES_LOG_2)]:,
+{
+    leaf_hashes: &'a [[u8; OUT_LEN]],
+    // This tree doesn't include leaves because we know the size
+    tree: [[u8; OUT_LEN]; num_hashes(NUM_LEAVES_LOG_2)],
+}
+
+// TODO: Replace hashing individual records with blake3 and building tree manually with building the
+//  tree using blake3 itself, such that the root is the same as hashing data with blake3, see
+//  https://github.com/BLAKE3-team/BLAKE3/issues/470 for details. Two options are:
+//  expand values to 1024 bytes or modify blake3 to use 32-byte chunk size (at which point it'll
+//  unfortunately stop being blake3)
+impl<'a, const NUM_LEAVES_LOG_2: u32> BalancedHashedMerkleTree<'a, NUM_LEAVES_LOG_2>
+where
+    [(); num_hashes(NUM_LEAVES_LOG_2)]:,
+{
+    /// Create a new tree from a fixed set of elements.
+    ///
+    /// The data structure is statically allocated and might be too large to fit on the stack!
+    /// If that is the case, use `new_boxed()` method.
+    pub fn new(leaf_hashes: &'a [[u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)]) -> Self {
+        let mut tree = [MaybeUninit::<[u8; OUT_LEN]>::uninit(); num_hashes(NUM_LEAVES_LOG_2)];
+
+        Self::init_internal(leaf_hashes, &mut tree);
+
+        Self {
+            leaf_hashes,
+            // SAFETY: Statically guaranteed for all elements to be initialized
+            tree: unsafe { tree.transpose().assume_init() },
+        }
+    }
+
+    /// Like [`Self::new()`], but creates heap-allocated instance, avoiding excessive stack usage
+    /// for large trees
+    #[cfg(feature = "alloc")]
+    pub fn new_boxed(leaf_hashes: &'a [[u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)]) -> Box<Self> {
+        let mut instance = Box::<Self>::new_uninit();
+        let instance_ptr = instance.as_mut_ptr();
+        // SAFETY: Valid and correctly aligned non-null pointer
+        unsafe {
+            (&raw mut (*instance_ptr).leaf_hashes).write(leaf_hashes);
+        }
+        let tree = {
+            // SAFETY: Valid and correctly aligned non-null pointer
+            let tree_ptr = unsafe { &raw mut (*instance_ptr).tree };
+            // SAFETY: Allocated and correctly aligned uninitialized data
+            unsafe {
+                tree_ptr
+                    .cast::<[MaybeUninit<[u8; OUT_LEN]>; num_hashes(NUM_LEAVES_LOG_2)]>()
+                    .as_mut_unchecked()
+            }
+        };
+
+        Self::init_internal(leaf_hashes, tree);
+
+        // SAFETY: Initialized field by field above
+        unsafe { instance.assume_init() }
+    }
+
+    fn init_internal(
+        leaf_hashes: &[[u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)],
+        tree: &mut [MaybeUninit<[u8; OUT_LEN]>; num_hashes(NUM_LEAVES_LOG_2)],
+    ) {
+        let mut tree_hashes = tree.as_mut_slice();
+        let mut level_hashes = leaf_hashes.as_slice();
+
+        let mut pair = [0u8; OUT_LEN * 2];
+        while level_hashes.len() > 1 {
+            let num_pairs = level_hashes.len() / 2;
+            let parent_hashes;
+            // SAFETY: The size of the tree is statically known to match the number of leaves and
+            // levels of hashes
+            (parent_hashes, tree_hashes) = unsafe { tree_hashes.split_at_mut_unchecked(num_pairs) };
+
+            for pair_index in 0..num_pairs {
+                // SAFETY: Entry is statically known to be present
+                let left_hash = unsafe { level_hashes.get_unchecked(pair_index * 2) };
+                // SAFETY: Entry is statically known to be present
+                let right_hash = unsafe { level_hashes.get_unchecked(pair_index * 2 + 1) };
+                // SAFETY: Entry is statically known to be present
+                let parent_hash = unsafe { parent_hashes.get_unchecked_mut(pair_index) };
+
+                pair[..OUT_LEN].copy_from_slice(left_hash);
+                pair[OUT_LEN..].copy_from_slice(right_hash);
+
+                parent_hash.write(*blake3::hash(&pair).as_bytes());
+            }
+
+            // SAFETY: Just initialized
+            level_hashes = unsafe { parent_hashes.assume_init_ref() };
+        }
+    }
+
+    /// Get the root of Merkle Tree.
+    ///
+    /// In case a tree contains a single leaf hash, that leaf hash is returned.
+    pub fn root(&self) -> [u8; OUT_LEN] {
+        *self
+            .tree
+            .last()
+            .or(self.leaf_hashes.last())
+            .expect("There is always at least one leaf hash; qed")
+    }
+
+    /// Iterator over proofs in the same order as provided leaf hashes
+    pub fn all_proofs(
+        &self,
+    ) -> impl ExactSizeIterator<Item = [[u8; OUT_LEN]; NUM_LEAVES_LOG_2 as usize]> + TrustedLen
+    where
+        [(); NUM_LEAVES_LOG_2 as usize]:,
+    {
+        let iter = self.leaf_hashes.array_chunks().enumerate().flat_map(
+            |(pair_index, &[left_hash, right_hash])| {
+                let mut left_proof =
+                    [MaybeUninit::<[u8; OUT_LEN]>::uninit(); NUM_LEAVES_LOG_2 as usize];
+                left_proof[0].write(right_hash);
+
+                let left_proof = {
+                    let (_, shared_proof) = left_proof.split_at_mut(1);
+
+                    let mut tree_hashes = self.tree.as_slice();
+                    let mut parent_position = pair_index;
+                    let mut parent_level_size = num_leaves(NUM_LEAVES_LOG_2) / 2;
+
+                    for hash in shared_proof {
+                        let parent_other_position = if parent_position % 2 == 0 {
+                            parent_position + 1
+                        } else {
+                            parent_position - 1
+                        };
+                        // SAFETY: Statically guaranteed to be present by constructor
+                        let other_hash =
+                            unsafe { tree_hashes.get_unchecked(parent_other_position) };
+                        hash.write(*other_hash);
+                        (_, tree_hashes) = tree_hashes.split_at(parent_level_size);
+
+                        parent_position /= 2;
+                        parent_level_size /= 2;
+                    }
+
+                    // SAFETY: Just initialized
+                    unsafe { left_proof.transpose().assume_init() }
+                };
+
+                let mut right_proof = left_proof;
+                right_proof[0] = left_hash;
+
+                [left_proof, right_proof]
+            },
+        );
+
+        ProofsIterator {
+            iter,
+            len: num_leaves(NUM_LEAVES_LOG_2),
+        }
+    }
+
+    /// Verify previously generated proof
+    pub fn verify(
+        root: &[u8; OUT_LEN],
+        proof: &[[u8; OUT_LEN]; NUM_LEAVES_LOG_2 as usize],
+        leaf_index: usize,
+        leaf_hash: [u8; OUT_LEN],
+    ) -> bool
+    where
+        [(); NUM_LEAVES_LOG_2 as usize]:,
+    {
+        if leaf_index >= num_leaves(NUM_LEAVES_LOG_2) {
+            return false;
+        }
+
+        let mut computed_root = leaf_hash;
+
+        let mut position = leaf_index;
+        let mut pair = [0u8; OUT_LEN * 2];
+        for hash in proof {
+            if position % 2 == 0 {
+                pair[..OUT_LEN].copy_from_slice(&computed_root);
+                pair[OUT_LEN..].copy_from_slice(hash);
+            } else {
+                pair[..OUT_LEN].copy_from_slice(hash);
+                pair[OUT_LEN..].copy_from_slice(&computed_root);
+            }
+
+            position /= 2;
+            computed_root = *blake3::hash(&pair).as_bytes();
+        }
+
+        root == &computed_root
+    }
+}
+
+struct ProofsIterator<Iter> {
+    iter: Iter,
+    len: usize,
+}
+
+impl<Iter> Iterator for ProofsIterator<Iter>
+where
+    Iter: Iterator,
+{
+    type Item = Iter::Item;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+
+    #[inline(always)]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.len
+    }
+}
+
+impl<Iter> ExactSizeIterator for ProofsIterator<Iter>
+where
+    Iter: Iterator,
+{
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+unsafe impl<Iter> TrustedLen for ProofsIterator<Iter> where Iter: Iterator {}

--- a/crates/shared/ab-merkle-tree/src/lib.rs
+++ b/crates/shared/ab-merkle-tree/src/lib.rs
@@ -1,0 +1,12 @@
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+#![feature(
+    array_chunks,
+    generic_const_exprs,
+    maybe_uninit_slice,
+    maybe_uninit_uninit_array_transpose,
+    ptr_as_ref_unchecked,
+    trusted_len
+)]
+#![no_std]
+
+pub mod balanced_hashed;

--- a/crates/shared/ab-merkle-tree/tests/balanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/tests/balanced_hashed.rs
@@ -1,0 +1,89 @@
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+#![feature(generic_const_exprs)]
+
+use ab_merkle_tree::balanced_hashed::{BalancedHashedMerkleTree, num_hashes, num_leaves};
+use blake3::OUT_LEN;
+use rand_chacha::ChaCha8Rng;
+use rand_core::{RngCore, SeedableRng};
+
+#[test]
+fn basic_0() {
+    test_basic::<0>();
+}
+
+#[test]
+fn basic_1() {
+    test_basic::<1>();
+}
+
+#[test]
+fn basic_2() {
+    test_basic::<2>();
+}
+
+#[test]
+fn basic_3() {
+    test_basic::<3>();
+}
+
+#[test]
+fn basic_4() {
+    test_basic::<4>();
+}
+
+#[test]
+fn basic_5() {
+    test_basic::<5>();
+}
+
+fn test_basic<const NUM_LEAVES_LOG_2: u32>()
+where
+    [(); NUM_LEAVES_LOG_2 as usize]:,
+    [(); num_leaves(NUM_LEAVES_LOG_2)]:,
+    [(); num_hashes(NUM_LEAVES_LOG_2)]:,
+{
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+
+    let leaf_hashes = {
+        let mut leaf_hashes = [[0u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)];
+        for hash in &mut leaf_hashes {
+            rng.fill_bytes(hash);
+        }
+        leaf_hashes
+    };
+
+    let tree = BalancedHashedMerkleTree::new(&leaf_hashes);
+    let root = tree.root();
+    #[cfg(feature = "alloc")]
+    assert_eq!(
+        BalancedHashedMerkleTree::new_boxed(&leaf_hashes).root(),
+        root
+    );
+
+    let random_hash = {
+        let mut hash = [0u8; OUT_LEN];
+        rng.fill_bytes(&mut hash);
+        hash
+    };
+    let random_proof = {
+        let mut proof = [[0u8; OUT_LEN]; NUM_LEAVES_LOG_2 as usize];
+        for hash in &mut proof {
+            rng.fill_bytes(hash);
+        }
+        proof
+    };
+    for (leaf_index, (proof, leaf_hash)) in tree.all_proofs().zip(leaf_hashes).enumerate().skip(2) {
+        assert!(
+            BalancedHashedMerkleTree::verify(&root, &proof, leaf_index, leaf_hash),
+            "num_leaves_log_2 {NUM_LEAVES_LOG_2} leaf_index {leaf_index}"
+        );
+        assert!(
+            !BalancedHashedMerkleTree::verify(&root, &proof, leaf_index, random_hash),
+            "num_leaves_log_2 {NUM_LEAVES_LOG_2} leaf_index {leaf_index}"
+        );
+        assert!(
+            !BalancedHashedMerkleTree::verify(&root, &random_proof, leaf_index, leaf_hash),
+            "num_leaves_log_2 {NUM_LEAVES_LOG_2} leaf_index {leaf_index}"
+        );
+    }
+}


### PR DESCRIPTION
This introduces `ab-merkle-tree` crate with `BalancedHashedMerkleTree` Merkle Tree implementation. It is narrowly scoped and I expect either another implementation to be introduced that handles cases with trees that are unbalanced and/or have arbitrary leaf size.

Ultimately we want to replace this with a native tree of blake3 hash, such that the root is the same as if we just hashed the leafs with blake3 directly, but that will take more effort and this should already be sufficient to swap KZG in the archiver.