### PR TITLE
Comitment related refactoring

### DIFF
--- a/specs/subspace-diff.md
+++ b/specs/subspace-diff.md
@@ -41,7 +41,7 @@ Dynamic issuance is different (not implemented right now, details will be added 
 Since KZG is no longer used and a farmer still does erasure coding during plotting, archiver was modified to also do
 erasure coding of records, so it can commit to erasure coded chunks too. This allows a farmer to generate proofs like
 before even though technically record doesn't contain parity chunks. To aid efficient verification of pieces, source and
-parity chunks are first committed to separately before combining into record commitment, with parity chunks root also
+parity chunks are first committed to separately before combining into record root, with parity chunks root also
 included in the piece alongside record root.
 
 ## Erasure coding
@@ -54,3 +54,7 @@ practice), increasing record size slightly and simplifying a lot of places in th
 
 Both pieces in a segment and chunks in a sector had source/parity interleaving, which for simplicity was removed. Now
 all source pieces/chunks go first, followed by all parity pieces/chunks.
+
+## Terminology
+
+After switching from KZG to Merkle Trees, commitments are renamed to roots.

--- a/specs/subspace-diff.md
+++ b/specs/subspace-diff.md
@@ -57,4 +57,4 @@ all source pieces/chunks go first, followed by all parity pieces/chunks.
 
 ## Terminology
 
-After switching from KZG to Merkle Trees, commitments are renamed to roots.
+After switching from KZG to Merkle Trees, commitments are renamed to roots, witnesses to proofs.

--- a/subspace/crates/pallet-subspace/README.md
+++ b/subspace/crates/pallet-subspace/README.md
@@ -3,14 +3,15 @@ Subspace consensus pallet.
 This pallet is in many ways complementary to `sc-consensus-subspace`.
 
 Pallet maintains crucial state required for Subspace Proof-of-Archival-Storage consensus:
+
 * global randomness
-  * based on c-correlation from <https://arxiv.org/abs/1910.02218>
-  * is used to later derive together with time slot a global challenge
+    * based on c-correlation from <https://arxiv.org/abs/1910.02218>
+    * is used to later derive together with time slot a global challenge
 * solution range, which is a range of valid solution for Proof-of-Archival-Storage puzzle
-  * conceptually similar to work difficulty in Proof-of-Work consensus
-  * is updated every Era
+    * conceptually similar to work difficulty in Proof-of-Work consensus
+    * is updated every Era
 * inherents for:
-  * storing segment headers and maintaining mapping from segment index to corresponding segment commitment such that
-    validity of piece from solution can be checked later
+    * storing segment headers and maintaining mapping from segment index to corresponding segment root such that
+      validity of piece from solution can be checked later
 
 Pallet also provides handy API for finding block author, block reward address, randomness and some others.

--- a/subspace/crates/pallet-subspace/src/benchmarking.rs
+++ b/subspace/crates/pallet-subspace/src/benchmarking.rs
@@ -10,7 +10,7 @@ mod benchmarks {
     use crate::{
         AllowAuthoringByAnyone, Call, Config, EnableRewards, EnableRewardsAt,
         NextSolutionRangeOverride, Pallet, PotSlotIterations, PotSlotIterationsUpdate,
-        PotSlotIterationsValue, RawOrigin as SubspaceOrigin, SegmentCommitment,
+        PotSlotIterationsValue, RawOrigin as SubspaceOrigin, SegmentRoot,
         ShouldAdjustSolutionRange, SolutionRanges,
     };
     #[cfg(not(feature = "std"))]
@@ -40,7 +40,7 @@ mod benchmarks {
         #[extrinsic_call]
         _(RawOrigin::None, segment_headers);
 
-        assert_eq!(SegmentCommitment::<T>::count(), x);
+        assert_eq!(SegmentRoot::<T>::count(), x);
     }
 
     /// Benchmark `enable_solution_range_adjustment` extrinsic with the worst possible conditions,
@@ -106,7 +106,7 @@ mod benchmarks {
     fn create_segment_header(segment_index: SegmentIndex) -> SegmentHeader {
         SegmentHeader::V0 {
             segment_index,
-            segment_commitment: subspace_core_primitives::segments::SegmentCommitment::default(),
+            segment_root: subspace_core_primitives::segments::SegmentRoot::default(),
             prev_segment_header_hash: Blake3Hash::default(),
             last_archived_block: LastArchivedBlock {
                 number: 0,

--- a/subspace/crates/pallet-subspace/src/extensions/benchmarking.rs
+++ b/subspace/crates/pallet-subspace/src/extensions/benchmarking.rs
@@ -2,8 +2,7 @@
 
 use crate::extensions::SubspaceExtension;
 use crate::pallet::{
-    BlockSlots, CurrentBlockAuthorInfo, SegmentCommitment as SubspaceSegmentCommitment,
-    SolutionRanges,
+    BlockSlots, CurrentBlockAuthorInfo, SegmentRoot as SubspaceSegmentRoot, SolutionRanges,
 };
 use crate::{Config, Pallet as Subspace};
 use frame_benchmarking::v2::*;
@@ -17,7 +16,7 @@ use sp_runtime::transaction_validity::TransactionSource;
 use sp_std::collections::btree_map::BTreeMap;
 use subspace_core_primitives::pieces::{PieceOffset, RecordChunk};
 use subspace_core_primitives::sectors::SectorIndex;
-use subspace_core_primitives::segments::{SegmentCommitment, SegmentIndex};
+use subspace_core_primitives::segments::{SegmentIndex, SegmentRoot};
 use subspace_core_primitives::solutions::RewardSignature;
 use subspace_core_primitives::PublicKey;
 

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -103,9 +103,9 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: u64) {
             history_size: HistorySize::from(SegmentIndex::ZERO),
             piece_offset: PieceOffset::default(),
             record_root: Default::default(),
-            record_witness: Default::default(),
+            record_proof: Default::default(),
             chunk,
-            chunk_witness: Default::default(),
+            chunk_proof: Default::default(),
             proof_of_space: Default::default(),
         },
     );

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -15,8 +15,7 @@ use std::sync::Once;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::pieces::{Piece, PieceOffset};
 use subspace_core_primitives::segments::{
-    ArchivedBlockProgress, HistorySize, LastArchivedBlock, SegmentCommitment, SegmentHeader,
-    SegmentIndex,
+    ArchivedBlockProgress, HistorySize, LastArchivedBlock, SegmentHeader, SegmentIndex, SegmentRoot,
 };
 use subspace_core_primitives::solutions::{Solution, SolutionRange};
 use subspace_core_primitives::PublicKey;
@@ -103,7 +102,7 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: u64) {
             sector_index: 0,
             history_size: HistorySize::from(SegmentIndex::ZERO),
             piece_offset: PieceOffset::default(),
-            record_commitment: Default::default(),
+            record_root: Default::default(),
             record_witness: Default::default(),
             chunk,
             chunk_witness: Default::default(),
@@ -163,7 +162,7 @@ pub fn new_test_ext() -> TestExternalities {
 pub fn create_segment_header(segment_index: SegmentIndex) -> SegmentHeader {
     SegmentHeader::V0 {
         segment_index,
-        segment_commitment: SegmentCommitment::default(),
+        segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,

--- a/subspace/crates/pallet-subspace/src/weights.rs
+++ b/subspace/crates/pallet-subspace/src/weights.rs
@@ -42,10 +42,10 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `Subspace::DidProcessSegmentHeaders` (r:1 w:1)
 	/// Proof: `Subspace::DidProcessSegmentHeaders` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Subspace::SegmentCommitment` (r:20 w:20)
-	/// Proof: `Subspace::SegmentCommitment` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Subspace::CounterForSegmentCommitment` (r:1 w:1)
-	/// Proof: `Subspace::CounterForSegmentCommitment` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `Subspace::SegmentRoot` (r:20 w:20)
+	/// Proof: `Subspace::SegmentRoot` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Subspace::CounterForSegmentRoot` (r:1 w:1)
+	/// Proof: `Subspace::CounterForSegmentRoot` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	/// Storage: `System::Digest` (r:1 w:1)
 	/// Proof: `System::Digest` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// The range of component `x` is `[1, 20]`.
@@ -114,10 +114,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	/// Storage: `Subspace::DidProcessSegmentHeaders` (r:1 w:1)
 	/// Proof: `Subspace::DidProcessSegmentHeaders` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Subspace::SegmentCommitment` (r:20 w:20)
-	/// Proof: `Subspace::SegmentCommitment` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Subspace::CounterForSegmentCommitment` (r:1 w:1)
-	/// Proof: `Subspace::CounterForSegmentCommitment` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `Subspace::SegmentRoot` (r:20 w:20)
+	/// Proof: `Subspace::SegmentRoot` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Subspace::CounterForSegmentRoot` (r:1 w:1)
+	/// Proof: `Subspace::CounterForSegmentRoot` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	/// Storage: `System::Digest` (r:1 w:1)
 	/// Proof: `System::Digest` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// The range of component `x` is `[1, 20]`.

--- a/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -395,9 +395,9 @@ where
                                 history_size: solution.history_size,
                                 piece_offset: solution.piece_offset,
                                 record_root: solution.record_root,
-                                record_witness: solution.record_witness,
+                                record_proof: solution.record_proof,
                                 chunk: solution.chunk,
-                                chunk_witness: solution.chunk_witness,
+                                chunk_proof: solution.chunk_proof,
                                 proof_of_space: solution.proof_of_space,
                             };
 

--- a/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -394,7 +394,7 @@ where
                                 sector_index,
                                 history_size: solution.history_size,
                                 piece_offset: solution.piece_offset,
-                                record_commitment: solution.record_commitment,
+                                record_root: solution.record_root,
                                 record_witness: solution.record_witness,
                                 chunk: solution.chunk,
                                 chunk_witness: solution.chunk_witness,

--- a/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -56,7 +56,7 @@ fn segment_headers_store_block_number_queries_work() {
 
     let segment_header0 = SegmentHeader::V0 {
         segment_index: SegmentIndex::ZERO,
-        segment_commitment: Default::default(),
+        segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,
@@ -66,7 +66,7 @@ fn segment_headers_store_block_number_queries_work() {
 
     let segment_header1 = SegmentHeader::V0 {
         segment_index: SegmentIndex::ONE,
-        segment_commitment: Default::default(),
+        segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: 652,
@@ -76,7 +76,7 @@ fn segment_headers_store_block_number_queries_work() {
 
     let segment_header2 = SegmentHeader::V0 {
         segment_index: SegmentIndex::from(2),
-        segment_commitment: Default::default(),
+        segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: 752,
@@ -86,7 +86,7 @@ fn segment_headers_store_block_number_queries_work() {
 
     let segment_header3 = SegmentHeader::V0 {
         segment_index: SegmentIndex::from(3),
-        segment_commitment: Default::default(),
+        segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: 806,
@@ -96,7 +96,7 @@ fn segment_headers_store_block_number_queries_work() {
 
     let segment_header4 = SegmentHeader::V0 {
         segment_index: SegmentIndex::from(4),
-        segment_commitment: Default::default(),
+        segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: 806,

--- a/subspace/crates/sc-consensus-subspace/src/block_import.rs
+++ b/subspace/crates/sc-consensus-subspace/src/block_import.rs
@@ -145,15 +145,15 @@ pub enum Error<Header: HeaderT> {
     /// Segment header not found
     #[error("Segment header for index {0} not found")]
     SegmentHeaderNotFound(SegmentIndex),
-    /// Different segment commitment found
+    /// Different segment root found
     #[error(
-        "Different segment commitment for segment index {0} was found in storage, likely fork \
+        "Different segment root for segment index {0} was found in storage, likely fork \
         below archiving point"
     )]
-    DifferentSegmentCommitment(SegmentIndex),
-    /// Segment commitment not found
-    #[error("Segment commitment for segment index {0} not found")]
-    SegmentCommitmentNotFound(SegmentIndex),
+    DifferentSegmentRoot(SegmentIndex),
+    /// Segment root not found
+    #[error("Segment root for segment index {0} not found")]
+    SegmentRootNotFound(SegmentIndex),
     /// Sector expired
     #[error("Sector expired")]
     SectorExpired {
@@ -450,13 +450,13 @@ where
         );
         let segment_index = piece_index.segment_index();
 
-        let segment_commitment = self
+        let segment_root = self
             .segment_headers_store
             .get_segment_header(segment_index)
-            .map(|segment_header| segment_header.segment_commitment())
-            .ok_or(Error::SegmentCommitmentNotFound(segment_index))?;
+            .map(|segment_header| segment_header.segment_root())
+            .ok_or(Error::SegmentRootNotFound(segment_index))?;
 
-        let sector_expiration_check_segment_commitment = self
+        let sector_expiration_check_segment_root = self
             .segment_headers_store
             .get_segment_header(
                 subspace_digest_items
@@ -467,7 +467,7 @@ where
                     .ok_or(Error::InvalidHistorySize)?
                     .segment_index(),
             )
-            .map(|segment_header| segment_header.segment_commitment());
+            .map(|segment_header| segment_header.segment_root());
 
         // Piece is not checked during initial block verification because it requires access to
         // segment header and runtime, check it now.
@@ -480,12 +480,12 @@ where
                 solution_range: subspace_digest_items.solution_range,
                 piece_check_params: Some(PieceCheckParams {
                     max_pieces_in_sector,
-                    segment_commitment,
+                    segment_root,
                     recent_segments: chain_constants.recent_segments(),
                     recent_history_fraction: chain_constants.recent_history_fraction(),
                     min_sector_lifetime: chain_constants.min_sector_lifetime(),
                     current_history_size: self.client.runtime_api().history_size(parent_hash)?,
-                    sector_expiration_check_segment_commitment,
+                    sector_expiration_check_segment_root,
                 }),
             },
         )
@@ -610,20 +610,20 @@ where
                 .extend(values.iter().map(|(k, v)| (k.to_vec(), Some(v.to_vec()))))
         });
 
-        for (&segment_index, segment_commitment) in &subspace_digest_items.segment_commitments {
-            let found_segment_commitment = self
+        for (&segment_index, segment_root) in &subspace_digest_items.segment_roots {
+            let found_segment_root = self
                 .segment_headers_store
                 .get_segment_header(segment_index)
                 .ok_or_else(|| Error::SegmentHeaderNotFound(segment_index))?
-                .segment_commitment();
+                .segment_root();
 
-            if &found_segment_commitment != segment_commitment {
+            if &found_segment_root != segment_root {
                 warn!(
-                    "Different segment commitment for segment index {} was found in storage, \
+                    "Different segment root for segment index {} was found in storage, \
                     likely fork below archiving point. expected {:?}, found {:?}",
-                    segment_index, segment_commitment, found_segment_commitment
+                    segment_index, segment_root, found_segment_root
                 );
-                return Err(Error::DifferentSegmentCommitment(segment_index));
+                return Err(Error::DifferentSegmentRoot(segment_index));
             }
         }
 

--- a/subspace/crates/sc-consensus-subspace/src/block_import.rs
+++ b/subspace/crates/sc-consensus-subspace/src/block_import.rs
@@ -117,9 +117,9 @@ pub enum Error<Header: HeaderT> {
     /// Invalid audit chunk offset
     #[error("Invalid audit chunk offset")]
     InvalidAuditChunkOffset,
-    /// Invalid chunk witness
-    #[error("Invalid chunk witness")]
-    InvalidChunkWitness,
+    /// Invalid chunk proof
+    #[error("Invalid chunk proof")]
+    InvalidChunkProof,
     /// Piece verification failed
     #[error("Piece verification failed")]
     InvalidPieceOffset {
@@ -227,7 +227,7 @@ where
                 VerificationPrimitiveError::InvalidAuditChunkOffset => {
                     Error::InvalidAuditChunkOffset
                 }
-                VerificationPrimitiveError::InvalidChunkWitness => Error::InvalidChunkWitness,
+                VerificationPrimitiveError::InvalidChunkProof => Error::InvalidChunkProof,
                 VerificationPrimitiveError::SectorExpired {
                     expiration_history_size,
                     current_history_size,

--- a/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -511,18 +511,18 @@ where
                     chain_constants.recent_history_fraction(),
                 )
                 .segment_index();
-            let maybe_segment_commitment = self
+            let maybe_segment_root = self
                 .segment_headers_store
                 .get_segment_header(segment_index)
-                .map(|segment_header| segment_header.segment_commitment());
+                .map(|segment_header| segment_header.segment_root());
 
-            let segment_commitment = match maybe_segment_commitment {
-                Some(segment_commitment) => segment_commitment,
+            let segment_root = match maybe_segment_root {
+                Some(segment_root) => segment_root,
                 None => {
                     warn!(
                         %slot,
                         %segment_index,
-                        "Segment commitment not found",
+                        "Segment root not found",
                     );
                     continue;
                 }
@@ -536,8 +536,8 @@ where
                     continue;
                 }
             };
-            let sector_expiration_check_segment_commitment = runtime_api
-                .segment_commitment(parent_hash, sector_expiration_check_segment_index)
+            let sector_expiration_check_segment_root = runtime_api
+                .segment_root(parent_hash, sector_expiration_check_segment_index)
                 .ok()?;
 
             let solution_verification_result = verify_solution::<PosTable>(
@@ -548,12 +548,12 @@ where
                     solution_range,
                     piece_check_params: Some(PieceCheckParams {
                         max_pieces_in_sector,
-                        segment_commitment,
+                        segment_root,
                         recent_segments: chain_constants.recent_segments(),
                         recent_history_fraction: chain_constants.recent_history_fraction(),
                         min_sector_lifetime: chain_constants.min_sector_lifetime(),
                         current_history_size: history_size,
-                        sector_expiration_check_segment_commitment,
+                        sector_expiration_check_segment_root,
                     }),
                 },
             );
@@ -582,7 +582,7 @@ where
                         }
                     } else if !parent_header.number().is_zero() {
                         // Not sending vote on top of genesis block since segment headers since piece
-                        // verification wouldn't be possible due to missing (for now) segment commitment
+                        // verification wouldn't be possible due to missing (for now) segment root
                         // info!(%slot, "🗳️ Claimed vote at slot");
 
                         // Votes were removed

--- a/subspace/crates/sp-consensus-subspace/src/lib.rs
+++ b/subspace/crates/sp-consensus-subspace/src/lib.rs
@@ -21,9 +21,7 @@ use sp_runtime_interface::pass_by::PassBy;
 use sp_std::num::NonZeroU32;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::pot::{PotCheckpoints, PotOutput, PotSeed};
-use subspace_core_primitives::segments::{
-    HistorySize, SegmentCommitment, SegmentHeader, SegmentIndex,
-};
+use subspace_core_primitives::segments::{HistorySize, SegmentHeader, SegmentIndex, SegmentRoot};
 use subspace_core_primitives::solutions::{Solution, SolutionRange};
 use subspace_core_primitives::{BlockNumber, PublicKey};
 use subspace_verification::VerifySolutionParams;
@@ -149,9 +147,9 @@ enum ConsensusLog {
     /// Solution range for next block/era.
     #[codec(index = 3)]
     NextSolutionRange(SolutionRange),
-    /// Segment commitments.
+    /// Segment roots.
     #[codec(index = 4)]
-    SegmentCommitment((SegmentIndex, SegmentCommitment)),
+    SegmentRoot((SegmentIndex, SegmentRoot)),
     /// Enable Solution range adjustment and Override Solution Range.
     #[codec(index = 5)]
     EnableSolutionRangeAdjustmentAndOverride(Option<SolutionRange>),
@@ -282,7 +280,7 @@ impl From<&Solution> for WrappedSolution {
             sector_index: solution.sector_index,
             history_size: solution.history_size,
             piece_offset: solution.piece_offset,
-            record_commitment: solution.record_commitment,
+            record_root: solution.record_root,
             record_witness: solution.record_witness,
             chunk: solution.chunk,
             chunk_witness: solution.chunk_witness,
@@ -372,8 +370,8 @@ sp_api::decl_runtime_apis! {
         /// How many pieces one sector is supposed to contain (max)
         fn max_pieces_in_sector() -> u16;
 
-        /// Get the segment commitment of records for specified segment index
-        fn segment_commitment(segment_index: SegmentIndex) -> Option<SegmentCommitment>;
+        /// Get the segment root of records for specified segment index
+        fn segment_root(segment_index: SegmentIndex) -> Option<SegmentRoot>;
 
         /// Returns `Vec<SegmentHeader>` if a given extrinsic has them.
         fn extract_segment_headers(ext: &Block::Extrinsic) -> Option<Vec<SegmentHeader >>;

--- a/subspace/crates/sp-consensus-subspace/src/lib.rs
+++ b/subspace/crates/sp-consensus-subspace/src/lib.rs
@@ -281,9 +281,9 @@ impl From<&Solution> for WrappedSolution {
             history_size: solution.history_size,
             piece_offset: solution.piece_offset,
             record_root: solution.record_root,
-            record_witness: solution.record_witness,
+            record_proof: solution.record_proof,
             chunk: solution.chunk,
-            chunk_witness: solution.chunk_witness,
+            chunk_proof: solution.chunk_proof,
             proof_of_space: solution.proof_of_space,
         })
     }

--- a/subspace/crates/subspace-archiving/src/archiver.rs
+++ b/subspace/crates/subspace-archiving/src/archiver.rs
@@ -234,9 +234,8 @@ pub enum ArchiverInstantiationError {
 ///
 /// It takes new confirmed (at `K` depth) blocks and concatenates them into a buffer, buffer is
 /// sliced into segments of [`RecordedHistorySegment::SIZE`] size, segments are sliced into source
-/// records of [`Record::SIZE`], records are erasure coded, committed to, then roots with
-/// witnesses are appended and records become pieces that are returned alongside the corresponding
-/// segment header.
+/// records of [`Record::SIZE`], records are erasure coded, committed to, then roots with proofs are
+/// appended and records become pieces that are returned alongside the corresponding segment header.
 ///
 /// ## Panics
 /// Panics when operating on blocks, whose length doesn't fit into u32 (should never be the case in
@@ -748,12 +747,12 @@ impl Archiver {
 
         let segment_root = SegmentRoot::from(segment_merkle_tree.root());
 
-        // Create witness for every record and write it to corresponding piece.
+        // Create proof for every record and write it to corresponding piece.
         pieces
             .iter_mut()
             .zip(segment_merkle_tree.all_proofs())
-            .for_each(|(piece, record_witness)| {
-                piece.witness_mut().copy_from_slice(&record_witness);
+            .for_each(|(piece, record_proof)| {
+                piece.proof_mut().copy_from_slice(&record_proof);
             });
 
         // Now produce segment header

--- a/subspace/crates/subspace-archiving/src/piece_reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/piece_reconstructor.rs
@@ -140,8 +140,8 @@ impl PiecesReconstructor {
         reconstructed_pieces
             .iter_mut()
             .zip(segment_merkle_tree.all_proofs())
-            .for_each(|(piece, record_witness)| {
-                piece.witness_mut().copy_from_slice(&record_witness);
+            .for_each(|(piece, record_proof)| {
+                piece.proof_mut().copy_from_slice(&record_proof);
             });
 
         Ok(reconstructed_pieces)

--- a/subspace/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/archiver.rs
@@ -12,7 +12,7 @@ use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping, GlobalO
 use subspace_core_primitives::pieces::{Piece, Record};
 use subspace_core_primitives::segments::{
     ArchivedBlockProgress, ArchivedHistorySegment, LastArchivedBlock, RecordedHistorySegment,
-    SegmentCommitment, SegmentHeader, SegmentIndex,
+    SegmentHeader, SegmentIndex, SegmentRoot,
 };
 use subspace_erasure_coding::ErasureCoding;
 use subspace_verification::is_piece_valid;
@@ -183,7 +183,7 @@ fn archiver() {
                 position,
                 is_piece_valid(
                     piece,
-                    &first_archived_segment.segment_header.segment_commitment(),
+                    &first_archived_segment.segment_header.segment_root(),
                     position as u32,
                 ),
             )
@@ -300,7 +300,7 @@ fn archiver() {
                     position,
                     is_piece_valid(
                         piece,
-                        &archived_segment.segment_header.segment_commitment(),
+                        &archived_segment.segment_header.segment_root(),
                         position as u32,
                     ),
                 )
@@ -372,7 +372,7 @@ fn archiver() {
                     position,
                     is_piece_valid(
                         piece,
-                        &archived_segment.segment_header.segment_commitment(),
+                        &archived_segment.segment_header.segment_root(),
                         position as u32,
                     ),
                 )
@@ -392,7 +392,7 @@ fn invalid_usage() {
             erasure_coding.clone(),
             SegmentHeader::V0 {
                 segment_index: SegmentIndex::ZERO,
-                segment_commitment: SegmentCommitment::default(),
+                segment_root: SegmentRoot::default(),
                 prev_segment_header_hash: Blake3Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -418,7 +418,7 @@ fn invalid_usage() {
             erasure_coding.clone(),
             SegmentHeader::V0 {
                 segment_index: SegmentIndex::ZERO,
-                segment_commitment: SegmentCommitment::default(),
+                segment_root: SegmentRoot::default(),
                 prev_segment_header_hash: Blake3Hash::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -561,7 +561,7 @@ fn object_on_the_edge_of_segment() {
             // Segment header segment item
             - SegmentItem::ParentSegmentHeader(SegmentHeader::V0 {
                 segment_index: SegmentIndex::ZERO,
-                segment_commitment: Default::default(),
+                segment_root: Default::default(),
                 prev_segment_header_hash: Default::default(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,

--- a/subspace/crates/subspace-core-primitives/src/pieces.rs
+++ b/subspace/crates/subspace-core-primitives/src/pieces.rs
@@ -767,16 +767,15 @@ impl RecordChunksRoot {
     pub const SIZE: usize = 32;
 }
 
-// TODO: Change root/witness terminology to root/proof
-/// Record witness contained within a piece.
+/// Record proof contained within a piece.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
 #[cfg_attr(
     feature = "scale-codec",
     derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
-pub struct RecordWitness([u8; RecordWitness::SIZE]);
+pub struct RecordProof([u8; RecordProof::SIZE]);
 
-impl fmt::Debug for RecordWitness {
+impl fmt::Debug for RecordProof {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.0 {
             write!(f, "{byte:02x}")?;
@@ -788,51 +787,51 @@ impl fmt::Debug for RecordWitness {
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct RecordWitnessBinary(#[serde(with = "BigArray")] [u8; RecordWitness::SIZE]);
+struct RecordProofBinary(#[serde(with = "BigArray")] [u8; RecordProof::SIZE]);
 
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct RecordWitnessHex(#[serde(with = "hex")] [u8; RecordWitness::SIZE]);
+struct RecordProofHex(#[serde(with = "hex")] [u8; RecordProof::SIZE]);
 
 #[cfg(feature = "serde")]
-impl Serialize for RecordWitness {
+impl Serialize for RecordProof {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            RecordWitnessHex(self.0).serialize(serializer)
+            RecordProofHex(self.0).serialize(serializer)
         } else {
-            RecordWitnessBinary(self.0).serialize(serializer)
+            RecordProofBinary(self.0).serialize(serializer)
         }
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for RecordWitness {
+impl<'de> Deserialize<'de> for RecordProof {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(Self(if deserializer.is_human_readable() {
-            RecordWitnessHex::deserialize(deserializer)?.0
+            RecordProofHex::deserialize(deserializer)?.0
         } else {
-            RecordWitnessBinary::deserialize(deserializer)?.0
+            RecordProofBinary::deserialize(deserializer)?.0
         }))
     }
 }
 
-impl Default for RecordWitness {
+impl Default for RecordProof {
     #[inline]
     fn default() -> Self {
         Self([0; Self::SIZE])
     }
 }
 
-impl TryFrom<&[u8]> for RecordWitness {
+impl TryFrom<&[u8]> for RecordProof {
     type Error = TryFromSliceError;
 
     #[inline]
@@ -841,58 +840,58 @@ impl TryFrom<&[u8]> for RecordWitness {
     }
 }
 
-impl AsRef<[u8]> for RecordWitness {
+impl AsRef<[u8]> for RecordProof {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl AsMut<[u8]> for RecordWitness {
+impl AsMut<[u8]> for RecordProof {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
 }
 
-impl From<&RecordWitness> for &[u8; RecordWitness::SIZE] {
+impl From<&RecordProof> for &[u8; RecordProof::SIZE] {
     #[inline]
-    fn from(value: &RecordWitness) -> Self {
-        // SAFETY: `RecordWitness` is `#[repr(transparent)]` and guaranteed to have the same
+    fn from(value: &RecordProof) -> Self {
+        // SAFETY: `RecordProof` is `#[repr(transparent)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl From<&[u8; RecordWitness::SIZE]> for &RecordWitness {
+impl From<&[u8; RecordProof::SIZE]> for &RecordProof {
     #[inline]
-    fn from(value: &[u8; RecordWitness::SIZE]) -> Self {
-        // SAFETY: `RecordWitness` is `#[repr(transparent)]` and guaranteed to have the same
+    fn from(value: &[u8; RecordProof::SIZE]) -> Self {
+        // SAFETY: `RecordProof` is `#[repr(transparent)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl From<&mut RecordWitness> for &mut [u8; RecordWitness::SIZE] {
+impl From<&mut RecordProof> for &mut [u8; RecordProof::SIZE] {
     #[inline]
-    fn from(value: &mut RecordWitness) -> Self {
-        // SAFETY: `RecordWitness` is `#[repr(transparent)]` and guaranteed to have the same
+    fn from(value: &mut RecordProof) -> Self {
+        // SAFETY: `RecordProof` is `#[repr(transparent)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl From<&mut [u8; RecordWitness::SIZE]> for &mut RecordWitness {
+impl From<&mut [u8; RecordProof::SIZE]> for &mut RecordProof {
     #[inline]
-    fn from(value: &mut [u8; RecordWitness::SIZE]) -> Self {
-        // SAFETY: `RecordWitness` is `#[repr(transparent)]` and guaranteed to have the same
+    fn from(value: &mut [u8; RecordProof::SIZE]) -> Self {
+        // SAFETY: `RecordProof` is `#[repr(transparent)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl RecordWitness {
-    /// Size of record witness in bytes.
+impl RecordProof {
+    /// Size of record proof in bytes.
     pub const SIZE: usize = OUT_LEN * Self::NUM_HASHES;
     const NUM_HASHES: usize = RecordedHistorySegment::NUM_PIECES.ilog2() as usize;
 }
@@ -902,7 +901,7 @@ impl RecordWitness {
 /// This version is allocated on the stack, for heap-allocated piece see [`Piece`].
 ///
 /// Internally a piece contains a record, followed by record root, supplementary record chunk
-/// root and a witness proving this piece belongs to can be used to verify that a piece belongs to
+/// root and a proof proving this piece belongs to can be used to verify that a piece belongs to
 /// the actual archival history of the blockchain.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, DerefMut, AsRef, AsMut)]
 #[repr(transparent)]
@@ -977,7 +976,7 @@ impl From<&mut [u8; PieceArray::SIZE]> for &mut PieceArray {
 impl PieceArray {
     /// Size of a piece (in bytes).
     pub const SIZE: usize =
-        Record::SIZE + RecordRoot::SIZE + RecordChunksRoot::SIZE + RecordWitness::SIZE;
+        Record::SIZE + RecordRoot::SIZE + RecordChunksRoot::SIZE + RecordProof::SIZE;
 
     /// Create boxed value without hitting stack overflow
     #[inline]
@@ -990,10 +989,10 @@ impl PieceArray {
 
     /// Split piece into underlying components.
     #[inline]
-    pub fn split(&self) -> (&Record, &RecordRoot, &RecordChunksRoot, &RecordWitness) {
+    pub fn split(&self) -> (&Record, &RecordRoot, &RecordChunksRoot, &RecordProof) {
         let (record, extra) = self.0.split_at(Record::SIZE);
         let (root, extra) = extra.split_at(RecordRoot::SIZE);
-        let (parity_chunks_root, witness) = extra.split_at(RecordChunksRoot::SIZE);
+        let (parity_chunks_root, proof) = extra.split_at(RecordChunksRoot::SIZE);
 
         let record = <&[u8; Record::SIZE]>::try_from(record)
             .expect("Slice of memory has correct length; qed");
@@ -1001,14 +1000,14 @@ impl PieceArray {
             .expect("Slice of memory has correct length; qed");
         let parity_chunks_root = <&[u8; RecordChunksRoot::SIZE]>::try_from(parity_chunks_root)
             .expect("Slice of memory has correct length; qed");
-        let witness = <&[u8; RecordWitness::SIZE]>::try_from(witness)
+        let proof = <&[u8; RecordProof::SIZE]>::try_from(proof)
             .expect("Slice of memory has correct length; qed");
 
         (
             record.into(),
             root.into(),
             parity_chunks_root.into(),
-            witness.into(),
+            proof.into(),
         )
     }
 
@@ -1020,11 +1019,11 @@ impl PieceArray {
         &mut Record,
         &mut RecordRoot,
         &mut RecordChunksRoot,
-        &mut RecordWitness,
+        &mut RecordProof,
     ) {
         let (record, extra) = self.0.split_at_mut(Record::SIZE);
         let (root, extra) = extra.split_at_mut(RecordRoot::SIZE);
-        let (parity_chunks_root, witness) = extra.split_at_mut(RecordChunksRoot::SIZE);
+        let (parity_chunks_root, proof) = extra.split_at_mut(RecordChunksRoot::SIZE);
 
         let record = <&mut [u8; Record::SIZE]>::try_from(record)
             .expect("Slice of memory has correct length; qed");
@@ -1032,14 +1031,14 @@ impl PieceArray {
             .expect("Slice of memory has correct length; qed");
         let parity_chunks_root = <&mut [u8; RecordChunksRoot::SIZE]>::try_from(parity_chunks_root)
             .expect("Slice of memory has correct length; qed");
-        let witness = <&mut [u8; RecordWitness::SIZE]>::try_from(witness)
+        let proof = <&mut [u8; RecordProof::SIZE]>::try_from(proof)
             .expect("Slice of memory has correct length; qed");
 
         (
             record.into(),
             root.into(),
             parity_chunks_root.into(),
-            witness.into(),
+            proof.into(),
         )
     }
 
@@ -1079,15 +1078,15 @@ impl PieceArray {
         self.split_mut().2
     }
 
-    /// Witness contained within a piece.
+    /// Proof contained within a piece.
     #[inline]
-    pub fn witness(&self) -> &RecordWitness {
+    pub fn proof(&self) -> &RecordProof {
         self.split().3
     }
 
-    /// Mutable witness contained within a piece.
+    /// Mutable proof contained within a piece.
     #[inline]
-    pub fn witness_mut(&mut self) -> &mut RecordWitness {
+    pub fn proof_mut(&mut self) -> &mut RecordProof {
         self.split_mut().3
     }
 

--- a/subspace/crates/subspace-core-primitives/src/pieces.rs
+++ b/subspace/crates/subspace-core-primitives/src/pieces.rs
@@ -511,15 +511,15 @@ impl Record {
     }
 }
 
-/// Record commitment contained within a piece.
+/// Record root contained within a piece.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
 #[cfg_attr(
     feature = "scale-codec",
     derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
-pub struct RecordCommitment([u8; RecordCommitment::SIZE]);
+pub struct RecordRoot([u8; RecordRoot::SIZE]);
 
-impl fmt::Debug for RecordCommitment {
+impl fmt::Debug for RecordRoot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.0 {
             write!(f, "{byte:02x}")?;
@@ -531,51 +531,51 @@ impl fmt::Debug for RecordCommitment {
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct RecordCommitmentBinary(#[serde(with = "BigArray")] [u8; RecordCommitment::SIZE]);
+struct RecordRootBinary(#[serde(with = "BigArray")] [u8; RecordRoot::SIZE]);
 
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct RecordCommitmentHex(#[serde(with = "hex")] [u8; RecordCommitment::SIZE]);
+struct RecordRootHex(#[serde(with = "hex")] [u8; RecordRoot::SIZE]);
 
 #[cfg(feature = "serde")]
-impl Serialize for RecordCommitment {
+impl Serialize for RecordRoot {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            RecordCommitmentHex(self.0).serialize(serializer)
+            RecordRootHex(self.0).serialize(serializer)
         } else {
-            RecordCommitmentBinary(self.0).serialize(serializer)
+            RecordRootBinary(self.0).serialize(serializer)
         }
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for RecordCommitment {
+impl<'de> Deserialize<'de> for RecordRoot {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(Self(if deserializer.is_human_readable() {
-            RecordCommitmentHex::deserialize(deserializer)?.0
+            RecordRootHex::deserialize(deserializer)?.0
         } else {
-            RecordCommitmentBinary::deserialize(deserializer)?.0
+            RecordRootBinary::deserialize(deserializer)?.0
         }))
     }
 }
 
-impl Default for RecordCommitment {
+impl Default for RecordRoot {
     #[inline]
     fn default() -> Self {
         Self([0; Self::SIZE])
     }
 }
 
-impl TryFrom<&[u8]> for RecordCommitment {
+impl TryFrom<&[u8]> for RecordRoot {
     type Error = TryFromSliceError;
 
     #[inline]
@@ -584,58 +584,58 @@ impl TryFrom<&[u8]> for RecordCommitment {
     }
 }
 
-impl AsRef<[u8]> for RecordCommitment {
+impl AsRef<[u8]> for RecordRoot {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl AsMut<[u8]> for RecordCommitment {
+impl AsMut<[u8]> for RecordRoot {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
 }
 
-impl From<&RecordCommitment> for &[u8; RecordCommitment::SIZE] {
+impl From<&RecordRoot> for &[u8; RecordRoot::SIZE] {
     #[inline]
-    fn from(value: &RecordCommitment) -> Self {
-        // SAFETY: `RecordCommitment` is `#[repr(transparent)]` and guaranteed to have the same
+    fn from(value: &RecordRoot) -> Self {
+        // SAFETY: `RecordRoot` is `#[repr(transparent)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl From<&[u8; RecordCommitment::SIZE]> for &RecordCommitment {
+impl From<&[u8; RecordRoot::SIZE]> for &RecordRoot {
     #[inline]
-    fn from(value: &[u8; RecordCommitment::SIZE]) -> Self {
-        // SAFETY: `RecordCommitment` is `#[repr(transparent)]` and guaranteed to have the same
+    fn from(value: &[u8; RecordRoot::SIZE]) -> Self {
+        // SAFETY: `RecordRoot` is `#[repr(transparent)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl From<&mut RecordCommitment> for &mut [u8; RecordCommitment::SIZE] {
+impl From<&mut RecordRoot> for &mut [u8; RecordRoot::SIZE] {
     #[inline]
-    fn from(value: &mut RecordCommitment) -> Self {
-        // SAFETY: `RecordCommitment` is `#[repr(transparent)]` and guaranteed to have the same
+    fn from(value: &mut RecordRoot) -> Self {
+        // SAFETY: `RecordRoot` is `#[repr(transparent)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl From<&mut [u8; RecordCommitment::SIZE]> for &mut RecordCommitment {
+impl From<&mut [u8; RecordRoot::SIZE]> for &mut RecordRoot {
     #[inline]
-    fn from(value: &mut [u8; RecordCommitment::SIZE]) -> Self {
-        // SAFETY: `RecordCommitment` is `#[repr(transparent)]` and guaranteed to have the same
+    fn from(value: &mut [u8; RecordRoot::SIZE]) -> Self {
+        // SAFETY: `RecordRoot` is `#[repr(transparent)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
-impl RecordCommitment {
-    /// Size of record commitment in bytes.
+impl RecordRoot {
+    /// Size of record root in bytes.
     pub const SIZE: usize = 32;
 }
 
@@ -767,7 +767,7 @@ impl RecordChunksRoot {
     pub const SIZE: usize = 32;
 }
 
-// TODO: Change commitment/witness terminology to root/proof
+// TODO: Change root/witness terminology to root/proof
 /// Record witness contained within a piece.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
 #[cfg_attr(
@@ -901,7 +901,7 @@ impl RecordWitness {
 ///
 /// This version is allocated on the stack, for heap-allocated piece see [`Piece`].
 ///
-/// Internally a piece contains a record, followed by record commitment, supplementary record chunk
+/// Internally a piece contains a record, followed by record root, supplementary record chunk
 /// root and a witness proving this piece belongs to can be used to verify that a piece belongs to
 /// the actual archival history of the blockchain.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, DerefMut, AsRef, AsMut)]
@@ -977,7 +977,7 @@ impl From<&mut [u8; PieceArray::SIZE]> for &mut PieceArray {
 impl PieceArray {
     /// Size of a piece (in bytes).
     pub const SIZE: usize =
-        Record::SIZE + RecordCommitment::SIZE + RecordChunksRoot::SIZE + RecordWitness::SIZE;
+        Record::SIZE + RecordRoot::SIZE + RecordChunksRoot::SIZE + RecordWitness::SIZE;
 
     /// Create boxed value without hitting stack overflow
     #[inline]
@@ -990,21 +990,14 @@ impl PieceArray {
 
     /// Split piece into underlying components.
     #[inline]
-    pub fn split(
-        &self,
-    ) -> (
-        &Record,
-        &RecordCommitment,
-        &RecordChunksRoot,
-        &RecordWitness,
-    ) {
+    pub fn split(&self) -> (&Record, &RecordRoot, &RecordChunksRoot, &RecordWitness) {
         let (record, extra) = self.0.split_at(Record::SIZE);
-        let (commitment, extra) = extra.split_at(RecordCommitment::SIZE);
+        let (root, extra) = extra.split_at(RecordRoot::SIZE);
         let (parity_chunks_root, witness) = extra.split_at(RecordChunksRoot::SIZE);
 
         let record = <&[u8; Record::SIZE]>::try_from(record)
             .expect("Slice of memory has correct length; qed");
-        let commitment = <&[u8; RecordCommitment::SIZE]>::try_from(commitment)
+        let root = <&[u8; RecordRoot::SIZE]>::try_from(root)
             .expect("Slice of memory has correct length; qed");
         let parity_chunks_root = <&[u8; RecordChunksRoot::SIZE]>::try_from(parity_chunks_root)
             .expect("Slice of memory has correct length; qed");
@@ -1013,7 +1006,7 @@ impl PieceArray {
 
         (
             record.into(),
-            commitment.into(),
+            root.into(),
             parity_chunks_root.into(),
             witness.into(),
         )
@@ -1025,17 +1018,17 @@ impl PieceArray {
         &mut self,
     ) -> (
         &mut Record,
-        &mut RecordCommitment,
+        &mut RecordRoot,
         &mut RecordChunksRoot,
         &mut RecordWitness,
     ) {
         let (record, extra) = self.0.split_at_mut(Record::SIZE);
-        let (commitment, extra) = extra.split_at_mut(RecordCommitment::SIZE);
+        let (root, extra) = extra.split_at_mut(RecordRoot::SIZE);
         let (parity_chunks_root, witness) = extra.split_at_mut(RecordChunksRoot::SIZE);
 
         let record = <&mut [u8; Record::SIZE]>::try_from(record)
             .expect("Slice of memory has correct length; qed");
-        let commitment = <&mut [u8; RecordCommitment::SIZE]>::try_from(commitment)
+        let root = <&mut [u8; RecordRoot::SIZE]>::try_from(root)
             .expect("Slice of memory has correct length; qed");
         let parity_chunks_root = <&mut [u8; RecordChunksRoot::SIZE]>::try_from(parity_chunks_root)
             .expect("Slice of memory has correct length; qed");
@@ -1044,7 +1037,7 @@ impl PieceArray {
 
         (
             record.into(),
-            commitment.into(),
+            root.into(),
             parity_chunks_root.into(),
             witness.into(),
         )
@@ -1062,15 +1055,15 @@ impl PieceArray {
         self.split_mut().0
     }
 
-    /// Commitment contained within a piece.
+    /// Root contained within a piece.
     #[inline]
-    pub fn commitment(&self) -> &RecordCommitment {
+    pub fn root(&self) -> &RecordRoot {
         self.split().1
     }
 
-    /// Mutable commitment contained within a piece.
+    /// Mutable root contained within a piece.
     #[inline]
-    pub fn commitment_mut(&mut self) -> &mut RecordCommitment {
+    pub fn root_mut(&mut self) -> &mut RecordRoot {
         self.split_mut().1
     }
 

--- a/subspace/crates/subspace-core-primitives/src/pieces/piece.rs
+++ b/subspace/crates/subspace-core-primitives/src/pieces/piece.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// This version is allocated on the heap, for stack-allocated piece see [`PieceArray`].
 ///
 /// Internally piece contains a record and corresponding witness that together with segment
-/// commitment of the segment this piece belongs to can be used to verify that a piece belongs to
+/// root of the segment this piece belongs to can be used to verify that a piece belongs to
 /// the actual archival history of the blockchain.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Piece(pub(super) CowBytes);

--- a/subspace/crates/subspace-core-primitives/src/pieces/piece.rs
+++ b/subspace/crates/subspace-core-primitives/src/pieces/piece.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///
 /// This version is allocated on the heap, for stack-allocated piece see [`PieceArray`].
 ///
-/// Internally piece contains a record and corresponding witness that together with segment
+/// Internally piece contains a record and corresponding proof that together with segment
 /// root of the segment this piece belongs to can be used to verify that a piece belongs to
 /// the actual archival history of the blockchain.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/subspace/crates/subspace-core-primitives/src/sectors.rs
+++ b/subspace/crates/subspace-core-primitives/src/sectors.rs
@@ -8,7 +8,7 @@ use crate::hashes::{
 };
 use crate::pieces::{PieceIndex, PieceOffset, Record};
 use crate::pos::PosSeed;
-use crate::segments::{HistorySize, SegmentCommitment};
+use crate::segments::{HistorySize, SegmentRoot};
 use crate::U256;
 use core::hash::Hash;
 use core::iter::Step;
@@ -141,7 +141,7 @@ impl SectorId {
     pub fn derive_expiration_history_size(
         &self,
         history_size: HistorySize,
-        sector_expiration_check_segment_commitment: &SegmentCommitment,
+        sector_expiration_check_segment_root: &SegmentRoot,
         min_sector_lifetime: HistorySize,
     ) -> Option<HistorySize> {
         let sector_expiration_check_history_size =
@@ -149,7 +149,7 @@ impl SectorId {
 
         let input_hash = U256::from_le_bytes(*blake3_hash_list(&[
             self.as_ref(),
-            sector_expiration_check_segment_commitment.as_ref(),
+            sector_expiration_check_segment_root.as_ref(),
         ]));
 
         let last_possible_expiration =

--- a/subspace/crates/subspace-core-primitives/src/segments.rs
+++ b/subspace/crates/subspace-core-primitives/src/segments.rs
@@ -448,7 +448,7 @@ impl RecordedHistorySegment {
     /// Size of recorded history segment in bytes.
     ///
     /// It includes half of the records (just source records) that will later be erasure coded and
-    /// together with corresponding roots and witnesses will result in
+    /// together with corresponding roots and proofs will result in
     /// [`Self::NUM_PIECES`] [`Piece`]s of archival history.
     pub const SIZE: usize = Record::SIZE * Self::NUM_RAW_RECORDS;
 

--- a/subspace/crates/subspace-core-primitives/src/segments/archival_history_segment.rs
+++ b/subspace/crates/subspace-core-primitives/src/segments/archival_history_segment.rs
@@ -20,7 +20,7 @@ impl ArchivedHistorySegment {
     /// Size of archived history segment in bytes.
     ///
     /// It includes erasure coded [`crate::pieces::PieceArray`]s (both source and parity) that are
-    /// composed of [`crate::pieces::Record`]s together with corresponding commitments and
+    /// composed of [`crate::pieces::Record`]s together with corresponding roots and
     /// witnesses.
     pub const SIZE: usize = Piece::SIZE * Self::NUM_PIECES;
 

--- a/subspace/crates/subspace-core-primitives/src/segments/archival_history_segment.rs
+++ b/subspace/crates/subspace-core-primitives/src/segments/archival_history_segment.rs
@@ -21,7 +21,7 @@ impl ArchivedHistorySegment {
     ///
     /// It includes erasure coded [`crate::pieces::PieceArray`]s (both source and parity) that are
     /// composed of [`crate::pieces::Record`]s together with corresponding roots and
-    /// witnesses.
+    /// proofs.
     pub const SIZE: usize = Piece::SIZE * Self::NUM_PIECES;
 
     /// Ensure archived history segment contains cheaply cloneable shared data.

--- a/subspace/crates/subspace-core-primitives/src/solutions.rs
+++ b/subspace/crates/subspace-core-primitives/src/solutions.rs
@@ -1,6 +1,6 @@
 //! Solutions-related data structures and functions.
 
-use crate::pieces::{PieceOffset, Record, RecordChunk, RecordCommitment, RecordWitness};
+use crate::pieces::{PieceOffset, Record, RecordChunk, RecordRoot, RecordWitness};
 use crate::pos::PosProof;
 use crate::sectors::SectorIndex;
 use crate::segments::{HistorySize, SegmentIndex};
@@ -240,9 +240,9 @@ pub struct Solution {
     pub history_size: HistorySize,
     /// Pieces offset within sector
     pub piece_offset: PieceOffset,
-    /// Record commitment that can use used to verify that piece was included in blockchain history
-    pub record_commitment: RecordCommitment,
-    /// Witness for above record commitment
+    /// Record root that can use used to verify that piece was included in blockchain history
+    pub record_root: RecordRoot,
+    /// Witness for above record root
     pub record_witness: RecordWitness,
     /// Chunk at above offset
     pub chunk: RecordChunk,
@@ -260,7 +260,7 @@ impl Solution {
             sector_index: 0,
             history_size: HistorySize::from(SegmentIndex::ZERO),
             piece_offset: PieceOffset::default(),
-            record_commitment: RecordCommitment::default(),
+            record_root: RecordRoot::default(),
             record_witness: RecordWitness::default(),
             chunk: RecordChunk::default(),
             chunk_witness: ChunkWitness::default(),

--- a/subspace/crates/subspace-core-primitives/src/solutions.rs
+++ b/subspace/crates/subspace-core-primitives/src/solutions.rs
@@ -1,6 +1,6 @@
 //! Solutions-related data structures and functions.
 
-use crate::pieces::{PieceOffset, Record, RecordChunk, RecordRoot, RecordWitness};
+use crate::pieces::{PieceOffset, Record, RecordChunk, RecordProof, RecordRoot};
 use crate::pos::PosProof;
 use crate::sectors::SectorIndex;
 use crate::segments::{HistorySize, SegmentIndex};
@@ -132,16 +132,16 @@ impl RewardSignature {
     pub const SIZE: usize = 64;
 }
 
-/// Witness for chunk contained within a record.
+/// Proof for chunk contained within a record.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
 #[cfg_attr(
     feature = "scale-codec",
     derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 #[repr(transparent)]
-pub struct ChunkWitness([u8; ChunkWitness::SIZE]);
+pub struct ChunkProof([u8; ChunkProof::SIZE]);
 
-impl fmt::Debug for ChunkWitness {
+impl fmt::Debug for ChunkProof {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.0 {
             write!(f, "{byte:02x}")?;
@@ -153,51 +153,51 @@ impl fmt::Debug for ChunkWitness {
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct ChunkWitnessBinary(#[serde(with = "BigArray")] [u8; ChunkWitness::SIZE]);
+struct ChunkProofBinary(#[serde(with = "BigArray")] [u8; ChunkProof::SIZE]);
 
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct ChunkWitnessHex(#[serde(with = "hex")] [u8; ChunkWitness::SIZE]);
+struct ChunkProofHex(#[serde(with = "hex")] [u8; ChunkProof::SIZE]);
 
 #[cfg(feature = "serde")]
-impl Serialize for ChunkWitness {
+impl Serialize for ChunkProof {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            ChunkWitnessHex(self.0).serialize(serializer)
+            ChunkProofHex(self.0).serialize(serializer)
         } else {
-            ChunkWitnessBinary(self.0).serialize(serializer)
+            ChunkProofBinary(self.0).serialize(serializer)
         }
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for ChunkWitness {
+impl<'de> Deserialize<'de> for ChunkProof {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(Self(if deserializer.is_human_readable() {
-            ChunkWitnessHex::deserialize(deserializer)?.0
+            ChunkProofHex::deserialize(deserializer)?.0
         } else {
-            ChunkWitnessBinary::deserialize(deserializer)?.0
+            ChunkProofBinary::deserialize(deserializer)?.0
         }))
     }
 }
 
-impl Default for ChunkWitness {
+impl Default for ChunkProof {
     #[inline]
     fn default() -> Self {
         Self([0; Self::SIZE])
     }
 }
 
-impl TryFrom<&[u8]> for ChunkWitness {
+impl TryFrom<&[u8]> for ChunkProof {
     type Error = TryFromSliceError;
 
     #[inline]
@@ -206,22 +206,22 @@ impl TryFrom<&[u8]> for ChunkWitness {
     }
 }
 
-impl AsRef<[u8]> for ChunkWitness {
+impl AsRef<[u8]> for ChunkProof {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl AsMut<[u8]> for ChunkWitness {
+impl AsMut<[u8]> for ChunkProof {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
 }
 
-impl ChunkWitness {
-    /// Size of chunk witness in bytes.
+impl ChunkProof {
+    /// Size of chunk proof in bytes.
     pub const SIZE: usize = OUT_LEN * Self::NUM_HASHES;
     const NUM_HASHES: usize = Record::NUM_S_BUCKETS.ilog2() as usize;
 }
@@ -242,12 +242,12 @@ pub struct Solution {
     pub piece_offset: PieceOffset,
     /// Record root that can use used to verify that piece was included in blockchain history
     pub record_root: RecordRoot,
-    /// Witness for above record root
-    pub record_witness: RecordWitness,
+    /// Proof for above record root
+    pub record_proof: RecordProof,
     /// Chunk at above offset
     pub chunk: RecordChunk,
-    /// Witness for above chunk
-    pub chunk_witness: ChunkWitness,
+    /// Proof for above chunk
+    pub chunk_proof: ChunkProof,
     /// Proof of space for piece offset
     pub proof_of_space: PosProof,
 }
@@ -261,9 +261,9 @@ impl Solution {
             history_size: HistorySize::from(SegmentIndex::ZERO),
             piece_offset: PieceOffset::default(),
             record_root: RecordRoot::default(),
-            record_witness: RecordWitness::default(),
+            record_proof: RecordProof::default(),
             chunk: RecordChunk::default(),
-            chunk_witness: ChunkWitness::default(),
+            chunk_proof: ChunkProof::default(),
             proof_of_space: PosProof::default(),
         }
     }

--- a/subspace/crates/subspace-farmer-components/src/plotting.rs
+++ b/subspace/crates/subspace-farmer-components/src/plotting.rs
@@ -807,7 +807,7 @@ fn process_piece(
             .as_flattened_mut()
             .copy_from_slice(piece.record().as_flattened());
         *metadata = RecordMetadata {
-            commitment: *piece.commitment(),
+            root: *piece.root(),
             parity_chunks_root: *piece.parity_chunks_root(),
             witness: *piece.witness(),
             piece_checksum: blake3_hash(piece.as_ref()),

--- a/subspace/crates/subspace-farmer-components/src/plotting.rs
+++ b/subspace/crates/subspace-farmer-components/src/plotting.rs
@@ -809,7 +809,7 @@ fn process_piece(
         *metadata = RecordMetadata {
             root: *piece.root(),
             parity_chunks_root: *piece.parity_chunks_root(),
-            witness: *piece.witness(),
+            proof: *piece.proof(),
             piece_checksum: blake3_hash(piece.as_ref()),
         };
     }

--- a/subspace/crates/subspace-farmer-components/src/proving.rs
+++ b/subspace/crates/subspace-farmer-components/src/proving.rs
@@ -281,7 +281,7 @@ where
                 sector_index: self.sector_metadata.sector_index,
                 history_size: self.sector_metadata.history_size,
                 piece_offset,
-                record_commitment: record_metadata.commitment,
+                record_root: record_metadata.root,
                 record_witness: record_metadata.witness,
                 chunk,
                 chunk_witness: ChunkWitness::from(chunk_witness),

--- a/subspace/crates/subspace-farmer-components/src/proving.rs
+++ b/subspace/crates/subspace-farmer-components/src/proving.rs
@@ -19,7 +19,7 @@ use std::io;
 use subspace_core_primitives::pieces::{PieceOffset, Record, RecordChunk};
 use subspace_core_primitives::pos::PosSeed;
 use subspace_core_primitives::sectors::{SBucket, SectorId};
-use subspace_core_primitives::solutions::{ChunkWitness, Solution, SolutionRange};
+use subspace_core_primitives::solutions::{ChunkProof, Solution, SolutionRange};
 use subspace_core_primitives::PublicKey;
 use subspace_erasure_coding::ErasureCoding;
 use subspace_proof_of_space::Table;
@@ -271,7 +271,7 @@ where
                 "Quality exists for this s-bucket, otherwise it wouldn't be a winning chunk; qed",
             );
 
-            let chunk_witness = record_merkle_tree
+            let chunk_proof = record_merkle_tree
                 .all_proofs()
                 .nth(usize::from(self.s_bucket))
                 .expect("Chunk offset is valid, hence corresponding proof exists; qed");
@@ -282,9 +282,9 @@ where
                 history_size: self.sector_metadata.history_size,
                 piece_offset,
                 record_root: record_metadata.root,
-                record_witness: record_metadata.witness,
+                record_proof: record_metadata.proof,
                 chunk,
-                chunk_witness: ChunkWitness::from(chunk_witness),
+                chunk_proof: ChunkProof::from(chunk_proof),
                 proof_of_space,
             }
         };

--- a/subspace/crates/subspace-farmer-components/src/reading.rs
+++ b/subspace/crates/subspace-farmer-components/src/reading.rs
@@ -398,7 +398,7 @@ pub fn recover_source_record(
     Ok(recovered_record)
 }
 
-/// Read metadata (commitment and witness) for record
+/// Read metadata (roots and witness) for record
 pub(crate) async fn read_record_metadata<S, A>(
     piece_offset: PieceOffset,
     pieces_in_sector: u16,
@@ -410,7 +410,7 @@ where
 {
     let sector_metadata_start = SectorContentsMap::encoded_size(pieces_in_sector) as u64
         + sector_record_chunks_size(pieces_in_sector) as u64;
-    // Move to the beginning of the commitment and witness we care about
+    // Move to the beginning of the root and witness we care about
     let record_metadata_offset =
         sector_metadata_start + RecordMetadata::encoded_size() as u64 * u64::from(piece_offset);
 
@@ -485,7 +485,7 @@ where
 
     piece.record_mut().copy_from_slice(record.as_slice());
 
-    *piece.commitment_mut() = record_metadata.commitment;
+    *piece.root_mut() = record_metadata.root;
     *piece.parity_chunks_root_mut() = record_metadata.parity_chunks_root;
     *piece.witness_mut() = record_metadata.witness;
 

--- a/subspace/crates/subspace-farmer-components/src/reading.rs
+++ b/subspace/crates/subspace-farmer-components/src/reading.rs
@@ -398,7 +398,7 @@ pub fn recover_source_record(
     Ok(recovered_record)
 }
 
-/// Read metadata (roots and witness) for record
+/// Read metadata (roots and proof) for record
 pub(crate) async fn read_record_metadata<S, A>(
     piece_offset: PieceOffset,
     pieces_in_sector: u16,
@@ -410,7 +410,7 @@ where
 {
     let sector_metadata_start = SectorContentsMap::encoded_size(pieces_in_sector) as u64
         + sector_record_chunks_size(pieces_in_sector) as u64;
-    // Move to the beginning of the root and witness we care about
+    // Move to the beginning of the root and proof we care about
     let record_metadata_offset =
         sector_metadata_start + RecordMetadata::encoded_size() as u64 * u64::from(piece_offset);
 
@@ -487,7 +487,7 @@ where
 
     *piece.root_mut() = record_metadata.root;
     *piece.parity_chunks_root_mut() = record_metadata.parity_chunks_root;
-    *piece.witness_mut() = record_metadata.witness;
+    *piece.proof_mut() = record_metadata.proof;
 
     // Verify checksum
     let actual_checksum = blake3_hash(piece.as_ref());

--- a/subspace/crates/subspace-farmer-components/src/sector.rs
+++ b/subspace/crates/subspace-farmer-components/src/sector.rs
@@ -15,7 +15,7 @@ use std::{mem, slice};
 use subspace_core_primitives::checksum::Blake3Checksummed;
 use subspace_core_primitives::hashes::{blake3_hash, Blake3Hash};
 use subspace_core_primitives::pieces::{
-    PieceOffset, Record, RecordChunksRoot, RecordCommitment, RecordWitness,
+    PieceOffset, Record, RecordChunksRoot, RecordRoot, RecordWitness,
 };
 use subspace_core_primitives::sectors::{SBucket, SectorIndex};
 use subspace_core_primitives::segments::{HistorySize, SegmentIndex};
@@ -42,7 +42,7 @@ pub const fn sector_record_metadata_size(pieces_in_sector: u16) -> usize {
 ///
 /// NOTE: Each sector also has corresponding fixed size metadata whose size can be obtained with
 /// [`SectorMetadataChecksummed::encoded_size()`], size of the record chunks (s-buckets) with
-/// [`sector_record_chunks_size()`] and size of record commitments and witnesses with
+/// [`sector_record_chunks_size()`] and size of record roots and witnesses with
 /// [`sector_record_metadata_size()`]. This function just combines those three together for
 /// convenience.
 #[inline]
@@ -136,11 +136,11 @@ impl SectorMetadataChecksummed {
     }
 }
 
-/// Commitment and witness corresponding to the same record
+/// Root and witness corresponding to the same record
 #[derive(Debug, Default, Clone, Encode, Decode)]
 pub(crate) struct RecordMetadata {
-    /// Record commitment
-    pub(crate) commitment: RecordCommitment,
+    /// Record root
+    pub(crate) root: RecordRoot,
     /// Parity chunks root
     pub(crate) parity_chunks_root: RecordChunksRoot,
     /// Record witness
@@ -151,7 +151,7 @@ pub(crate) struct RecordMetadata {
 
 impl RecordMetadata {
     pub(crate) const fn encoded_size() -> usize {
-        RecordWitness::SIZE + RecordCommitment::SIZE + RecordChunksRoot::SIZE + Blake3Hash::SIZE
+        RecordWitness::SIZE + RecordRoot::SIZE + RecordChunksRoot::SIZE + Blake3Hash::SIZE
     }
 }
 
@@ -160,7 +160,7 @@ impl RecordMetadata {
 pub(crate) struct RawSector {
     /// List of records, likely downloaded from the network
     pub(crate) records: Vec<Record>,
-    /// Metadata (commitment and witness) corresponding to the same record
+    /// Metadata (root and witness) corresponding to the same record
     pub(crate) metadata: Vec<RecordMetadata>,
 }
 

--- a/subspace/crates/subspace-farmer-components/src/sector.rs
+++ b/subspace/crates/subspace-farmer-components/src/sector.rs
@@ -15,7 +15,7 @@ use std::{mem, slice};
 use subspace_core_primitives::checksum::Blake3Checksummed;
 use subspace_core_primitives::hashes::{blake3_hash, Blake3Hash};
 use subspace_core_primitives::pieces::{
-    PieceOffset, Record, RecordChunksRoot, RecordRoot, RecordWitness,
+    PieceOffset, Record, RecordChunksRoot, RecordProof, RecordRoot,
 };
 use subspace_core_primitives::sectors::{SBucket, SectorIndex};
 use subspace_core_primitives::segments::{HistorySize, SegmentIndex};
@@ -42,7 +42,7 @@ pub const fn sector_record_metadata_size(pieces_in_sector: u16) -> usize {
 ///
 /// NOTE: Each sector also has corresponding fixed size metadata whose size can be obtained with
 /// [`SectorMetadataChecksummed::encoded_size()`], size of the record chunks (s-buckets) with
-/// [`sector_record_chunks_size()`] and size of record roots and witnesses with
+/// [`sector_record_chunks_size()`] and size of record roots and proofs with
 /// [`sector_record_metadata_size()`]. This function just combines those three together for
 /// convenience.
 #[inline]
@@ -136,22 +136,22 @@ impl SectorMetadataChecksummed {
     }
 }
 
-/// Root and witness corresponding to the same record
+/// Root and proof corresponding to the same record
 #[derive(Debug, Default, Clone, Encode, Decode)]
 pub(crate) struct RecordMetadata {
     /// Record root
     pub(crate) root: RecordRoot,
     /// Parity chunks root
     pub(crate) parity_chunks_root: RecordChunksRoot,
-    /// Record witness
-    pub(crate) witness: RecordWitness,
+    /// Record proof
+    pub(crate) proof: RecordProof,
     /// Checksum (hash) of the whole piece
     pub(crate) piece_checksum: Blake3Hash,
 }
 
 impl RecordMetadata {
     pub(crate) const fn encoded_size() -> usize {
-        RecordWitness::SIZE + RecordRoot::SIZE + RecordChunksRoot::SIZE + Blake3Hash::SIZE
+        RecordProof::SIZE + RecordRoot::SIZE + RecordChunksRoot::SIZE + Blake3Hash::SIZE
     }
 }
 
@@ -160,7 +160,7 @@ impl RecordMetadata {
 pub(crate) struct RawSector {
     /// List of records, likely downloaded from the network
     pub(crate) records: Vec<Record>,
-    /// Metadata (root and witness) corresponding to the same record
+    /// Metadata (root and proof) corresponding to the same record
     pub(crate) metadata: Vec<RecordMetadata>,
 }
 

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -21,7 +21,7 @@ use subspace_farmer::cluster::controller::farms::{maintain_farms, FarmIndex};
 use subspace_farmer::cluster::nats_client::NatsClient;
 use subspace_farmer::farm::plotted_pieces::PlottedPieces;
 use subspace_farmer::farmer_cache::{FarmerCache, FarmerCaches};
-use subspace_farmer::farmer_piece_getter::piece_validator::SegmentCommitmentPieceValidator;
+use subspace_farmer::farmer_piece_getter::piece_validator::SegmentRootPieceValidator;
 use subspace_farmer::farmer_piece_getter::{DsnCacheRetryPolicy, FarmerPieceGetter};
 use subspace_farmer::node_client::caching_proxy_node_client::CachingProxyNodeClient;
 use subspace_farmer::node_client::rpc_node_client::RpcNodeClient;
@@ -164,7 +164,7 @@ pub(super) async fn controller(
 
     let piece_provider = PieceProvider::new(
         node.clone(),
-        SegmentCommitmentPieceValidator::new(node.clone(), node_client.clone()),
+        SegmentRootPieceValidator::new(node.clone(), node_client.clone()),
         Arc::new(Semaphore::new(
             out_connections as usize * PIECE_PROVIDER_MULTIPLIER,
         )),

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -24,7 +24,7 @@ use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer::farm::plotted_pieces::PlottedPieces;
 use subspace_farmer::farm::{PlottedSectors, SectorPlottingDetails, SectorUpdate};
 use subspace_farmer::farmer_cache::{FarmerCache, FarmerCaches};
-use subspace_farmer::farmer_piece_getter::piece_validator::SegmentCommitmentPieceValidator;
+use subspace_farmer::farmer_piece_getter::piece_validator::SegmentRootPieceValidator;
 use subspace_farmer::farmer_piece_getter::{DsnCacheRetryPolicy, FarmerPieceGetter};
 use subspace_farmer::node_client::caching_proxy_node_client::CachingProxyNodeClient;
 use subspace_farmer::node_client::rpc_node_client::RpcNodeClient;
@@ -454,7 +454,7 @@ where
     let erasure_coding = ErasureCoding::new();
     let piece_provider = PieceProvider::new(
         node.clone(),
-        SegmentCommitmentPieceValidator::new(node.clone(), node_client.clone()),
+        SegmentRootPieceValidator::new(node.clone(), node_client.clone()),
         Arc::new(Semaphore::new(
             out_connections as usize * PIECE_PROVIDER_MULTIPLIER,
         )),

--- a/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -290,7 +290,7 @@ async fn basic() {
         {
             let segment_header = SegmentHeader::V0 {
                 segment_index: SegmentIndex::ONE,
-                segment_commitment: Default::default(),
+                segment_root: Default::default(),
                 prev_segment_header_hash: [0; 32].into(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,
@@ -348,7 +348,7 @@ async fn basic() {
         for segment_index in [2, 3] {
             let segment_header = SegmentHeader::V0 {
                 segment_index: SegmentIndex::from(segment_index),
-                segment_commitment: Default::default(),
+                segment_root: Default::default(),
                 prev_segment_header_hash: [0; 32].into(),
                 last_archived_block: LastArchivedBlock {
                     number: 0,

--- a/subspace/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/subspace/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -921,23 +921,23 @@ where
                     %expiration_check_segment_index,
                     "Determined sector expiration check segment index"
                 );
-                let maybe_sector_expiration_check_segment_commitment = node_client
+                let maybe_sector_expiration_check_segment_root = node_client
                     .segment_headers(vec![expiration_check_segment_index])
                     .await
                     .map_err(|error| PlottingError::FailedToGetSegmentHeader { error })?
                     .into_iter()
                     .next()
                     .flatten()
-                    .map(|segment_header| segment_header.segment_commitment());
+                    .map(|segment_header| segment_header.segment_root());
 
-                if let Some(sector_expiration_check_segment_commitment) =
-                    maybe_sector_expiration_check_segment_commitment
+                if let Some(sector_expiration_check_segment_root) =
+                    maybe_sector_expiration_check_segment_root
                 {
                     let sector_id = SectorId::new(public_key_hash, sector_index, history_size);
                     let expiration_history_size = sector_id
                         .derive_expiration_history_size(
                             history_size,
-                            &sector_expiration_check_segment_commitment,
+                            &sector_expiration_check_segment_root,
                             min_sector_lifetime,
                         )
                         .expect(

--- a/subspace/crates/subspace-networking/src/utils/piece_provider.rs
+++ b/subspace/crates/subspace-networking/src/utils/piece_provider.rs
@@ -30,10 +30,10 @@ use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use tokio_stream::StreamMap;
 use tracing::{debug, trace, warn, Instrument};
 
-/// Validates piece against using its commitment.
+/// Validates piece against using its root.
 #[async_trait]
 pub trait PieceValidator: Sync + Send {
-    /// Validates piece against using its commitment.
+    /// Validates piece against using its root.
     async fn validate_piece(
         &self,
         source_peer_id: PeerId,

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -49,9 +49,7 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::pieces::Piece;
-use subspace_core_primitives::segments::{
-    HistorySize, SegmentCommitment, SegmentHeader, SegmentIndex,
-};
+use subspace_core_primitives::segments::{HistorySize, SegmentHeader, SegmentIndex, SegmentRoot};
 use subspace_core_primitives::solutions::solution_range_to_pieces;
 use subspace_core_primitives::{PublicKey, SlotNumber};
 use subspace_runtime_primitives::utility::{
@@ -554,8 +552,8 @@ impl_runtime_apis! {
             MAX_PIECES_IN_SECTOR
         }
 
-        fn segment_commitment(segment_index: SegmentIndex) -> Option<SegmentCommitment> {
-            Subspace::segment_commitment(segment_index)
+        fn segment_root(segment_index: SegmentIndex) -> Option<SegmentRoot> {
+            Subspace::segment_root(segment_index)
         }
 
         fn extract_segment_headers(ext: &<Block as BlockT>::Extrinsic) -> Option<Vec<SegmentHeader >> {

--- a/subspace/crates/subspace-service/src/lib.rs
+++ b/subspace/crates/subspace-service/src/lib.rs
@@ -19,7 +19,7 @@ mod utils;
 use crate::config::{ChainSyncMode, SubspaceConfiguration, SubspaceNetworking};
 use crate::dsn::{create_dsn_instance, DsnConfigurationError};
 use crate::metrics::NodeMetrics;
-use crate::sync_from_dsn::piece_validator::SegmentCommitmentPieceValidator;
+use crate::sync_from_dsn::piece_validator::SegmentRootPieceValidator;
 use crate::sync_from_dsn::snap_sync::snap_sync;
 use crate::sync_from_dsn::DsnPieceGetter;
 use crate::task_spawner::SpawnTasksParams;
@@ -496,7 +496,7 @@ where
 
             let piece_provider = PieceProvider::new(
                 node.clone(),
-                SegmentCommitmentPieceValidator::new(node.clone(), segment_headers_store.clone()),
+                SegmentRootPieceValidator::new(node.clone(), segment_headers_store.clone()),
                 Arc::new(Semaphore::new(
                     out_connections as usize * PIECE_PROVIDER_MULTIPLIER,
                 )),

--- a/subspace/crates/subspace-service/src/sync_from_dsn/segment_header_downloader.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/segment_header_downloader.rs
@@ -135,7 +135,7 @@ impl<'a> SegmentHeaderDownloader<'a> {
             trace!(%retry_attempt, "Downloading last segment headers");
 
             // Get random peers. Some of them could be bootstrap nodes with no support for
-            // request-response protocol for segment commitment.
+            // request-response protocol for segment root.
             let get_peers_result = self
                 .dsn_node
                 .get_closest_peers(PeerId::random().into())

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -10,7 +10,7 @@ use subspace_archiving::archiver::SegmentItem;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::objects::GlobalObject;
 use subspace_core_primitives::segments::{
-    ArchivedBlockProgress, LastArchivedBlock, SegmentCommitment, SegmentHeader, SegmentIndex,
+    ArchivedBlockProgress, LastArchivedBlock, SegmentHeader, SegmentIndex, SegmentRoot,
 };
 use subspace_runtime_primitives::MAX_BLOCK_LENGTH;
 
@@ -33,7 +33,7 @@ const BLOCK_CONTINUATION_VARIANT: u8 = 3;
 pub fn min_segment_header_encoded_size() -> usize {
     let min_segment_header = SegmentHeader::V0 {
         segment_index: 0.into(),
-        segment_commitment: SegmentCommitment::default(),
+        segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: 0,
@@ -49,7 +49,7 @@ pub fn min_segment_header_encoded_size() -> usize {
 pub fn max_segment_header_encoded_size() -> usize {
     let max_segment_header = SegmentHeader::V0 {
         segment_index: u64::MAX.into(),
-        segment_commitment: SegmentCommitment::default(),
+        segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: u32::MAX,

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -7,8 +7,7 @@ use rand::{thread_rng, RngCore};
 use std::iter;
 use subspace_core_primitives::hashes::blake3_hash;
 use subspace_core_primitives::segments::{
-    ArchivedBlockProgress, ArchivedHistorySegment, LastArchivedBlock, SegmentCommitment,
-    SegmentHeader,
+    ArchivedBlockProgress, ArchivedHistorySegment, LastArchivedBlock, SegmentHeader, SegmentRoot,
 };
 use subspace_logging::init_logger;
 
@@ -87,7 +86,7 @@ fn write_segment_header(mut piece: &mut Piece, remaining_len: usize) -> Vec<u8> 
         // SegmentHeader
         let segment_header = SegmentHeader::V0 {
             segment_index: u64::MAX.into(),
-            segment_commitment: SegmentCommitment::default(),
+            segment_root: SegmentRoot::default(),
             prev_segment_header_hash: Blake3Hash::default(),
             last_archived_block: LastArchivedBlock {
                 number: u32::MAX,


### PR DESCRIPTION
After switching from KZG to Merkle Trees, commitments are renamed to roots, witnesses to proofs