### PR TITLE
More trivial types

### DIFF
--- a/crates/contracts/core/ab-contracts-io-type/src/bool.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/bool.rs
@@ -1,0 +1,63 @@
+use crate::metadata::IoTypeMetadataKind;
+use crate::trivial_type::TrivialType;
+use core::ops::Not;
+
+/// Just like `bool`, but any bit pattern is valid.
+///
+/// For `bool` only `0` and `1` are valid bit patterns out of 256 possible, anything else is
+/// undefined behavior. This type changes that by treating `0` as `false` and everything else as
+/// `true`, making it safer to use and allowing it to implement `TrivialType`.
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[repr(C)]
+pub struct Bool {
+    byte: u8,
+}
+
+impl Not for Bool {
+    type Output = Self;
+
+    #[inline(always)]
+    fn not(self) -> Self::Output {
+        Self {
+            byte: (self.byte == 0) as u8,
+        }
+    }
+}
+
+impl From<bool> for Bool {
+    #[inline(always)]
+    fn from(value: bool) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<Bool> for bool {
+    #[inline(always)]
+    fn from(value: Bool) -> Self {
+        value.get()
+    }
+}
+
+unsafe impl TrivialType for Bool {
+    const METADATA: &[u8] = &[IoTypeMetadataKind::Bool as u8];
+}
+
+impl Bool {
+    /// Create a new instance from existing boolean value
+    #[inline(always)]
+    pub const fn new(value: bool) -> Self {
+        Self { byte: value as u8 }
+    }
+
+    /// Get the value
+    #[inline(always)]
+    pub const fn get(&self) -> bool {
+        self.byte != 0
+    }
+
+    /// Set new value
+    #[inline(always)]
+    pub const fn set(&mut self, value: bool) {
+        self.byte = value as u8;
+    }
+}

--- a/crates/contracts/core/ab-contracts-io-type/src/fixed_capacity_bytes.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/fixed_capacity_bytes.rs
@@ -1,0 +1,276 @@
+use crate::metadata::{IoTypeMetadataKind, MAX_METADATA_CAPACITY, concat_metadata_sources};
+use crate::trivial_type::TrivialType;
+
+/// Container for storing a number of bytes limited by the specified fixed capacity as `u8`.
+///
+/// See also [`FixedCapacityBytesU16`] if you need to store more bytes.
+///
+/// In contrast to [`VariableBytes`], which can store arbitrary amount of data and can change the
+/// capacity, this container has fixed predefined capacity and occupies it regardless of how many
+/// bytes are actually stored inside. This might seem limiting but allows implementing
+/// [`TrivialType`] trait, enabling its use for fields in data structures that derive
+/// [`TrivialType`] themselves, which isn't the case with [`VariableBytes`].
+///
+/// [`VariableBytes`]: crate::variable_bytes::VariableBytes
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct FixedCapacityBytesU8<const CAPACITY: usize> {
+    len: u8,
+    bytes: [u8; CAPACITY],
+}
+
+impl<const CAPACITY: usize> Default for FixedCapacityBytesU8<CAPACITY> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self {
+            len: 0,
+            bytes: [0; CAPACITY],
+        }
+    }
+}
+
+unsafe impl<const CAPACITY: usize> TrivialType for FixedCapacityBytesU8<CAPACITY> {
+    const METADATA: &[u8] = {
+        #[inline(always)]
+        const fn metadata(capacity: usize) -> ([u8; MAX_METADATA_CAPACITY], usize) {
+            assert!(
+                capacity <= u8::MAX as usize,
+                "`FixedCapacityBytesU8` capacity must not exceed `u8::MAX`"
+            );
+            concat_metadata_sources(&[&[
+                IoTypeMetadataKind::FixedCapacityBytes8b as u8,
+                capacity as u8,
+            ]])
+        }
+        metadata(CAPACITY).0.split_at(metadata(CAPACITY).1).0
+    };
+}
+
+impl<const CAPACITY: usize> FixedCapacityBytesU8<CAPACITY> {
+    /// Try to create an instance from provided bytes.
+    ///
+    /// Returns `None` if provided bytes do not fit into the capacity.
+    #[inline(always)]
+    pub fn try_from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() > CAPACITY {
+            return None;
+        }
+
+        Some(Self {
+            len: bytes.len() as u8,
+            bytes: {
+                let mut buffer = [0; CAPACITY];
+                buffer[..bytes.len()].copy_from_slice(bytes);
+                buffer
+            },
+        })
+    }
+
+    /// Access to stored bytes
+    #[inline(always)]
+    pub fn get_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+
+    /// Exclusive access to stored bytes
+    #[inline(always)]
+    pub fn get_bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes[..self.len as usize]
+    }
+
+    /// Number of stored bytes
+    #[inline(always)]
+    pub const fn len(&self) -> u8 {
+        self.len
+    }
+
+    /// Returns `true` if length is zero
+    #[inline(always)]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Append some bytes.
+    ///
+    /// `true` is returned on success, but if there isn't enough capacity left, `false` is.
+    #[inline(always)]
+    #[must_use = "Operation may fail"]
+    pub fn append(&mut self, bytes: &[u8]) -> bool {
+        let len = self.len();
+        if bytes.len() + len as usize > CAPACITY {
+            return false;
+        }
+
+        self.bytes[..bytes.len()].copy_from_slice(bytes);
+
+        true
+    }
+
+    /// Truncate stored bytes to this length.
+    ///
+    /// Returns `true` on success or `false` if `new_len` is larger than [`Self::len()`].
+    #[inline(always)]
+    #[must_use = "Operation may fail"]
+    pub fn truncate(&mut self, new_len: u8) -> bool {
+        if new_len > self.len() {
+            return false;
+        }
+
+        self.len = new_len;
+
+        true
+    }
+
+    /// Copy from specified bytes.
+    ///
+    /// Returns `false` if capacity is not enough to copy contents of `src`
+    #[inline(always)]
+    #[must_use = "Operation may fail"]
+    pub fn copy_from<T>(&mut self, src: &[u8]) -> bool {
+        if src.len() > CAPACITY {
+            return false;
+        }
+
+        self.bytes[..src.len()].copy_from_slice(src);
+        self.len = src.len() as u8;
+
+        true
+    }
+}
+
+/// Container for storing a number of bytes limited by the specified fixed capacity as `u16`.
+///
+/// See also [`FixedCapacityBytesU8`] if you need to store fewer bytes.
+///
+/// In contrast to [`VariableBytes`], which can store arbitrary amount of data and can change the
+/// capacity, this container has fixed predefined capacity and occupies it regardless of how many
+/// bytes are actually stored inside. This might seem limiting but allows implementing
+/// [`TrivialType`] trait, enabling its use for fields in data structures that derive
+/// [`TrivialType`] themselves, which isn't the case with [`VariableBytes`].
+///
+/// [`VariableBytes`]: crate::variable_bytes::VariableBytes
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct FixedCapacityBytesU16<const CAPACITY: usize> {
+    len: u16,
+    bytes: [u8; CAPACITY],
+}
+
+impl<const CAPACITY: usize> Default for FixedCapacityBytesU16<CAPACITY> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self {
+            len: 0,
+            bytes: [0; CAPACITY],
+        }
+    }
+}
+
+unsafe impl<const CAPACITY: usize> TrivialType for FixedCapacityBytesU16<CAPACITY> {
+    const METADATA: &[u8] = {
+        #[inline(always)]
+        const fn metadata(capacity: usize) -> ([u8; MAX_METADATA_CAPACITY], usize) {
+            assert!(
+                capacity <= u16::MAX as usize,
+                "`FixedCapacityBytesU16` capacity must not exceed `u16::MAX`"
+            );
+            concat_metadata_sources(&[&[
+                IoTypeMetadataKind::FixedCapacityBytes16b as u8,
+                capacity as u8,
+            ]])
+        }
+        metadata(CAPACITY).0.split_at(metadata(CAPACITY).1).0
+    };
+}
+
+impl<const CAPACITY: usize> FixedCapacityBytesU16<CAPACITY> {
+    /// Try to create an instance from provided bytes.
+    ///
+    /// Returns `None` if provided bytes do not fit into the capacity.
+    #[inline(always)]
+    pub fn try_from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() > CAPACITY {
+            return None;
+        }
+
+        Some(Self {
+            len: bytes.len() as u16,
+            bytes: {
+                let mut buffer = [0; CAPACITY];
+                buffer[..bytes.len()].copy_from_slice(bytes);
+                buffer
+            },
+        })
+    }
+
+    /// Access to stored bytes
+    #[inline(always)]
+    pub fn get_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+
+    /// Exclusive access to stored bytes
+    #[inline(always)]
+    pub fn get_bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes[..self.len as usize]
+    }
+
+    /// Number of stored bytes
+    #[inline(always)]
+    pub const fn len(&self) -> u16 {
+        self.len
+    }
+
+    /// Returns `true` if length is zero
+    #[inline(always)]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Append some bytes.
+    ///
+    /// `true` is returned on success, but if there isn't enough capacity left, `false` is.
+    #[inline(always)]
+    #[must_use = "Operation may fail"]
+    pub fn append(&mut self, bytes: &[u8]) -> bool {
+        let len = self.len();
+        if bytes.len() + len as usize > CAPACITY {
+            return false;
+        }
+
+        self.bytes[..bytes.len()].copy_from_slice(bytes);
+
+        true
+    }
+
+    /// Truncate stored bytes to this length.
+    ///
+    /// Returns `true` on success or `false` if `new_len` is larger than [`Self::len()`].
+    #[inline(always)]
+    #[must_use = "Operation may fail"]
+    pub fn truncate(&mut self, new_len: u16) -> bool {
+        if new_len > self.len() {
+            return false;
+        }
+
+        self.len = new_len;
+
+        true
+    }
+
+    /// Copy from specified bytes.
+    ///
+    /// Returns `false` if capacity is not enough to copy contents of `src`
+    #[inline(always)]
+    #[must_use = "Operation may fail"]
+    pub fn copy_from<T>(&mut self, src: &[u8]) -> bool {
+        if src.len() > CAPACITY {
+            return false;
+        }
+
+        self.bytes[..src.len()].copy_from_slice(src);
+        self.len = src.len() as u16;
+
+        true
+    }
+}

--- a/crates/contracts/core/ab-contracts-io-type/src/fixed_capacity_string.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/fixed_capacity_string.rs
@@ -1,0 +1,114 @@
+use crate::fixed_capacity_bytes::{FixedCapacityBytesU8, FixedCapacityBytesU16};
+use crate::metadata::{IoTypeMetadataKind, MAX_METADATA_CAPACITY, concat_metadata_sources};
+use crate::trivial_type::TrivialType;
+use core::ops::{Deref, DerefMut};
+
+/// Container for storing a UTF-8 string limited by the specified fixed bytes capacity as `u8`.
+///
+/// This is a string only by convention, there is no runtime verification done, contents is
+/// treated as regular bytes.
+///
+/// See also [`FixedCapacityStringU16`] if you need to store more bytes.
+///
+/// This is just a wrapper for [`FixedCapacityBytesU8`] that the type dereferences to with a
+/// different semantic meaning.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct FixedCapacityStringU8<const CAPACITY: usize> {
+    bytes: FixedCapacityBytesU8<CAPACITY>,
+}
+
+impl<const CAPACITY: usize> Default for FixedCapacityStringU8<CAPACITY> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self {
+            bytes: FixedCapacityBytesU8::default(),
+        }
+    }
+}
+
+impl<const CAPACITY: usize> Deref for FixedCapacityStringU8<CAPACITY> {
+    type Target = FixedCapacityBytesU8<CAPACITY>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.bytes
+    }
+}
+
+impl<const CAPACITY: usize> DerefMut for FixedCapacityStringU8<CAPACITY> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.bytes
+    }
+}
+
+unsafe impl<const CAPACITY: usize> TrivialType for FixedCapacityStringU8<CAPACITY> {
+    const METADATA: &[u8] = {
+        #[inline(always)]
+        const fn metadata(capacity: usize) -> ([u8; MAX_METADATA_CAPACITY], usize) {
+            assert!(
+                capacity <= u8::MAX as usize,
+                "`FixedCapacityStringU8` capacity must not exceed `u8::MAX`"
+            );
+            concat_metadata_sources(&[&[
+                IoTypeMetadataKind::FixedCapacityString8b as u8,
+                capacity as u8,
+            ]])
+        }
+        metadata(CAPACITY).0.split_at(metadata(CAPACITY).1).0
+    };
+}
+
+/// Container for storing a UTF-8 string limited by the specified fixed bytes capacity as `u16`.
+///
+/// This is a string only by convention, there is no runtime verification done, contents is
+/// treated as regular bytes.
+///
+/// See also [`FixedCapacityStringU8`] if you need to store fewer bytes.
+///
+/// This is just a wrapper for [`FixedCapacityBytesU16`] that the type dereferences to with a
+/// different semantic meaning.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct FixedCapacityStringU16<const CAPACITY: usize> {
+    bytes: FixedCapacityBytesU16<CAPACITY>,
+}
+
+impl<const CAPACITY: usize> Default for FixedCapacityStringU16<CAPACITY> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self {
+            bytes: FixedCapacityBytesU16::default(),
+        }
+    }
+}
+
+impl<const CAPACITY: usize> Deref for FixedCapacityStringU16<CAPACITY> {
+    type Target = FixedCapacityBytesU16<CAPACITY>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.bytes
+    }
+}
+
+impl<const CAPACITY: usize> DerefMut for FixedCapacityStringU16<CAPACITY> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.bytes
+    }
+}
+
+unsafe impl<const CAPACITY: usize> TrivialType for FixedCapacityStringU16<CAPACITY> {
+    const METADATA: &[u8] = {
+        #[inline(always)]
+        const fn metadata(capacity: usize) -> ([u8; MAX_METADATA_CAPACITY], usize) {
+            assert!(
+                capacity <= u16::MAX as usize,
+                "`FixedCapacityStringU16` capacity must not exceed `u16::MAX`"
+            );
+            concat_metadata_sources(&[&[
+                IoTypeMetadataKind::FixedCapacityString16b as u8,
+                capacity as u8,
+            ]])
+        }
+        metadata(CAPACITY).0.split_at(metadata(CAPACITY).1).0
+    };
+}

--- a/crates/contracts/core/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(maybe_uninit_slice, non_null_from_ref, ptr_as_uninit)]
 #![no_std]
 
+pub mod bool;
 pub mod fixed_capacity_bytes;
 pub mod fixed_capacity_string;
 pub mod maybe_data;

--- a/crates/contracts/core/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(maybe_uninit_slice, non_null_from_ref, ptr_as_uninit)]
 #![no_std]
 
+pub mod fixed_capacity_bytes;
 pub mod maybe_data;
 pub mod metadata;
 pub mod trivial_type;
@@ -212,5 +213,8 @@ pub unsafe trait IoType {
     unsafe fn as_mut_ptr(&mut self) -> impl DerefMut<Target = NonNull<Self::PointerType>>;
 }
 
-/// Marker trait, companion to [`IoType`] that indicates the ability to store optional contents
+/// Marker trait, companion to [`IoType`] that indicates the ability to store optional contents.
+///
+/// This means that zero bytes size is a valid invariant. This type is never implemented for types
+/// implementing [`TrivialType`] because they always have fixed size, and it is not zero.
 pub trait IoTypeOptional: IoType {}

--- a/crates/contracts/core/ab-contracts-io-type/src/lib.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_std]
 
 pub mod fixed_capacity_bytes;
+pub mod fixed_capacity_string;
 pub mod maybe_data;
 pub mod metadata;
 pub mod trivial_type;

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
@@ -72,7 +72,7 @@ impl IoTypeDetails {
 pub enum IoTypeMetadataKind {
     /// `()`
     Unit,
-    /// `bool`
+    /// [`Bool`](crate::bool::Bool)
     Bool,
     /// `u8`
     U8,

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
@@ -364,6 +364,22 @@ pub enum IoTypeMetadataKind {
     /// Encoded as follows:
     /// * 2 bytes capacity (little-endian)
     FixedCapacityBytes16b,
+    /// Fixed capacity UTF-8 string with up to 2^8 bytes capacity.
+    ///
+    /// This is a string only by convention, there is no runtime verification done, contents is
+    /// treated as regular bytes.
+    ///
+    /// Encoded as follows:
+    /// * 1 byte capacity
+    FixedCapacityString8b,
+    /// Fixed capacity UTF-8 bytes with up to 2^16 bytes capacity.
+    ///
+    /// This is a string only by convention, there is no runtime verification done, contents is
+    /// treated as regular bytes.
+    ///
+    /// Encoded as follows:
+    /// * 2 bytes capacity (little-endian)
+    FixedCapacityString16b,
     /// Address of a contract.
     ///
     /// Internally `u128` with `8` byte alignment
@@ -472,6 +488,8 @@ impl IoTypeMetadataKind {
             89 => Self::VariableElements0,
             90 => Self::FixedCapacityBytes8b,
             91 => Self::FixedCapacityBytes16b,
+            92 => Self::FixedCapacityString8b,
+            93 => Self::FixedCapacityString16b,
             128 => Self::Address,
             129 => Self::Balance,
             _ => {

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata.rs
@@ -260,19 +260,19 @@ pub enum IoTypeMetadataKind {
     EnumNoFields10,
     /// Array `[T; N]` with up to 2^8 elements.
     ///
-    /// Arrays with up to 2^8 encoded as follows:
+    /// Encoded as follows:
     /// * 1 byte number of elements
     /// * Recursive metadata of contained type
     Array8b,
     /// Array `[T; N]` with up to 2^16 elements.
     ///
-    /// Arrays with up to 2^16 encoded as follows:
+    /// Encoded as follows:
     /// * 2 bytes number of elements (little-endian)
     /// * Recursive metadata of contained type
     Array16b,
     /// Array `[T; N]` with up to 2^32 elements.
     ///
-    /// Arrays with up to 2^32 encoded as follows:
+    /// Encoded as follows:
     /// * 4 bytes number of elements (little-endian)
     /// * Recursive metadata of contained type
     Array32b,
@@ -298,17 +298,17 @@ pub enum IoTypeMetadataKind {
     ArrayU8x4096,
     /// Variable bytes with up to 2^8 bytes recommended allocation.
     ///
-    /// Variable bytes with up to 2^8 bytes encoded as follows:
+    /// Encoded as follows:
     /// * 1 byte recommended allocation in bytes
     VariableBytes8b,
     /// Variable bytes with up to 2^16 bytes recommended allocation.
     ///
-    /// Variable bytes with up to 2^16 bytes encoded as follows:
+    /// Encoded as follows:
     /// * 2 bytes recommended allocation in bytes (little-endian)
     VariableBytes16b,
     /// Variable bytes with up to 2^32 bytes recommended allocation.
     ///
-    /// Variable bytes with up to 2^8 bytes encoded as follows:
+    /// Encoded as follows:
     /// * 4 bytes recommended allocation in bytes (little-endian)
     VariableBytes32b,
     /// Compact alias [`VariableBytes<0>`](crate::variable_bytes::VariableBytes)
@@ -339,21 +339,31 @@ pub enum IoTypeMetadataKind {
     VariableBytes1048576,
     /// Variable elements with up to 2^8 elements recommended allocation.
     ///
-    /// Variable elements with up to 2^8 elements encoded as follows:
+    /// Encoded as follows:
     /// * 1 byte recommended allocation in bytes
     VariableElements8b,
     /// Variable elements with up to 2^16 elements recommended allocation.
     ///
-    /// Variable elements with up to 2^16 elements encoded as follows:
+    /// Encoded as follows:
     /// * 2 bytes recommended allocation in elements (little-endian)
     VariableElements16b,
     /// Variable elements with up to 2^32 elements recommended allocation.
     ///
-    /// Variable elements with up to 2^8 elements encoded as follows:
+    /// Encoded as follows:
     /// * 4 bytes recommended allocation in elements (little-endian)
     VariableElements32b,
     /// Compact alias [`VariableElements<0, T>`](crate::variable_elements::VariableElements)
     VariableElements0,
+    /// Fixed capacity bytes with up to 2^8 bytes capacity.
+    ///
+    /// Encoded as follows:
+    /// * 1 byte capacity
+    FixedCapacityBytes8b,
+    /// Fixed capacity bytes with up to 2^16 bytes capacity.
+    ///
+    /// Encoded as follows:
+    /// * 2 bytes capacity (little-endian)
+    FixedCapacityBytes16b,
     /// Address of a contract.
     ///
     /// Internally `u128` with `8` byte alignment
@@ -460,6 +470,8 @@ impl IoTypeMetadataKind {
             87 => Self::VariableElements16b,
             88 => Self::VariableElements32b,
             89 => Self::VariableElements0,
+            90 => Self::FixedCapacityBytes8b,
+            91 => Self::FixedCapacityBytes16b,
             128 => Self::Address,
             129 => Self::Balance,
             _ => {

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/compact.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/compact.rs
@@ -255,12 +255,12 @@ pub(super) const fn compact_metadata<'i, 'o>(
         | IoTypeMetadataKind::ArrayU8x1024
         | IoTypeMetadataKind::ArrayU8x2028
         | IoTypeMetadataKind::ArrayU8x4096 => copy_n_bytes(input, output, 1),
-        IoTypeMetadataKind::VariableBytes8b | IoTypeMetadataKind::FixedCapacityBytes8b => {
-            copy_n_bytes(input, output, 1 + 1)
-        }
-        IoTypeMetadataKind::VariableBytes16b | IoTypeMetadataKind::FixedCapacityBytes16b => {
-            copy_n_bytes(input, output, 1 + 2)
-        }
+        IoTypeMetadataKind::VariableBytes8b
+        | IoTypeMetadataKind::FixedCapacityBytes8b
+        | IoTypeMetadataKind::FixedCapacityString8b => copy_n_bytes(input, output, 1 + 1),
+        IoTypeMetadataKind::VariableBytes16b
+        | IoTypeMetadataKind::FixedCapacityBytes16b
+        | IoTypeMetadataKind::FixedCapacityString16b => copy_n_bytes(input, output, 1 + 2),
         IoTypeMetadataKind::VariableBytes32b => copy_n_bytes(input, output, 1 + 4),
         IoTypeMetadataKind::VariableBytes0
         | IoTypeMetadataKind::VariableBytes512

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/compact.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/compact.rs
@@ -255,8 +255,12 @@ pub(super) const fn compact_metadata<'i, 'o>(
         | IoTypeMetadataKind::ArrayU8x1024
         | IoTypeMetadataKind::ArrayU8x2028
         | IoTypeMetadataKind::ArrayU8x4096 => copy_n_bytes(input, output, 1),
-        IoTypeMetadataKind::VariableBytes8b => copy_n_bytes(input, output, 1 + 1),
-        IoTypeMetadataKind::VariableBytes16b => copy_n_bytes(input, output, 1 + 2),
+        IoTypeMetadataKind::VariableBytes8b | IoTypeMetadataKind::FixedCapacityBytes8b => {
+            copy_n_bytes(input, output, 1 + 1)
+        }
+        IoTypeMetadataKind::VariableBytes16b | IoTypeMetadataKind::FixedCapacityBytes16b => {
+            copy_n_bytes(input, output, 1 + 2)
+        }
         IoTypeMetadataKind::VariableBytes32b => copy_n_bytes(input, output, 1 + 4),
         IoTypeMetadataKind::VariableBytes0
         | IoTypeMetadataKind::VariableBytes512

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/tests.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/tests.rs
@@ -93,6 +93,8 @@ fn check_repr() {
         (IoTypeMetadataKind::VariableElements16b, 87),
         (IoTypeMetadataKind::VariableElements32b, 88),
         (IoTypeMetadataKind::VariableElements0, 89),
+        (IoTypeMetadataKind::FixedCapacityBytes8b, 90),
+        (IoTypeMetadataKind::FixedCapacityBytes16b, 91),
         (IoTypeMetadataKind::Address, 128),
         (IoTypeMetadataKind::Balance, 129),
     ];

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/tests.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/tests.rs
@@ -95,6 +95,8 @@ fn check_repr() {
         (IoTypeMetadataKind::VariableElements0, 89),
         (IoTypeMetadataKind::FixedCapacityBytes8b, 90),
         (IoTypeMetadataKind::FixedCapacityBytes16b, 91),
+        (IoTypeMetadataKind::FixedCapacityString8b, 92),
+        (IoTypeMetadataKind::FixedCapacityString16b, 93),
         (IoTypeMetadataKind::Address, 128),
         (IoTypeMetadataKind::Balance, 129),
     ];

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/type_details.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/type_details.rs
@@ -182,7 +182,9 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
         IoTypeMetadataKind::ArrayU8x1024 => Some((IoTypeDetails::bytes(1024), metadata)),
         IoTypeMetadataKind::ArrayU8x2028 => Some((IoTypeDetails::bytes(2028), metadata)),
         IoTypeMetadataKind::ArrayU8x4096 => Some((IoTypeDetails::bytes(4096), metadata)),
-        IoTypeMetadataKind::VariableBytes8b | IoTypeMetadataKind::FixedCapacityBytes8b => {
+        IoTypeMetadataKind::VariableBytes8b
+        | IoTypeMetadataKind::FixedCapacityBytes8b
+        | IoTypeMetadataKind::FixedCapacityString8b => {
             if metadata.is_empty() {
                 return None;
             }
@@ -192,7 +194,9 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
 
             Some((IoTypeDetails::bytes(num_bytes), metadata))
         }
-        IoTypeMetadataKind::VariableBytes16b | IoTypeMetadataKind::FixedCapacityBytes16b => {
+        IoTypeMetadataKind::VariableBytes16b
+        | IoTypeMetadataKind::FixedCapacityBytes16b
+        | IoTypeMetadataKind::FixedCapacityString16b => {
             if metadata.is_empty() {
                 return None;
             }

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/type_details.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/type_details.rs
@@ -182,7 +182,7 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
         IoTypeMetadataKind::ArrayU8x1024 => Some((IoTypeDetails::bytes(1024), metadata)),
         IoTypeMetadataKind::ArrayU8x2028 => Some((IoTypeDetails::bytes(2028), metadata)),
         IoTypeMetadataKind::ArrayU8x4096 => Some((IoTypeDetails::bytes(4096), metadata)),
-        IoTypeMetadataKind::VariableBytes8b => {
+        IoTypeMetadataKind::VariableBytes8b | IoTypeMetadataKind::FixedCapacityBytes8b => {
             if metadata.is_empty() {
                 return None;
             }
@@ -192,7 +192,7 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
 
             Some((IoTypeDetails::bytes(num_bytes), metadata))
         }
-        IoTypeMetadataKind::VariableBytes16b => {
+        IoTypeMetadataKind::VariableBytes16b | IoTypeMetadataKind::FixedCapacityBytes16b => {
             if metadata.is_empty() {
                 return None;
             }

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/type_name.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/type_name.rs
@@ -127,6 +127,9 @@ pub(super) const fn type_name(mut metadata: &[u8]) -> Option<&[u8]> {
         IoTypeMetadataKind::FixedCapacityBytes8b | IoTypeMetadataKind::FixedCapacityBytes16b => {
             b"FixedCapacityBytes"
         }
+        IoTypeMetadataKind::FixedCapacityString8b | IoTypeMetadataKind::FixedCapacityString16b => {
+            b"FixedCapacityString"
+        }
         IoTypeMetadataKind::Address => b"Address",
         IoTypeMetadataKind::Balance => b"Balance",
     })

--- a/crates/contracts/core/ab-contracts-io-type/src/metadata/type_name.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/metadata/type_name.rs
@@ -124,6 +124,9 @@ pub(super) const fn type_name(mut metadata: &[u8]) -> Option<&[u8]> {
         | IoTypeMetadataKind::VariableElements16b
         | IoTypeMetadataKind::VariableElements32b
         | IoTypeMetadataKind::VariableElements0 => b"VariableElements",
+        IoTypeMetadataKind::FixedCapacityBytes8b | IoTypeMetadataKind::FixedCapacityBytes16b => {
+            b"FixedCapacityBytes"
+        }
         IoTypeMetadataKind::Address => b"Address",
         IoTypeMetadataKind::Balance => b"Balance",
     })

--- a/crates/contracts/core/ab-contracts-io-type/src/trivial_type.rs
+++ b/crates/contracts/core/ab-contracts-io-type/src/trivial_type.rs
@@ -85,9 +85,6 @@ where
 unsafe impl TrivialType for () {
     const METADATA: &[u8] = &[IoTypeMetadataKind::Unit as u8];
 }
-unsafe impl TrivialType for bool {
-    const METADATA: &[u8] = &[IoTypeMetadataKind::Bool as u8];
-}
 unsafe impl TrivialType for u8 {
     const METADATA: &[u8] = &[IoTypeMetadataKind::U8 as u8];
 }

--- a/crates/contracts/example/ab-example-contract-flipper/benches/flip.rs
+++ b/crates/contracts/example/ab-example-contract-flipper/benches/flip.rs
@@ -1,5 +1,6 @@
 use ab_contracts_common::env::MethodContext;
 use ab_contracts_common::{Address, Contract, ShardIndex};
+use ab_contracts_io_type::bool::Bool;
 use ab_example_contract_flipper::{Flipper, FlipperExt};
 use ab_executor_native::NativeExecutor;
 use ab_system_contract_code::CodeExt;
@@ -21,7 +22,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
 
         // Initialize state
-        env.flipper_new(MethodContext::Keep, flipper_address, &true)
+        env.flipper_new(MethodContext::Keep, flipper_address, &Bool::new(true))
             .unwrap();
 
         flipper_address

--- a/crates/contracts/example/ab-example-contract-flipper/src/lib.rs
+++ b/crates/contracts/example/ab-example-contract-flipper/src/lib.rs
@@ -1,18 +1,19 @@
 #![no_std]
 
+use ab_contracts_io_type::bool::Bool;
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_macros::contract;
 
 #[derive(Debug, Copy, Clone, TrivialType)]
 #[repr(C)]
 pub struct Flipper {
-    pub value: bool,
+    pub value: Bool,
 }
 
 #[contract]
 impl Flipper {
     #[init]
-    pub fn new(#[input] &init_value: &bool) -> Self {
+    pub fn new(#[input] &init_value: &Bool) -> Self {
         Self { value: init_value }
     }
 
@@ -22,7 +23,7 @@ impl Flipper {
     }
 
     #[view]
-    pub fn value(&self) -> bool {
+    pub fn value(&self) -> Bool {
         self.value
     }
 }

--- a/crates/contracts/example/ab-example-contract-flipper/tests/basic.rs
+++ b/crates/contracts/example/ab-example-contract-flipper/tests/basic.rs
@@ -1,5 +1,6 @@
 use ab_contracts_common::env::MethodContext;
 use ab_contracts_common::{Address, Contract, ShardIndex};
+use ab_contracts_io_type::bool::Bool;
 use ab_example_contract_flipper::{Flipper, FlipperExt};
 use ab_executor_native::NativeExecutor;
 use ab_system_contract_code::CodeExt;
@@ -20,7 +21,7 @@ fn basic() {
             .code_deploy(MethodContext::Keep, Address::SYSTEM_CODE, &Flipper::code())
             .unwrap();
 
-        let init_value = true;
+        let init_value = Bool::new(true);
 
         // Initialize state
         env.flipper_new(MethodContext::Keep, flipper_address, &init_value)

--- a/crates/contracts/example/ab-example-contract-wallet/benches/example-contract-wallet.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/benches/example-contract-wallet.rs
@@ -1,6 +1,7 @@
 use crate::ffi::flip::FlipperFlipArgs;
 use ab_contracts_common::env::{Blake3Hash, MethodContext};
 use ab_contracts_common::{Address, Contract, ShardIndex};
+use ab_contracts_io_type::bool::Bool;
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_macros::contract;
 use ab_contracts_standards::tx_handler::TxHandler;
@@ -17,13 +18,13 @@ use schnorrkel::Keypair;
 #[derive(Debug, Copy, Clone, TrivialType)]
 #[repr(C)]
 pub struct Flipper {
-    pub value: bool,
+    pub value: Bool,
 }
 
 #[contract]
 impl Flipper {
     #[init]
-    pub fn new(#[input] &init_value: &bool) -> Self {
+    pub fn new(#[input] &init_value: &Bool) -> Self {
         Self { value: init_value }
     }
 
@@ -74,7 +75,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             .unwrap();
 
         // Initialize state
-        env.flipper_new(MethodContext::Keep, flipper_address, &true)
+        env.flipper_new(MethodContext::Keep, flipper_address, &Bool::new(true))
             .unwrap();
 
         flipper_address

--- a/crates/contracts/example/ab-example-contract-wallet/tests/flip.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/tests/flip.rs
@@ -4,6 +4,7 @@
 use crate::ffi::flip::FlipperFlipArgs;
 use ab_contracts_common::env::{Blake3Hash, MethodContext};
 use ab_contracts_common::{Address, Contract, ShardIndex};
+use ab_contracts_io_type::bool::Bool;
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_macros::contract;
 use ab_contracts_standards::tx_handler::TxHandler;
@@ -19,13 +20,13 @@ use schnorrkel::Keypair;
 #[derive(Debug, Copy, Clone, TrivialType)]
 #[repr(C)]
 pub struct Flipper {
-    pub value: bool,
+    pub value: Bool,
 }
 
 #[contract]
 impl Flipper {
     #[init]
-    pub fn new(#[input] &init_value: &bool) -> Self {
+    pub fn new(#[input] &init_value: &Bool) -> Self {
         Self { value: init_value }
     }
 
@@ -77,7 +78,7 @@ fn flip() {
             .unwrap();
 
         // Initialize state
-        env.flipper_new(MethodContext::Keep, flipper_address, &true)
+        env.flipper_new(MethodContext::Keep, flipper_address, &Bool::new(true))
             .unwrap();
 
         flipper_address

--- a/crates/contracts/system/ab-system-contract-state/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-state/src/lib.rs
@@ -2,6 +2,7 @@
 
 use ab_contracts_common::env::Env;
 use ab_contracts_common::{Address, ContractError};
+use ab_contracts_io_type::bool::Bool;
 use ab_contracts_io_type::trivial_type::TrivialType;
 use ab_contracts_io_type::variable_bytes::VariableBytes;
 use ab_contracts_macros::contract;
@@ -60,7 +61,7 @@ impl State {
         ),
         #[input] state: &VariableBytes<RECOMMENDED_STATE_CAPACITY>,
     ) -> Result<(), ContractError> {
-        if !Self::is_empty(contract_state) {
+        if !Self::is_empty(contract_state).get() {
             return Err(ContractError::Conflict);
         }
 
@@ -99,21 +100,21 @@ impl State {
         #[slot] (address, state): (&Address, &mut VariableBytes<RECOMMENDED_STATE_CAPACITY>),
         #[input] old_state: &VariableBytes<RECOMMENDED_STATE_CAPACITY>,
         #[input] new_state: &VariableBytes<RECOMMENDED_STATE_CAPACITY>,
-    ) -> Result<bool, ContractError> {
+    ) -> Result<Bool, ContractError> {
         // TODO: Check shard?
         if env.caller() != address {
             return Err(ContractError::Forbidden);
         }
 
         if state.get_initialized() != old_state.get_initialized() {
-            return Ok(false);
+            return Ok(Bool::new(false));
         }
 
         if !state.copy_from(new_state) {
             return Err(ContractError::BadInput);
         }
 
-        Ok(true)
+        Ok(Bool::new(true))
     }
 
     /// Read state
@@ -131,7 +132,7 @@ impl State {
 
     /// Check if the state is empty
     #[view]
-    pub fn is_empty(#[slot] contract_state: &VariableBytes<RECOMMENDED_STATE_CAPACITY>) -> bool {
-        contract_state.size() == 0
+    pub fn is_empty(#[slot] contract_state: &VariableBytes<RECOMMENDED_STATE_CAPACITY>) -> Bool {
+        Bool::new(contract_state.size() == 0)
     }
 }


### PR DESCRIPTION
`Bool` is an alternative for `bool` that is UB-safe for any bit pattern.

`FixedCapacityBytesU8` and `FixedCapacityBytesU16` are fixed size containers implementing `TrivialType`, which are helpful for composition when it is necessary to allow for differently sized inputs as fields in a struct, but undesirable to deal with `VariableBytes` that erases inner type information.

`FixedCapacityStringU8` and `FixedCapacityStringU16` are similarly to bytes and are in fact just wrappers, but semantically are storing UTF-8 bytes, which is useful for presenting their contents in UI as text instead of hex bytes.

This allows to do things like this:
```rust
#[derive(Copy, Clone, TrivialType)]
#[repr(C)]
struct Item {
    title: FixedCapacityStringU8<255>,
    description: FixedCapacityStringU16<1024>,
}
```

In this case the size of the data structure is always `1 + 255 + 2 + 1024` bytes, alignment `2`, but `title` and `description` can contain strings in `0..=255` and `0..=1024` bytes ranges accordingly.

Of course, when these are rendered as string, lossy best effort representation must be chosen since bytes are not really guaranteed to be strings.