### PR TITLE
Replace erasure coding library

### DIFF
--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -11796,7 +11796,6 @@ dependencies = [
  "parity-scale-codec",
  "schnorrkel",
  "subspace-core-primitives",
- "subspace-kzg",
  "subspace-proof-of-space",
  "thiserror 2.0.12",
 ]

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -8087,6 +8087,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
+
+[[package]]
 name = "reconnecting-jsonrpsee-ws-client"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8129,6 +8135,16 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.64",
+]
+
+[[package]]
+name = "reed-solomon-simd"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6badd4f4b9c93832eb3707431e8e7bea282fae96801312f0990d48b030f8c5"
+dependencies = [
+ "fixedbitset",
+ "readme-rustdocifier",
 ]
 
 [[package]]
@@ -11349,7 +11365,6 @@ dependencies = [
  "serde",
  "subspace-core-primitives",
  "subspace-erasure-coding",
- "subspace-kzg",
  "subspace-verification",
  "thiserror 2.0.12",
 ]
@@ -11399,6 +11414,7 @@ version = "0.1.0"
 dependencies = [
  "kzg",
  "rand 0.8.5",
+ "reed-solomon-simd",
  "rust-kzg-blst",
  "subspace-core-primitives",
  "subspace-kzg",
@@ -11490,7 +11506,6 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-data-retrieval",
  "subspace-erasure-coding",
- "subspace-kzg",
  "subspace-proof-of-space",
  "subspace-verification",
  "thiserror 2.0.12",

--- a/subspace/Cargo.toml
+++ b/subspace/Cargo.toml
@@ -79,6 +79,7 @@ rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 rand_core = "0.6.4"
 rayon = "1.10.0"
+reed-solomon-simd = { version = "3.0.1", default-features = false }
 rust-kzg-blst = { git = "https://github.com/grandinetech/rust-kzg", rev = "6c8fcc623df3d7e8c0f30951a49bfea764f90bf4", default-features = false }
 sc-basic-authorship = { git = "https://github.com/subspace/polkadot-sdk", rev = "ad62cc9ef87e5c004b1432bbc4ad7c3ef2980ec6" }
 sc-chain-spec = { git = "https://github.com/subspace/polkadot-sdk", rev = "ad62cc9ef87e5c004b1432bbc4ad7c3ef2980ec6" }
@@ -215,6 +216,7 @@ parking_lot = { opt-level = 3 }
 parking_lot_core = { opt-level = 3 }
 percent-encoding = { opt-level = 3 }
 primitive-types = { opt-level = 3 }
+reed-solomon-simd = { opt-level = 3 }
 ring = { opt-level = 3 }
 rustls = { opt-level = 3 }
 sha2 = { opt-level = 3 }

--- a/subspace/crates/sp-consensus-subspace/Cargo.toml
+++ b/subspace/crates/sp-consensus-subspace/Cargo.toml
@@ -30,7 +30,7 @@ sp-runtime-interface.workspace = true
 sp-std.workspace = true
 sp-timestamp.workspace = true
 subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
-subspace-verification = { workspace = true, features = ["alloc", "scale-codec"] }
+subspace-verification = { workspace = true, features = ["scale-codec"] }
 thiserror.workspace = true
 
 [features]

--- a/subspace/crates/subspace-archiving/Cargo.toml
+++ b/subspace/crates/subspace-archiving/Cargo.toml
@@ -23,7 +23,6 @@ rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
 subspace-erasure-coding.workspace = true
-subspace-kzg.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
@@ -48,7 +47,6 @@ std = [
     "parity-scale-codec/std",
     "serde",
     "subspace-erasure-coding/std",
-    "subspace-kzg/std",
     "thiserror/std",
 ]
 

--- a/subspace/crates/subspace-archiving/src/lib.rs
+++ b/subspace/crates/subspace-archiving/src/lib.rs
@@ -1,6 +1,6 @@
 //! Collection of modules used for dealing with archived state of Subspace Network.
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(array_chunks, iter_collect_into)]
+#![feature(array_chunks, iter_array_chunks, iter_collect_into, new_zeroed_alloc)]
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 // TODO: This feature is not actually used in this crate, but is added as a workaround for
 //  https://github.com/rust-lang/rust/issues/139376

--- a/subspace/crates/subspace-erasure-coding/Cargo.toml
+++ b/subspace/crates/subspace-erasure-coding/Cargo.toml
@@ -12,6 +12,8 @@ include = [
 
 [dependencies]
 kzg.workspace = true
+# TODO: This is not actually `no_std` compatible yet, see https://github.com/AndersTrier/reed-solomon-simd/pull/63
+reed-solomon-simd = { workspace = true }
 rust-kzg-blst.workspace = true
 subspace-core-primitives = { workspace = true, features = ["alloc"] }
 subspace-kzg.workspace = true

--- a/subspace/crates/subspace-erasure-coding/src/lib.rs
+++ b/subspace/crates/subspace-erasure-coding/src/lib.rs
@@ -1,3 +1,9 @@
+#![feature(trusted_len)]
+#![feature(
+    maybe_uninit_slice,
+    maybe_uninit_uninit_array_transpose,
+    maybe_uninit_write_slice
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(test)]
@@ -9,12 +15,27 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::sync::Arc;
 #[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::num::NonZeroUsize;
 use kzg::{FFTSettings, PolyRecover, DAS};
+use reed_solomon_simd::{ReedSolomonDecoder, ReedSolomonEncoder};
 use rust_kzg_blst::types::fft_settings::FsFFTSettings;
 use rust_kzg_blst::types::poly::FsPoly;
+use std::iter::TrustedLen;
+use std::mem::MaybeUninit;
 use subspace_kzg::Scalar;
+
+/// State of the shard for recovery
+pub enum RecoveryShardState<PresentShard, MissingShard> {
+    /// Shard is present and will be used for recovery
+    Present(PresentShard),
+    /// Shard is missing and needs to be recovered
+    MissingRecover(MissingShard),
+    /// Shard is missing and does not need to be recovered
+    MissingIgnore,
+}
 
 /// Erasure coding abstraction.
 ///
@@ -40,10 +61,180 @@ impl ErasureCoding {
         self.fft_settings.max_width
     }
 
+    /// Extend sources using erasure coding
+    pub fn extend<'a, SourceIter, ParityIter, SourceBytes, ParityBytes>(
+        &self,
+        source: SourceIter,
+        parity: ParityIter,
+    ) -> Result<(), String>
+    where
+        SourceIter: TrustedLen<Item = SourceBytes>,
+        ParityIter: TrustedLen<Item = ParityBytes>,
+        SourceBytes: AsRef<[u8]> + 'a,
+        ParityBytes: AsMut<[u8]> + 'a,
+    {
+        let mut source = source.peekable();
+        let shard_byte_len = source
+            .peek()
+            .map(|shard| shard.as_ref().len())
+            .unwrap_or_default();
+        // TODO: Fix error type
+        let mut encoder =
+            ReedSolomonEncoder::new(source.size_hint().0, parity.size_hint().0, shard_byte_len)
+                .map_err(|error| error.to_string())?;
+
+        for shard in source {
+            encoder
+                .add_original_shard(shard)
+                .map_err(|error| error.to_string())?;
+        }
+
+        let result = encoder.encode().map_err(|error| error.to_string())?;
+
+        for (input, mut output) in result.recovery_iter().zip(parity) {
+            let output = output.as_mut();
+            if output.len() != shard_byte_len {
+                return Err("Wrong parity shard byte length; qed".to_string());
+            }
+            output.copy_from_slice(input);
+        }
+
+        Ok(())
+    }
+
+    /// Recover missing shards
+    // TODO: Refactor to use byte slices once shards are no longer interleaved
+    pub fn recover<'a, SourceIter, ParityIter>(
+        &self,
+        source: SourceIter,
+        parity: ParityIter,
+    ) -> Result<(), String>
+    where
+        SourceIter: TrustedLen<Item = RecoveryShardState<&'a [u8], &'a mut [u8]>>,
+        ParityIter: TrustedLen<Item = RecoveryShardState<&'a [u8], &'a mut [u8]>>,
+    {
+        // TODO: Fix error type
+        let num_source = source.size_hint().0;
+        let num_parity = parity.size_hint().0;
+        let mut source = source.enumerate().peekable();
+        let mut parity = parity.enumerate().peekable();
+        let mut shard_byte_len = 0;
+
+        while let Some((_, shard)) = source.peek_mut() {
+            match shard {
+                RecoveryShardState::Present(shard_bytes) => {
+                    shard_byte_len = shard_bytes.len();
+                    break;
+                }
+                RecoveryShardState::MissingRecover(shard_bytes) => {
+                    shard_byte_len = shard_bytes.len();
+                    break;
+                }
+                RecoveryShardState::MissingIgnore => {
+                    // Skip, it is inconsequential here
+                    source.next();
+                }
+            }
+        }
+        if shard_byte_len == 0 {
+            while let Some((_, shard)) = parity.peek_mut() {
+                match shard {
+                    RecoveryShardState::Present(shard_bytes) => {
+                        shard_byte_len = shard_bytes.len();
+                        break;
+                    }
+                    RecoveryShardState::MissingRecover(shard_bytes) => {
+                        shard_byte_len = shard_bytes.len();
+                        break;
+                    }
+                    RecoveryShardState::MissingIgnore => {
+                        // Skip, it is inconsequential here
+                        parity.next();
+                    }
+                }
+            }
+        }
+
+        let mut decoder = ReedSolomonDecoder::new(num_source, num_parity, shard_byte_len)
+            .map_err(|error| error.to_string())?;
+
+        let mut all_source_shards = vec![MaybeUninit::uninit(); num_source];
+        let mut source_shards_to_recover = Vec::new();
+        for (index, shard) in source {
+            match shard {
+                RecoveryShardState::Present(shard_bytes) => {
+                    all_source_shards[index].write(shard_bytes);
+                    decoder
+                        .add_original_shard(index, shard_bytes)
+                        .map_err(|error| error.to_string())?;
+                }
+                RecoveryShardState::MissingRecover(shard_bytes) => {
+                    source_shards_to_recover.push((index, shard_bytes));
+                }
+                RecoveryShardState::MissingIgnore => {}
+            }
+        }
+
+        let mut parity_shards_to_recover = Vec::new();
+        for (index, shard) in parity {
+            match shard {
+                RecoveryShardState::Present(shard_bytes) => {
+                    decoder
+                        .add_recovery_shard(index, shard_bytes)
+                        .map_err(|error| error.to_string())?;
+                }
+                RecoveryShardState::MissingRecover(shard_bytes) => {
+                    parity_shards_to_recover.push((index, shard_bytes));
+                }
+                RecoveryShardState::MissingIgnore => {}
+            }
+        }
+
+        let result = decoder.decode().map_err(|error| error.to_string())?;
+
+        for (index, output) in source_shards_to_recover {
+            if output.len() != shard_byte_len {
+                return Err("Wrong source shard byte length; qed".to_string());
+            }
+            let shard = result
+                .restored_original(index)
+                .expect("Always corresponds to a missing original shard; qed");
+            all_source_shards[index].write(shard);
+            output.copy_from_slice(shard);
+        }
+
+        let all_source_shards = unsafe { all_source_shards.assume_init_ref() };
+        if !parity_shards_to_recover.is_empty() {
+            let mut encoder = ReedSolomonEncoder::new(num_source, num_parity, shard_byte_len)
+                .map_err(|error| error.to_string())?;
+
+            for shard in all_source_shards {
+                encoder
+                    .add_original_shard(shard)
+                    .map_err(|error| error.to_string())?;
+            }
+
+            let result = encoder.encode().map_err(|error| error.to_string())?;
+
+            for (index, output) in parity_shards_to_recover {
+                if output.len() != shard_byte_len {
+                    return Err("Wrong parity shard byte length; qed".to_string());
+                }
+                output.copy_from_slice(
+                    result
+                        .recovery(index)
+                        .expect("Always corresponds to a missing parity shard; qed"),
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     /// Extend sources using erasure coding.
     ///
     /// Returns parity data.
-    pub fn extend(&self, source: &[Scalar]) -> Result<Vec<Scalar>, String> {
+    pub fn extend_legacy(&self, source: &[Scalar]) -> Result<Vec<Scalar>, String> {
         // TODO: das_fft_extension modifies buffer internally, it needs to change to use
         //  pre-allocated buffer instead of allocating a new one
         self.fft_settings
@@ -55,7 +246,7 @@ impl ErasureCoding {
     ///
     /// Both in input and output source shards are interleaved with parity shards:
     /// source, parity, source, parity, ...
-    pub fn recover(&self, shards: &[Option<Scalar>]) -> Result<Vec<Scalar>, String> {
+    pub fn recover_legacy(&self, shards: &[Option<Scalar>]) -> Result<Vec<Scalar>, String> {
         let poly = FsPoly::recover_poly_from_samples(
             Scalar::slice_option_to_repr(shards),
             &self.fft_settings,
@@ -66,12 +257,12 @@ impl ErasureCoding {
 
     /// Recovery of source shards from given shards (at least 1/2 should be `Some`).
     ///
-    /// The same as [`ErasureCoding::recover()`], but returns only source shards in form of an
+    /// The same as [`ErasureCoding::recover_legacy()`], but returns only source shards in form of an
     /// iterator.
-    pub fn recover_source(
+    pub fn recover_source_legacy(
         &self,
         shards: &[Option<Scalar>],
     ) -> Result<impl ExactSizeIterator<Item = Scalar>, String> {
-        Ok(self.recover(shards)?.into_iter().step_by(2))
+        Ok(self.recover_legacy(shards)?.into_iter().step_by(2))
     }
 }

--- a/subspace/crates/subspace-erasure-coding/src/tests.rs
+++ b/subspace/crates/subspace-erasure-coding/src/tests.rs
@@ -45,7 +45,7 @@ fn basic_data() {
         .map(Scalar::from)
         .collect::<Vec<_>>();
 
-    let parity_shards = ec.extend(&source_shards).unwrap();
+    let parity_shards = ec.extend_legacy(&source_shards).unwrap();
 
     assert_ne!(source_shards, parity_shards);
 
@@ -57,7 +57,7 @@ fn basic_data() {
             .collect::<Vec<_>>(),
     );
 
-    let recovered = interleaved_to_concatenated(ec.recover(&partial_shards).unwrap());
+    let recovered = interleaved_to_concatenated(ec.recover_legacy(&partial_shards).unwrap());
 
     assert_eq!(
         recovered,
@@ -77,10 +77,10 @@ fn bad_shards_number() {
 
     let source_shards = vec![Default::default(); num_shards - 1];
 
-    assert!(ec.extend(&source_shards).is_err());
+    assert!(ec.extend_legacy(&source_shards).is_err());
 
     let partial_shards = vec![Default::default(); num_shards - 1];
-    assert!(ec.recover(&partial_shards).is_err());
+    assert!(ec.recover_legacy(&partial_shards).is_err());
 }
 
 #[test]
@@ -98,12 +98,12 @@ fn not_enough_partial() {
         .for_each(|maybe_scalar| {
             maybe_scalar.replace(Scalar::default());
         });
-    assert!(ec.recover(&partial_shards).is_err());
+    assert!(ec.recover_legacy(&partial_shards).is_err());
 
     // Any half is sufficient
     partial_shards
         .last_mut()
         .unwrap()
         .replace(Scalar::default());
-    assert!(ec.recover(&partial_shards).is_ok());
+    assert!(ec.recover_legacy(&partial_shards).is_ok());
 }

--- a/subspace/crates/subspace-farmer-components/Cargo.toml
+++ b/subspace/crates/subspace-farmer-components/Cargo.toml
@@ -36,7 +36,6 @@ subspace-archiving = { workspace = true, features = ["std", "parallel"] }
 subspace-core-primitives = { workspace = true, features = ["parallel"] }
 subspace-data-retrieval.workspace = true
 subspace-erasure-coding.workspace = true
-subspace-kzg.workspace = true
 subspace-proof-of-space = { workspace = true, features = ["parallel"] }
 subspace-verification.workspace = true
 thiserror.workspace = true

--- a/subspace/crates/subspace-farmer-components/src/lib.rs
+++ b/subspace/crates/subspace-farmer-components/src/lib.rs
@@ -7,6 +7,7 @@
     const_trait_impl,
     exact_size_is_empty,
     int_roundings,
+    iter_array_chunks,
     iter_collect_into,
     never_type,
     new_zeroed_alloc,

--- a/subspace/crates/subspace-verification/Cargo.toml
+++ b/subspace/crates/subspace-verification/Cargo.toml
@@ -20,14 +20,12 @@ ab-merkle-tree = { workspace = true }
 parity-scale-codec = { workspace = true, optional = true }
 schnorrkel.workspace = true
 subspace-core-primitives.workspace = true
-subspace-kzg = { workspace = true, optional = true }
 subspace-proof-of-space.workspace = true
 thiserror.workspace = true
 
 [features]
 alloc = [
     "ab-merkle-tree/alloc",
-    "dep:subspace-kzg",
     "subspace-core-primitives/alloc",
 ]
 scale-codec = [
@@ -38,6 +36,5 @@ scale-codec = [
 std = [
     "parity-scale-codec?/std",
     "schnorrkel/std",
-    "subspace-kzg?/std",
     "thiserror/std",
 ]

--- a/subspace/crates/subspace-verification/src/lib.rs
+++ b/subspace/crates/subspace-verification/src/lib.rs
@@ -8,12 +8,7 @@
 #![feature(generic_const_exprs)]
 #![no_std]
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
 use ab_merkle_tree::balanced_hashed::BalancedHashedMerkleTree;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 use core::mem;
 use core::simd::Simd;
 #[cfg(feature = "scale-codec")]
@@ -29,8 +24,6 @@ use subspace_core_primitives::sectors::{SectorId, SectorSlotChallenge};
 use subspace_core_primitives::segments::{HistorySize, RecordedHistorySegment, SegmentCommitment};
 use subspace_core_primitives::solutions::{RewardSignature, Solution, SolutionRange};
 use subspace_core_primitives::{BlockNumber, BlockWeight, PublicKey, ScalarBytes, SlotNumber};
-#[cfg(feature = "alloc")]
-use subspace_kzg::Scalar;
 use subspace_proof_of_space::Table;
 
 /// Errors encountered by the Subspace consensus primitives.
@@ -317,19 +310,6 @@ pub fn is_piece_valid(
     position: u32,
 ) -> bool {
     let (record, &record_commitment, parity_chunks_root, record_witness) = piece.split();
-
-    let mut scalars = Vec::with_capacity(record.len().next_power_of_two());
-
-    for record_chunk in record.iter() {
-        match Scalar::try_from(record_chunk) {
-            Ok(scalar) => {
-                scalars.push(scalar);
-            }
-            _ => {
-                return false;
-            }
-        }
-    }
 
     let source_record_merkle_tree_root =
         BalancedHashedMerkleTree::<{ Record::NUM_CHUNKS.ilog2() }>::new_boxed(record).root();


### PR DESCRIPTION
This replaces KZG-based erasure coding with much faster `reed-solomon-simd`.

The rest of the architecture is still the same: 31-byte raw record chunks, interleaved source and parity chunks/pieces. A lot of TODOs were added to change that.

I have not adjusted tests in `subspace-erasure-coding` yet, but it is being tested indirectly by `subspace-archiving` crate. The reason is that I want to improve API before writing tests, it is currently unnecessarily annoying to use and will get better as interleaving is removed and all chunks are 32 bytes.

Archiving performance improved as well from ~2.13 seconds to 0.5s, with plenty optimizations left to be done.

Block production, of course, still works.