### PR TITLE
Refactoring and cleanups

### DIFF
--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -11367,7 +11367,6 @@ dependencies = [
  "subspace-archiving",
  "subspace-core-primitives",
  "subspace-logging",
- "subspace-runtime-primitives",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -37,7 +37,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 use subspace_archiving::archiver::NewArchivedSegment;
-use subspace_core_primitives::BlockHash;
+use subspace_core_primitives::block::BlockHash;
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use subspace_core_primitives::pot::SlotNumber;
 use subspace_core_primitives::segments::{HistorySize, SegmentHeader, SegmentIndex};

--- a/subspace/crates/sc-consensus-subspace/src/archiver.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver.rs
@@ -61,7 +61,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 use subspace_archiving::archiver::{Archiver, NewArchivedSegment};
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::objects::{BlockObjectMapping, GlobalObject};
 use subspace_core_primitives::segments::{RecordedHistorySegment, SegmentHeader, SegmentIndex};
 use tracing::{debug, info, trace, warn};

--- a/subspace/crates/sc-consensus-subspace/src/archiver.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver.rs
@@ -50,14 +50,12 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_consensus_subspace::{SubspaceApi, SubspaceJustification};
 use sp_objects::ObjectsApi;
-use sp_runtime::Justifications;
 use sp_runtime::generic::SignedBlock;
-use sp_runtime::traits::{
-    Block as BlockT, BlockNumber as BlockNumberT, CheckedSub, Header, NumberFor, One, Zero,
-};
+use sp_runtime::traits::{Block as BlockT, Header, NumberFor, Zero};
+use sp_runtime::{Justifications, SaturatedConversion};
 use std::error::Error;
 use std::future::Future;
-use std::num::NonZeroU32;
+use std::num::NonZeroU64;
 use std::slice;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU16, Ordering};
@@ -355,7 +353,7 @@ pub enum CreateObjectMappings {
     /// The archiver will fail if it can't get the data for this block, but snap sync doesn't store
     /// the genesis data on disk.  So avoiding genesis also avoids this error.
     /// <https://github.com/paritytech/polkadot-sdk/issues/5366>
-    Block(NonZeroU32),
+    Block(NonZeroU64),
 
     /// Create object mappings as archiving is happening.
     Yes,
@@ -399,7 +397,7 @@ impl CreateObjectMappings {
 fn find_last_archived_block<Block, Client, AS>(
     client: &Client,
     segment_headers_store: &SegmentHeadersStore<AS>,
-    best_block_to_archive: NumberFor<Block>,
+    best_block_to_archive: BlockNumber,
     create_object_mappings: bool,
 ) -> sp_blockchain::Result<Option<(SegmentHeader, SignedBlock<Block>, BlockObjectMapping)>>
 where
@@ -423,13 +421,16 @@ where
     {
         let last_archived_block_number = segment_header.last_archived_block().number;
 
-        if NumberFor::<Block>::from(last_archived_block_number) > best_block_to_archive {
+        if last_archived_block_number > best_block_to_archive {
             // Last archived block in segment header is too high for current state of the chain
             // (segment headers store may know about more blocks in existence than is currently
             // imported)
             continue;
         }
-        let Some(last_archived_block_hash) = client.hash(last_archived_block_number.into())? else {
+        let Some(last_archived_block_hash) = client.hash(NumberFor::<Block>::saturated_from(
+            last_archived_block_number,
+        ))?
+        else {
             // This block number is not in our chain yet (segment headers store may know about more
             // blocks in existence than is currently imported)
             continue;
@@ -497,7 +498,7 @@ where
     Block: BlockT,
 {
     archiver: Archiver,
-    best_archived_block: (Block::Hash, NumberFor<Block>),
+    best_archived_block: (Block::Hash, BlockNumber),
 }
 
 /// Encode block for archiving purposes.
@@ -574,7 +575,7 @@ where
 
 fn initialize_archiver<Block, Client, AS>(
     segment_headers_store: &SegmentHeadersStore<AS>,
-    subspace_link: &SubspaceLink<Block>,
+    subspace_link: &SubspaceLink,
     client: &Client,
     create_object_mappings: CreateObjectMappings,
 ) -> sp_blockchain::Result<InitializedArchiver<Block>>
@@ -603,9 +604,13 @@ where
         best_block_to_archive = best_block_to_archive.min(block_number);
     }
 
-    if (best_block_to_archive..best_block_number)
-        .any(|block_number| client.hash(block_number.into()).ok().flatten().is_none())
-    {
+    if (best_block_to_archive..best_block_number).any(|block_number| {
+        client
+            .hash(NumberFor::<Block>::saturated_from(block_number))
+            .ok()
+            .flatten()
+            .is_none()
+    }) {
         // If there are blocks missing headers between best block to archive and best block of the
         // blockchain it means newer block was inserted in some special way and as such is by
         // definition valid, so we can simply assume that is our best block to archive instead
@@ -616,7 +621,9 @@ where
     // create mappings for it, so the node must exit with an error. We ignore genesis here, because
     // it doesn't have mappings.
     if create_object_mappings.is_enabled() && best_block_to_archive >= 1 {
-        let Some(best_block_to_archive_hash) = client.hash(best_block_to_archive.into())? else {
+        let Some(best_block_to_archive_hash) =
+            client.hash(NumberFor::<Block>::saturated_from(best_block_to_archive))?
+        else {
             let error = format!(
                 "Missing hash for mapping block {best_block_to_archive}, \
                 try a higher block number, or wipe your node and restart with `--sync full`"
@@ -655,7 +662,7 @@ where
     let maybe_last_archived_block = find_last_archived_block(
         client,
         segment_headers_store,
-        best_block_to_archive.into(),
+        best_block_to_archive,
         create_object_mappings.is_enabled(),
     )?;
 
@@ -677,7 +684,7 @@ where
             // is nothing else available
             best_archived_block.replace((
                 last_archived_block.block.hash(),
-                *last_archived_block.block.header().number(),
+                (*last_archived_block.block.header().number()).saturated_into::<BlockNumber>(),
             ));
 
             let last_archived_block_encoded = encode_block(last_archived_block);
@@ -740,7 +747,7 @@ where
                         || client.runtime_api(),
                         |runtime_api, block_number| {
                             let block_hash = client
-                                .hash(block_number.into())?
+                                .hash(NumberFor::<Block>::saturated_from(block_number))?
                                 .expect("All blocks since last archived must be present; qed");
 
                             let block = client
@@ -769,11 +776,15 @@ where
                 blocks_to_archive
                     .last()
                     .map(|(block, _block_object_mappings)| {
-                        (block.block.hash(), *block.block.header().number())
+                        (
+                            block.block.hash(),
+                            (*block.block.header().number()).saturated_into::<BlockNumber>(),
+                        )
                     });
 
             for (signed_block, block_object_mappings) in blocks_to_archive {
-                let block_number_to_archive = *signed_block.block.header().number();
+                let block_number_to_archive =
+                    (*signed_block.block.header().number()).saturated_into::<BlockNumber>();
                 let encoded_block = encode_block(signed_block);
 
                 debug!(
@@ -808,11 +819,8 @@ where
     })
 }
 
-fn finalize_block<Block, Backend, Client>(
-    client: &Client,
-    hash: Block::Hash,
-    number: NumberFor<Block>,
-) where
+fn finalize_block<Block, Backend, Client>(client: &Client, hash: Block::Hash, number: BlockNumber)
+where
     Block: BlockT,
     Backend: BackendT<Block>,
     Client: LockImportRun<Block, Backend> + Finalizer<Block, Backend>,
@@ -874,7 +882,7 @@ fn finalize_block<Block, Backend, Client>(
 /// efficient overall and during sync only total sync time matters.
 pub fn create_subspace_archiver<Block, Backend, Client, AS>(
     segment_headers_store: SegmentHeadersStore<AS>,
-    subspace_link: SubspaceLink<Block>,
+    subspace_link: SubspaceLink,
     client: Arc<Client>,
     create_object_mappings: CreateObjectMappings,
 ) -> sp_blockchain::Result<impl Future<Output = sp_blockchain::Result<()>> + Send + 'static>
@@ -929,7 +937,7 @@ where
                 create_object_mappings,
             )?,
         };
-        let confirmation_depth_k = subspace_link.chain_constants.confirmation_depth_k().into();
+        let confirmation_depth_k = subspace_link.chain_constants.confirmation_depth_k();
 
         let InitializedArchiver {
             mut archiver,
@@ -942,7 +950,7 @@ where
         {
             let importing_block_number = block_importing_notification.block_number;
             let block_number_to_archive =
-                match importing_block_number.checked_sub(&confirmation_depth_k) {
+                match importing_block_number.checked_sub(confirmation_depth_k) {
                     Some(block_number_to_archive) => block_number_to_archive,
                     None => {
                         // Too early to archive blocks
@@ -957,7 +965,6 @@ where
                 .number;
             let create_mappings =
                 create_object_mappings.is_enabled_for_block(last_archived_block_number);
-            let last_archived_block_number = NumberFor::<Block>::from(last_archived_block_number);
             trace!(
                 %importing_block_number,
                 %block_number_to_archive,
@@ -985,7 +992,7 @@ where
             // block number (rather than block number at some depth) to allow for special sync
             // modes where pre-verified blocks are inserted at some point in the future comparing to
             // previously existing blocks
-            if best_archived_block_number + One::one() != block_number_to_archive {
+            if best_archived_block_number + 1 != block_number_to_archive {
                 InitializedArchiver {
                     archiver,
                     best_archived_block: (best_archived_block_hash, best_archived_block_number),
@@ -996,14 +1003,16 @@ where
                     create_object_mappings,
                 )?;
 
-                if best_archived_block_number + One::one() == block_number_to_archive {
+                if best_archived_block_number + 1 == block_number_to_archive {
                     // As expected, can archive this block
                 } else if best_archived_block_number >= block_number_to_archive {
                     // Special sync mode where verified blocks were inserted into blockchain
                     // directly, archiving of this block will naturally happen later
                     continue;
                 } else if client
-                    .block_hash(importing_block_number - One::one())?
+                    .block_hash(NumberFor::<Block>::saturated_from(
+                        importing_block_number - 1,
+                    ))?
                     .is_none()
                 {
                     // We may have imported some block using special sync mode and block we're about
@@ -1051,9 +1060,11 @@ where
                     .map(|segment_header| segment_header.last_archived_block().number)
                     // Make sure not to finalize block number that does not yet exist (segment
                     // headers store may contain future blocks during initial sync)
-                    .map(|block_number| block_number_to_archive.min(block_number.into()))
+                    .map(|block_number| block_number_to_archive.min(block_number))
                     // Do not finalize blocks twice
-                    .filter(|block_number| *block_number > client.info().finalized_number);
+                    .filter(|&block_number| {
+                        block_number > client.info().finalized_number.saturated_into()
+                    });
 
                 if let Some(block_number_to_finalize) = maybe_block_number_to_finalize {
                     {
@@ -1065,7 +1076,9 @@ where
 
                         while let Some(notification) = import_notification.next().await {
                             // Wait for importing block to finish importing
-                            if notification.header.number() == &importing_block_number {
+                            if (*notification.header.number()).saturated_into::<BlockNumber>()
+                                == importing_block_number
+                            {
                                 break;
                             }
                         }
@@ -1073,8 +1086,8 @@ where
 
                     // Block is not guaranteed to be present this deep if we have only synced recent
                     // blocks
-                    if let Some(block_hash_to_finalize) =
-                        client.block_hash(block_number_to_finalize)?
+                    if let Some(block_hash_to_finalize) = client
+                        .block_hash(NumberFor::<Block>::saturated_from(block_number_to_finalize))?
                     {
                         finalize_block(&*client, block_hash_to_finalize, block_number_to_finalize);
                     }
@@ -1095,9 +1108,9 @@ async fn archive_block<Block, Backend, Client, AS>(
     object_mapping_notification_sender: SubspaceNotificationSender<ObjectMappingNotification>,
     archived_segment_notification_sender: SubspaceNotificationSender<ArchivedSegmentNotification>,
     best_archived_block_hash: Block::Hash,
-    block_number_to_archive: NumberFor<Block>,
+    block_number_to_archive: BlockNumber,
     create_object_mappings: CreateObjectMappings,
-) -> sp_blockchain::Result<(Block::Hash, NumberFor<Block>)>
+) -> sp_blockchain::Result<(Block::Hash, BlockNumber)>
 where
     Block: BlockT,
     Backend: BackendT<Block>,
@@ -1116,7 +1129,7 @@ where
     let block = client
         .block(
             client
-                .block_hash(block_number_to_archive)?
+                .block_hash(NumberFor::<Block>::saturated_from(block_number_to_archive))?
                 .expect("Older block by number must always exist"),
         )?
         .expect("Older block by number must always exist");
@@ -1139,11 +1152,7 @@ where
         )));
     }
 
-    let create_mappings = create_object_mappings.is_enabled_for_block(
-        block_number_to_archive.try_into().unwrap_or_else(|_| {
-            unreachable!("sp_runtime::BlockNumber fits into subspace_primitives::BlockNumber; qed")
-        }),
-    );
+    let create_mappings = create_object_mappings.is_enabled_for_block(block_number_to_archive);
 
     let block_object_mappings = if create_mappings {
         client
@@ -1183,20 +1192,14 @@ where
     Ok((block_hash_to_archive, block_number_to_archive))
 }
 
-fn send_object_mapping_notification<BlockNum>(
+fn send_object_mapping_notification(
     object_mapping_notification_sender: &SubspaceNotificationSender<ObjectMappingNotification>,
     object_mapping: Vec<GlobalObject>,
-    block_number: BlockNum,
-) where
-    BlockNum: BlockNumberT,
-{
+    block_number: BlockNumber,
+) {
     if object_mapping.is_empty() {
         return;
     }
-
-    let block_number = TryInto::<BlockNumber>::try_into(block_number).unwrap_or_else(|_| {
-        unreachable!("sp_runtime::BlockNumber fits into subspace_primitives::BlockNumber; qed");
-    });
 
     let object_mapping_notification = ObjectMappingNotification {
         object_mapping,

--- a/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -112,14 +112,14 @@ fn segment_headers_store_block_number_queries_work() {
     let segment_header0 = segment_headers
         .get_segment_header(SegmentIndex::ZERO)
         .unwrap();
-    let result = segment_headers.segment_headers_for_block(1u32);
+    let result = segment_headers.segment_headers_for_block(1);
     assert_eq!(result, vec![segment_header0]);
 
     // Special case, genesis segment header is included in block 1, not later
     let result = segment_headers.segment_headers_for_block(confirmation_depth_k + 1);
     assert_eq!(result, vec![]);
 
-    for num in 2u32..752u32 {
+    for num in 2..752_u64 {
         let result = segment_headers.segment_headers_for_block(num);
         assert_eq!(result, vec![]);
     }
@@ -133,7 +133,7 @@ fn segment_headers_store_block_number_queries_work() {
         ])
         .unwrap();
 
-    for num in 2u32..752u32 {
+    for num in 2..752_u64 {
         let result = segment_headers.segment_headers_for_block(num);
         assert_eq!(result, vec![]);
     }
@@ -143,11 +143,11 @@ fn segment_headers_store_block_number_queries_work() {
         .get_segment_header(SegmentIndex::ONE)
         .unwrap();
     // last archived block + confirmation depth + 1
-    let result = segment_headers.segment_headers_for_block(753u32);
+    let result = segment_headers.segment_headers_for_block(753);
     assert_eq!(result, vec![segment_header1]);
 
     // No segment headers in between
-    for num in 754u32..852u32 {
+    for num in 754..852_u64 {
         let result = segment_headers.segment_headers_for_block(num);
         assert_eq!(result, vec![]);
     }
@@ -156,13 +156,13 @@ fn segment_headers_store_block_number_queries_work() {
     let segment_header2 = segment_headers
         .get_segment_header(SegmentIndex::from(2))
         .unwrap();
-    let result = segment_headers.segment_headers_for_block(853u32);
+    let result = segment_headers.segment_headers_for_block(853);
     assert_eq!(result, vec![segment_header2]);
 
     // End of third segment
     let segment_header3 = segment_headers
         .get_segment_header(SegmentIndex::from(3))
         .unwrap();
-    let result = segment_headers.segment_headers_for_block(907u32);
+    let result = segment_headers.segment_headers_for_block(907);
     assert_eq!(result, vec![segment_header3, segment_header4]);
 }

--- a/subspace/crates/sc-consensus-subspace/src/aux_schema.rs
+++ b/subspace/crates/sc-consensus-subspace/src/aux_schema.rs
@@ -3,7 +3,7 @@
 use parity_scale_codec::{Decode, Encode};
 use sc_client_api::backend::AuxStore;
 use sp_blockchain::{Error as ClientError, Result as ClientResult};
-use subspace_core_primitives::BlockWeight;
+use subspace_core_primitives::block::BlockWeight;
 
 fn load_decode<B, T>(backend: &B, key: &[u8]) -> ClientResult<Option<T>>
 where

--- a/subspace/crates/sc-consensus-subspace/src/block_import.rs
+++ b/subspace/crates/sc-consensus-subspace/src/block_import.rs
@@ -31,8 +31,8 @@ use sp_consensus_subspace::digests::{
 };
 use sp_consensus_subspace::{PotNextSlotInput, SubspaceApi, SubspaceJustification};
 use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
-use sp_runtime::Justifications;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, One};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, One};
+use sp_runtime::{Justifications, SaturatedConversion};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use subspace_core_primitives::BlockNumber;
@@ -51,12 +51,9 @@ use tracing::warn;
 /// Notification with number of the block that is about to be imported and acknowledgement sender
 /// that can be used to pause block production if desired.
 #[derive(Debug, Clone)]
-pub struct BlockImportingNotification<Block>
-where
-    Block: BlockT,
-{
+pub struct BlockImportingNotification {
     /// Block number
-    pub block_number: NumberFor<Block>,
+    pub block_number: BlockNumber,
     /// Sender for pausing the block import when operator is not fast enough to process
     /// the consensus block.
     pub acknowledgement_sender: mpsc::Sender<()>,
@@ -253,23 +250,19 @@ where
 }
 
 /// A block-import handler for Subspace.
-pub struct SubspaceBlockImport<PosTable, Block, Client, I, CIDP, AS>
-where
-    Block: BlockT,
-{
+pub struct SubspaceBlockImport<PosTable, Block, Client, I, CIDP, AS> {
     inner: I,
     client: Arc<Client>,
-    subspace_link: SubspaceLink<Block>,
+    subspace_link: SubspaceLink,
     create_inherent_data_providers: CIDP,
     segment_headers_store: SegmentHeadersStore<AS>,
     pot_verifier: PotVerifier,
-    _pos_table: PhantomData<PosTable>,
+    _phantom: PhantomData<(PosTable, Block)>,
 }
 
 impl<PosTable, Block, I, Client, CIDP, AS> Clone
     for SubspaceBlockImport<PosTable, Block, Client, I, CIDP, AS>
 where
-    Block: BlockT,
     I: Clone,
     CIDP: Clone,
 {
@@ -281,7 +274,7 @@ where
             create_inherent_data_providers: self.create_inherent_data_providers.clone(),
             segment_headers_store: self.segment_headers_store.clone(),
             pot_verifier: self.pot_verifier.clone(),
-            _pos_table: PhantomData,
+            _phantom: PhantomData,
         }
     }
 }
@@ -300,7 +293,7 @@ where
     pub fn new(
         client: Arc<Client>,
         block_import: I,
-        subspace_link: SubspaceLink<Block>,
+        subspace_link: SubspaceLink,
         create_inherent_data_providers: CIDP,
         segment_headers_store: SegmentHeadersStore<AS>,
         pot_verifier: PotVerifier,
@@ -312,7 +305,7 @@ where
             create_inherent_data_providers,
             segment_headers_store,
             pot_verifier,
-            _pos_table: PhantomData,
+            _phantom: PhantomData,
         }
     }
 
@@ -559,7 +552,7 @@ where
         mut block: BlockImportParams<Block>,
     ) -> Result<ImportResult, Self::Error> {
         let block_hash = block.post_hash();
-        let block_number = *block.header.number();
+        let block_number = (*block.header.number()).saturated_into::<BlockNumber>();
 
         // Early exit if block already in chain
         match self.client.status(block_hash)? {

--- a/subspace/crates/sc-consensus-subspace/src/block_import.rs
+++ b/subspace/crates/sc-consensus-subspace/src/block_import.rs
@@ -35,7 +35,7 @@ use sp_runtime::traits::{Block as BlockT, Header as HeaderT, One};
 use sp_runtime::{Justifications, SaturatedConversion};
 use std::marker::PhantomData;
 use std::sync::Arc;
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::pot::SlotNumber;
 use subspace_core_primitives::sectors::SectorId;

--- a/subspace/crates/sc-consensus-subspace/src/lib.rs
+++ b/subspace/crates/sc-consensus-subspace/src/lib.rs
@@ -23,11 +23,10 @@ use crate::notification::{SubspaceNotificationSender, SubspaceNotificationStream
 use crate::slot_worker::{NewSlotNotification, RewardSigningNotification};
 use ab_erasure_coding::ErasureCoding;
 use sp_consensus_subspace::ChainConstants;
-use sp_runtime::traits::Block as BlockT;
 
 /// State that must be shared between various consensus components.
 #[derive(Clone)]
-pub struct SubspaceLink<Block: BlockT> {
+pub struct SubspaceLink {
     new_slot_notification_sender: SubspaceNotificationSender<NewSlotNotification>,
     new_slot_notification_stream: SubspaceNotificationStream<NewSlotNotification>,
     reward_signing_notification_sender: SubspaceNotificationSender<RewardSigningNotification>,
@@ -36,15 +35,13 @@ pub struct SubspaceLink<Block: BlockT> {
     object_mapping_notification_stream: SubspaceNotificationStream<ObjectMappingNotification>,
     archived_segment_notification_sender: SubspaceNotificationSender<ArchivedSegmentNotification>,
     archived_segment_notification_stream: SubspaceNotificationStream<ArchivedSegmentNotification>,
-    block_importing_notification_sender:
-        SubspaceNotificationSender<BlockImportingNotification<Block>>,
-    block_importing_notification_stream:
-        SubspaceNotificationStream<BlockImportingNotification<Block>>,
+    block_importing_notification_sender: SubspaceNotificationSender<BlockImportingNotification>,
+    block_importing_notification_stream: SubspaceNotificationStream<BlockImportingNotification>,
     chain_constants: ChainConstants,
     erasure_coding: ErasureCoding,
 }
 
-impl<Block: BlockT> SubspaceLink<Block> {
+impl SubspaceLink {
     /// Create new instance.
     pub fn new(chain_constants: ChainConstants, erasure_coding: ErasureCoding) -> Self {
         let (new_slot_notification_sender, new_slot_notification_stream) =
@@ -108,7 +105,7 @@ impl<Block: BlockT> SubspaceLink<Block> {
     /// potentially fail to import in Substrate's internals.
     pub fn block_importing_notification_stream(
         &self,
-    ) -> SubspaceNotificationStream<BlockImportingNotification<Block>> {
+    ) -> SubspaceNotificationStream<BlockImportingNotification> {
         self.block_importing_notification_stream.clone()
     }
 

--- a/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -168,7 +168,7 @@ where
     /// Strategy and parameters for backing off block production.
     pub backoff_authoring_blocks: Option<BS>,
     /// The source of timestamps for relative slots
-    pub subspace_link: SubspaceLink<Block>,
+    pub subspace_link: SubspaceLink,
     /// Persistent storage of segment headers
     pub segment_headers_store: SegmentHeadersStore<AS>,
     /// The proportion of the slot dedicated to proposing.
@@ -197,7 +197,7 @@ where
     justification_sync_link: L,
     force_authoring: bool,
     backoff_authoring_blocks: Option<BS>,
-    subspace_link: SubspaceLink<Block>,
+    subspace_link: SubspaceLink,
     reward_signing_context: SigningContext,
     block_proposal_slot_portion: SlotProportion,
     max_block_proposal_slot_portion: Option<SlotProportion>,
@@ -342,7 +342,7 @@ where
         slot: Slot,
         _aux_data: &Self::AuxData,
     ) -> Option<Self::Claim> {
-        let slot = SlotNumber::new(u64::from(slot));
+        let slot = SlotNumber::new(<u64 as From<Slot>>::from(slot));
 
         let parent_pre_digest = match extract_pre_digest(parent_header) {
             Ok(pre_digest) => pre_digest,

--- a/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -47,7 +47,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::pot::{PotCheckpoints, PotOutput, SlotNumber};
 use subspace_core_primitives::sectors::SectorId;

--- a/subspace/crates/sc-consensus-subspace/src/verifier.rs
+++ b/subspace/crates/sc-consensus-subspace/src/verifier.rs
@@ -38,7 +38,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::available_parallelism;
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::pot::SlotNumber;
 use subspace_core_primitives::solutions::{SolutionVerifyError, SolutionVerifyParams};

--- a/subspace/crates/sp-consensus-subspace/src/lib.rs
+++ b/subspace/crates/sp-consensus-subspace/src/lib.rs
@@ -14,7 +14,7 @@ use core::num::NonZeroU32;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{ConsensusEngineId, Justification};
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::pot::{PotCheckpoints, PotOutput, PotSeed, SlotDuration, SlotNumber};
 use subspace_core_primitives::segments::{HistorySize, SegmentHeader, SegmentIndex, SegmentRoot};

--- a/subspace/crates/subspace-archiving/src/archiver.rs
+++ b/subspace/crates/subspace-archiving/src/archiver.rs
@@ -6,7 +6,7 @@ use core::cmp::Ordering;
 use parity_scale_codec::{Compact, CompactLen, Decode, Encode, Input, Output};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::objects::{BlockObject, BlockObjectMapping, GlobalObject};
 use subspace_core_primitives::pieces::Record;

--- a/subspace/crates/subspace-archiving/src/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/reconstructor.rs
@@ -3,7 +3,7 @@ use ab_erasure_coding::{ErasureCoding, ErasureCodingError, RecoveryShardState};
 use alloc::vec::Vec;
 use core::mem;
 use parity_scale_codec::Decode;
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::pieces::Piece;
 use subspace_core_primitives::segments::{
     ArchivedBlockProgress, ArchivedHistorySegment, LastArchivedBlock, RecordedHistorySegment,

--- a/subspace/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/archiver.rs
@@ -261,13 +261,13 @@ fn archiver() {
         let archived_segment = archived_segments.first().unwrap();
         let last_archived_block = archived_segment.segment_header.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived(), Some(111848003));
+        assert_eq!(last_archived_block.partial_archived(), Some(111847999));
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
         let last_archived_block = archived_segment.segment_header.last_archived_block();
         assert_eq!(last_archived_block.number, 2);
-        assert_eq!(last_archived_block.partial_archived(), Some(246065642));
+        assert_eq!(last_archived_block.partial_archived(), Some(246065634));
     }
 
     // Check that both archived segments have expected content and valid pieces in them
@@ -313,7 +313,7 @@ fn archiver() {
 
     // Add a block such that it fits in the next segment exactly
     let block_3 = {
-        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369910];
+        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369920];
         rng.fill_bytes(block.as_mut_slice());
         block
     };

--- a/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -148,7 +148,7 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(33554322)
+                archived_progress: ArchivedBlockProgress::Partial(33554318)
             }
         );
 
@@ -168,7 +168,7 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(33554322)
+                archived_progress: ArchivedBlockProgress::Partial(33554318)
             }
         );
     }
@@ -189,7 +189,7 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(167771961)
+                archived_progress: ArchivedBlockProgress::Partial(167771953)
             }
         );
     }
@@ -211,7 +211,7 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(167771961)
+                archived_progress: ArchivedBlockProgress::Partial(167771953)
             }
         );
     }
@@ -232,7 +232,7 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(301989600)
+                archived_progress: ArchivedBlockProgress::Partial(301989588)
             }
         );
     }
@@ -254,7 +254,7 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: 3,
-                archived_progress: ArchivedBlockProgress::Partial(301989600)
+                archived_progress: ArchivedBlockProgress::Partial(301989588)
             }
         );
     }

--- a/subspace/crates/subspace-core-primitives/src/block.rs
+++ b/subspace/crates/subspace-core-primitives/src/block.rs
@@ -1,0 +1,10 @@
+//! Block-related primitives
+
+/// Block number in Subspace network
+pub type BlockNumber = u64;
+/// Block hash in Subspace network
+pub type BlockHash = [u8; 32];
+/// BlockWeight type for fork choice rule.
+///
+/// The smaller the solution range is, the heavier is the block.
+pub type BlockWeight = u128;

--- a/subspace/crates/subspace-core-primitives/src/lib.rs
+++ b/subspace/crates/subspace-core-primitives/src/lib.rs
@@ -31,7 +31,7 @@ const _: () = {
 };
 
 /// Block number in Subspace network.
-pub type BlockNumber = u32;
+pub type BlockNumber = u64;
 
 /// Block hash in Subspace network.
 pub type BlockHash = [u8; 32];

--- a/subspace/crates/subspace-core-primitives/src/lib.rs
+++ b/subspace/crates/subspace-core-primitives/src/lib.rs
@@ -9,6 +9,7 @@
 //  https://github.com/rust-lang/rust/issues/133199
 #![feature(generic_const_exprs)]
 
+pub mod block;
 #[cfg(feature = "scale-codec")]
 pub mod checksum;
 pub mod hashes;
@@ -29,14 +30,3 @@ const _: () = {
         "Must be at least 32-bit platform"
     );
 };
-
-/// Block number in Subspace network.
-pub type BlockNumber = u64;
-
-/// Block hash in Subspace network.
-pub type BlockHash = [u8; 32];
-
-/// BlockWeight type for fork choice rules.
-///
-/// The closer solution's tag is to the target, the heavier it is.
-pub type BlockWeight = u128;

--- a/subspace/crates/subspace-core-primitives/src/segments.rs
+++ b/subspace/crates/subspace-core-primitives/src/segments.rs
@@ -3,13 +3,13 @@
 #[cfg(feature = "alloc")]
 mod archival_history_segment;
 
+use crate::block::BlockNumber;
+use crate::hashes::Blake3Hash;
 #[cfg(feature = "scale-codec")]
 use crate::hashes::blake3_hash;
-use crate::hashes::Blake3Hash;
 use crate::pieces::{PieceIndex, Record};
 #[cfg(feature = "alloc")]
 pub use crate::segments::archival_history_segment::ArchivedHistorySegment;
-use crate::BlockNumber;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use core::array::TryFromSliceError;

--- a/subspace/crates/subspace-core-primitives/src/segments.rs
+++ b/subspace/crates/subspace-core-primitives/src/segments.rs
@@ -3,13 +3,13 @@
 #[cfg(feature = "alloc")]
 mod archival_history_segment;
 
-use crate::BlockNumber;
-use crate::hashes::Blake3Hash;
 #[cfg(feature = "scale-codec")]
 use crate::hashes::blake3_hash;
+use crate::hashes::Blake3Hash;
 use crate::pieces::{PieceIndex, Record};
 #[cfg(feature = "alloc")]
 pub use crate::segments::archival_history_segment::ArchivedHistorySegment;
+use crate::BlockNumber;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use core::array::TryFromSliceError;
@@ -328,7 +328,7 @@ impl LastArchivedBlock {
 
     /// Sets new number of partially archived bytes.
     #[inline(always)]
-    pub fn set_partial_archived(&mut self, new_partial: BlockNumber) {
+    pub fn set_partial_archived(&mut self, new_partial: u32) {
         self.archived_progress.set_partial(new_partial);
     }
 

--- a/subspace/crates/subspace-core-primitives/src/solutions.rs
+++ b/subspace/crates/subspace-core-primitives/src/solutions.rs
@@ -1,6 +1,6 @@
 //! Solutions-related data structures and functions.
 
-use crate::BlockNumber;
+use crate::block::BlockNumber;
 use crate::hashes::{Blake3Hash, blake3_hash_with_key};
 use crate::pieces::{PieceOffset, Record, RecordChunk, RecordProof, RecordRoot};
 use crate::pos::{PosProof, PosSeed};

--- a/subspace/crates/subspace-node/src/chain_spec.rs
+++ b/subspace/crates/subspace-node/src/chain_spec.rs
@@ -6,7 +6,7 @@ use sc_service::ChainType;
 use sp_core::crypto::Ss58Codec;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::pot::PotKey;
 use subspace_core_primitives::solutions::SolutionRange;
 use subspace_runtime::{

--- a/subspace/crates/subspace-node/src/chain_spec.rs
+++ b/subspace/crates/subspace-node/src/chain_spec.rs
@@ -6,6 +6,7 @@ use sc_service::ChainType;
 use sp_core::crypto::Ss58Codec;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
+use subspace_core_primitives::BlockNumber;
 use subspace_core_primitives::pot::PotKey;
 use subspace_core_primitives::solutions::SolutionRange;
 use subspace_runtime::{
@@ -23,7 +24,7 @@ struct GenesisParams {
     allow_authoring_by: AllowAuthoringBy,
     pot_slot_iterations: NonZeroU32,
     enable_dynamic_cost_of_storage: bool,
-    confirmation_depth_k: u32,
+    confirmation_depth_k: BlockNumber,
 }
 
 pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {

--- a/subspace/crates/subspace-node/src/commands/run/consensus.rs
+++ b/subspace/crates/subspace-node/src/commands/run/consensus.rs
@@ -15,10 +15,9 @@ use sc_storage_monitor::StorageMonitorParams;
 use std::collections::HashSet;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::num::NonZeroU32;
+use std::num::NonZeroU64;
 use std::path::PathBuf;
 use std::str::FromStr;
-use subspace_core_primitives::BlockNumber;
 use subspace_networking::libp2p::Multiaddr;
 use subspace_networking::libp2p::multiaddr::Protocol;
 use subspace_service::config::{
@@ -31,7 +30,7 @@ use tracing::{error, warn};
 
 /// Roughly 138k empty blocks can fit into one archived segment, hence we need to not allow to prune
 /// more blocks that this
-const MIN_STATE_PRUNING: BlockNumber = 140_000;
+const MIN_STATE_PRUNING: u32 = 140_000;
 
 fn parse_timekeeper_cpu_cores(
     s: &str,
@@ -315,7 +314,7 @@ pub enum CreateObjectMappingConfig {
     /// The archiver will fail if it can't get the data for this block, and snap sync doesn't store
     /// the genesis data on disk. So avoiding genesis also avoids this error.
     /// <https://github.com/paritytech/polkadot-sdk/issues/5366>
-    Block(NonZeroU32),
+    Block(NonZeroU64),
 
     /// Create object mappings as archiving is happening.
     /// This continues from the last archived segment, but mappings that were in the channel or RPC
@@ -545,7 +544,7 @@ pub(super) fn create_consensus_chain_configuration(
             timekeeper_options.timekeeper = true;
 
             if create_object_mappings.is_none() {
-                create_object_mappings = Some(CreateObjectMappingConfig::Block(NonZeroU32::MIN));
+                create_object_mappings = Some(CreateObjectMappingConfig::Block(NonZeroU64::MIN));
             }
 
             if sync.is_none() {

--- a/subspace/crates/subspace-runtime-primitives/src/lib.rs
+++ b/subspace/crates/subspace-runtime-primitives/src/lib.rs
@@ -18,7 +18,7 @@ use scale_info::TypeInfo;
 use sp_core::parameter_types;
 use sp_runtime::traits::{Bounded, IdentifyAccount, Verify};
 use sp_runtime::{FixedPointNumber, MultiSignature, Perbill, Perquintill};
-pub use subspace_core_primitives::BlockNumber;
+pub use subspace_core_primitives::block::BlockNumber;
 
 /// Minimum desired number of replicas of the blockchain to be stored by the network,
 /// impacts storage fees.
@@ -88,10 +88,10 @@ parameter_types! {
 /// allowing for them to continue syncing the network through upgrades to even the core data
 /// structures.
 pub mod opaque {
-    use super::BlockNumber;
     pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
     use sp_runtime::generic;
     use sp_runtime::traits::BlakeTwo256;
+    use subspace_core_primitives::block::BlockNumber;
 
     /// Opaque block header type.
     pub type Header = generic::Header<BlockNumber, BlakeTwo256>;

--- a/subspace/crates/subspace-runtime-primitives/src/lib.rs
+++ b/subspace/crates/subspace-runtime-primitives/src/lib.rs
@@ -68,7 +68,7 @@ pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::Account
 pub type Balance = u128;
 
 /// Index of a transaction in the chain.
-pub type Nonce = u32;
+pub type Nonce = u64;
 
 /// A hash of some data used by the chain.
 pub type Hash = sp_core::H256;

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -46,6 +46,7 @@ use sp_runtime::type_with_default::TypeWithDefault;
 use sp_runtime::{ApplyExtrinsicResult, ExtrinsicInclusionMode, generic};
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::objects::BlockObjectMapping;
 use subspace_core_primitives::pieces::Piece;
@@ -55,7 +56,7 @@ use subspace_runtime_primitives::utility::{
     DefaultNonceProvider, MaybeNestedCall, MaybeUtilityCall,
 };
 use subspace_runtime_primitives::{
-    AccountId, BLOCK_WEIGHT_FOR_2_SEC, Balance, BlockNumber, ConsensusEventSegmentSize, Hash,
+    AccountId, BLOCK_WEIGHT_FOR_2_SEC, Balance, ConsensusEventSegmentSize, Hash,
     MIN_REPLICATION_FACTOR, Moment, NORMAL_DISPATCH_RATIO, Nonce, SHANNON, SLOT_PROBABILITY,
     Signature, SlowAdjustingFeeUpdate, TargetBlockFullness, maximum_normal_block_length,
 };

--- a/subspace/crates/subspace-runtime/src/lib.rs
+++ b/subspace/crates/subspace-runtime/src/lib.rs
@@ -98,7 +98,7 @@ const POT_ENTROPY_INJECTION_DELAY: SlotNumber = SlotNumber::new(15);
 
 // Entropy injection interval must be bigger than injection delay or else we may end up in a
 // situation where we'll need to do more than one injection at the same slot
-const_assert!(POT_ENTROPY_INJECTION_INTERVAL as u64 > POT_ENTROPY_INJECTION_DELAY.as_u64());
+const_assert!(POT_ENTROPY_INJECTION_INTERVAL > POT_ENTROPY_INJECTION_DELAY.as_u64());
 // Entropy injection delay must be bigger than block authoring delay or else we may include
 // invalid future proofs in parent block, +1 ensures we do not have unnecessary reorgs that will
 // inevitably happen otherwise

--- a/subspace/crates/subspace-service/src/lib.rs
+++ b/subspace/crates/subspace-service/src/lib.rs
@@ -24,7 +24,6 @@ use crate::sync_from_dsn::snap_sync::snap_sync;
 use crate::task_spawner::SpawnTasksParams;
 use ab_erasure_coding::ErasureCoding;
 use async_lock::Semaphore;
-use core::sync::atomic::{AtomicU32, Ordering};
 use frame_system_rpc_runtime_api::AccountNonceApi;
 use futures::channel::oneshot;
 use jsonrpsee::RpcModule;
@@ -75,6 +74,7 @@ use sp_runtime::traits::{Block as BlockT, BlockIdTo};
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
 use static_assertions::const_assert;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use subspace_core_primitives::pot::PotSeed;
 use subspace_networking::libp2p::multiaddr::Protocol;
@@ -189,13 +189,13 @@ where
     /// Subspace block import
     pub block_import: BoxBlockImport<Block>,
     /// Subspace link
-    pub subspace_link: SubspaceLink<Block>,
+    pub subspace_link: SubspaceLink,
     /// Segment headers store
     pub segment_headers_store: SegmentHeadersStore<FullClient<RuntimeApi>>,
     /// Proof of time verifier
     pub pot_verifier: PotVerifier,
     /// Approximate target block number for syncing purposes
-    pub sync_target_block_number: Arc<AtomicU32>,
+    pub sync_target_block_number: Arc<AtomicU64>,
 }
 
 type PartialComponents<RuntimeApi> = sc_service::PartialComponents<
@@ -308,7 +308,7 @@ where
         pot_verifier.clone(),
     );
 
-    let sync_target_block_number = Arc::new(AtomicU32::new(0));
+    let sync_target_block_number = Arc::new(AtomicU64::new(0));
     let transaction_pool = Arc::from(
         sc_transaction_pool::Builder::new(
             task_manager.spawn_essential_handle(),
@@ -389,8 +389,7 @@ where
     /// Block signing stream.
     pub reward_signing_notification_stream: SubspaceNotificationStream<RewardSigningNotification>,
     /// Stream of notifications about blocks about to be imported.
-    pub block_importing_notification_stream:
-        SubspaceNotificationStream<BlockImportingNotification<Block>>,
+    pub block_importing_notification_stream: SubspaceNotificationStream<BlockImportingNotification>,
     /// Archived segment stream.
     pub archived_segment_notification_stream:
         SubspaceNotificationStream<ArchivedSegmentNotification>,

--- a/subspace/crates/subspace-service/src/sync_from_dsn.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn.rs
@@ -24,7 +24,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::pieces::{Piece, PieceIndex};
 use subspace_core_primitives::segments::SegmentIndex;
 use subspace_data_retrieval::piece_getter::PieceGetter;

--- a/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -14,7 +14,7 @@ use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use subspace_archiving::reconstructor::Reconstructor;
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::segments::SegmentIndex;
 use subspace_data_retrieval::segment_downloading::download_segment_pieces;
 use tokio::task;

--- a/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -8,9 +8,9 @@ use sc_consensus_subspace::archiver::{SegmentHeadersStore, decode_block, encode_
 use sc_service::Error;
 use sc_tracing::tracing::{debug, trace};
 use sp_consensus::BlockOrigin;
-use sp_runtime::Saturating;
+use sp_runtime::SaturatedConversion;
 use sp_runtime::generic::SignedBlock;
-use sp_runtime::traits::{Block as BlockT, Header, NumberFor, One};
+use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use subspace_archiving::reconstructor::Reconstructor;
@@ -36,7 +36,7 @@ pub(super) async fn import_blocks_from_dsn<Block, AS, Client, PG, IQS>(
     piece_getter: &PG,
     import_queue_service: &mut IQS,
     last_processed_segment_index: &mut SegmentIndex,
-    last_processed_block_number: &mut <Block::Header as Header>::Number,
+    last_processed_block_number: &mut BlockNumber,
     erasure_coding: &ErasureCoding,
 ) -> Result<u64, Error>
 where
@@ -97,8 +97,6 @@ where
             "Checking segment header"
         );
 
-        let last_archived_block_number = NumberFor::<Block>::from(last_archived_block_number);
-
         let info = client.info();
         // We have already processed this block, it can't change
         if last_archived_block_number <= *last_processed_block_number {
@@ -109,7 +107,7 @@ where
         }
         // Just one partial unprocessed block and this was the last segment available, so nothing to
         // import
-        if last_archived_block_number == *last_processed_block_number + One::one()
+        if last_archived_block_number == *last_processed_block_number + 1
             && last_archived_block_partial
             && segment_indices_iter.peek().is_none()
         {
@@ -141,14 +139,13 @@ where
 
         let mut blocks_to_import = Vec::with_capacity(QUEUED_BLOCKS_LIMIT as usize);
 
-        let mut best_block_number = info.best_number;
+        let mut best_block_number = info.best_number.saturated_into::<BlockNumber>();
         for (block_number, block_bytes) in blocks {
-            let block_number = block_number.into();
-            if block_number == 0u32.into() {
+            if block_number == 0 {
                 let signed_block = client
                     .block(
                         client
-                            .hash(block_number)?
+                            .hash(NumberFor::<Block>::saturated_from(block_number))?
                             .expect("Block before best block number must always be found; qed"),
                     )?
                     .expect("Block before best block number must always be found; qed");
@@ -165,7 +162,7 @@ where
             // than `QUEUED_BLOCKS_LIMIT` elements in the queue, but it should be rare and
             // insignificant. Feel free to address this in case you have a good strategy, but it
             // seems like complexity is not worth it.
-            while block_number.saturating_sub(best_block_number) >= QUEUED_BLOCKS_LIMIT.into() {
+            while block_number.saturating_sub(best_block_number) >= QUEUED_BLOCKS_LIMIT {
                 if !blocks_to_import.is_empty() {
                     // Import queue handles verification and importing it into the client
                     import_queue_service
@@ -178,7 +175,7 @@ where
                     "Number of importing blocks reached queue limit, waiting before retrying"
                 );
                 tokio::time::sleep(WAIT_FOR_BLOCKS_TO_IMPORT).await;
-                best_block_number = client.info().best_number;
+                best_block_number = client.info().best_number.saturated_into::<BlockNumber>();
             }
 
             let signed_block =

--- a/subspace/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use subspace_archiving::reconstructor::Reconstructor;
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::segments::SegmentIndex;
 use subspace_data_retrieval::segment_downloading::download_segment_pieces;
 use subspace_networking::Node;

--- a/subspace/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -367,7 +367,7 @@ where
 
     // Wait for blocks to be imported
     // TODO: Replace this hack with actual watching of block import
-    wait_for_block_import(client.as_ref(), last_block_number.into()).await;
+    wait_for_block_import(client.as_ref(), last_block_number).await;
 
     debug!(info = ?client.info(), "Snap sync finished successfully");
 

--- a/subspace/crates/subspace-service/src/utils.rs
+++ b/subspace/crates/subspace-service/src/utils.rs
@@ -3,7 +3,7 @@ use sc_client_api::BlockchainEvents;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::SaturatedConversion;
 use sp_runtime::traits::{Block as BlockT, Header};
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use tracing::{debug, trace};
 
 pub async fn wait_for_block_import<Block, Client>(

--- a/subspace/crates/subspace-service/src/utils.rs
+++ b/subspace/crates/subspace-service/src/utils.rs
@@ -1,12 +1,14 @@
 use futures::StreamExt;
 use sc_client_api::BlockchainEvents;
 use sp_blockchain::HeaderBackend;
-use sp_runtime::traits::{Block as BlockT, Header, NumberFor};
+use sp_runtime::SaturatedConversion;
+use sp_runtime::traits::{Block as BlockT, Header};
+use subspace_core_primitives::BlockNumber;
 use tracing::{debug, trace};
 
 pub async fn wait_for_block_import<Block, Client>(
     client: &Client,
-    waiting_block_number: NumberFor<Block>,
+    waiting_block_number: BlockNumber,
 ) where
     Block: BlockT,
     Client: HeaderBackend<Block> + BlockchainEvents<Block>,
@@ -19,12 +21,12 @@ pub async fn wait_for_block_import<Block, Client>(
         "Waiting client info: {:?}", info
     );
 
-    if info.best_number >= waiting_block_number {
+    if info.best_number.saturated_into::<BlockNumber>() >= waiting_block_number {
         return;
     }
 
     while let Some(block) = blocks_stream.next().await {
-        let current_block_number = *block.header.number();
+        let current_block_number = (*block.header.number()).saturated_into::<BlockNumber>();
         trace!(%current_block_number, %waiting_block_number, "Waiting for the target block");
 
         if current_block_number >= waiting_block_number {

--- a/subspace/crates/subspace-verification/src/lib.rs
+++ b/subspace/crates/subspace-verification/src/lib.rs
@@ -8,7 +8,7 @@ pub mod sr25519;
 use schnorrkel::SignatureError;
 use schnorrkel::context::SigningContext;
 use sr25519::RewardSignature;
-use subspace_core_primitives::BlockWeight;
+use subspace_core_primitives::block::BlockWeight;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::solutions::SolutionRange;
 

--- a/subspace/shared/subspace-data-retrieval/Cargo.toml
+++ b/subspace/shared/subspace-data-retrieval/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true, features = ["std"] }
-parity-scale-codec = { workspace = true, features = ["derive"] }
+parity-scale-codec = { workspace = true, features = ["derive", "std"] }
 subspace-archiving = { workspace = true, features = ["parallel"] }
 subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
 thiserror = { workspace = true }
@@ -25,7 +25,7 @@ tokio = { workspace = true, features = ["sync", "rt"] }
 tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-rand = { workspace = true }
+rand = { workspace = true, features = ["std", "std_rng"] }
 subspace-logging = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 

--- a/subspace/shared/subspace-data-retrieval/Cargo.toml
+++ b/subspace/shared/subspace-data-retrieval/Cargo.toml
@@ -20,8 +20,6 @@ hex = { workspace = true, features = ["std"] }
 parity-scale-codec = { workspace = true, features = ["derive"] }
 subspace-archiving = { workspace = true, features = ["parallel"] }
 subspace-core-primitives = { workspace = true, features = ["alloc", "scale-codec"] }
-# TODO: Get rid of this dependency, this is not the right place for it
-subspace-runtime-primitives = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }
 tracing = { workspace = true, features = ["std"] }

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -7,7 +7,7 @@ use crate::object_fetcher::{Error, decode_data_length};
 use parity_scale_codec::{Decode, Encode, Input, IoReader};
 use std::io::Cursor;
 use subspace_archiving::archiver::SegmentItem;
-use subspace_core_primitives::BlockNumber;
+use subspace_core_primitives::block::BlockNumber;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::objects::GlobalObject;
 use subspace_core_primitives::segments::{

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -13,7 +13,9 @@ use subspace_core_primitives::objects::GlobalObject;
 use subspace_core_primitives::segments::{
     ArchivedBlockProgress, LastArchivedBlock, SegmentHeader, SegmentIndex, SegmentRoot,
 };
-use subspace_runtime_primitives::MAX_BLOCK_LENGTH;
+
+/// Maximum block length for non-`Normal` extrinsic is 5 MiB.
+pub const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
 
 /// The maximum amount of segment padding.
 ///
@@ -157,7 +159,6 @@ mod test {
     use parity_scale_codec::{Compact, CompactLen};
     use subspace_archiving::archiver::Segment;
     use subspace_core_primitives::objects::BlockObjectMapping;
-    use subspace_runtime_primitives::MAX_BLOCK_LENGTH;
 
     #[test]
     fn max_segment_padding_constant() {

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -7,6 +7,7 @@ use crate::object_fetcher::{Error, decode_data_length};
 use parity_scale_codec::{Decode, Encode, Input, IoReader};
 use std::io::Cursor;
 use subspace_archiving::archiver::SegmentItem;
+use subspace_core_primitives::BlockNumber;
 use subspace_core_primitives::hashes::Blake3Hash;
 use subspace_core_primitives::objects::GlobalObject;
 use subspace_core_primitives::segments::{
@@ -52,7 +53,7 @@ pub fn max_segment_header_encoded_size() -> usize {
         segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),
         last_archived_block: LastArchivedBlock {
-            number: u32::MAX,
+            number: BlockNumber::MAX,
             archived_progress: ArchivedBlockProgress::Partial(u32::MAX),
         },
     };

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -230,8 +230,9 @@ fn create_mapping(
         // Find the next piece index with a segment header
         let segment_header_piece_index =
             start_piece_index.next_multiple_of(ArchivedHistorySegment::NUM_PIECES);
-        // And the piece before it can have padding
-        let padding_piece_index = segment_header_piece_index.checked_sub(1);
+        // And the source piece before it can have padding
+        let padding_piece_index =
+            segment_header_piece_index.checked_sub(RecordedHistorySegment::NUM_RAW_RECORDS + 1);
 
         // Skip padding if needed
         if let Some(padding_piece_index) = padding_piece_index
@@ -244,7 +245,19 @@ fn create_mapping(
                 start_piece_index,
                 pieces_len,
                 original_len,
-            );
+            )
+            .unwrap_or_else(|| {
+                panic!(
+                    "must have padding when skip_padding is set: \
+                    skip_padding: {skip_padding} bytes, \
+                    raw_data_after_segment_header: {} bytes, \
+                    padding_piece_index: {padding_piece_index}, \
+                    start_piece_index: {start_piece_index}, \
+                    pieces_len: {pieces_len}, \
+                    original_len: {original_len}",
+                    raw_data_after_segment_header.len(),
+                )
+            });
 
             // Delete the padding bytes we want to skip
             let replaced_padding_data = raw_data
@@ -264,32 +277,34 @@ fn create_mapping(
             );
         }
 
-        // If the offset hasn't already skipped the segment header, skip it now
-        if segment_header_piece_index > start_piece_index {
+        // If this is a segment header piece, the offset will have already skipped the segment
+        // header. If it's any other piece, skip it now.
+        if PieceIndex::from(start_piece_index as u64).position() != 0 {
             let original_len = raw_data.len();
 
-            let mut byte_position_in_raw_data = byte_position_in_extract_raw_data(
+            if let Some(mut byte_position_in_raw_data) = byte_position_in_extract_raw_data(
                 segment_header_piece_index,
                 start_piece_index,
                 pieces_len,
                 original_len,
-            );
-            byte_position_in_raw_data -= skip_padding;
+            ) {
+                byte_position_in_raw_data -= skip_padding;
 
-            // Replace the entire piece with just the raw data after the segment header
-            let _replaced_piece_data = raw_data
-                .splice(
-                    // The entire piece range, in bytes
-                    byte_position_in_raw_data..byte_position_in_raw_data + Record::SIZE,
-                    // The remaining data from the piece, excluding the segment header
-                    raw_data_after_segment_header.iter().copied(),
-                )
-                .collect::<Vec<_>>();
+                // Replace the entire piece with just the raw data after the segment header
+                let _replaced_piece_data = raw_data
+                    .splice(
+                        // The entire piece range, in bytes
+                        byte_position_in_raw_data..byte_position_in_raw_data + Record::SIZE,
+                        // The remaining data from the piece, excluding the segment header
+                        raw_data_after_segment_header.iter().copied(),
+                    )
+                    .collect::<Vec<_>>();
 
-            assert_eq!(
-                raw_data.len(),
-                original_len - Record::SIZE + raw_data_after_segment_header.len()
-            );
+                assert_eq!(
+                    raw_data.len(),
+                    original_len - Record::SIZE + raw_data_after_segment_header.len()
+                );
+            }
         }
     }
 
@@ -311,16 +326,22 @@ fn create_mapping(
 }
 
 /// Returns the byte position of a piece in the raw data, after checking it is valid.
+/// Returns `None` if the piece index is not in the supplied pieces.
 fn byte_position_in_extract_raw_data(
     piece_index: usize,
     start_piece_index: usize,
     pieces_len: usize,
     raw_data_len: usize,
-) -> usize {
+) -> Option<usize> {
     let piece_position_in_raw_data = piece_index - start_piece_index;
+
+    if piece_position_in_raw_data >= pieces_len {
+        return None;
+    }
+
     assert!(
         piece_position_in_raw_data < max_supported_object_length().div_ceil(Record::SIZE),
-        "{piece_position_in_raw_data} < {}",
+        "object length not supported: {piece_position_in_raw_data} < {}",
         max_supported_object_length().div_ceil(Record::SIZE)
     );
     assert!(
@@ -331,10 +352,10 @@ fn byte_position_in_extract_raw_data(
     let byte_position_in_raw_data = piece_position_in_raw_data * Record::SIZE;
     assert!(
         byte_position_in_raw_data < raw_data_len,
-        "{byte_position_in_raw_data} < {raw_data_len}",
+        "byte position not in raw data: {byte_position_in_raw_data} < {raw_data_len}",
     );
 
-    byte_position_in_raw_data
+    Some(byte_position_in_raw_data)
 }
 
 /// Creates an object fetcher from a piece and piece index.

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -89,7 +89,7 @@ fn write_segment_header(mut piece: &mut Piece, remaining_len: usize) -> Vec<u8> 
             segment_root: SegmentRoot::default(),
             prev_segment_header_hash: Blake3Hash::default(),
             last_archived_block: LastArchivedBlock {
-                number: u32::MAX,
+                number: u64::MAX,
                 archived_progress: ArchivedBlockProgress::Partial(u32::MAX),
             },
         }


### PR DESCRIPTION
The biggest change here is that `BlockNumber` in Subspace was changed to `u64` to align with type alias in `ab-contracts-common`, block-related type aliases are also moved into separate module, leaving no standalone items in the root of `subspace-core-primitives`.

There are also some more minor cleanups.