### PR TITLE
Refactor record commitment

### DIFF
--- a/specs/subspace-diff.md
+++ b/specs/subspace-diff.md
@@ -36,4 +36,6 @@ Dynamic issuance is different (not implemented right now, details will be added 
 
 Since KZG is no longer used and a farmer still does erasure coding during plotting, archiver was modified to also do
 erasure coding of records, so it can commit to erasure coded chunks too. This allows a farmer to generate proofs like
-before even though technically record doesn't contain parity chunks.
+before even though technically record doesn't contain parity chunks. To aid efficient verification of pieces, source and
+parity chunks are first committed to separately before combining into record commitment, with parity chunks root also
+included in the piece alongside record root.

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -11796,7 +11796,6 @@ dependencies = [
  "parity-scale-codec",
  "schnorrkel",
  "subspace-core-primitives",
- "subspace-erasure-coding",
  "subspace-kzg",
  "subspace-proof-of-space",
  "thiserror 2.0.12",

--- a/subspace/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/archiver.rs
@@ -202,7 +202,6 @@ fn archiver() {
             (
                 position,
                 is_piece_valid(
-                    &erasure_coding,
                     piece,
                     &first_archived_segment.segment_header.segment_commitment(),
                     position as u32,
@@ -320,7 +319,6 @@ fn archiver() {
                 (
                     position,
                     is_piece_valid(
-                        &erasure_coding,
                         piece,
                         &archived_segment.segment_header.segment_commitment(),
                         position as u32,
@@ -354,7 +352,7 @@ fn archiver() {
     // archived segments and mappings once last block is added
     {
         let mut archiver_with_initial_state = Archiver::with_initial_state(
-            erasure_coding.clone(),
+            erasure_coding,
             last_segment_header,
             &block_2,
             BlockObjectMapping::default(),
@@ -393,7 +391,6 @@ fn archiver() {
                 (
                     position,
                     is_piece_valid(
-                        &erasure_coding,
                         piece,
                         &archived_segment.segment_header.segment_commitment(),
                         position as u32,

--- a/subspace/crates/subspace-farmer-components/Cargo.toml
+++ b/subspace/crates/subspace-farmer-components/Cargo.toml
@@ -33,7 +33,7 @@ schnorrkel.workspace = true
 serde = { workspace = true, features = ["derive"] }
 static_assertions.workspace = true
 subspace-archiving = { workspace = true, features = ["std", "parallel"] }
-subspace-core-primitives.workspace = true
+subspace-core-primitives = { workspace = true, features = ["parallel"] }
 subspace-data-retrieval.workspace = true
 subspace-erasure-coding.workspace = true
 subspace-kzg.workspace = true

--- a/subspace/crates/subspace-farmer-components/src/plotting.rs
+++ b/subspace/crates/subspace-farmer-components/src/plotting.rs
@@ -829,6 +829,7 @@ fn process_piece(
             .copy_from_slice(piece.record().as_flattened());
         *metadata = RecordMetadata {
             commitment: *piece.commitment(),
+            parity_chunks_root: *piece.parity_chunks_root(),
             witness: *piece.witness(),
             piece_checksum: blake3_hash(piece.as_ref()),
         };

--- a/subspace/crates/subspace-farmer-components/src/reading.rs
+++ b/subspace/crates/subspace-farmer-components/src/reading.rs
@@ -483,6 +483,7 @@ where
         });
 
     *piece.commitment_mut() = record_metadata.commitment;
+    *piece.parity_chunks_root_mut() = record_metadata.parity_chunks_root;
     *piece.witness_mut() = record_metadata.witness;
 
     // Verify checksum

--- a/subspace/crates/subspace-farmer-components/src/sector.rs
+++ b/subspace/crates/subspace-farmer-components/src/sector.rs
@@ -14,7 +14,9 @@ use std::ops::{Deref, DerefMut};
 use std::{mem, slice};
 use subspace_core_primitives::checksum::Blake3Checksummed;
 use subspace_core_primitives::hashes::{blake3_hash, Blake3Hash};
-use subspace_core_primitives::pieces::{PieceOffset, Record, RecordCommitment, RecordWitness};
+use subspace_core_primitives::pieces::{
+    PieceOffset, Record, RecordChunksRoot, RecordCommitment, RecordWitness,
+};
 use subspace_core_primitives::sectors::{SBucket, SectorIndex};
 use subspace_core_primitives::segments::{HistorySize, SegmentIndex};
 use thiserror::Error;
@@ -139,6 +141,8 @@ impl SectorMetadataChecksummed {
 pub(crate) struct RecordMetadata {
     /// Record commitment
     pub(crate) commitment: RecordCommitment,
+    /// Parity chunks root
+    pub(crate) parity_chunks_root: RecordChunksRoot,
     /// Record witness
     pub(crate) witness: RecordWitness,
     /// Checksum (hash) of the whole piece
@@ -147,7 +151,7 @@ pub(crate) struct RecordMetadata {
 
 impl RecordMetadata {
     pub(crate) const fn encoded_size() -> usize {
-        RecordWitness::SIZE + RecordCommitment::SIZE + Blake3Hash::SIZE
+        RecordWitness::SIZE + RecordCommitment::SIZE + RecordChunksRoot::SIZE + Blake3Hash::SIZE
     }
 }
 

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -15,8 +15,6 @@ use std::path::PathBuf;
 use std::pin::{pin, Pin};
 use std::sync::Arc;
 use std::time::Duration;
-use subspace_core_primitives::pieces::Record;
-use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer::cluster::controller::caches::maintain_caches;
 use subspace_farmer::cluster::controller::controller_service;
 use subspace_farmer::cluster::controller::farms::{maintain_farms, FarmIndex};
@@ -164,18 +162,9 @@ pub(super) async fn controller(
         .map_err(|error| anyhow!("Failed to configure networking: {error}"))?
     };
 
-    let erasure_coding = ErasureCoding::new(
-        NonZeroUsize::new(Record::NUM_S_BUCKETS.next_power_of_two().ilog2() as usize)
-            .expect("Not zero; qed"),
-    )
-    .map_err(|error| anyhow!("Failed to instantiate erasure coding: {error}"))?;
     let piece_provider = PieceProvider::new(
         node.clone(),
-        SegmentCommitmentPieceValidator::new(
-            node.clone(),
-            node_client.clone(),
-            erasure_coding.clone(),
-        ),
+        SegmentCommitmentPieceValidator::new(node.clone(), node_client.clone()),
         Arc::new(Semaphore::new(
             out_connections as usize * PIECE_PROVIDER_MULTIPLIER,
         )),

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -459,11 +459,7 @@ where
     .map_err(|error| anyhow!("Failed to instantiate erasure coding: {error}"))?;
     let piece_provider = PieceProvider::new(
         node.clone(),
-        SegmentCommitmentPieceValidator::new(
-            node.clone(),
-            node_client.clone(),
-            erasure_coding.clone(),
-        ),
+        SegmentCommitmentPieceValidator::new(node.clone(), node_client.clone()),
         Arc::new(Semaphore::new(
             out_connections as usize * PIECE_PROVIDER_MULTIPLIER,
         )),

--- a/subspace/crates/subspace-service/src/lib.rs
+++ b/subspace/crates/subspace-service/src/lib.rs
@@ -505,11 +505,7 @@ where
 
             let piece_provider = PieceProvider::new(
                 node.clone(),
-                SegmentCommitmentPieceValidator::new(
-                    node.clone(),
-                    subspace_link.erasure_coding().clone(),
-                    segment_headers_store.clone(),
-                ),
+                SegmentCommitmentPieceValidator::new(node.clone(), segment_headers_store.clone()),
                 Arc::new(Semaphore::new(
                     out_connections as usize * PIECE_PROVIDER_MULTIPLIER,
                 )),

--- a/subspace/crates/subspace-verification/Cargo.toml
+++ b/subspace/crates/subspace-verification/Cargo.toml
@@ -20,7 +20,6 @@ ab-merkle-tree = { workspace = true }
 parity-scale-codec = { workspace = true, optional = true }
 schnorrkel.workspace = true
 subspace-core-primitives.workspace = true
-subspace-erasure-coding = { workspace = true, optional = true }
 subspace-kzg = { workspace = true, optional = true }
 subspace-proof-of-space.workspace = true
 thiserror.workspace = true
@@ -28,7 +27,6 @@ thiserror.workspace = true
 [features]
 alloc = [
     "ab-merkle-tree/alloc",
-    "dep:subspace-erasure-coding",
     "dep:subspace-kzg",
     "subspace-core-primitives/alloc",
 ]
@@ -40,7 +38,6 @@ scale-codec = [
 std = [
     "parity-scale-codec?/std",
     "schnorrkel/std",
-    "subspace-erasure-coding?/std",
     "subspace-kzg?/std",
     "thiserror/std",
 ]


### PR DESCRIPTION
This changes the way record chunks are committed to and includes parity chunks root in the piece (see spec update).

There is some awkwardness in solution proving/verification due to erasure coding library producing interleaved chunks and record commitment in archiver assuming all source chunks go before parity chunks. This is because erasure coding library will be swapped later with a different and faster alternative, which will not do interleaving anymore (at least I expect it will not).

Not doing interleaving is a huge help with data retrieval too (as learned in Subspace). It is tricky enough to retrieve data as is with parts of it potentially crossing segment boundary. Interleaving data within a segment causes even more complexity with extra helper functions that I'd rather not have.

The library I plan to use for erasure coding is `reed-solomon-simd`, which until https://github.com/AndersTrier/reed-solomon-simd/pull/62 and its future follow-up land will not support `no_std`, which was a problem because prior to this PR `subspace-verification` (used in runtime) temporarily depended on `subspace-erasure-coding` for piece verification with `alloc` feature (but without `std`). Now this temporary issue is gone and I can go ahead with erasure coding library swap even though it is not a perfect fit yet.