### PR TITLE
Archiver cleanups

### DIFF
--- a/crates/shared/ab-core-primitives/src/segments.rs
+++ b/crates/shared/ab-core-primitives/src/segments.rs
@@ -351,20 +351,15 @@ impl LastArchivedBlock {
 #[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub enum SegmentHeader {
-    /// V0 of the segment header data structure
-    #[cfg_attr(feature = "scale-codec", codec(index = 0))]
-    #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-    V0 {
-        /// Segment index
-        segment_index: SegmentIndex,
-        /// Root of roots of all records in a segment.
-        segment_root: SegmentRoot,
-        /// Hash of the segment header of the previous segment
-        prev_segment_header_hash: Blake3Hash,
-        /// Last archived block
-        last_archived_block: LastArchivedBlock,
-    },
+pub struct SegmentHeader {
+    /// Segment index
+    pub segment_index: SegmentIndex,
+    /// Root of roots of all records in a segment.
+    pub segment_root: SegmentRoot,
+    /// Hash of the segment header of the previous segment
+    pub prev_segment_header_hash: Blake3Hash,
+    /// Last archived block
+    pub last_archived_block: LastArchivedBlock,
 }
 
 impl SegmentHeader {
@@ -374,44 +369,6 @@ impl SegmentHeader {
     #[inline(always)]
     pub fn hash(&self) -> Blake3Hash {
         blake3_hash(&self.encode())
-    }
-
-    /// Segment index
-    #[inline(always)]
-    pub fn segment_index(&self) -> SegmentIndex {
-        match self {
-            Self::V0 { segment_index, .. } => *segment_index,
-        }
-    }
-
-    /// Segment root of the records in a segment.
-    #[inline(always)]
-    pub fn segment_root(&self) -> SegmentRoot {
-        match self {
-            Self::V0 { segment_root, .. } => *segment_root,
-        }
-    }
-
-    /// Hash of the segment header of the previous segment
-    #[inline(always)]
-    pub fn prev_segment_header_hash(&self) -> Blake3Hash {
-        match self {
-            Self::V0 {
-                prev_segment_header_hash,
-                ..
-            } => *prev_segment_header_hash,
-        }
-    }
-
-    /// Last archived block
-    #[inline(always)]
-    pub fn last_archived_block(&self) -> LastArchivedBlock {
-        match self {
-            Self::V0 {
-                last_archived_block,
-                ..
-            } => *last_archived_block,
-        }
     }
 }
 

--- a/subspace/crates/pallet-subspace/src/lib.rs
+++ b/subspace/crates/pallet-subspace/src/lib.rs
@@ -751,14 +751,11 @@ impl<T: Config> Pallet<T> {
         );
 
         for segment_header in segment_headers {
-            SegmentRoot::<T>::insert(
-                segment_header.segment_index(),
-                segment_header.segment_root(),
-            );
+            SegmentRoot::<T>::insert(segment_header.segment_index, segment_header.segment_root);
             // Deposit global randomness data such that light client can validate blocks later.
             frame_system::Pallet::<T>::deposit_log(DigestItem::segment_root(
-                segment_header.segment_index(),
-                segment_header.segment_root(),
+                segment_header.segment_index,
+                segment_header.segment_root,
             ));
             Self::deposit_event(Event::SegmentHeaderStored { segment_header });
         }
@@ -913,21 +910,21 @@ fn check_segment_headers<T: Config>(
     };
 
     // Segment in segment headers should monotonically increase
-    if first_segment_header.segment_index() > SegmentIndex::ZERO
-        && !SegmentRoot::<T>::contains_key(first_segment_header.segment_index() - SegmentIndex::ONE)
+    if first_segment_header.segment_index > SegmentIndex::ZERO
+        && !SegmentRoot::<T>::contains_key(first_segment_header.segment_index - SegmentIndex::ONE)
     {
         return Err(InvalidTransaction::BadMandatory.into());
     }
 
     // Segment headers should never repeat
-    if SegmentRoot::<T>::contains_key(first_segment_header.segment_index()) {
+    if SegmentRoot::<T>::contains_key(first_segment_header.segment_index) {
         return Err(InvalidTransaction::BadMandatory.into());
     }
 
-    let mut last_segment_index = first_segment_header.segment_index();
+    let mut last_segment_index = first_segment_header.segment_index;
 
     for segment_header in segment_headers_iter {
-        let segment_index = segment_header.segment_index();
+        let segment_index = segment_header.segment_index;
 
         // Segment in segment headers should monotonically increase
         if segment_index != last_segment_index + SegmentIndex::ONE {

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -156,7 +156,7 @@ pub fn new_test_ext() -> TestExternalities {
 }
 
 pub fn create_segment_header(segment_index: SegmentIndex) -> SegmentHeader {
-    SegmentHeader::V0 {
+    SegmentHeader {
         segment_index,
         segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -162,7 +162,7 @@ pub fn create_segment_header(segment_index: SegmentIndex) -> SegmentHeader {
         prev_segment_header_hash: Blake3Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::ZERO,
-            archived_progress: ArchivedBlockProgress::Complete,
+            archived_progress: ArchivedBlockProgress::new_complete(),
         },
     }
 }

--- a/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -545,7 +545,7 @@ where
                     acknowledgement_sender,
                 } = archived_segment_notification;
 
-                let segment_index = archived_segment.segment_header.segment_index();
+                let segment_index = archived_segment.segment_header.segment_index;
 
                 // Store acknowledgment sender so that we can retrieve it when acknowledgement
                 // comes from the farmer, but only if unsafe APIs are allowed
@@ -701,8 +701,7 @@ where
             }
         };
 
-        if requested_piece_index.segment_index() == archived_segment.segment_header.segment_index()
-        {
+        if requested_piece_index.segment_index() == archived_segment.segment_header.segment_index {
             return Ok(archived_segment
                 .pieces
                 .pieces()

--- a/subspace/crates/sc-consensus-subspace/src/archiver.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver.rs
@@ -179,7 +179,7 @@ where
         // Check all input segment headers to see which ones are not stored yet and verifying that segment indices are
         // monotonically increasing
         for segment_header in segment_headers {
-            let segment_index = segment_header.segment_index();
+            let segment_index = segment_header.segment_index;
             match maybe_last_segment_index {
                 Some(last_segment_index) => {
                     if segment_index <= last_segment_index {
@@ -276,19 +276,18 @@ where
                 .expect("Segment headers are stored in monotonically increasing order; qed");
 
             // The block immediately after the archived segment adding the confirmation depth
-            let target_block_number = current_segment_header.last_archived_block().number
+            let target_block_number = current_segment_header.last_archived_block.number
                 + BlockNumber::ONE
                 + self.confirmation_depth_k;
             if target_block_number == block_number {
                 let mut headers_for_block = vec![current_segment_header];
 
                 // Check block spanning multiple segments
-                let last_archived_block_number =
-                    current_segment_header.last_archived_block().number;
+                let last_archived_block_number = current_segment_header.last_archived_block.number;
                 let mut segment_index = current_segment_index - SegmentIndex::ONE;
 
                 while let Some(segment_header) = self.get_segment_header(segment_index) {
-                    if segment_header.last_archived_block().number == last_archived_block_number {
+                    if segment_header.last_archived_block.number == last_archived_block_number {
                         headers_for_block.insert(0, segment_header);
                         segment_index -= SegmentIndex::ONE;
                     } else {
@@ -419,7 +418,7 @@ where
         .rev()
         .filter_map(|segment_index| segment_headers_store.get_segment_header(segment_index))
     {
-        let last_archived_block_number = segment_header.last_archived_block().number;
+        let last_archived_block_number = segment_header.last_archived_block.number;
 
         if last_archived_block_number > best_block_to_archive {
             // Last archived block in segment header is too high for current state of the chain
@@ -680,7 +679,7 @@ where
             maybe_last_archived_block
         {
             // Continuing from existing initial state
-            let last_archived_block_number = last_segment_header.last_archived_block().number;
+            let last_archived_block_number = last_segment_header.last_archived_block.number;
             info!(
                 %last_archived_block_number,
                 "Resuming archiver from last archived block",
@@ -968,7 +967,7 @@ where
             let last_archived_block_number = segment_headers_store
                 .last_segment_header()
                 .expect("Exists after archiver initialization; qed")
-                .last_archived_block()
+                .last_archived_block
                 .number;
             let create_mappings =
                 create_object_mappings.is_enabled_for_block(last_archived_block_number);
@@ -1064,7 +1063,7 @@ where
                     .and_then(|segment_index| {
                         segment_headers_store.get_segment_header(segment_index)
                     })
-                    .map(|segment_header| segment_header.last_archived_block().number)
+                    .map(|segment_header| segment_header.last_archived_block.number)
                     // Make sure not to finalize block number that does not yet exist (segment
                     // headers store may contain future blocks during initial sync)
                     .map(|block_number| block_number_to_archive.min(block_number))
@@ -1225,7 +1224,7 @@ async fn send_archived_segment_notification(
     archived_segment_notification_sender: &SubspaceNotificationSender<ArchivedSegmentNotification>,
     archived_segment: NewArchivedSegment,
 ) {
-    let segment_index = archived_segment.segment_header.segment_index();
+    let segment_index = archived_segment.segment_header.segment_index;
     let (acknowledgement_sender, mut acknowledgement_receiver) =
         tracing_unbounded::<()>("subspace_acknowledgement", 1000);
     // Keep `archived_segment` around until all acknowledgements are received since some receivers

--- a/subspace/crates/sc-consensus-subspace/src/archiver.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver.rs
@@ -475,8 +475,9 @@ where
     let encoded_block = encode_block(signed_block);
 
     // There are no mappings in the genesis block, so they can be ignored
-    let block_outcome =
-        Archiver::new(erasure_coding).add_block(encoded_block, BlockObjectMapping::default());
+    let block_outcome = Archiver::new(erasure_coding)
+        .add_block(encoded_block, BlockObjectMapping::default())
+        .expect("Block is never empty and doesn't exceed u32; qed");
     let new_archived_segment = block_outcome
         .archived_segments
         .into_iter()
@@ -798,7 +799,9 @@ where
                     encoded_block.len() as f32 / 1024.0
                 );
 
-                let block_outcome = archiver.add_block(encoded_block, block_object_mappings);
+                let block_outcome = archiver
+                    .add_block(encoded_block, block_object_mappings)
+                    .expect("Block is never empty and doesn't exceed u32; qed");
                 send_object_mapping_notification(
                     &subspace_link.object_mapping_notification_sender,
                     block_outcome.object_mapping,
@@ -1181,7 +1184,9 @@ where
         encoded_block.len() as f32 / 1024.0
     );
 
-    let block_outcome = archiver.add_block(encoded_block, block_object_mappings);
+    let block_outcome = archiver
+        .add_block(encoded_block, block_object_mappings)
+        .expect("Block is never empty and doesn't exceed u32; qed");
     send_object_mapping_notification(
         &object_mapping_notification_sender,
         block_outcome.object_mapping,

--- a/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -56,7 +56,7 @@ fn segment_headers_store_block_number_queries_work() {
 
     // Several starting segments from gemini-3h
 
-    let segment_header0 = SegmentHeader::V0 {
+    let segment_header0 = SegmentHeader {
         segment_index: SegmentIndex::ZERO,
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
@@ -66,7 +66,7 @@ fn segment_headers_store_block_number_queries_work() {
         },
     };
 
-    let segment_header1 = SegmentHeader::V0 {
+    let segment_header1 = SegmentHeader {
         segment_index: SegmentIndex::ONE,
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
@@ -76,7 +76,7 @@ fn segment_headers_store_block_number_queries_work() {
         },
     };
 
-    let segment_header2 = SegmentHeader::V0 {
+    let segment_header2 = SegmentHeader {
         segment_index: SegmentIndex::from(2),
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
@@ -86,7 +86,7 @@ fn segment_headers_store_block_number_queries_work() {
         },
     };
 
-    let segment_header3 = SegmentHeader::V0 {
+    let segment_header3 = SegmentHeader {
         segment_index: SegmentIndex::from(3),
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
@@ -96,7 +96,7 @@ fn segment_headers_store_block_number_queries_work() {
         },
     };
 
-    let segment_header4 = SegmentHeader::V0 {
+    let segment_header4 = SegmentHeader {
         segment_index: SegmentIndex::from(4),
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),

--- a/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -6,6 +6,7 @@ use ab_core_primitives::segments::{
 use parking_lot::RwLock;
 use sc_client_api::AuxStore;
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 struct MemAuxStore {
@@ -61,7 +62,7 @@ fn segment_headers_store_block_number_queries_work() {
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(0),
-            archived_progress: ArchivedBlockProgress::Partial(5),
+            archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
         },
     };
 
@@ -71,7 +72,7 @@ fn segment_headers_store_block_number_queries_work() {
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(652),
-            archived_progress: ArchivedBlockProgress::Partial(5),
+            archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
         },
     };
 
@@ -81,7 +82,7 @@ fn segment_headers_store_block_number_queries_work() {
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(752),
-            archived_progress: ArchivedBlockProgress::Partial(5),
+            archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
         },
     };
 
@@ -91,7 +92,7 @@ fn segment_headers_store_block_number_queries_work() {
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(806),
-            archived_progress: ArchivedBlockProgress::Partial(5),
+            archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
         },
     };
 
@@ -101,7 +102,7 @@ fn segment_headers_store_block_number_queries_work() {
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(806),
-            archived_progress: ArchivedBlockProgress::Partial(5),
+            archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
         },
     };
 

--- a/subspace/crates/sc-consensus-subspace/src/block_import.rs
+++ b/subspace/crates/sc-consensus-subspace/src/block_import.rs
@@ -447,7 +447,7 @@ where
         let segment_root = self
             .segment_headers_store
             .get_segment_header(segment_index)
-            .map(|segment_header| segment_header.segment_root())
+            .map(|segment_header| segment_header.segment_root)
             .ok_or(Error::SegmentRootNotFound(segment_index))?;
 
         let sector_expiration_check_segment_root = self
@@ -461,7 +461,7 @@ where
                     .ok_or(Error::InvalidHistorySize)?
                     .segment_index(),
             )
-            .map(|segment_header| segment_header.segment_root());
+            .map(|segment_header| segment_header.segment_root);
 
         // Piece is not checked during initial block verification because it requires access to
         // segment header and runtime, check it now.
@@ -613,7 +613,7 @@ where
                 .segment_headers_store
                 .get_segment_header(segment_index)
                 .ok_or_else(|| Error::SegmentHeaderNotFound(segment_index))?
-                .segment_root();
+                .segment_root;
 
             if &found_segment_root != segment_root {
                 warn!(

--- a/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -520,7 +520,7 @@ where
             let maybe_segment_root = self
                 .segment_headers_store
                 .get_segment_header(segment_index)
-                .map(|segment_header| segment_header.segment_root());
+                .map(|segment_header| segment_header.segment_root);
 
             let segment_root = match maybe_segment_root {
                 Some(segment_root) => segment_root,

--- a/subspace/crates/subspace-archiving/src/archiver.rs
+++ b/subspace/crates/subspace-archiving/src/archiver.rs
@@ -268,9 +268,9 @@ impl Archiver {
     ) -> Result<Self, ArchiverInstantiationError> {
         let mut archiver = Self::new(erasure_coding);
 
-        archiver.segment_index = segment_header.segment_index() + SegmentIndex::ONE;
+        archiver.segment_index = segment_header.segment_index + SegmentIndex::ONE;
         archiver.prev_segment_header_hash = segment_header.hash();
-        archiver.last_archived_block = Some(segment_header.last_archived_block());
+        archiver.last_archived_block = Some(segment_header.last_archived_block);
 
         // The first thing in the buffer should be segment header
         archiver
@@ -782,7 +782,7 @@ impl Archiver {
             });
 
         // Now produce segment header
-        let segment_header = SegmentHeader::V0 {
+        let segment_header = SegmentHeader {
             segment_index: self.segment_index,
             segment_root,
             prev_segment_header_hash: self.prev_segment_header_hash,

--- a/subspace/crates/subspace-archiving/src/archiver.rs
+++ b/subspace/crates/subspace-archiving/src/archiver.rs
@@ -264,7 +264,7 @@ impl Archiver {
                     // Take part of the encoded block that wasn't archived yet and push to the
                     // buffer as a block continuation
                     object_mapping
-                        .objects_mut()
+                        .objects
                         .retain_mut(|block_object: &mut BlockObject| {
                             if block_object.offset >= archived_block_bytes {
                                 block_object.offset -= archived_block_bytes;
@@ -474,9 +474,9 @@ impl Archiver {
 
                     bytes.truncate(split_point);
 
-                    let continuation_object_mapping = BlockObjectMapping::V0 {
+                    let continuation_object_mapping = BlockObjectMapping {
                         objects: object_mapping
-                            .objects_mut()
+                            .objects
                             .extract_if(.., |block_object: &mut BlockObject| {
                                 if block_object.offset >= split_point as u32 {
                                     block_object.offset -= split_point as u32;
@@ -522,9 +522,9 @@ impl Archiver {
 
                     bytes.truncate(split_point);
 
-                    let continuation_object_mapping = BlockObjectMapping::V0 {
+                    let continuation_object_mapping = BlockObjectMapping {
                         objects: object_mapping
-                            .objects_mut()
+                            .objects
                             .extract_if(.., |block_object: &mut BlockObject| {
                                 if block_object.offset >= split_point as u32 {
                                     block_object.offset -= split_point as u32;
@@ -626,7 +626,7 @@ impl Archiver {
                     bytes,
                     object_mapping,
                 } => {
-                    for block_object in object_mapping.objects_mut().drain(..) {
+                    for block_object in object_mapping.objects.drain(..) {
                         // `+1` corresponds to `SegmentItem::X {}` enum variant encoding
                         let offset_in_segment = base_offset_in_segment
                             + 1

--- a/subspace/crates/subspace-archiving/src/objects.rs
+++ b/subspace/crates/subspace-archiving/src/objects.rs
@@ -6,7 +6,6 @@
 
 use ab_core_primitives::hashes::Blake3Hash;
 use ab_core_primitives::pieces::PieceIndex;
-use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -22,16 +21,6 @@ pub struct BlockObject {
     pub offset: u32,
 }
 
-/// Mapping of objects stored inside the block
-#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[cfg_attr(feature = "serde", serde(rename_all_fields = "camelCase"))]
-pub struct BlockObjectMapping {
-    /// Objects stored inside the block
-    pub objects: Vec<BlockObject>,
-}
-
 /// Object stored in the history of the blockchain
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -45,14 +34,4 @@ pub struct GlobalObject {
     pub piece_index: PieceIndex,
     /// Raw record offset of the object in that piece, for use with `Record::to_raw_record_bytes`
     pub offset: u32,
-}
-
-/// Mapping of objects stored in the history of the blockchain
-#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[cfg_attr(feature = "serde", serde(rename_all_fields = "camelCase"))]
-pub struct GlobalObjectMapping {
-    /// Objects stored in the history of the blockchain
-    pub objects: Vec<GlobalObject>,
 }

--- a/subspace/crates/subspace-archiving/src/objects.rs
+++ b/subspace/crates/subspace-archiving/src/objects.rs
@@ -23,52 +23,13 @@ pub struct BlockObject {
 }
 
 /// Mapping of objects stored inside the block
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "serde", serde(rename_all_fields = "camelCase"))]
-pub enum BlockObjectMapping {
-    /// V0 of object mapping data structure
-    #[codec(index = 0)]
-    V0 {
-        /// Objects stored inside the block
-        objects: Vec<BlockObject>,
-    },
-}
-
-impl Default for BlockObjectMapping {
-    #[inline(always)]
-    fn default() -> Self {
-        Self::V0 {
-            objects: Vec::new(),
-        }
-    }
-}
-
-impl BlockObjectMapping {
-    /// Returns a newly created BlockObjectMapping from a list of object mappings
-    #[inline(always)]
-    pub fn from_objects(objects: impl IntoIterator<Item = BlockObject>) -> Self {
-        Self::V0 {
-            objects: objects.into_iter().collect(),
-        }
-    }
-
-    /// Returns the object mappings
-    #[inline(always)]
-    pub fn objects(&self) -> &[BlockObject] {
-        match self {
-            Self::V0 { objects, .. } => objects,
-        }
-    }
-
-    /// Returns the object mappings as a mutable slice
-    #[inline(always)]
-    pub fn objects_mut(&mut self) -> &mut Vec<BlockObject> {
-        match self {
-            Self::V0 { objects, .. } => objects,
-        }
-    }
+pub struct BlockObjectMapping {
+    /// Objects stored inside the block
+    pub objects: Vec<BlockObject>,
 }
 
 /// Object stored in the history of the blockchain
@@ -87,50 +48,11 @@ pub struct GlobalObject {
 }
 
 /// Mapping of objects stored in the history of the blockchain
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "serde", serde(rename_all_fields = "camelCase"))]
-pub enum GlobalObjectMapping {
-    /// V0 of object mapping data structure
-    #[codec(index = 0)]
-    V0 {
-        /// Objects stored in the history of the blockchain
-        objects: Vec<GlobalObject>,
-    },
-}
-
-impl Default for GlobalObjectMapping {
-    #[inline(always)]
-    fn default() -> Self {
-        Self::V0 {
-            objects: Vec::new(),
-        }
-    }
-}
-
-impl GlobalObjectMapping {
-    /// Returns a newly created GlobalObjectMapping from a list of object mappings
-    #[inline(always)]
-    pub fn from_objects(objects: impl IntoIterator<Item = GlobalObject>) -> Self {
-        Self::V0 {
-            objects: objects.into_iter().collect(),
-        }
-    }
-
-    /// Returns the object mappings
-    #[inline(always)]
-    pub fn objects(&self) -> &[GlobalObject] {
-        match self {
-            Self::V0 { objects, .. } => objects,
-        }
-    }
-
-    /// Returns the object mappings as a mutable slice
-    #[inline(always)]
-    pub fn objects_mut(&mut self) -> &mut Vec<GlobalObject> {
-        match self {
-            Self::V0 { objects, .. } => objects,
-        }
-    }
+pub struct GlobalObjectMapping {
+    /// Objects stored in the history of the blockchain
+    pub objects: Vec<GlobalObject>,
 }

--- a/subspace/crates/subspace-archiving/src/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/reconstructor.rs
@@ -2,8 +2,7 @@ use crate::archiver::{Segment, SegmentItem};
 use ab_core_primitives::block::BlockNumber;
 use ab_core_primitives::pieces::Piece;
 use ab_core_primitives::segments::{
-    ArchivedBlockProgress, ArchivedHistorySegment, LastArchivedBlock, RecordedHistorySegment,
-    SegmentHeader, SegmentIndex,
+    ArchivedHistorySegment, LastArchivedBlock, RecordedHistorySegment, SegmentHeader, SegmentIndex,
 };
 use ab_erasure_coding::{ErasureCoding, ErasureCodingError, RecoveryShardState};
 use alloc::vec::Vec;
@@ -205,15 +204,15 @@ impl Reconstructor {
                         .segment_header
                         .replace(segment_header);
 
-                    match archived_progress {
-                        ArchivedBlockProgress::Complete => {
+                    match archived_progress.partial() {
+                        None => {
                             reconstructed_contents
                                 .blocks
                                 .push((next_block_number, mem::take(&mut partial_block)));
 
                             next_block_number = number + BlockNumber::ONE;
                         }
-                        ArchivedBlockProgress::Partial(_bytes) => {
+                        Some(_bytes) => {
                             next_block_number = number;
 
                             if partial_block.is_empty() {

--- a/subspace/crates/subspace-archiving/src/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/reconstructor.rs
@@ -134,13 +134,13 @@ impl Reconstructor {
         &mut self,
         segment_pieces: &[Option<Piece>],
     ) -> Result<ReconstructedContents, ReconstructorError> {
-        let items = self.reconstruct_segment(segment_pieces)?.into_items();
+        let segment = self.reconstruct_segment(segment_pieces)?;
 
         let mut reconstructed_contents = ReconstructedContents::default();
         let mut next_block_number = BlockNumber::ZERO;
         let mut partial_block = self.partial_block.take().unwrap_or_default();
 
-        for segment_item in items {
+        for segment_item in segment.items {
             match segment_item {
                 SegmentItem::Padding => {
                     // Doesn't contain anything

--- a/subspace/crates/subspace-archiving/src/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/reconstructor.rs
@@ -181,7 +181,7 @@ impl Reconstructor {
                     partial_block.extend_from_slice(&bytes);
                 }
                 SegmentItem::ParentSegmentHeader(segment_header) => {
-                    let segment_index = segment_header.segment_index();
+                    let segment_index = segment_header.segment_index;
 
                     if let Some(last_segment_index) = self.last_segment_index {
                         if last_segment_index != segment_index {
@@ -198,7 +198,7 @@ impl Reconstructor {
                     let LastArchivedBlock {
                         number,
                         archived_progress,
-                    } = segment_header.last_archived_block();
+                    } = segment_header.last_archived_block;
 
                     reconstructed_contents
                         .segment_header

--- a/subspace/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/archiver.rs
@@ -64,7 +64,7 @@ fn archiver() {
             .as_mut()
             .write_all(&Compact(128_u64).encode())
             .unwrap();
-        let object_mapping = BlockObjectMapping::V0 {
+        let object_mapping = BlockObjectMapping {
             objects: vec![
                 BlockObject {
                     hash: Blake3Hash::default(),
@@ -87,7 +87,7 @@ fn archiver() {
     // There is not enough data to produce archived segment yet
     assert!(archived_segments.is_empty());
     // All block mappings must appear in the global object mapping
-    assert_eq!(object_mapping.len(), block_0_object_mapping.objects().len());
+    assert_eq!(object_mapping.len(), block_0_object_mapping.objects.len());
 
     let (block_1, block_1_object_mapping) = {
         let mut block = vec![0u8; RecordedHistorySegment::SIZE / 3 * 2];
@@ -105,7 +105,7 @@ fn archiver() {
             .as_mut()
             .write_all(&Compact(100_u64).encode())
             .unwrap();
-        let object_mapping = BlockObjectMapping::V0 {
+        let object_mapping = BlockObjectMapping {
             objects: vec![
                 BlockObject {
                     hash: Blake3Hash::default(),
@@ -156,12 +156,12 @@ fn archiver() {
     }
 
     // All block mappings must appear in the global object mapping
-    assert_eq!(object_mapping.len(), block_1_object_mapping.objects().len());
+    assert_eq!(object_mapping.len(), block_1_object_mapping.objects.len());
     {
         // 4 objects fit into the first segment, 2 from block 0 and 2 from block 1
         let block_objects = iter::repeat(block_0.as_ref())
-            .zip(block_0_object_mapping.objects())
-            .chain(iter::repeat(block_1.as_ref()).zip(block_1_object_mapping.objects()))
+            .zip(&block_0_object_mapping.objects)
+            .chain(iter::repeat(block_1.as_ref()).zip(&block_1_object_mapping.objects))
             .take(4);
         let global_objects = block_0_outcome
             .object_mapping
@@ -255,7 +255,7 @@ fn archiver() {
     );
     {
         let block_objects =
-            iter::repeat(block_1.as_ref()).zip(block_1_object_mapping.objects().iter().skip(2));
+            iter::repeat(block_1.as_ref()).zip(block_1_object_mapping.objects.iter().skip(2));
         let global_objects = object_mapping.into_iter().map(|object_mapping| {
             (
                 Piece::from(
@@ -546,7 +546,7 @@ fn spill_over_edge_case() {
     let block_outcome = archiver
         .add_block(
             vec![0u8; RecordedHistorySegment::SIZE],
-            BlockObjectMapping::V0 {
+            BlockObjectMapping {
                 objects: vec![BlockObject {
                     hash: Blake3Hash::default(),
                     offset: 0,
@@ -633,7 +633,7 @@ fn object_on_the_edge_of_segment() {
             .clone()
             .add_block(
                 second_block.clone(),
-                BlockObjectMapping::V0 {
+                BlockObjectMapping {
                     objects: vec![BlockObject {
                         hash: object_mapping.hash,
                         offset: object_mapping.offset - 1,
@@ -655,7 +655,7 @@ fn object_on_the_edge_of_segment() {
     let block_2_outcome = archiver
         .add_block(
             second_block,
-            BlockObjectMapping::V0 {
+            BlockObjectMapping {
                 objects: vec![object_mapping],
             },
         )

--- a/subspace/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/archiver.rs
@@ -151,7 +151,7 @@ fn archiver() {
         assert_eq!(last_archived_block.number, BlockNumber::ONE);
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(67108853).unwrap())
+            Some(NonZeroU32::new(67108854).unwrap())
         );
     }
 
@@ -275,7 +275,7 @@ fn archiver() {
         assert_eq!(last_archived_block.number, BlockNumber::new(2));
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(111848001).unwrap())
+            Some(NonZeroU32::new(111848003).unwrap())
         );
     }
     {
@@ -284,7 +284,7 @@ fn archiver() {
         assert_eq!(last_archived_block.number, BlockNumber::new(2));
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(246065638).unwrap())
+            Some(NonZeroU32::new(246065641).unwrap())
         );
     }
 
@@ -331,7 +331,7 @@ fn archiver() {
 
     // Add a block such that it fits in the next segment exactly
     let block_3 = {
-        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369916];
+        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369912];
         rng.fill_bytes(block.as_mut_slice());
         block
     };
@@ -487,8 +487,6 @@ fn one_byte_smaller_segment() {
     // vector length encoding will take 2 bytes to encode, thus it will be impossible to slice
     // internal bytes of the segment item anyway
     let block_size = RecordedHistorySegment::SIZE
-        // Segment enum variant
-        - 1
         - 1
         // This is a rough number (a bit fewer bytes will be included in practice), but it is
         // close enough and practically will always result in the same compact length.
@@ -597,8 +595,6 @@ fn object_on_the_edge_of_segment() {
         hash: Blake3Hash::default(),
         // Offset is designed to fall exactly on the edge of the segment
         offset: RecordedHistorySegment::SIZE as u32
-            // Segment enum variant
-            - 1
             // Segment header segment item
             - SegmentItem::ParentSegmentHeader(SegmentHeader {
                 segment_index: SegmentIndex::ZERO,

--- a/subspace/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/archiver.rs
@@ -137,17 +137,17 @@ fn archiver() {
         ArchivedHistorySegment::NUM_PIECES
     );
     assert_eq!(
-        first_archived_segment.segment_header.segment_index(),
+        first_archived_segment.segment_header.segment_index,
         SegmentIndex::ZERO
     );
     assert_eq!(
         first_archived_segment
             .segment_header
-            .prev_segment_header_hash(),
+            .prev_segment_header_hash,
         Blake3Hash::default(),
     );
     {
-        let last_archived_block = first_archived_segment.segment_header.last_archived_block();
+        let last_archived_block = first_archived_segment.segment_header.last_archived_block;
         assert_eq!(last_archived_block.number, BlockNumber::ONE);
         assert_eq!(
             last_archived_block.partial_archived(),
@@ -190,7 +190,7 @@ fn archiver() {
             (
                 position,
                 piece.is_valid(
-                    &first_archived_segment.segment_header.segment_root(),
+                    &first_archived_segment.segment_header.segment_root,
                     position as u32,
                 ),
             )
@@ -251,7 +251,7 @@ fn archiver() {
         block_1_outcome.object_mapping[2]
             .piece_index
             .segment_index(),
-        archived_segments[0].segment_header.segment_index(),
+        archived_segments[0].segment_header.segment_index,
     );
     {
         let block_objects =
@@ -271,20 +271,20 @@ fn archiver() {
     // Check archived bytes for block with index `2` in each archived segment
     {
         let archived_segment = archived_segments.first().unwrap();
-        let last_archived_block = archived_segment.segment_header.last_archived_block();
+        let last_archived_block = archived_segment.segment_header.last_archived_block;
         assert_eq!(last_archived_block.number, BlockNumber::new(2));
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(111848000).unwrap())
+            Some(NonZeroU32::new(111848001).unwrap())
         );
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
-        let last_archived_block = archived_segment.segment_header.last_archived_block();
+        let last_archived_block = archived_segment.segment_header.last_archived_block;
         assert_eq!(last_archived_block.number, BlockNumber::new(2));
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(246065636).unwrap())
+            Some(NonZeroU32::new(246065638).unwrap())
         );
     }
 
@@ -298,11 +298,11 @@ fn archiver() {
             ArchivedHistorySegment::NUM_PIECES
         );
         assert_eq!(
-            archived_segment.segment_header.segment_index(),
+            archived_segment.segment_header.segment_index,
             expected_segment_index
         );
         assert_eq!(
-            archived_segment.segment_header.prev_segment_header_hash(),
+            archived_segment.segment_header.prev_segment_header_hash,
             previous_segment_header_hash
         );
 
@@ -315,7 +315,7 @@ fn archiver() {
                 (
                     position,
                     piece.is_valid(
-                        &archived_segment.segment_header.segment_root(),
+                        &archived_segment.segment_header.segment_root,
                         position as u32,
                     ),
                 )
@@ -331,7 +331,7 @@ fn archiver() {
 
     // Add a block such that it fits in the next segment exactly
     let block_3 = {
-        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369918];
+        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369916];
         rng.fill_bytes(block.as_mut_slice());
         block
     };
@@ -376,7 +376,7 @@ fn archiver() {
     // Block should fit exactly into the last archived segment (rare case)
     {
         let archived_segment = archived_segments.first().unwrap();
-        let last_archived_block = archived_segment.segment_header.last_archived_block();
+        let last_archived_block = archived_segment.segment_header.last_archived_block;
         assert_eq!(last_archived_block.number, BlockNumber::new(3));
         assert_eq!(last_archived_block.partial_archived(), None);
 
@@ -389,7 +389,7 @@ fn archiver() {
                 (
                     position,
                     piece.is_valid(
-                        &archived_segment.segment_header.segment_root(),
+                        &archived_segment.segment_header.segment_root,
                         position as u32,
                     ),
                 )
@@ -415,7 +415,7 @@ fn invalid_usage() {
     {
         let result = Archiver::with_initial_state(
             erasure_coding.clone(),
-            SegmentHeader::V0 {
+            SegmentHeader {
                 segment_index: SegmentIndex::ZERO,
                 segment_root: SegmentRoot::default(),
                 prev_segment_header_hash: Blake3Hash::default(),
@@ -443,7 +443,7 @@ fn invalid_usage() {
     {
         let result = Archiver::with_initial_state(
             erasure_coding.clone(),
-            SegmentHeader::V0 {
+            SegmentHeader {
                 segment_index: SegmentIndex::ZERO,
                 segment_root: SegmentRoot::default(),
                 prev_segment_header_hash: Blake3Hash::default(),
@@ -564,7 +564,7 @@ fn spill_over_edge_case() {
     assert_eq!(object_mapping.len(), 1);
     assert_eq!(
         object_mapping[0].piece_index.segment_index(),
-        archived_segments[1].segment_header.segment_index(),
+        archived_segments[1].segment_header.segment_index,
     );
 }
 
@@ -586,7 +586,7 @@ fn object_on_the_edge_of_segment() {
     let left_unarchived_from_first_block = first_block.len() as u32
         - archived_segment
             .segment_header
-            .last_archived_block()
+            .last_archived_block
             .archived_progress
             .partial()
             .unwrap()
@@ -600,7 +600,7 @@ fn object_on_the_edge_of_segment() {
             // Segment enum variant
             - 1
             // Segment header segment item
-            - SegmentItem::ParentSegmentHeader(SegmentHeader::V0 {
+            - SegmentItem::ParentSegmentHeader(SegmentHeader {
                 segment_index: SegmentIndex::ZERO,
                 segment_root: Default::default(),
                 prev_segment_header_hash: Default::default(),
@@ -652,7 +652,7 @@ fn object_on_the_edge_of_segment() {
         assert_eq!(object_mapping.len(), 1);
         assert_eq!(
             object_mapping[0].piece_index.segment_index(),
-            archived_segments[0].segment_header.segment_index(),
+            archived_segments[0].segment_header.segment_index,
         );
     }
 
@@ -672,7 +672,7 @@ fn object_on_the_edge_of_segment() {
     assert_eq!(object_mapping.len(), 1);
     assert_eq!(
         object_mapping[0].piece_index.segment_index(),
-        archived_segments[1].segment_header.segment_index(),
+        archived_segments[1].segment_header.segment_index,
     );
 
     // Ensure bytes are mapped correctly

--- a/subspace/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -30,6 +30,7 @@ fn segment_reconstruction_works() {
 
     let archived_segments = archiver
         .add_block(block, BlockObjectMapping::default())
+        .unwrap()
         .archived_segments;
 
     assert_eq!(archived_segments.len(), 1);
@@ -78,6 +79,7 @@ fn piece_reconstruction_works() {
 
     let archived_segments = archiver
         .add_block(block, BlockObjectMapping::default())
+        .unwrap()
         .archived_segments;
 
     assert_eq!(archived_segments.len(), 1);
@@ -140,6 +142,7 @@ fn segment_reconstruction_fails() {
 
     let archived_segments = archiver
         .add_block(block, BlockObjectMapping::default())
+        .unwrap()
         .archived_segments;
 
     assert_eq!(archived_segments.len(), 1);
@@ -179,6 +182,7 @@ fn piece_reconstruction_fails() {
 
     let archived_segments = archiver
         .add_block(block, BlockObjectMapping::default())
+        .unwrap()
         .archived_segments;
 
     assert_eq!(archived_segments.len(), 1);

--- a/subspace/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/piece_reconstruction.rs
@@ -6,7 +6,6 @@ use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use subspace_archiving::archiver::Archiver;
-use subspace_archiving::objects::BlockObjectMapping;
 use subspace_archiving::piece_reconstructor::{PiecesReconstructor, ReconstructorError};
 
 fn pieces_to_option_of_pieces(pieces: &FlatPieces) -> Vec<Option<Piece>> {
@@ -29,7 +28,7 @@ fn segment_reconstruction_works() {
     let block = get_random_block(&mut rng);
 
     let archived_segments = archiver
-        .add_block(block, BlockObjectMapping::default())
+        .add_block(block, Vec::new())
         .unwrap()
         .archived_segments;
 
@@ -78,7 +77,7 @@ fn piece_reconstruction_works() {
     let block = get_random_block(&mut rng);
 
     let archived_segments = archiver
-        .add_block(block, BlockObjectMapping::default())
+        .add_block(block, Vec::new())
         .unwrap()
         .archived_segments;
 
@@ -141,7 +140,7 @@ fn segment_reconstruction_fails() {
     let block = get_random_block(&mut rng);
 
     let archived_segments = archiver
-        .add_block(block, BlockObjectMapping::default())
+        .add_block(block, Vec::new())
         .unwrap()
         .archived_segments;
 
@@ -181,7 +180,7 @@ fn piece_reconstruction_fails() {
     let block = get_random_block(&mut rng);
 
     let archived_segments = archiver
-        .add_block(block, BlockObjectMapping::default())
+        .add_block(block, Vec::new())
         .unwrap()
         .archived_segments;
 

--- a/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -11,7 +11,6 @@ use std::assert_matches::assert_matches;
 use std::iter;
 use std::num::NonZeroU32;
 use subspace_archiving::archiver::Archiver;
-use subspace_archiving::objects::BlockObjectMapping;
 use subspace_archiving::reconstructor::{Reconstructor, ReconstructorError};
 
 fn pieces_to_option_of_pieces(pieces: &FlatPieces) -> Vec<Option<Piece>> {
@@ -54,31 +53,31 @@ fn basic() {
         block
     };
     let archived_segments = archiver
-        .add_block(block_0.clone(), BlockObjectMapping::default())
+        .add_block(block_0.clone(), Vec::new())
         .unwrap()
         .archived_segments
         .into_iter()
         .chain(
             archiver
-                .add_block(block_1.clone(), BlockObjectMapping::default())
+                .add_block(block_1.clone(), Vec::new())
                 .unwrap()
                 .archived_segments,
         )
         .chain(
             archiver
-                .add_block(block_2.clone(), BlockObjectMapping::default())
+                .add_block(block_2.clone(), Vec::new())
                 .unwrap()
                 .archived_segments,
         )
         .chain(
             archiver
-                .add_block(block_3.clone(), BlockObjectMapping::default())
+                .add_block(block_3.clone(), Vec::new())
                 .unwrap()
                 .archived_segments,
         )
         .chain(
             archiver
-                .add_block(block_4, BlockObjectMapping::default())
+                .add_block(block_4, Vec::new())
                 .unwrap()
                 .archived_segments,
         )
@@ -307,13 +306,13 @@ fn partial_data() {
         block
     };
     let archived_segments = archiver
-        .add_block(block_0.clone(), BlockObjectMapping::default())
+        .add_block(block_0.clone(), Vec::new())
         .unwrap()
         .archived_segments
         .into_iter()
         .chain(
             archiver
-                .add_block(block_1, BlockObjectMapping::default())
+                .add_block(block_1, Vec::new())
                 .unwrap()
                 .archived_segments,
         )
@@ -390,7 +389,7 @@ fn invalid_usage() {
     };
 
     let archived_segments = archiver
-        .add_block(block_0, BlockObjectMapping::default())
+        .add_block(block_0, Vec::new())
         .unwrap()
         .archived_segments;
 

--- a/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -113,11 +113,11 @@ fn basic() {
         );
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index(),
+            contents.segment_header.unwrap().segment_index,
             SegmentIndex::ZERO
         );
         assert_eq!(
-            contents.segment_header.unwrap().last_archived_block(),
+            contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
                 number: BlockNumber::new(1),
                 archived_progress: ArchivedBlockProgress::new_partial(
@@ -135,11 +135,11 @@ fn basic() {
         assert_eq!(contents.blocks, vec![(BlockNumber::new(2), block_2)]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index(),
+            contents.segment_header.unwrap().segment_index,
             SegmentIndex::ZERO
         );
         assert_eq!(
-            contents.segment_header.unwrap().last_archived_block(),
+            contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
                 number: BlockNumber::new(1),
                 archived_progress: ArchivedBlockProgress::new_partial(
@@ -158,15 +158,15 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index(),
+            contents.segment_header.unwrap().segment_index,
             SegmentIndex::ONE
         );
         assert_eq!(
-            contents.segment_header.unwrap().last_archived_block(),
+            contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(33554319).unwrap()
+                    NonZeroU32::new(33554320).unwrap()
                 )
             }
         );
@@ -180,15 +180,15 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index(),
+            contents.segment_header.unwrap().segment_index,
             SegmentIndex::ONE
         );
         assert_eq!(
-            contents.segment_header.unwrap().last_archived_block(),
+            contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(33554319).unwrap()
+                    NonZeroU32::new(33554320).unwrap()
                 )
             }
         );
@@ -203,15 +203,15 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index(),
+            contents.segment_header.unwrap().segment_index,
             SegmentIndex::from(2)
         );
         assert_eq!(
-            contents.segment_header.unwrap().last_archived_block(),
+            contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(167771955).unwrap()
+                    NonZeroU32::new(167771957).unwrap()
                 )
             }
         );
@@ -227,15 +227,15 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index(),
+            contents.segment_header.unwrap().segment_index,
             SegmentIndex::from(2)
         );
         assert_eq!(
-            contents.segment_header.unwrap().last_archived_block(),
+            contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(167771955).unwrap()
+                    NonZeroU32::new(167771957).unwrap()
                 )
             }
         );
@@ -250,15 +250,15 @@ fn basic() {
         assert_eq!(contents.blocks, vec![(BlockNumber::new(3), block_3)]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index(),
+            contents.segment_header.unwrap().segment_index,
             SegmentIndex::from(3)
         );
         assert_eq!(
-            contents.segment_header.unwrap().last_archived_block(),
+            contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(301989591).unwrap()
+                    NonZeroU32::new(301989594).unwrap()
                 )
             }
         );
@@ -274,15 +274,15 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index(),
+            contents.segment_header.unwrap().segment_index,
             SegmentIndex::from(3)
         );
         assert_eq!(
-            contents.segment_header.unwrap().last_archived_block(),
+            contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(301989591).unwrap()
+                    NonZeroU32::new(301989594).unwrap()
                 )
             }
         );

--- a/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -9,6 +9,7 @@ use rand_chacha::ChaCha8Rng;
 use rand_core::{RngCore, SeedableRng};
 use std::assert_matches::assert_matches;
 use std::iter;
+use std::num::NonZeroU32;
 use subspace_archiving::archiver::Archiver;
 use subspace_archiving::objects::BlockObjectMapping;
 use subspace_archiving::reconstructor::{Reconstructor, ReconstructorError};
@@ -54,26 +55,31 @@ fn basic() {
     };
     let archived_segments = archiver
         .add_block(block_0.clone(), BlockObjectMapping::default())
+        .unwrap()
         .archived_segments
         .into_iter()
         .chain(
             archiver
                 .add_block(block_1.clone(), BlockObjectMapping::default())
+                .unwrap()
                 .archived_segments,
         )
         .chain(
             archiver
                 .add_block(block_2.clone(), BlockObjectMapping::default())
+                .unwrap()
                 .archived_segments,
         )
         .chain(
             archiver
                 .add_block(block_3.clone(), BlockObjectMapping::default())
+                .unwrap()
                 .archived_segments,
         )
         .chain(
             archiver
                 .add_block(block_4, BlockObjectMapping::default())
+                .unwrap()
                 .archived_segments,
         )
         .collect::<Vec<_>>();
@@ -114,7 +120,9 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: BlockNumber::new(1),
-                archived_progress: ArchivedBlockProgress::Partial(67108853)
+                archived_progress: ArchivedBlockProgress::new_partial(
+                    NonZeroU32::new(67108853).unwrap()
+                )
             }
         );
 
@@ -134,7 +142,9 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: BlockNumber::new(1),
-                archived_progress: ArchivedBlockProgress::Partial(67108853)
+                archived_progress: ArchivedBlockProgress::new_partial(
+                    NonZeroU32::new(67108853).unwrap()
+                )
             }
         );
     }
@@ -155,7 +165,9 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: BlockNumber::new(3),
-                archived_progress: ArchivedBlockProgress::Partial(33554318)
+                archived_progress: ArchivedBlockProgress::new_partial(
+                    NonZeroU32::new(33554319).unwrap()
+                )
             }
         );
 
@@ -175,7 +187,9 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: BlockNumber::new(3),
-                archived_progress: ArchivedBlockProgress::Partial(33554318)
+                archived_progress: ArchivedBlockProgress::new_partial(
+                    NonZeroU32::new(33554319).unwrap()
+                )
             }
         );
     }
@@ -196,7 +210,9 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: BlockNumber::new(3),
-                archived_progress: ArchivedBlockProgress::Partial(167771953)
+                archived_progress: ArchivedBlockProgress::new_partial(
+                    NonZeroU32::new(167771955).unwrap()
+                )
             }
         );
     }
@@ -218,7 +234,9 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: BlockNumber::new(3),
-                archived_progress: ArchivedBlockProgress::Partial(167771953)
+                archived_progress: ArchivedBlockProgress::new_partial(
+                    NonZeroU32::new(167771955).unwrap()
+                )
             }
         );
     }
@@ -239,7 +257,9 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: BlockNumber::new(3),
-                archived_progress: ArchivedBlockProgress::Partial(301989588)
+                archived_progress: ArchivedBlockProgress::new_partial(
+                    NonZeroU32::new(301989591).unwrap()
+                )
             }
         );
     }
@@ -261,7 +281,9 @@ fn basic() {
             contents.segment_header.unwrap().last_archived_block(),
             LastArchivedBlock {
                 number: BlockNumber::new(3),
-                archived_progress: ArchivedBlockProgress::Partial(301989588)
+                archived_progress: ArchivedBlockProgress::new_partial(
+                    NonZeroU32::new(301989591).unwrap()
+                )
             }
         );
     }
@@ -286,11 +308,13 @@ fn partial_data() {
     };
     let archived_segments = archiver
         .add_block(block_0.clone(), BlockObjectMapping::default())
+        .unwrap()
         .archived_segments
         .into_iter()
         .chain(
             archiver
                 .add_block(block_1, BlockObjectMapping::default())
+                .unwrap()
                 .archived_segments,
         )
         .collect::<Vec<_>>();
@@ -367,6 +391,7 @@ fn invalid_usage() {
 
     let archived_segments = archiver
         .add_block(block_0, BlockObjectMapping::default())
+        .unwrap()
         .archived_segments;
 
     assert_eq!(archived_segments.len(), 4);

--- a/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -121,7 +121,7 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(1),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(67108853).unwrap()
+                    NonZeroU32::new(67108854).unwrap()
                 )
             }
         );
@@ -143,7 +143,7 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(1),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(67108853).unwrap()
+                    NonZeroU32::new(67108854).unwrap()
                 )
             }
         );
@@ -166,7 +166,7 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(33554320).unwrap()
+                    NonZeroU32::new(33554322).unwrap()
                 )
             }
         );
@@ -188,7 +188,7 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(33554320).unwrap()
+                    NonZeroU32::new(33554322).unwrap()
                 )
             }
         );
@@ -211,7 +211,7 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(167771957).unwrap()
+                    NonZeroU32::new(167771960).unwrap()
                 )
             }
         );
@@ -235,7 +235,7 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(167771957).unwrap()
+                    NonZeroU32::new(167771960).unwrap()
                 )
             }
         );
@@ -258,7 +258,7 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(301989594).unwrap()
+                    NonZeroU32::new(301989598).unwrap()
                 )
             }
         );
@@ -282,7 +282,7 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(301989594).unwrap()
+                    NonZeroU32::new(301989598).unwrap()
                 )
             }
         );

--- a/subspace/crates/subspace-farmer-components/benches/auditing.rs
+++ b/subspace/crates/subspace-farmer-components/benches/auditing.rs
@@ -57,6 +57,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
             Default::default(),
         )
+        .unwrap()
         .archived_segments
         .into_iter()
         .next()

--- a/subspace/crates/subspace-farmer-components/benches/plotting.rs
+++ b/subspace/crates/subspace-farmer-components/benches/plotting.rs
@@ -46,6 +46,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
             Default::default(),
         )
+        .unwrap()
         .archived_segments
         .into_iter()
         .next()

--- a/subspace/crates/subspace-farmer-components/benches/proving.rs
+++ b/subspace/crates/subspace-farmer-components/benches/proving.rs
@@ -65,6 +65,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
             Default::default(),
         )
+        .unwrap()
         .archived_segments
         .into_iter()
         .next()

--- a/subspace/crates/subspace-farmer-components/benches/reading.rs
+++ b/subspace/crates/subspace-farmer-components/benches/reading.rs
@@ -57,6 +57,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
             Default::default(),
         )
+        .unwrap()
         .archived_segments
         .into_iter()
         .next()

--- a/subspace/crates/subspace-farmer/src/cluster/controller.rs
+++ b/subspace/crates/subspace-farmer/src/cluster/controller.rs
@@ -104,7 +104,7 @@ impl GenericBroadcast for ClusterControllerArchivedSegmentHeaderBroadcast {
         Some(HeaderValue::from(
             format!(
                 "archived-segment-{}",
-                self.archived_segment_header.segment_index()
+                self.archived_segment_header.segment_index
             )
             .as_str(),
         ))
@@ -557,7 +557,7 @@ impl NodeClient for ClusterNodeClient {
 
                 move |broadcast| {
                     let archived_segment_header = broadcast.archived_segment_header;
-                    let segment_index = archived_segment_header.segment_index();
+                    let segment_index = archived_segment_header.segment_index;
 
                     let maybe_archived_segment_header = if let Some(last_archived_segment_index) =
                         last_archived_segment_index
@@ -772,7 +772,7 @@ where
         );
 
         node_client
-            .acknowledge_archived_segment_header(archived_segment_header.segment_index())
+            .acknowledge_archived_segment_header(archived_segment_header.segment_index)
             .await
             .map_err(|error| anyhow!("Failed to acknowledge archived segment header: {error}"))?;
 

--- a/subspace/crates/subspace-farmer/src/farmer_cache.rs
+++ b/subspace/crates/subspace-farmer/src/farmer_cache.rs
@@ -688,7 +688,7 @@ where
     ) where
         PG: PieceGetter,
     {
-        let segment_index = segment_header.segment_index();
+        let segment_index = segment_header.segment_index;
         debug!(%segment_index, "Starting to process newly archived segment");
 
         if *last_segment_index_internal < segment_index {

--- a/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -289,7 +289,7 @@ async fn basic() {
         // side effects, but acknowledgement will indicate that keep-up after initial sync has
         // finished
         {
-            let segment_header = SegmentHeader::V0 {
+            let segment_header = SegmentHeader {
                 segment_index: SegmentIndex::ONE,
                 segment_root: Default::default(),
                 prev_segment_header_hash: [0; 32].into(),
@@ -349,7 +349,7 @@ async fn basic() {
         // Send two more segment headers (one is not enough because for above peer ID there are no
         // pieces for it to store)
         for segment_index in [2, 3] {
-            let segment_header = SegmentHeader::V0 {
+            let segment_header = SegmentHeader {
                 segment_index: SegmentIndex::from(segment_index),
                 segment_root: Default::default(),
                 prev_segment_header_hash: [0; 32].into(),

--- a/subspace/crates/subspace-farmer/src/farmer_piece_getter/piece_validator.rs
+++ b/subspace/crates/subspace-farmer/src/farmer_piece_getter/piece_validator.rs
@@ -57,7 +57,7 @@ where
         };
 
         let segment_root = match segment_headers.into_iter().next().flatten() {
-            Some(segment_header) => segment_header.segment_root(),
+            Some(segment_header) => segment_header.segment_root,
             None => {
                 error!(
                     %piece_index,

--- a/subspace/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
+++ b/subspace/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
@@ -30,8 +30,7 @@ struct SegmentHeaders {
 
 impl SegmentHeaders {
     fn push(&mut self, archived_segment_header: SegmentHeader) {
-        if self.segment_headers.len() == u64::from(archived_segment_header.segment_index()) as usize
-        {
+        if self.segment_headers.len() == u64::from(archived_segment_header.segment_index) as usize {
             self.segment_headers.push(archived_segment_header);
         }
     }
@@ -168,7 +167,7 @@ where
                 while let Some(archived_segment_header) =
                     archived_segments_notifications.next().await
                 {
-                    let segment_index = archived_segment_header.segment_index();
+                    let segment_index = archived_segment_header.segment_index;
                     trace!(
                         ?archived_segment_header,
                         "New archived archived segment header notification"

--- a/subspace/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/subspace/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -792,7 +792,7 @@ where
     while let Some(segment_header) = archived_segments_notifications.next().await {
         debug!(?segment_header, "New archived segment");
         if let Err(error) = node_client
-            .acknowledge_archived_segment_header(segment_header.segment_index())
+            .acknowledge_archived_segment_header(segment_header.segment_index)
             .await
         {
             debug!(%error, "Failed to acknowledge segment header");
@@ -859,9 +859,7 @@ where
     let mut sectors_to_replot = Vec::with_capacity(usize::from(target_sector_count) / 10);
 
     loop {
-        let segment_index = archived_segments_receiver
-            .borrow_and_update()
-            .segment_index();
+        let segment_index = archived_segments_receiver.borrow_and_update().segment_index;
         trace!(%segment_index, "New archived segment received");
 
         let sectors_metadata = sectors_metadata.read().await;
@@ -929,7 +927,7 @@ where
                     .into_iter()
                     .next()
                     .flatten()
-                    .map(|segment_header| segment_header.segment_root());
+                    .map(|segment_header| segment_header.segment_root);
 
                 if let Some(sector_expiration_check_segment_root) =
                     maybe_sector_expiration_check_segment_root

--- a/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -83,9 +83,9 @@ where
             .get_segment_header(segment_index)
             .expect("Statically guaranteed to exist, see checks above; qed");
 
-        let last_archived_block_number = segment_header.last_archived_block().number;
+        let last_archived_block_number = segment_header.last_archived_block.number;
         let last_archived_block_partial = segment_header
-            .last_archived_block()
+            .last_archived_block
             .archived_progress
             .partial()
             .is_some();

--- a/subspace/crates/subspace-service/src/sync_from_dsn/piece_validator.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/piece_validator.rs
@@ -44,7 +44,7 @@ where
 
         let maybe_segment_header = self.segment_headers_store.get_segment_header(segment_index);
         let segment_root = match maybe_segment_header {
-            Some(segment_header) => segment_header.segment_root(),
+            Some(segment_header) => segment_header.segment_root,
             None => {
                 error!(%segment_index, "No segment root in the cache.");
 

--- a/subspace/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/snap_sync.rs
@@ -166,7 +166,7 @@ where
                 .ok_or_else(|| {
                     format!("Failed to get segment index {segment_index} during snap sync")
                 })?;
-            let last_archived_block = segment_header.last_archived_block();
+            let last_archived_block = segment_header.last_archived_block;
 
             // If older segment header ends with fully archived block then no additional
             // information is necessary

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -1,9 +1,7 @@
 //! Fetching objects stored in the archived history of Subspace Network.
 
 use crate::object_fetcher::partial_object::{PartialObject, RawPieceData};
-use crate::object_fetcher::segment_header::{
-    MAX_SEGMENT_PADDING, max_segment_header_encoded_size, min_segment_header_encoded_size,
-};
+use crate::object_fetcher::segment_header::{MAX_SEGMENT_PADDING, segment_header_encoded_size};
 use crate::piece_fetcher::download_pieces;
 use crate::piece_getter::PieceGetter;
 use ab_core_primitives::hashes::Blake3Hash;
@@ -44,7 +42,7 @@ pub fn max_supported_object_length() -> usize {
         - MAX_SEGMENT_PADDING
         - 1
         - 1
-        - max_segment_header_encoded_size()
+        - segment_header_encoded_size()
         - 1
         - MAX_ENCODED_LENGTH_SIZE * 2
 }
@@ -116,7 +114,7 @@ pub enum Error {
     #[error(
         "Piece offset is inside the segment header, min size of segment header: {}, object: \
         {mapping:?}",
-        min_segment_header_encoded_size()
+        segment_header_encoded_size()
     )]
     PieceOffsetInSegmentHeader { mapping: GlobalObject },
 
@@ -269,10 +267,10 @@ where
 
             // We could parse each segment header to do this check perfectly, but it's an edge
             // case, so we just do a best-effort check
-            if piece_index.position() == 0 && offset < min_segment_header_encoded_size() as u32 {
+            if piece_index.position() == 0 && offset < segment_header_encoded_size() as u32 {
                 debug!(
                     ?mapping,
-                    min_segment_header_encoded_size = ?min_segment_header_encoded_size(),
+                    min_segment_header_encoded_size = ?segment_header_encoded_size(),
                     "Invalid offset for object: must not be inside the segment header",
                 );
 

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -10,7 +10,7 @@ use ab_core_primitives::segments::{RecordedHistorySegment, SegmentIndex};
 use parity_scale_codec::{Compact, CompactLen, Decode};
 use std::sync::Arc;
 use subspace_archiving::archiver::SegmentItem;
-use subspace_archiving::objects::{GlobalObject, GlobalObjectMapping};
+use subspace_archiving::objects::GlobalObject;
 use tracing::{debug, trace, warn};
 
 mod partial_object;
@@ -239,14 +239,14 @@ where
     /// Checks the objects' hashes to make sure the correct bytes are returned.
     pub async fn fetch_objects(
         &self,
-        mappings: GlobalObjectMapping,
+        global_objects: Vec<GlobalObject>,
     ) -> Result<Vec<Vec<u8>>, Error> {
-        let mut objects = Vec::with_capacity(mappings.objects.len());
+        let mut objects = Vec::with_capacity(global_objects.len());
 
         // TODO:
         // - keep the last downloaded piece until it's no longer needed
         // - document sorting mappings in piece index order
-        for mapping in mappings.objects {
+        for mapping in global_objects {
             let GlobalObject {
                 piece_index,
                 offset,

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -241,12 +241,12 @@ where
         &self,
         mappings: GlobalObjectMapping,
     ) -> Result<Vec<Vec<u8>>, Error> {
-        let mut objects = Vec::with_capacity(mappings.objects().len());
+        let mut objects = Vec::with_capacity(mappings.objects.len());
 
         // TODO:
         // - keep the last downloaded piece until it's no longer needed
         // - document sorting mappings in piece index order
-        for &mapping in mappings.objects() {
+        for mapping in mappings.objects {
             let GlobalObject {
                 piece_index,
                 offset,

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -34,7 +34,7 @@ const BLOCK_CONTINUATION_VARIANT: u8 = 3;
 /// The size of a segment header.
 #[inline]
 pub fn segment_header_encoded_size() -> usize {
-    let min_segment_header = SegmentHeader::V0 {
+    let min_segment_header = SegmentHeader {
         segment_index: 0.into(),
         segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -134,7 +134,7 @@ mod test {
     fn block_continuation_variant_constant() {
         let block_continuation = SegmentItem::BlockContinuation {
             bytes: Vec::new(),
-            object_mapping: Default::default(),
+            block_objects: Default::default(),
         };
         let block_continuation = block_continuation.encode();
 

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -31,36 +31,20 @@ const SEGMENT_VERSION_VARIANT: u8 = 0;
 /// The variant for block continuations.
 const BLOCK_CONTINUATION_VARIANT: u8 = 3;
 
-/// The minimum size of a segment header.
+/// The size of a segment header.
 #[inline]
-pub fn min_segment_header_encoded_size() -> usize {
+pub fn segment_header_encoded_size() -> usize {
     let min_segment_header = SegmentHeader::V0 {
         segment_index: 0.into(),
         segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::ZERO,
-            archived_progress: ArchivedBlockProgress::Complete,
+            archived_progress: ArchivedBlockProgress::new_complete(),
         },
     };
 
     min_segment_header.encoded_size()
-}
-
-/// The maximum size of the segment header.
-#[inline]
-pub fn max_segment_header_encoded_size() -> usize {
-    let max_segment_header = SegmentHeader::V0 {
-        segment_index: u64::MAX.into(),
-        segment_root: SegmentRoot::default(),
-        prev_segment_header_hash: Blake3Hash::default(),
-        last_archived_block: LastArchivedBlock {
-            number: BlockNumber::ZERO,
-            archived_progress: ArchivedBlockProgress::Partial(u32::MAX),
-        },
-    };
-
-    max_segment_header.encoded_size()
 }
 
 /// Removes the segment header from the start of a piece, and returns the remaining data.
@@ -164,16 +148,6 @@ mod test {
         assert_eq!(
             MAX_SEGMENT_PADDING,
             Compact::compact_len(&MAX_BLOCK_LENGTH) - Compact::<u32>::compact_len(&1)
-        );
-    }
-
-    #[test]
-    fn segment_header_length_constants() {
-        assert!(
-            min_segment_header_encoded_size() < max_segment_header_encoded_size(),
-            "min_segment_header_encoded_size: {} must be less than max_segment_header_encoded_size: {}",
-            min_segment_header_encoded_size(),
-            max_segment_header_encoded_size()
         );
     }
 

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -86,7 +86,7 @@ fn write_segment_header(mut piece: &mut Piece, remaining_len: usize) -> Vec<u8> 
         // Segment::V0 and SegmentItem::ParentSegmentHeader(_) variants
         let segment_variants = [0_u8, 4_u8];
         // SegmentHeader
-        let segment_header = SegmentHeader::V0 {
+        let segment_header = SegmentHeader {
             segment_index: u64::MAX.into(),
             segment_root: SegmentRoot::default(),
             prev_segment_header_hash: Blake3Hash::default(),

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -83,8 +83,8 @@ fn write_segment_header(mut piece: &mut Piece, remaining_len: usize) -> Vec<u8> 
     let segment_prefix_len = {
         let mut raw_data = extract_raw_data_mut(vec![&mut piece]);
 
-        // Segment::V0 and SegmentItem::ParentSegmentHeader(_) variants
-        let segment_variants = [0_u8, 4_u8];
+        // SegmentItem::ParentSegmentHeader(_) variant
+        let segment_variants = [4_u8];
         // SegmentHeader
         let segment_header = SegmentHeader {
             segment_index: u64::MAX.into(),

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -10,6 +10,7 @@ use ab_core_primitives::segments::{
 use parity_scale_codec::{Compact, CompactLen, Encode};
 use rand::{RngCore, thread_rng};
 use std::iter;
+use std::num::NonZeroU32;
 use subspace_logging::init_logger;
 
 /// Returns a piece filled with random data.
@@ -91,7 +92,7 @@ fn write_segment_header(mut piece: &mut Piece, remaining_len: usize) -> Vec<u8> 
             prev_segment_header_hash: Blake3Hash::default(),
             last_archived_block: LastArchivedBlock {
                 number: BlockNumber::MAX,
-                archived_progress: ArchivedBlockProgress::Partial(u32::MAX),
+                archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::MAX),
             },
         }
         .encode();
@@ -393,7 +394,7 @@ async fn get_single_piece_object_no_padding() {
 
     // Set up the test case
     // - start of segment, offset already excludes segment header
-    let offset = max_segment_header_encoded_size() + 1;
+    let offset = segment_header_encoded_size() + 1;
     let object_len = 100;
     let piece_index = 0;
 
@@ -654,8 +655,7 @@ async fn get_multi_piece_object_length_outside_padding() {
     // Leave space for the block and object lengths, segment header data, and segment, header, and
     // block enum variants. Strictly we want compact_encoded(object_len) here, but it doesn't
     // change the encoded size in practice.
-    let overhead =
-        2 * compact_encoded(4 * Record::SIZE).len() + max_segment_header_encoded_size() + 3;
+    let overhead = 2 * compact_encoded(4 * Record::SIZE).len() + segment_header_encoded_size() + 3;
     let object_len = 4 * Record::SIZE - overhead;
     let offset = 0;
     let start_piece_index = RecordedHistorySegment::NUM_RAW_RECORDS - 2;
@@ -690,7 +690,7 @@ async fn get_multi_piece_object_length_outside_padding() {
     // change the encoded size in practice.
     let skip_padding = MAX_SEGMENT_PADDING;
     let overhead = 2 * compact_encoded(6 * Record::SIZE).len()
-        + max_segment_header_encoded_size()
+        + segment_header_encoded_size()
         + 3
         + skip_padding;
     let object_len = 6 * Record::SIZE - overhead;

--- a/subspace/shared/subspace-data-retrieval/src/piece_getter.rs
+++ b/subspace/shared/subspace-data-retrieval/src/piece_getter.rs
@@ -54,7 +54,7 @@ where
 #[async_trait]
 impl PieceGetter for NewArchivedSegment {
     async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
-        if piece_index.segment_index() == self.segment_header.segment_index() {
+        if piece_index.segment_index() == self.segment_header.segment_index {
             return Ok(Some(
                 self.pieces
                     .pieces()


### PR DESCRIPTION
This removes versioning from some data structures (that I don't see changing easily in the foreseeable future) and applies other cleanups to archiving-related code that makes it a bit simpler and more efficient. More archiver changes are coming as described in https://github.com/nazar-pc/abundance/issues/183, this is just preparation for that.