### PR TITLE
Faster Merkle Tree Root creation

### DIFF
--- a/crates/shared/ab-merkle-tree/src/balanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/src/balanced_hashed.rs
@@ -8,18 +8,6 @@ use core::iter::TrustedLen;
 use core::mem;
 use core::mem::MaybeUninit;
 
-/// Number of hashes, including root and excluding already provided leaf hashes
-#[inline(always)]
-pub const fn num_hashes(num_leaves_log_2: u32) -> usize {
-    2_usize.pow(num_leaves_log_2) - 1
-}
-
-/// Number of leaves in a tree
-#[inline(always)]
-pub const fn num_leaves(num_leaves_log_2: u32) -> usize {
-    2_usize.pow(num_leaves_log_2)
-}
-
 /// Merkle Tree variant that has hash-sized leaves and is fully balanced according to configured
 /// generic parameter.
 ///
@@ -29,16 +17,14 @@ pub const fn num_leaves(num_leaves_log_2: u32) -> usize {
 ///
 /// With all parameters of the tree known statically, it results in the most efficient version of
 /// the code being generated for a given set of parameters.
-///
-/// `NUM_LEAVES_LOG_2` is base-2 logarithm of the number of leaves in a tree.
 #[derive(Debug)]
-pub struct BalancedHashedMerkleTree<'a, const NUM_LEAVES_LOG_2: u32>
+pub struct BalancedHashedMerkleTree<'a, const N: usize>
 where
-    [(); num_hashes(NUM_LEAVES_LOG_2)]:,
+    [(); N - 1]:,
 {
     leaf_hashes: &'a [[u8; OUT_LEN]],
     // This tree doesn't include leaves because we know the size
-    tree: [[u8; OUT_LEN]; num_hashes(NUM_LEAVES_LOG_2)],
+    tree: [[u8; OUT_LEN]; N - 1],
 }
 
 // TODO: Replace hashing individual records with blake3 and building tree manually with building the
@@ -46,16 +32,16 @@ where
 //  https://github.com/BLAKE3-team/BLAKE3/issues/470 for details. Two options are:
 //  expand values to 1024 bytes or modify blake3 to use 32-byte chunk size (at which point it'll
 //  unfortunately stop being blake3)
-impl<'a, const NUM_LEAVES_LOG_2: u32> BalancedHashedMerkleTree<'a, NUM_LEAVES_LOG_2>
+impl<'a, const N: usize> BalancedHashedMerkleTree<'a, N>
 where
-    [(); num_hashes(NUM_LEAVES_LOG_2)]:,
+    [(); N - 1]:,
 {
     /// Create a new tree from a fixed set of elements.
     ///
     /// The data structure is statically allocated and might be too large to fit on the stack!
     /// If that is the case, use `new_boxed()` method.
-    pub fn new(leaf_hashes: &'a [[u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)]) -> Self {
-        let mut tree = [MaybeUninit::<[u8; OUT_LEN]>::uninit(); num_hashes(NUM_LEAVES_LOG_2)];
+    pub fn new(leaf_hashes: &'a [[u8; OUT_LEN]; N]) -> Self {
+        let mut tree = [MaybeUninit::<[u8; OUT_LEN]>::uninit(); _];
 
         Self::init_internal(leaf_hashes, &mut tree);
 
@@ -69,7 +55,7 @@ where
     /// Like [`Self::new()`], but used pre-allocated memory for instantiation
     pub fn new_in<'b>(
         instance: &'b mut MaybeUninit<Self>,
-        leaf_hashes: &'a [[u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)],
+        leaf_hashes: &'a [[u8; OUT_LEN]; N],
     ) -> &'b mut Self {
         let instance_ptr = instance.as_mut_ptr();
         // SAFETY: Valid and correctly aligned non-null pointer
@@ -82,7 +68,7 @@ where
             // SAFETY: Allocated and correctly aligned uninitialized data
             unsafe {
                 tree_ptr
-                    .cast::<[MaybeUninit<[u8; OUT_LEN]>; num_hashes(NUM_LEAVES_LOG_2)]>()
+                    .cast::<[MaybeUninit<[u8; OUT_LEN]>; N - 1]>()
                     .as_mut_unchecked()
             }
         };
@@ -96,7 +82,7 @@ where
     /// Like [`Self::new()`], but creates heap-allocated instance, avoiding excessive stack usage
     /// for large trees
     #[cfg(feature = "alloc")]
-    pub fn new_boxed(leaf_hashes: &'a [[u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)]) -> Box<Self> {
+    pub fn new_boxed(leaf_hashes: &'a [[u8; OUT_LEN]; N]) -> Box<Self> {
         let mut instance = Box::<Self>::new_uninit();
 
         Self::new_in(&mut instance, leaf_hashes);
@@ -106,8 +92,8 @@ where
     }
 
     fn init_internal(
-        leaf_hashes: &[[u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)],
-        tree: &mut [MaybeUninit<[u8; OUT_LEN]>; num_hashes(NUM_LEAVES_LOG_2)],
+        leaf_hashes: &[[u8; OUT_LEN]; N],
+        tree: &mut [MaybeUninit<[u8; OUT_LEN]>; N - 1],
     ) {
         let mut tree_hashes = tree.as_mut_slice();
         let mut level_hashes = leaf_hashes.as_slice();
@@ -143,18 +129,16 @@ where
     ///
     /// This is functionally equivalent to creating an instance first and calling [`Self::root()`]
     /// method, but is faster and avoids heap allocation when root is the only thing that is needed.
-    pub fn compute_root_only(
-        leaf_hashes: &[[u8; OUT_LEN]; num_leaves(NUM_LEAVES_LOG_2)],
-    ) -> [u8; OUT_LEN]
+    pub fn compute_root_only(leaf_hashes: &[[u8; OUT_LEN]; N]) -> [u8; OUT_LEN]
     where
-        [(); NUM_LEAVES_LOG_2 as usize + 1]:,
+        [(); N.ilog2() as usize + 1]:,
     {
         if leaf_hashes.len() == 1 {
             return leaf_hashes[0];
         }
 
         // Stack of intermediate nodes per tree level
-        let mut stack = [[0u8; OUT_LEN]; NUM_LEAVES_LOG_2 as usize + 1];
+        let mut stack = [[0u8; OUT_LEN]; N.ilog2() as usize + 1];
         // Bitmask: bit `i = 1` if level `i` is active
         let mut active_levels = 0_u32;
 
@@ -182,7 +166,7 @@ where
             active_levels |= 1 << level;
         }
 
-        stack[NUM_LEAVES_LOG_2 as usize]
+        stack[N.ilog2() as usize]
     }
 
     /// Get the root of Merkle Tree.
@@ -200,14 +184,13 @@ where
     /// Iterator over proofs in the same order as provided leaf hashes
     pub fn all_proofs(
         &self,
-    ) -> impl ExactSizeIterator<Item = [u8; OUT_LEN * NUM_LEAVES_LOG_2 as usize]> + TrustedLen
+    ) -> impl ExactSizeIterator<Item = [u8; OUT_LEN * N.ilog2() as usize]> + TrustedLen
     where
-        [(); OUT_LEN * NUM_LEAVES_LOG_2 as usize]:,
+        [(); OUT_LEN * N.ilog2() as usize]:,
     {
         let iter = self.leaf_hashes.array_chunks().enumerate().flat_map(
             |(pair_index, &[left_hash, right_hash])| {
-                let mut left_proof =
-                    [MaybeUninit::<[u8; OUT_LEN]>::uninit(); NUM_LEAVES_LOG_2 as usize];
+                let mut left_proof = [MaybeUninit::<[u8; OUT_LEN]>::uninit(); N.ilog2() as usize];
                 left_proof[0].write(right_hash);
 
                 let left_proof = {
@@ -215,7 +198,7 @@ where
 
                     let mut tree_hashes = self.tree.as_slice();
                     let mut parent_position = pair_index;
-                    let mut parent_level_size = num_leaves(NUM_LEAVES_LOG_2) / 2;
+                    let mut parent_level_size = N / 2;
 
                     for hash in shared_proof {
                         let parent_other_position = if parent_position % 2 == 0 {
@@ -245,38 +228,35 @@ where
                 // SAFETY: From and to have the same size and alignment
                 let left_proof = unsafe {
                     mem::transmute_copy::<
-                        [[u8; OUT_LEN]; NUM_LEAVES_LOG_2 as usize],
-                        [u8; OUT_LEN * NUM_LEAVES_LOG_2 as usize],
+                        [[u8; OUT_LEN]; N.ilog2() as usize],
+                        [u8; OUT_LEN * N.ilog2() as usize],
                     >(&left_proof)
                 };
                 let right_proof = unsafe {
                     mem::transmute_copy::<
-                        [[u8; OUT_LEN]; NUM_LEAVES_LOG_2 as usize],
-                        [u8; OUT_LEN * NUM_LEAVES_LOG_2 as usize],
+                        [[u8; OUT_LEN]; N.ilog2() as usize],
+                        [u8; OUT_LEN * N.ilog2() as usize],
                     >(&right_proof)
                 };
                 [left_proof, right_proof]
             },
         );
 
-        ProofsIterator {
-            iter,
-            len: num_leaves(NUM_LEAVES_LOG_2),
-        }
+        ProofsIterator { iter, len: N }
     }
 
     /// Verify previously generated proof
     #[inline]
     pub fn verify(
         root: &[u8; OUT_LEN],
-        proof: &[u8; OUT_LEN * NUM_LEAVES_LOG_2 as usize],
+        proof: &[u8; OUT_LEN * N.ilog2() as usize],
         leaf_index: usize,
         leaf_hash: [u8; OUT_LEN],
     ) -> bool
     where
-        [(); OUT_LEN * NUM_LEAVES_LOG_2 as usize]:,
+        [(); OUT_LEN * N.ilog2() as usize]:,
     {
-        if leaf_index >= num_leaves(NUM_LEAVES_LOG_2) {
+        if leaf_index >= N {
             return false;
         }
 

--- a/crates/shared/ab-merkle-tree/src/lib.rs
+++ b/crates/shared/ab-merkle-tree/src/lib.rs
@@ -1,6 +1,7 @@
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![feature(
     array_chunks,
+    generic_arg_infer,
     generic_const_exprs,
     maybe_uninit_slice,
     maybe_uninit_uninit_array_transpose,

--- a/crates/shared/ab-merkle-tree/tests/balanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/tests/balanced_hashed.rs
@@ -39,6 +39,7 @@ fn basic_5() {
 fn test_basic<const NUM_LEAVES_LOG_2: u32>()
 where
     [(); OUT_LEN * NUM_LEAVES_LOG_2 as usize]:,
+    [(); NUM_LEAVES_LOG_2 as usize + 1]:,
     [(); num_leaves(NUM_LEAVES_LOG_2)]:,
     [(); num_hashes(NUM_LEAVES_LOG_2)]:,
 {
@@ -57,6 +58,11 @@ where
     #[cfg(feature = "alloc")]
     assert_eq!(
         BalancedHashedMerkleTree::new_boxed(&leaf_hashes).root(),
+        root
+    );
+
+    assert_eq!(
+        BalancedHashedMerkleTree::compute_root_only(&leaf_hashes),
         root
     );
 

--- a/subspace/crates/pallet-subspace/Cargo.toml
+++ b/subspace/crates/pallet-subspace/Cargo.toml
@@ -58,7 +58,6 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "subspace-runtime-primitives/std",
-    "subspace-verification/std"
 ]
 runtime-benchmarks = [
     "frame-benchmarking",

--- a/subspace/crates/sp-consensus-subspace/Cargo.toml
+++ b/subspace/crates/sp-consensus-subspace/Cargo.toml
@@ -52,7 +52,6 @@ std = [
     "sp-runtime-interface/std",
     "sp-std/std",
     "sp-timestamp/std",
-    "subspace-verification/std",
     "thiserror/std",
 ]
 

--- a/subspace/crates/subspace-archiving/Cargo.toml
+++ b/subspace/crates/subspace-archiving/Cargo.toml
@@ -30,7 +30,7 @@ criterion.workspace = true
 rand_core = { workspace = true }
 rand_chacha = { workspace = true }
 subspace-core-primitives.workspace = true
-subspace-verification = { workspace = true, features = ["alloc"] }
+subspace-verification = { workspace = true }
 
 [features]
 parallel = [

--- a/subspace/crates/subspace-archiving/src/archiver.rs
+++ b/subspace/crates/subspace-archiving/src/archiver.rs
@@ -704,7 +704,6 @@ impl Archiver {
             // could have been a single tree, and it would end up with the same root. Building them
             // separately requires less RAM and allows to capture parity chunks root more easily.
             let iter = source_pieces.map(|piece| {
-                // TODO: Reuse allocations between iterations
                 let [source_chunks_root, parity_chunks_root] = {
                     let mut parity_chunks = Record::new_boxed();
 
@@ -715,21 +714,15 @@ impl Archiver {
                             input; qed",
                         );
 
-                    let source_chunks_root = BalancedHashedMerkleTree::<
-                        { Record::NUM_CHUNKS.ilog2() },
-                    >::compute_root_only(
-                        piece.record()
-                    );
-                    let parity_chunks_root = BalancedHashedMerkleTree::<
-                        { Record::NUM_CHUNKS.ilog2() },
-                    >::compute_root_only(
-                        &parity_chunks
-                    );
+                    let source_chunks_root =
+                        BalancedHashedMerkleTree::compute_root_only(piece.record());
+                    let parity_chunks_root =
+                        BalancedHashedMerkleTree::compute_root_only(&parity_chunks);
 
                     [source_chunks_root, parity_chunks_root]
                 };
 
-                let record_commitment = BalancedHashedMerkleTree::<1>::compute_root_only(&[
+                let record_commitment = BalancedHashedMerkleTree::compute_root_only(&[
                     source_chunks_root,
                     parity_chunks_root,
                 ]);
@@ -746,7 +739,7 @@ impl Archiver {
         };
 
         let segment_merkle_tree =
-            BalancedHashedMerkleTree::<{ ArchivedHistorySegment::NUM_PIECES.ilog2() }>::new_boxed(
+            BalancedHashedMerkleTree::<{ ArchivedHistorySegment::NUM_PIECES }>::new_boxed(
                 record_commitments
                     .as_slice()
                     .try_into()

--- a/subspace/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -1,5 +1,4 @@
 use ab_merkle_tree::balanced_hashed::BalancedHashedMerkleTree;
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -93,48 +92,43 @@ impl PiecesReconstructor {
             let iter = reconstructed_pieces.par_iter_mut().zip_eq(input_pieces);
 
             iter.map(|(piece, maybe_input_piece)| {
-                let (record_commitment, parity_chunks_root) = if let Some(input_piece) =
-                    maybe_input_piece
-                {
-                    (
-                        **input_piece.commitment(),
-                        **input_piece.parity_chunks_root(),
-                    )
-                } else {
-                    // TODO: Reuse allocations between iterations
-                    let [source_chunks_root, parity_chunks_root] = {
-                        let mut record_merkle_tree = Box::<
-                            BalancedHashedMerkleTree<{ Record::NUM_CHUNKS.ilog2() }>,
-                        >::new_uninit();
-
-                        let source_chunks_root = BalancedHashedMerkleTree::new_in(
-                            &mut record_merkle_tree,
-                            piece.record(),
+                let (record_commitment, parity_chunks_root) =
+                    if let Some(input_piece) = maybe_input_piece {
+                        (
+                            **input_piece.commitment(),
+                            **input_piece.parity_chunks_root(),
                         )
+                    } else {
+                        // TODO: Reuse allocations between iterations
+                        let [source_chunks_root, parity_chunks_root] = {
+                            let mut parity_chunks = Record::new_boxed();
+
+                            self.erasure_coding
+                                .extend(piece.record().iter(), parity_chunks.iter_mut())?;
+
+                            let source_chunks_root = BalancedHashedMerkleTree::<
+                                { Record::NUM_CHUNKS.ilog2() },
+                            >::compute_root_only(
+                                piece.record()
+                            );
+
+                            let parity_chunks_root = BalancedHashedMerkleTree::<
+                                { Record::NUM_CHUNKS.ilog2() },
+                            >::compute_root_only(
+                                &parity_chunks
+                            );
+
+                            [source_chunks_root, parity_chunks_root]
+                        };
+
+                        let record_commitment = BalancedHashedMerkleTree::<1>::new(&[
+                            source_chunks_root,
+                            parity_chunks_root,
+                        ])
                         .root();
 
-                        let mut parity_chunks = Record::new_boxed();
-
-                        self.erasure_coding
-                            .extend(piece.record().iter(), parity_chunks.iter_mut())?;
-
-                        let parity_chunks_root = BalancedHashedMerkleTree::new_in(
-                            &mut record_merkle_tree,
-                            &parity_chunks,
-                        )
-                        .root();
-
-                        [source_chunks_root, parity_chunks_root]
+                        (record_commitment, parity_chunks_root)
                     };
-
-                    let record_commitment = BalancedHashedMerkleTree::<1>::new(&[
-                        source_chunks_root,
-                        parity_chunks_root,
-                    ])
-                    .root();
-
-                    (record_commitment, parity_chunks_root)
-                };
 
                 piece.commitment_mut().copy_from_slice(&record_commitment);
                 piece

--- a/subspace/crates/subspace-farmer-components/src/proving.rs
+++ b/subspace/crates/subspace-farmer-components/src/proving.rs
@@ -248,9 +248,9 @@ where
             //  allows the code to compile. Constant 16 is hardcoded here and in `if` branch below
             //  for compilation to succeed
             const _: () = {
-                assert!(Record::NUM_S_BUCKETS.ilog2() == 16);
+                assert!(Record::NUM_S_BUCKETS == 65536);
             };
-            let record_merkle_tree = BalancedHashedMerkleTree::<16>::new_boxed(
+            let record_merkle_tree = BalancedHashedMerkleTree::<65536>::new_boxed(
                 RecordChunk::slice_to_repr(chunks.as_slice())
                     .try_into()
                     .expect("Statically guaranteed to have correct length; qed"),

--- a/subspace/crates/subspace-farmer/Cargo.toml
+++ b/subspace/crates/subspace-farmer/Cargo.toml
@@ -61,7 +61,7 @@ subspace-networking.workspace = true
 subspace-proof-of-space.workspace = true
 subspace-proof-of-space-gpu = { workspace = true, optional = true }
 subspace-rpc-primitives.workspace = true
-subspace-verification = { workspace = true, features = ["alloc"] }
+subspace-verification = { workspace = true }
 substrate-bip39.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/subspace/crates/subspace-verification/Cargo.toml
+++ b/subspace/crates/subspace-verification/Cargo.toml
@@ -24,17 +24,7 @@ subspace-proof-of-space.workspace = true
 thiserror.workspace = true
 
 [features]
-alloc = [
-    "ab-merkle-tree/alloc",
-    "subspace-core-primitives/alloc",
-]
 scale-codec = [
-    "alloc",
     "dep:parity-scale-codec",
     "subspace-core-primitives/scale-codec",
-]
-std = [
-    "parity-scale-codec?/std",
-    "schnorrkel/std",
-    "thiserror/std",
 ]

--- a/subspace/crates/subspace-verification/Cargo.toml
+++ b/subspace/crates/subspace-verification/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "subspace-verification"
 version = "0.1.0"
-authors = ["Vedhavyas Singareddi <ved@subspace.network>"]
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2021"
 license = "0BSD"
 homepage = "https://subspace.network"

--- a/subspace/crates/subspace-verification/src/lib.rs
+++ b/subspace/crates/subspace-verification/src/lib.rs
@@ -16,9 +16,9 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use schnorrkel::context::SigningContext;
 use schnorrkel::SignatureError;
 use subspace_core_primitives::hashes::{blake3_hash_list, blake3_hash_with_key, Blake3Hash};
-#[cfg(feature = "alloc")]
-use subspace_core_primitives::pieces::PieceArray;
-use subspace_core_primitives::pieces::{Record, RecordChunk, RecordCommitment, RecordWitness};
+use subspace_core_primitives::pieces::{
+    PieceArray, Record, RecordChunk, RecordCommitment, RecordWitness,
+};
 use subspace_core_primitives::pot::PotOutput;
 use subspace_core_primitives::sectors::{SectorId, SectorSlotChallenge};
 use subspace_core_primitives::segments::{HistorySize, RecordedHistorySegment, SegmentCommitment};
@@ -292,7 +292,6 @@ where
 }
 
 /// Validate witness embedded within a piece produced by archiver
-#[cfg(feature = "alloc")]
 pub fn is_piece_valid(
     piece: &PieceArray,
     segment_commitment: &SegmentCommitment,
@@ -301,10 +300,11 @@ pub fn is_piece_valid(
     let (record, &record_commitment, parity_chunks_root, record_witness) = piece.split();
 
     let source_record_merkle_tree_root =
-        BalancedHashedMerkleTree::<{ Record::NUM_CHUNKS.ilog2() }>::new_boxed(record).root();
-    let record_merkle_tree_root =
-        BalancedHashedMerkleTree::<1>::new(&[source_record_merkle_tree_root, **parity_chunks_root])
-            .root();
+        BalancedHashedMerkleTree::<{ Record::NUM_CHUNKS.ilog2() }>::compute_root_only(record);
+    let record_merkle_tree_root = BalancedHashedMerkleTree::<1>::compute_root_only(&[
+        source_record_merkle_tree_root,
+        **parity_chunks_root,
+    ]);
 
     if record_merkle_tree_root != *record_commitment {
         return false;

--- a/subspace/crates/subspace-verification/src/lib.rs
+++ b/subspace/crates/subspace-verification/src/lib.rs
@@ -217,10 +217,10 @@ where
     //  the code to compile. Constant 16 is hardcoded here and in `if` branch below for compilation
     //  to succeed
     const _: () = {
-        assert!(Record::NUM_S_BUCKETS.ilog2() == 16);
+        assert!(Record::NUM_S_BUCKETS == 65536);
     };
     // Check that chunk belongs to the record
-    if !BalancedHashedMerkleTree::<16>::verify(
+    if !BalancedHashedMerkleTree::<65536>::verify(
         &solution.record_commitment,
         &solution.chunk_witness,
         usize::from(s_bucket_audit_index),
@@ -299,9 +299,8 @@ pub fn is_piece_valid(
 ) -> bool {
     let (record, &record_commitment, parity_chunks_root, record_witness) = piece.split();
 
-    let source_record_merkle_tree_root =
-        BalancedHashedMerkleTree::<{ Record::NUM_CHUNKS.ilog2() }>::compute_root_only(record);
-    let record_merkle_tree_root = BalancedHashedMerkleTree::<1>::compute_root_only(&[
+    let source_record_merkle_tree_root = BalancedHashedMerkleTree::compute_root_only(record);
+    let record_merkle_tree_root = BalancedHashedMerkleTree::compute_root_only(&[
         source_record_merkle_tree_root,
         **parity_chunks_root,
     ]);
@@ -310,7 +309,7 @@ pub fn is_piece_valid(
         return false;
     }
 
-    BalancedHashedMerkleTree::<{ RecordedHistorySegment::NUM_PIECES.ilog2() }>::verify(
+    BalancedHashedMerkleTree::<{ RecordedHistorySegment::NUM_PIECES }>::verify(
         segment_commitment,
         record_witness,
         position as usize,
@@ -325,7 +324,7 @@ pub fn is_record_commitment_valid(
     record_witness: &RecordWitness,
     position: u32,
 ) -> bool {
-    BalancedHashedMerkleTree::<{ RecordedHistorySegment::NUM_PIECES.ilog2() }>::verify(
+    BalancedHashedMerkleTree::<{ RecordedHistorySegment::NUM_PIECES }>::verify(
         segment_commitment,
         record_witness,
         position as usize,


### PR DESCRIPTION
This makes API more convenient, avoids allocations in many cases and enables full API of `subspace-verification` without the need of a global allocator.

This also improves archiving performance further. While the benchmark is flaky, I saw the time as low as 0.24s and even single core archiving is now twice as fast a multi-core previously at 1.8s.

There are still more optimizations to do, but this is quite decent as is.