### PR TITLE
Add more spans to macro-generated code

### DIFF
--- a/crates/contracts/core/ab-contracts-macros-impl/src/contract.rs
+++ b/crates/contracts/core/ab-contracts-macros-impl/src/contract.rs
@@ -680,10 +680,10 @@ fn generate_extension_trait(
     );
     let definitions = trait_ext_components
         .iter()
-        .map(|components| &components.definitions);
+        .map(|components| &components.definition);
     let impls = trait_ext_components
         .iter()
-        .map(|components| &components.impls);
+        .map(|components| &components.r#impl);
 
     quote! {
         use ffi::*;


### PR DESCRIPTION
This may help with IDE support if IDE is smart enough (IntelliJ Rust plugin isn't)