### PR TITLE
Add a version to transaction header to reduce wasted space in owned transaction

### DIFF
--- a/crates/contracts/core/ab-contracts-test-utils/src/transaction_builder.rs
+++ b/crates/contracts/core/ab-contracts-test-utils/src/transaction_builder.rs
@@ -75,6 +75,7 @@ impl TransactionBuilder {
     ) -> OwnedTransaction {
         OwnedTransaction {
             header: TransactionHeader {
+                version: 0,
                 block_hash: BlockHash::default(),
                 gas_limit: Gas::default(),
                 contract: self.contract,

--- a/crates/contracts/example/ab-example-contract-wallet/benches/example-contract-wallet.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/benches/example-contract-wallet.rs
@@ -85,6 +85,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     let header = TransactionHeader {
+        version: 0,
         block_hash: BlockHash::default(),
         gas_limit: Default::default(),
         contract: wallet_address,

--- a/crates/contracts/example/ab-example-contract-wallet/tests/basic.rs
+++ b/crates/contracts/example/ab-example-contract-wallet/tests/basic.rs
@@ -88,6 +88,7 @@ fn flip() {
     });
 
     let header = TransactionHeader {
+        version: 0,
         block_hash: BlockHash::default(),
         gas_limit: Default::default(),
         contract: wallet_address,

--- a/crates/execution/ab-executor-native/src/lib.rs
+++ b/crates/execution/ab-executor-native/src/lib.rs
@@ -21,7 +21,7 @@ use ab_contracts_standards::tx_handler::TxHandlerExt;
 use ab_core_primitives::address::Address;
 use ab_core_primitives::balance::Balance;
 use ab_core_primitives::shard::ShardIndex;
-use ab_core_primitives::transaction::{Transaction, TransactionSlot};
+use ab_core_primitives::transaction::{Transaction, TransactionHeader, TransactionSlot};
 use ab_executor_slots::{Slot, SlotKey, Slots};
 use ab_io_type::variable_bytes::VariableBytes;
 use ab_io_type::variable_elements::VariableElements;
@@ -285,6 +285,10 @@ impl NativeExecutor {
         transaction: Transaction<'_>,
         slots: &Slots,
     ) -> Result<(), ContractError> {
+        if transaction.header.version != TransactionHeader::TRANSACTION_VERSION {
+            return Err(ContractError::BadInput);
+        }
+
         let env_state = EnvState {
             shard_index: self.shard_index,
             padding_0: Default::default(),
@@ -338,6 +342,10 @@ impl NativeExecutor {
         transaction: Transaction<'_>,
         slots: &mut Slots,
     ) -> Result<(), ContractError> {
+        if transaction.header.version != TransactionHeader::TRANSACTION_VERSION {
+            return Err(ContractError::BadInput);
+        }
+
         // TODO: This is a pretty large data structure to copy around, try to make it a reference
         let env_state = EnvState {
             shard_index: self.shard_index,
@@ -392,6 +400,10 @@ impl NativeExecutor {
         transaction: Transaction<'_>,
         slots: &mut Slots,
     ) -> Result<(), ContractError> {
+        if transaction.header.version != TransactionHeader::TRANSACTION_VERSION {
+            return Err(ContractError::BadInput);
+        }
+
         // TODO: This is a pretty large data structure to copy around, try to make it a reference
         let env_state = EnvState {
             shard_index: self.shard_index,

--- a/crates/shared/ab-core-primitives/src/lib.rs
+++ b/crates/shared/ab-core-primitives/src/lib.rs
@@ -6,6 +6,7 @@
     array_chunks,
     const_trait_impl,
     const_try,
+    generic_arg_infer,
     portable_simd,
     ptr_as_ref_unchecked,
     step_trait

--- a/crates/shared/ab-core-primitives/src/transaction.rs
+++ b/crates/shared/ab-core-primitives/src/transaction.rs
@@ -24,12 +24,20 @@ pub struct TransactionHash(Blake3Hash);
 #[derive(Debug, Copy, Clone, TrivialType)]
 #[repr(C)]
 pub struct TransactionHeader {
+    // TODO: Some more complex field?
+    /// Transaction version
+    pub version: u64,
     /// Block hash at which transaction was created
     pub block_hash: BlockHash,
     /// Gas limit
     pub gas_limit: Gas,
     /// Contract implementing `TxHandler` trait to use for transaction verification and execution
     pub contract: Address,
+}
+
+impl TransactionHeader {
+    /// The only supported transaction version right now
+    pub const TRANSACTION_VERSION: u64 = 0;
 }
 
 /// Transaction slot

--- a/crates/shared/ab-core-primitives/src/transaction/owned.rs
+++ b/crates/shared/ab-core-primitives/src/transaction/owned.rs
@@ -21,7 +21,7 @@ pub struct OwnedTransactionLengths {
     /// Seal length
     pub seal: u32,
     /// Not used and must be set to `0`
-    pub padding: [u8; 12],
+    pub padding: [u8; 4],
 }
 
 /// Errors for [`OwnedTransaction`]

--- a/crates/shared/ab-core-primitives/src/transaction/owned.rs
+++ b/crates/shared/ab-core-primitives/src/transaction/owned.rs
@@ -30,6 +30,9 @@ pub enum OwnedTransactionError {
     /// Not enough bytes
     #[error("Not enough bytes")]
     NotEnoughBytes,
+    /// Invalid padding
+    #[error("Invalid padding")]
+    InvalidPadding,
     /// Payload is not a multiple of `u128`
     #[error("Payload is not a multiple of `u128`")]
     PayloadIsNotMultipleOfU128,
@@ -90,8 +93,12 @@ impl OwnedTransaction {
             write_slots,
             payload,
             seal,
-            padding: _,
+            padding,
         } = lengths;
+
+        if padding != [0; _] {
+            return Err(OwnedTransactionError::InvalidPadding);
+        }
 
         if payload % u128::SIZE != 0 {
             return Err(OwnedTransactionError::PayloadIsNotMultipleOfU128);


### PR DESCRIPTION
This reduces wasted space from 12 bytes to 4 and version might in fact be useful in the future