### PR TITLE
Disable cache on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+        # Cache on Windows is so slow, it is faster without it, see many reports like
+        # https://github.com/actions/runner-images/issues/7320
+        if: runner.os != 'Windows'
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -64,6 +67,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+        # Cache on Windows is so slow, it is faster without it, see many reports like
+        # https://github.com/actions/runner-images/issues/7320
+        if: runner.os != 'Windows'
 
       - name: cargo clippy
         run: |
@@ -112,6 +118,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+        # Cache on Windows is so slow, it is faster without it, see many reports like
+        # https://github.com/actions/runner-images/issues/7320
+        if: runner.os != 'Windows'
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # 2.47.0
@@ -167,6 +176,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+        # Cache on Windows is so slow, it is faster without it, see many reports like
+        # https://github.com/actions/runner-images/issues/7320
+        if: runner.os != 'Windows'
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # 2.47.0
@@ -217,6 +229,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+        # Cache on Windows is so slow, it is faster without it, see many reports like
+        # https://github.com/actions/runner-images/issues/7320
+        if: runner.os != 'Windows'
 
       - name: Ensure no panics in annotated code
         env:
@@ -281,6 +296,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+        # Cache on Windows is so slow, it is faster without it, see many reports like
+        # https://github.com/actions/runner-images/issues/7320
+        if: runner.os != 'Windows'
 
       - name: Ensure contracts compile for a custom target
         run: |


### PR DESCRIPTION
Networking on Windows to GitHub's servers is so bad, it is faster not to use cache. That is when it doesn't fail altogether.

Disable caching on Windows to speed things up.