### PR TITLE
Archiving refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,17 +56,10 @@ thiserror = { version = "2.0.12", default-features = false }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 
-# The list of dependencies below (which can be both direct and indirect dependencies) are crates that are suspected to
-# be CPU-intensive. They are unlikely to require debugging (as some of their debug info might be missing) or to require
-# to be frequently recompiled. We compile these dependencies with `opt-level=3` even in "dev" mode to make "dev" mode
-# more usable.
-# The majority of these crates are cryptographic libraries.
-#
-# This list is ordered alphabetically.
+# Following libraries have a major impact on developement experience and need to be compiled with optimizations even in
+# debug builds
 [profile.dev.package]
-ab-merkle-tree = { opt-level = 3 }
 blake3 = { opt-level = 3 }
-curve25519-dalek = { opt-level = 3 }
 reed-solomon-simd = { opt-level = 3 }
 
 [workspace.lints.rust]

--- a/crates/shared/ab-core-primitives/src/hashes.rs
+++ b/crates/shared/ab-core-primitives/src/hashes.rs
@@ -145,7 +145,7 @@ impl Blake3Hash {
 /// BLAKE3 hashing of a single value.
 #[inline(always)]
 pub fn blake3_hash(data: &[u8]) -> Blake3Hash {
-    blake3::hash(data).as_bytes().into()
+    Blake3Hash(*blake3::hash(data).as_bytes())
 }
 
 /// BLAKE3 hashing of a single value in parallel (only useful for large values well above 128kiB).

--- a/crates/shared/ab-core-primitives/src/segments.rs
+++ b/crates/shared/ab-core-primitives/src/segments.rs
@@ -284,7 +284,7 @@ impl Default for ArchivedBlockProgress {
     /// to be transitioned into the partial state after some overflow checking.
     #[inline(always)]
     fn default() -> Self {
-        Self { bytes: 0 }
+        Self::new_complete()
     }
 }
 

--- a/specs/00-subspace-diff.md
+++ b/specs/00-subspace-diff.md
@@ -48,6 +48,15 @@ before even though technically record doesn't contain parity chunks. To aid effi
 parity chunks are first committed to separately before combining into record root, with parity chunks root also
 included in the piece alongside record root.
 
+`Segment` data structure is no longer an enum (it is unlikely to need to be changed and even if it does, `SegmentItem`
+is already an enum and can support that. `ArchivedBlockProgress` is simplified to a single `u32` (where `0` means block
+is complete), resulting in `SegmentHeader` being constant size. `SegmentHeader` was also updated to a data structure
+that doesn't have padding bytes in memory, and its in-memory representation is what is being used to derive segment
+header hash. All byte lengths in various segment items have changed their encoding from variable-length SCALE encoding
+to little-endian `u32` as well, making them fixed size too. As a result, the whole segment construction is now
+predictable and deterministic, allowing for efficient piece retrieval, the implementation is simpler and without tricky
+edge-cases around variable length encoding.
+
 ## Erasure coding
 
 Erasure coding is no longer based on BLS12-381 (related to KZG), instead [reed-solomon-simd] library is used. Not only

--- a/subspace/Cargo.toml
+++ b/subspace/Cargo.toml
@@ -172,8 +172,6 @@ zeroize = "1.8.1"
 #
 # This list is ordered alphabetically.
 [profile.dev.package]
-ab-core-primitives = { opt-level = 3 }
-ab-merkle-tree = { opt-level = 3 }
 bitvec = { opt-level = 3 }
 blake2 = { opt-level = 3 }
 blake3 = { opt-level = 3 }

--- a/subspace/crates/pallet-subspace/src/lib.rs
+++ b/subspace/crates/pallet-subspace/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(array_chunks, assert_matches, portable_simd)]
+#![feature(array_chunks, assert_matches, generic_arg_infer)]
 #![warn(unused_must_use, unsafe_code, unused_variables)]
 
 extern crate alloc;

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -163,6 +163,7 @@ pub fn create_segment_header(segment_index: SegmentIndex) -> SegmentHeader {
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::ZERO,
             archived_progress: ArchivedBlockProgress::new_complete(),
+            padding: [0; _],
         },
     }
 }

--- a/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -63,6 +63,7 @@ fn segment_headers_store_block_number_queries_work() {
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(0),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
+            padding: [0; _],
         },
     };
 
@@ -73,6 +74,7 @@ fn segment_headers_store_block_number_queries_work() {
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(652),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
+            padding: [0; _],
         },
     };
 
@@ -83,6 +85,7 @@ fn segment_headers_store_block_number_queries_work() {
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(752),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
+            padding: [0; _],
         },
     };
 
@@ -93,6 +96,7 @@ fn segment_headers_store_block_number_queries_work() {
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(806),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
+            padding: [0; _],
         },
     };
 
@@ -103,6 +107,7 @@ fn segment_headers_store_block_number_queries_work() {
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::new(806),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
+            padding: [0; _],
         },
     };
 

--- a/subspace/crates/sc-consensus-subspace/src/lib.rs
+++ b/subspace/crates/sc-consensus-subspace/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! All of the modules here are crucial for consensus, open each module for specific details.
 
-#![feature(try_blocks, duration_constructors)]
+#![feature(generic_arg_infer, try_blocks, duration_constructors)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 

--- a/subspace/crates/subspace-archiving/src/archiver.rs
+++ b/subspace/crates/subspace-archiving/src/archiver.rs
@@ -408,6 +408,7 @@ impl Archiver {
                         last_archived_block.replace(LastArchivedBlock {
                             number: BlockNumber::ZERO,
                             archived_progress: ArchivedBlockProgress::new_complete(),
+                            padding: [0; _],
                         });
                     }
                 }

--- a/subspace/crates/subspace-archiving/src/archiver.rs
+++ b/subspace/crates/subspace-archiving/src/archiver.rs
@@ -392,6 +392,8 @@ impl Archiver {
 
         let mut segment_size = segment.encoded_size();
 
+        // TODO: It is possible to simplify this whole loop to `if` in case "in progress" segment
+        //  with precomputed size is stored somewhere already
         // 6 bytes is just large enough to encode a segment item (1 byte for enum variant, 4 bytes
         // for length and 1 for the actual data, while segment header item is never the last one)
         while RecordedHistorySegment::SIZE.saturating_sub(segment_size) >= 6 {

--- a/subspace/crates/subspace-archiving/src/lib.rs
+++ b/subspace/crates/subspace-archiving/src/lib.rs
@@ -1,5 +1,5 @@
 //! Collection of modules used for dealing with archived state of Subspace Network.
-#![feature(array_chunks, iter_array_chunks, iter_collect_into)]
+#![feature(array_chunks, generic_arg_infer, iter_array_chunks, iter_collect_into)]
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 // TODO: This feature is not actually used in this crate, but is added as a workaround for
 //  https://github.com/rust-lang/rust/issues/139376

--- a/subspace/crates/subspace-archiving/src/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/reconstructor.rs
@@ -21,6 +21,9 @@ pub enum ReconstructorError {
     /// Segment size is not bigger than record size
     #[error("Error during segment decoding: {0}")]
     SegmentDecoding(parity_scale_codec::Error),
+    /// Invalid padding
+    #[error("Invalid padding")]
+    InvalidPadding,
     /// Incorrect segment order, each next segment must have monotonically increasing segment index
     #[error(
         "Incorrect segment order, expected index {expected_segment_index}, actual \
@@ -198,8 +201,12 @@ impl Reconstructor {
                     let LastArchivedBlock {
                         number,
                         archived_progress,
-                        padding: _,
+                        padding,
                     } = segment_header.last_archived_block;
+
+                    if padding != [0; _] {
+                        return Err(ReconstructorError::InvalidPadding);
+                    }
 
                     reconstructed_contents
                         .segment_header

--- a/subspace/crates/subspace-archiving/src/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/reconstructor.rs
@@ -159,7 +159,7 @@ impl Reconstructor {
 
                     reconstructed_contents
                         .blocks
-                        .push((next_block_number, bytes));
+                        .push((next_block_number, Vec::from(bytes)));
 
                     next_block_number += BlockNumber::ONE;
                 }
@@ -172,7 +172,7 @@ impl Reconstructor {
                         next_block_number += BlockNumber::ONE;
                     }
 
-                    partial_block = bytes;
+                    partial_block = Vec::from(bytes);
                 }
                 SegmentItem::BlockContinuation { bytes, .. } => {
                     if partial_block.is_empty() {

--- a/subspace/crates/subspace-archiving/src/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/src/reconstructor.rs
@@ -198,6 +198,7 @@ impl Reconstructor {
                     let LastArchivedBlock {
                         number,
                         archived_progress,
+                        padding: _,
                     } = segment_header.last_archived_block;
 
                     reconstructed_contents

--- a/subspace/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/archiver.rs
@@ -269,7 +269,7 @@ fn archiver() {
         assert_eq!(last_archived_block.number, BlockNumber::new(2));
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(111848003).unwrap())
+            Some(NonZeroU32::new(111847999).unwrap())
         );
     }
     {
@@ -278,7 +278,7 @@ fn archiver() {
         assert_eq!(last_archived_block.number, BlockNumber::new(2));
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(246065641).unwrap())
+            Some(NonZeroU32::new(246065633).unwrap())
         );
     }
 
@@ -325,7 +325,7 @@ fn archiver() {
 
     // Add a block such that it fits in the next segment exactly
     let block_3 = {
-        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369912];
+        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369924];
         rng.fill_bytes(block.as_mut_slice());
         block
     };
@@ -412,6 +412,7 @@ fn invalid_usage() {
                     archived_progress: ArchivedBlockProgress::new_partial(
                         NonZeroU32::new(10).unwrap(),
                     ),
+                    padding: [0; _],
                 },
             },
             &[0u8; 10],
@@ -440,6 +441,7 @@ fn invalid_usage() {
                     archived_progress: ArchivedBlockProgress::new_partial(
                         NonZeroU32::new(10).unwrap(),
                     ),
+                    padding: [0; _],
                 },
             },
             &[0u8; 6],
@@ -587,6 +589,7 @@ fn object_on_the_edge_of_segment() {
                 last_archived_block: LastArchivedBlock {
                     number: BlockNumber::ZERO,
                     archived_progress: ArchivedBlockProgress::new_complete(),
+                    padding: [0; _],
                 },
             })
                 .encoded_size() as u32

--- a/subspace/crates/subspace-archiving/tests/integration/archiver.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/archiver.rs
@@ -6,7 +6,7 @@ use ab_core_primitives::segments::{
     SegmentHeader, SegmentIndex, SegmentRoot,
 };
 use ab_erasure_coding::ErasureCoding;
-use parity_scale_codec::{Compact, CompactLen, Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 use rand_chacha::ChaCha8Rng;
 use rand_core::{RngCore, SeedableRng};
 #[cfg(feature = "parallel")]
@@ -20,15 +20,14 @@ use subspace_archiving::objects::{BlockObject, GlobalObject};
 
 fn extract_data<O: Into<u32>>(data: &[u8], offset: O) -> &[u8] {
     let offset: u32 = offset.into();
-    let Compact(size) = Compact::<u32>::decode(&mut &data[offset as usize..]).unwrap();
-    &data[offset as usize + Compact::compact_len(&size)..][..size as usize]
+    let size = u32::decode(&mut &data[offset as usize..]).unwrap();
+    &data[offset as usize + u32::encoded_fixed_size().unwrap()..][..size as usize]
 }
 
 fn extract_data_from_source_record<O: Into<u32>>(record: &Record, offset: O) -> &[u8] {
     let offset: u32 = offset.into();
-    let Compact(size) =
-        Compact::<u32>::decode(&mut &record.as_flattened()[offset as usize..]).unwrap();
-    &record.as_flattened()[offset as usize + Compact::compact_len(&size)..][..size as usize]
+    let size = u32::decode(&mut &record.as_flattened()[offset as usize..]).unwrap();
+    &record.as_flattened()[offset as usize + u32::encoded_fixed_size().unwrap()..][..size as usize]
 }
 
 #[track_caller]
@@ -56,13 +55,10 @@ fn archiver() {
         let mut block = vec![0u8; RecordedHistorySegment::SIZE / 2];
         rng.fill_bytes(block.as_mut_slice());
 
-        block[0..]
-            .as_mut()
-            .write_all(&Compact(100_u64).encode())
-            .unwrap();
+        block[0..].as_mut().write_all(&100_u32.encode()).unwrap();
         block[RecordedHistorySegment::SIZE / 3..]
             .as_mut()
-            .write_all(&Compact(128_u64).encode())
+            .write_all(&128_u32.encode())
             .unwrap();
         let block_objects = vec![
             BlockObject {
@@ -93,15 +89,15 @@ fn archiver() {
 
         block[RecordedHistorySegment::SIZE / 6..]
             .as_mut()
-            .write_all(&Compact(100_u64).encode())
+            .write_all(&100_u32.encode())
             .unwrap();
         block[RecordedHistorySegment::SIZE / 5..]
             .as_mut()
-            .write_all(&Compact(2048_u64).encode())
+            .write_all(&2048_u32.encode())
             .unwrap();
         block[RecordedHistorySegment::SIZE / 3 * 2 - 200..]
             .as_mut()
-            .write_all(&Compact(100_u64).encode())
+            .write_all(&100_u32.encode())
             .unwrap();
         let block_objects = vec![
             BlockObject {
@@ -464,25 +460,20 @@ fn invalid_usage() {
     }
 }
 
-// Please check commits where this tests are introduced for the edge cases they are testing (filling
-// encoded segment) and ensure they still test those edge cases in case you have to decrease piece
-// size in the future.
-
 #[test]
-fn one_byte_smaller_segment() {
+fn early_segment_creation() {
     let erasure_coding = ErasureCoding::new();
 
-    // Carefully compute the block size such that there is just 2 bytes left to fill the segment,
-    // but this should already produce archived segment since just enum variant and smallest compact
-    // vector length encoding will take 2 bytes to encode, thus it will be impossible to slice
-    // internal bytes of the segment item anyway
+    // Carefully compute the block size such that there is just 5 bytes left to fill the segment,
+    // but this should already produce an archived segment because just enum variant and the
+    // smallest segment item encoding will take 6 bytes to encode
     let block_size = RecordedHistorySegment::SIZE
-        - 1
-        // This is a rough number (a bit fewer bytes will be included in practice), but it is
-        // close enough and practically will always result in the same compact length.
-        - Compact::compact_len(&(RecordedHistorySegment::SIZE as u32))
-        // We leave two bytes at the end intentionally
-        - 2;
+        - 2 * (
+            // Enum variant
+            1
+            // Byte length encoding
+            + u32::encoded_fixed_size().unwrap()
+        );
     assert_eq!(
         Archiver::new(erasure_coding.clone())
             .add_block(vec![0u8; block_size], Vec::new())
@@ -491,66 +482,15 @@ fn one_byte_smaller_segment() {
             .len(),
         1
     );
-    // Cutting just one byte more is not sufficient to produce a segment, this is a protection
-    // against code regressions
+
+    // Cutting just one byte and block length is no longer large enough to produce a segment because
+    // 6 bytes is enough for one more segment item
     assert!(
         Archiver::new(erasure_coding)
             .add_block(vec![0u8; block_size - 1], Vec::new())
             .unwrap()
             .archived_segments
             .is_empty()
-    );
-}
-
-#[test]
-fn spill_over_edge_case() {
-    let erasure_coding = ErasureCoding::new();
-    let mut archiver = Archiver::new(erasure_coding);
-
-    // Carefully compute the block size such that there is just 2 bytes left to fill the segment,
-    // but this should already produce archived segment since just enum variant and smallest compact
-    // vector length encoding will take 2 bytes to encode, thus it will be impossible to slice
-    // internal bytes of the segment item anyway
-    let block_size = RecordedHistorySegment::SIZE
-        // Segment enum variant
-        - 1
-        // Block continuation segment item enum variant
-        - 1
-        // This is a rough number (a bit fewer bytes will be included in practice), but it is
-        // close enough and practically will always result in the same compact length.
-        - Compact::compact_len(&(RecordedHistorySegment::SIZE as u32))
-        // We leave three bytes at the end intentionally
-        - 3;
-    assert!(
-        archiver
-            .add_block(vec![0u8; block_size], Vec::new())
-            .unwrap()
-            .archived_segments
-            .is_empty()
-    );
-
-    // Here we add one more block with internal length that takes 4 bytes in compact length
-    // encoding + one more for enum variant, this should result in new segment being created, but
-    // the very first segment item will not include newly added block because it would result in
-    // subtracting with overflow when trying to slice internal bytes of the segment item
-    let block_outcome = archiver
-        .add_block(
-            vec![0u8; RecordedHistorySegment::SIZE],
-            vec![BlockObject {
-                hash: Blake3Hash::default(),
-                offset: 0,
-            }],
-        )
-        .unwrap();
-    let archived_segments = block_outcome.archived_segments;
-    let object_mapping = block_outcome.global_objects;
-    assert_eq!(archived_segments.len(), 2);
-
-    // If spill over actually happened, we'll not find object mapping in the first segment
-    assert_eq!(object_mapping.len(), 1);
-    assert_eq!(
-        object_mapping[0].piece_index.segment_index(),
-        archived_segments[1].segment_header.segment_index,
     );
 }
 
@@ -595,16 +535,14 @@ fn object_on_the_edge_of_segment() {
                 .encoded_size() as u32
             // Block continuation segment item enum variant
             - 1
-            // Compact length of block continuation segment item bytes length.
-            - Compact::compact_len(&left_unarchived_from_first_block) as u32
+            // Block continuation segment item bytes length
+            - u32::encoded_fixed_size().unwrap() as u32
             // Block continuation segment item bytes (that didn't fit into the very first segment)
             - left_unarchived_from_first_block
             // One byte for block start segment item enum variant
             - 1
-            // Compact encoding of bytes length.
-            // This is a rough number (a bit fewer bytes will be included in practice), but it is
-            // close enough and practically will always result in the same compact length.
-            - Compact::compact_len(&(RecordedHistorySegment::SIZE as u32)) as u32,
+            // Bytes length
+            - u32::encoded_fixed_size().unwrap() as u32,
     };
     let mut mapped_bytes = [0u8; 32];
     rng.fill_bytes(&mut mapped_bytes);

--- a/subspace/crates/subspace-archiving/tests/integration/main.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/main.rs
@@ -1,4 +1,4 @@
-#![feature(assert_matches)]
+#![feature(assert_matches, generic_arg_infer)]
 
 mod archiver;
 mod piece_reconstruction;

--- a/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
+++ b/subspace/crates/subspace-archiving/tests/integration/reconstructor.rs
@@ -121,7 +121,8 @@ fn basic() {
                 number: BlockNumber::new(1),
                 archived_progress: ArchivedBlockProgress::new_partial(
                     NonZeroU32::new(67108854).unwrap()
-                )
+                ),
+                padding: [0; _],
             }
         );
 
@@ -143,7 +144,8 @@ fn basic() {
                 number: BlockNumber::new(1),
                 archived_progress: ArchivedBlockProgress::new_partial(
                     NonZeroU32::new(67108854).unwrap()
-                )
+                ),
+                padding: [0; _],
             }
         );
     }
@@ -165,8 +167,9 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(33554322).unwrap()
-                )
+                    NonZeroU32::new(33554318).unwrap()
+                ),
+                padding: [0; _],
             }
         );
 
@@ -187,8 +190,9 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(33554322).unwrap()
-                )
+                    NonZeroU32::new(33554318).unwrap()
+                ),
+                padding: [0; _],
             }
         );
     }
@@ -210,8 +214,9 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(167771960).unwrap()
-                )
+                    NonZeroU32::new(167771952).unwrap()
+                ),
+                padding: [0; _],
             }
         );
     }
@@ -234,8 +239,9 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(167771960).unwrap()
-                )
+                    NonZeroU32::new(167771952).unwrap()
+                ),
+                padding: [0; _],
             }
         );
     }
@@ -257,8 +263,9 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(301989598).unwrap()
-                )
+                    NonZeroU32::new(301989586).unwrap()
+                ),
+                padding: [0; _],
             }
         );
     }
@@ -281,8 +288,9 @@ fn basic() {
             LastArchivedBlock {
                 number: BlockNumber::new(3),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(301989598).unwrap()
-                )
+                    NonZeroU32::new(301989586).unwrap()
+                ),
+                padding: [0; _],
             }
         );
     }

--- a/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -296,6 +296,7 @@ async fn basic() {
                 last_archived_block: LastArchivedBlock {
                     number: BlockNumber::ZERO,
                     archived_progress: Default::default(),
+                    padding: [0; _],
                 },
             };
 
@@ -356,6 +357,7 @@ async fn basic() {
                 last_archived_block: LastArchivedBlock {
                     number: BlockNumber::ZERO,
                     archived_progress: Default::default(),
+                    padding: [0; _],
                 },
             };
 

--- a/subspace/crates/subspace-farmer/src/lib.rs
+++ b/subspace/crates/subspace-farmer/src/lib.rs
@@ -7,6 +7,7 @@
     exact_size_is_empty,
     fmt_helpers_for_derive,
     future_join,
+    generic_arg_infer,
     impl_trait_in_assoc_type,
     int_roundings,
     iter_collect_into,

--- a/subspace/shared/subspace-data-retrieval/src/lib.rs
+++ b/subspace/shared/subspace-data-retrieval/src/lib.rs
@@ -1,6 +1,6 @@
 //! Fetching data from the archived history of the Subspace Distributed Storage Network.
 
-#![feature(exact_size_is_empty, trusted_len)]
+#![feature(exact_size_is_empty, generic_arg_infer, trusted_len)]
 
 pub mod object_fetcher;
 pub mod piece_fetcher;

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher.rs
@@ -193,6 +193,8 @@ pub enum Error {
     },
 }
 
+// TODO: This no longer corresponds to the latest simplified archiving mechanism and needs to be
+//  rewritten
 /// Object fetcher for the Subspace DSN.
 pub struct ObjectFetcher<PG>
 where

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -121,7 +121,7 @@ pub fn strip_segment_header(
 #[cfg(test)]
 mod test {
     use super::*;
-    use parity_scale_codec::{Compact, CompactLen};
+    use parity_scale_codec::{Compact, CompactLen, DecodeAll};
 
     #[test]
     fn max_segment_padding_constant() {
@@ -133,12 +133,14 @@ mod test {
 
     #[test]
     fn block_continuation_variant_constant() {
-        let block_continuation = SegmentItem::BlockContinuation {
-            bytes: Vec::new(),
-            block_objects: Default::default(),
-        };
-        let block_continuation = block_continuation.encode();
+        let segment_item =
+            SegmentItem::decode_all(&mut [BLOCK_CONTINUATION_VARIANT, 1, 0, 0, 0, 42].as_slice())
+                .unwrap();
 
-        assert_eq!(block_continuation[0], BLOCK_CONTINUATION_VARIANT);
+        if let SegmentItem::BlockContinuation { bytes, .. } = segment_item {
+            assert_eq!(Vec::from(bytes).as_slice(), &[42]);
+        } else {
+            panic!("Wrong `BLOCK_CONTINUATION_VARIANT` constant");
+        }
     }
 }

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -38,6 +38,7 @@ pub fn segment_header_encoded_size() -> usize {
         last_archived_block: LastArchivedBlock {
             number: BlockNumber::ZERO,
             archived_progress: ArchivedBlockProgress::new_complete(),
+            padding: [0; _],
         },
     };
 

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -93,6 +93,7 @@ fn write_segment_header(mut piece: &mut Piece, remaining_len: usize) -> Vec<u8> 
             last_archived_block: LastArchivedBlock {
                 number: BlockNumber::MAX,
                 archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::MAX),
+                padding: [0; _],
             },
         }
         .encode();


### PR DESCRIPTION
This is probably the last change to archiving in the nearest future and resolves https://github.com/nazar-pc/abundance/issues/183.

The key thing is that all data structures are now encoded in fully predictable way: `SegmentHeader` is constant size, length used in segment items is encoded as `u32` rather than using SCALE compact length encoding. As the result, it is easy to retrieve data since as soon as we know the length of the data (for which we may need to download one piece) we can immediately calculate the number of remaining pieces that need to be downloaded.

Overall I'm quite happy with how things turned out. There are still things to optimize in the code, but I don't expect the core logic to change. The only upcoming update related to archiver will be adding super segment information to each piece.

Object fetcher is broken now. Tests don't fail because object fetcher is not being tested against the actual archiving, instead it produces some mock data that happen to no longer correspond to the archiver. Fixing it right now isn't worth it because it needs to be rewritten in a simpler way and someone will have to do it once final `Piece` structure is in place.