### PR TITLE
Unaligned wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,9 @@ name = "ab-io-type"
 version = "0.0.1"
 dependencies = [
  "ab-trivial-type-derive",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
 ]
 
 [[package]]

--- a/crates/shared/ab-archiving/tests/integration/archiver.rs
+++ b/crates/shared/ab-archiving/tests/integration/archiver.rs
@@ -130,7 +130,7 @@ fn archiver() {
         ArchivedHistorySegment::NUM_PIECES
     );
     assert_eq!(
-        first_archived_segment.segment_header.segment_index,
+        first_archived_segment.segment_header.segment_index(),
         SegmentIndex::ZERO
     );
     assert_eq!(
@@ -141,7 +141,7 @@ fn archiver() {
     );
     {
         let last_archived_block = first_archived_segment.segment_header.last_archived_block;
-        assert_eq!(last_archived_block.number, BlockNumber::ONE);
+        assert_eq!(last_archived_block.number(), BlockNumber::ONE);
         assert_eq!(
             last_archived_block.partial_archived(),
             Some(NonZeroU32::new(67108854).unwrap())
@@ -242,7 +242,7 @@ fn archiver() {
         block_1_outcome.global_objects[2]
             .piece_index
             .segment_index(),
-        archived_segments[0].segment_header.segment_index,
+        archived_segments[0].segment_header.segment_index(),
     );
     {
         let block_objects =
@@ -263,19 +263,19 @@ fn archiver() {
     {
         let archived_segment = archived_segments.first().unwrap();
         let last_archived_block = archived_segment.segment_header.last_archived_block;
-        assert_eq!(last_archived_block.number, BlockNumber::new(2));
+        assert_eq!(last_archived_block.number(), BlockNumber::new(2));
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(111847999).unwrap())
+            Some(NonZeroU32::new(111848003).unwrap())
         );
     }
     {
         let archived_segment = archived_segments.get(1).unwrap();
         let last_archived_block = archived_segment.segment_header.last_archived_block;
-        assert_eq!(last_archived_block.number, BlockNumber::new(2));
+        assert_eq!(last_archived_block.number(), BlockNumber::new(2));
         assert_eq!(
             last_archived_block.partial_archived(),
-            Some(NonZeroU32::new(246065633).unwrap())
+            Some(NonZeroU32::new(246065641).unwrap())
         );
     }
 
@@ -289,7 +289,7 @@ fn archiver() {
             ArchivedHistorySegment::NUM_PIECES
         );
         assert_eq!(
-            archived_segment.segment_header.segment_index,
+            archived_segment.segment_header.segment_index(),
             expected_segment_index
         );
         assert_eq!(
@@ -322,7 +322,7 @@ fn archiver() {
 
     // Add a block such that it fits in the next segment exactly
     let block_3 = {
-        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369924];
+        let mut block = vec![0u8; RecordedHistorySegment::SIZE - 22369914];
         rng.fill_bytes(block.as_mut_slice());
         block
     };
@@ -362,7 +362,7 @@ fn archiver() {
     {
         let archived_segment = archived_segments.first().unwrap();
         let last_archived_block = archived_segment.segment_header.last_archived_block;
-        assert_eq!(last_archived_block.number, BlockNumber::new(3));
+        assert_eq!(last_archived_block.number(), BlockNumber::new(3));
         assert_eq!(last_archived_block.partial_archived(), None);
 
         #[cfg(not(feature = "parallel"))]
@@ -401,15 +401,14 @@ fn invalid_usage() {
         let result = Archiver::with_initial_state(
             erasure_coding.clone(),
             SegmentHeader {
-                segment_index: SegmentIndex::ZERO,
+                segment_index: SegmentIndex::ZERO.into(),
                 segment_root: SegmentRoot::default(),
                 prev_segment_header_hash: Blake3Hash::default(),
                 last_archived_block: LastArchivedBlock {
-                    number: BlockNumber::ZERO,
+                    number: BlockNumber::ZERO.into(),
                     archived_progress: ArchivedBlockProgress::new_partial(
                         NonZeroU32::new(10).unwrap(),
                     ),
-                    padding: [0; _],
                 },
             },
             &[0u8; 10],
@@ -430,15 +429,14 @@ fn invalid_usage() {
         let result = Archiver::with_initial_state(
             erasure_coding.clone(),
             SegmentHeader {
-                segment_index: SegmentIndex::ZERO,
+                segment_index: SegmentIndex::ZERO.into(),
                 segment_root: SegmentRoot::default(),
                 prev_segment_header_hash: Blake3Hash::default(),
                 last_archived_block: LastArchivedBlock {
-                    number: BlockNumber::ZERO,
+                    number: BlockNumber::ZERO.into(),
                     archived_progress: ArchivedBlockProgress::new_partial(
                         NonZeroU32::new(10).unwrap(),
                     ),
-                    padding: [0; _],
                 },
             },
             &[0u8; 6],
@@ -526,13 +524,12 @@ fn object_on_the_edge_of_segment() {
         offset: RecordedHistorySegment::SIZE as u32
             // Segment header segment item
             - SegmentItem::ParentSegmentHeader(SegmentHeader {
-                segment_index: SegmentIndex::ZERO,
+                segment_index: SegmentIndex::ZERO.into(),
                 segment_root: Default::default(),
                 prev_segment_header_hash: Default::default(),
                 last_archived_block: LastArchivedBlock {
-                    number: BlockNumber::ZERO,
+                    number: BlockNumber::ZERO.into(),
                     archived_progress: ArchivedBlockProgress::new_complete(),
-                    padding: [0; _],
                 },
             })
                 .encoded_size() as u32
@@ -574,7 +571,7 @@ fn object_on_the_edge_of_segment() {
         assert_eq!(object_mapping.len(), 1);
         assert_eq!(
             object_mapping[0].piece_index.segment_index(),
-            archived_segments[0].segment_header.segment_index,
+            archived_segments[0].segment_header.segment_index(),
         );
     }
 
@@ -589,7 +586,7 @@ fn object_on_the_edge_of_segment() {
     assert_eq!(object_mapping.len(), 1);
     assert_eq!(
         object_mapping[0].piece_index.segment_index(),
-        archived_segments[1].segment_header.segment_index,
+        archived_segments[1].segment_header.segment_index(),
     );
 
     // Ensure bytes are mapped correctly

--- a/crates/shared/ab-archiving/tests/integration/reconstructor.rs
+++ b/crates/shared/ab-archiving/tests/integration/reconstructor.rs
@@ -113,17 +113,16 @@ fn basic() {
         );
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index,
+            contents.segment_header.unwrap().segment_index(),
             SegmentIndex::ZERO
         );
         assert_eq!(
             contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
-                number: BlockNumber::new(1),
+                number: BlockNumber::new(1).into(),
                 archived_progress: ArchivedBlockProgress::new_partial(
                     NonZeroU32::new(67108854).unwrap()
                 ),
-                padding: [0; _],
             }
         );
 
@@ -136,17 +135,16 @@ fn basic() {
         assert_eq!(contents.blocks, vec![(BlockNumber::new(2), block_2)]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index,
+            contents.segment_header.unwrap().segment_index(),
             SegmentIndex::ZERO
         );
         assert_eq!(
             contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
-                number: BlockNumber::new(1),
+                number: BlockNumber::new(1).into(),
                 archived_progress: ArchivedBlockProgress::new_partial(
                     NonZeroU32::new(67108854).unwrap()
                 ),
-                padding: [0; _],
             }
         );
     }
@@ -160,17 +158,16 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index,
+            contents.segment_header.unwrap().segment_index(),
             SegmentIndex::ONE
         );
         assert_eq!(
             contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
-                number: BlockNumber::new(3),
+                number: BlockNumber::new(3).into(),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(33554318).unwrap()
+                    NonZeroU32::new(33554322).unwrap()
                 ),
-                padding: [0; _],
             }
         );
 
@@ -183,17 +180,16 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index,
+            contents.segment_header.unwrap().segment_index(),
             SegmentIndex::ONE
         );
         assert_eq!(
             contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
-                number: BlockNumber::new(3),
+                number: BlockNumber::new(3).into(),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(33554318).unwrap()
+                    NonZeroU32::new(33554322).unwrap()
                 ),
-                padding: [0; _],
             }
         );
     }
@@ -207,17 +203,16 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index,
+            contents.segment_header.unwrap().segment_index(),
             SegmentIndex::from(2)
         );
         assert_eq!(
             contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
-                number: BlockNumber::new(3),
+                number: BlockNumber::new(3).into(),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(167771952).unwrap()
+                    NonZeroU32::new(167771960).unwrap()
                 ),
-                padding: [0; _],
             }
         );
     }
@@ -232,17 +227,16 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index,
+            contents.segment_header.unwrap().segment_index(),
             SegmentIndex::from(2)
         );
         assert_eq!(
             contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
-                number: BlockNumber::new(3),
+                number: BlockNumber::new(3).into(),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(167771952).unwrap()
+                    NonZeroU32::new(167771960).unwrap()
                 ),
-                padding: [0; _],
             }
         );
     }
@@ -256,17 +250,16 @@ fn basic() {
         assert_eq!(contents.blocks, vec![(BlockNumber::new(3), block_3)]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index,
+            contents.segment_header.unwrap().segment_index(),
             SegmentIndex::from(3)
         );
         assert_eq!(
             contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
-                number: BlockNumber::new(3),
+                number: BlockNumber::new(3).into(),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(301989586).unwrap()
+                    NonZeroU32::new(301989598).unwrap()
                 ),
-                padding: [0; _],
             }
         );
     }
@@ -281,17 +274,16 @@ fn basic() {
         assert_eq!(contents.blocks, vec![]);
         assert!(contents.segment_header.is_some());
         assert_eq!(
-            contents.segment_header.unwrap().segment_index,
+            contents.segment_header.unwrap().segment_index(),
             SegmentIndex::from(3)
         );
         assert_eq!(
             contents.segment_header.unwrap().last_archived_block,
             LastArchivedBlock {
-                number: BlockNumber::new(3),
+                number: BlockNumber::new(3).into(),
                 archived_progress: ArchivedBlockProgress::new_partial(
-                    NonZeroU32::new(301989586).unwrap()
+                    NonZeroU32::new(301989598).unwrap()
                 ),
-                padding: [0; _],
             }
         );
     }

--- a/crates/shared/ab-core-primitives/Cargo.toml
+++ b/crates/shared/ab-core-primitives/Cargo.toml
@@ -42,6 +42,7 @@ alloc = [
 scale-codec = [
     "dep:parity-scale-codec",
     "dep:scale-info",
+    "ab-io-type/scale-codec",
     "alloc",
 ]
 # Enables some APIs
@@ -50,8 +51,9 @@ parallel = [
     "dep:rayon",
 ]
 serde = [
-    "alloc",
     "dep:serde",
+    "ab-io-type/serde",
+    "alloc",
     "bytes/serde",
     "hex/serde",
 ]

--- a/crates/shared/ab-core-primitives/src/hashes.rs
+++ b/crates/shared/ab-core-primitives/src/hashes.rs
@@ -10,9 +10,7 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 #[cfg(feature = "scale-codec")]
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "serde")]
-use serde::{Deserializer, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// BLAKE3 hash output transparent wrapper
 #[derive(

--- a/crates/shared/ab-core-primitives/src/pieces.rs
+++ b/crates/shared/ab-core-primitives/src/pieces.rs
@@ -13,9 +13,7 @@ pub use crate::pieces::flat_pieces::FlatPieces;
 pub use crate::pieces::piece::Piece;
 use crate::segments::{RecordedHistorySegment, SegmentIndex, SegmentRoot};
 #[cfg(feature = "serde")]
-use ::serde::{Deserialize, Serialize};
-#[cfg(feature = "serde")]
-use ::serde::{Deserializer, Serializer};
+use ::serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ab_merkle_tree::balanced_hashed::BalancedHashedMerkleTree;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;

--- a/crates/shared/ab-core-primitives/src/pieces.rs
+++ b/crates/shared/ab-core-primitives/src/pieces.rs
@@ -14,6 +14,7 @@ pub use crate::pieces::piece::Piece;
 use crate::segments::{RecordedHistorySegment, SegmentIndex, SegmentRoot};
 #[cfg(feature = "serde")]
 use ::serde::{Deserialize, Deserializer, Serialize, Serializer};
+use ab_io_type::trivial_type::TrivialType;
 use ab_merkle_tree::balanced_hashed::BalancedHashedMerkleTree;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
@@ -65,7 +66,7 @@ use serde_big_array::BigArray;
     derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[repr(transparent)]
+#[repr(C)]
 pub struct PieceIndex(u64);
 
 impl Step for PieceIndex {
@@ -166,13 +167,14 @@ impl PieceIndex {
     MulAssign,
     Div,
     DivAssign,
+    TrivialType,
 )]
 #[cfg_attr(
     feature = "scale-codec",
     derive(Encode, Decode, MaxEncodedLen, TypeInfo)
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[repr(transparent)]
+#[repr(C)]
 pub struct PieceOffset(u16);
 
 impl Step for PieceOffset {
@@ -242,6 +244,7 @@ impl PieceOffset {
     AsMut,
     Deref,
     DerefMut,
+    TrivialType,
 )]
 #[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -297,7 +300,7 @@ impl RecordChunk {
 ///
 /// NOTE: This is a stack-allocated data structure and can cause stack overflow!
 #[derive(Copy, Clone, Eq, PartialEq, Deref, DerefMut)]
-#[repr(transparent)]
+#[repr(C)]
 pub struct Record([[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]);
 
 impl fmt::Debug for Record {
@@ -333,7 +336,7 @@ impl AsMut<[u8]> for Record {
 impl From<&Record> for &[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS] {
     #[inline]
     fn from(value: &Record) -> Self {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
 }
@@ -341,7 +344,7 @@ impl From<&Record> for &[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS] {
 impl From<&[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]> for &Record {
     #[inline]
     fn from(value: &[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]) -> Self {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
 }
@@ -349,7 +352,7 @@ impl From<&[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]> for &Record {
 impl From<&mut Record> for &mut [[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS] {
     #[inline]
     fn from(value: &mut Record) -> Self {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
 }
@@ -357,7 +360,7 @@ impl From<&mut Record> for &mut [[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS] {
 impl From<&mut [[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]> for &mut Record {
     #[inline]
     fn from(value: &mut [[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]) -> Self {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
 }
@@ -365,7 +368,7 @@ impl From<&mut [[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]> for &mut Record {
 impl From<&Record> for &[u8; Record::SIZE] {
     #[inline]
     fn from(value: &Record) -> Self {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         // as inner array, while array of byte arrays has the same alignment as a single byte
         unsafe { mem::transmute(value) }
     }
@@ -374,7 +377,7 @@ impl From<&Record> for &[u8; Record::SIZE] {
 impl From<&[u8; Record::SIZE]> for &Record {
     #[inline]
     fn from(value: &[u8; Record::SIZE]) -> Self {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         // as inner array, while array of byte arrays has the same alignment as a single byte
         unsafe { mem::transmute(value) }
     }
@@ -383,7 +386,7 @@ impl From<&[u8; Record::SIZE]> for &Record {
 impl From<&mut Record> for &mut [u8; Record::SIZE] {
     #[inline]
     fn from(value: &mut Record) -> Self {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         // as inner array, while array of byte arrays has the same alignment as a single byte
         unsafe { mem::transmute(value) }
     }
@@ -392,7 +395,7 @@ impl From<&mut Record> for &mut [u8; Record::SIZE] {
 impl From<&mut [u8; Record::SIZE]> for &mut Record {
     #[inline]
     fn from(value: &mut [u8; Record::SIZE]) -> Self {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         // as inner array, while array of byte arrays has the same alignment as a single byte
         unsafe { mem::transmute(value) }
     }
@@ -427,7 +430,7 @@ impl Record {
         let mut records = Vec::with_capacity(length);
         {
             let slice = records.spare_capacity_mut();
-            // SAFETY: Same memory layout due to `#[repr(transparent)]` on `Record` and
+            // SAFETY: Same memory layout due to `#[repr(C)]` on `Record` and
             // `MaybeUninit<[[T; M]; N]>` is guaranteed to have the same layout as
             // `[[MaybeUninit<T>; M]; N]`
             let slice = unsafe {
@@ -453,7 +456,7 @@ impl Record {
     /// purposes.
     #[inline]
     pub fn slice_to_repr(value: &[Self]) -> &[[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]] {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
 
@@ -461,7 +464,7 @@ impl Record {
     /// purposes.
     #[inline]
     pub fn slice_from_repr(value: &[[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]]) -> &[Self] {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
 
@@ -471,7 +474,7 @@ impl Record {
     pub fn slice_mut_to_repr(
         value: &mut [Self],
     ) -> &mut [[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]] {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
 
@@ -481,17 +484,18 @@ impl Record {
     pub fn slice_mut_from_repr(
         value: &mut [[[u8; RecordChunk::SIZE]; Record::NUM_CHUNKS]],
     ) -> &mut [Self] {
-        // SAFETY: `Record` is `#[repr(transparent)]` and guaranteed to have the same memory layout
+        // SAFETY: `Record` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute(value) }
     }
 }
 
 /// Record root contained within a piece.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into, TrivialType)]
 #[cfg_attr(
     feature = "scale-codec",
     derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
+#[repr(C)]
 pub struct RecordRoot([u8; RecordRoot::SIZE]);
 
 impl fmt::Debug for RecordRoot {
@@ -576,7 +580,7 @@ impl AsMut<[u8]> for RecordRoot {
 impl From<&RecordRoot> for &[u8; RecordRoot::SIZE] {
     #[inline]
     fn from(value: &RecordRoot) -> Self {
-        // SAFETY: `RecordRoot` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordRoot` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -585,7 +589,7 @@ impl From<&RecordRoot> for &[u8; RecordRoot::SIZE] {
 impl From<&[u8; RecordRoot::SIZE]> for &RecordRoot {
     #[inline]
     fn from(value: &[u8; RecordRoot::SIZE]) -> Self {
-        // SAFETY: `RecordRoot` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordRoot` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -594,7 +598,7 @@ impl From<&[u8; RecordRoot::SIZE]> for &RecordRoot {
 impl From<&mut RecordRoot> for &mut [u8; RecordRoot::SIZE] {
     #[inline]
     fn from(value: &mut RecordRoot) -> Self {
-        // SAFETY: `RecordRoot` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordRoot` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -603,7 +607,7 @@ impl From<&mut RecordRoot> for &mut [u8; RecordRoot::SIZE] {
 impl From<&mut [u8; RecordRoot::SIZE]> for &mut RecordRoot {
     #[inline]
     fn from(value: &mut [u8; RecordRoot::SIZE]) -> Self {
-        // SAFETY: `RecordRoot` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordRoot` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -719,7 +723,7 @@ impl AsMut<[u8]> for RecordChunksRoot {
 impl From<&RecordChunksRoot> for &[u8; RecordChunksRoot::SIZE] {
     #[inline]
     fn from(value: &RecordChunksRoot) -> Self {
-        // SAFETY: `RecordChunksRoot` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordChunksRoot` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -728,7 +732,7 @@ impl From<&RecordChunksRoot> for &[u8; RecordChunksRoot::SIZE] {
 impl From<&[u8; RecordChunksRoot::SIZE]> for &RecordChunksRoot {
     #[inline]
     fn from(value: &[u8; RecordChunksRoot::SIZE]) -> Self {
-        // SAFETY: `RecordChunksRoot` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordChunksRoot` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -737,7 +741,7 @@ impl From<&[u8; RecordChunksRoot::SIZE]> for &RecordChunksRoot {
 impl From<&mut RecordChunksRoot> for &mut [u8; RecordChunksRoot::SIZE] {
     #[inline]
     fn from(value: &mut RecordChunksRoot) -> Self {
-        // SAFETY: `RecordChunksRoot` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordChunksRoot` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -746,7 +750,7 @@ impl From<&mut RecordChunksRoot> for &mut [u8; RecordChunksRoot::SIZE] {
 impl From<&mut [u8; RecordChunksRoot::SIZE]> for &mut RecordChunksRoot {
     #[inline]
     fn from(value: &mut [u8; RecordChunksRoot::SIZE]) -> Self {
-        // SAFETY: `RecordChunksRoot` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordChunksRoot` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -758,11 +762,12 @@ impl RecordChunksRoot {
 }
 
 /// Record proof contained within a piece.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, From, Into, TrivialType)]
 #[cfg_attr(
     feature = "scale-codec",
     derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
+#[repr(C)]
 pub struct RecordProof([[u8; OUT_LEN]; RecordProof::NUM_HASHES]);
 
 impl fmt::Debug for RecordProof {
@@ -802,7 +807,7 @@ impl Serialize for RecordProof {
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            // SAFETY: `RecordProofHexHash` is `#[repr(transparent)]` and guaranteed to have the
+            // SAFETY: `RecordProofHexHash` is `#[repr(C)]` and guaranteed to have the
             // same memory layout
             RecordProofHex(unsafe {
                 mem::transmute::<
@@ -825,7 +830,7 @@ impl<'de> Deserialize<'de> for RecordProof {
         D: Deserializer<'de>,
     {
         Ok(Self(if deserializer.is_human_readable() {
-            // SAFETY: `RecordProofHexHash` is `#[repr(transparent)]` and guaranteed to have the
+            // SAFETY: `RecordProofHexHash` is `#[repr(C)]` and guaranteed to have the
             // same memory layout
             unsafe {
                 mem::transmute::<
@@ -863,7 +868,7 @@ impl AsMut<[u8]> for RecordProof {
 impl From<&RecordProof> for &[u8; RecordProof::SIZE] {
     #[inline]
     fn from(value: &RecordProof) -> Self {
-        // SAFETY: `RecordProof` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordProof` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -872,7 +877,7 @@ impl From<&RecordProof> for &[u8; RecordProof::SIZE] {
 impl From<&[u8; RecordProof::SIZE]> for &RecordProof {
     #[inline]
     fn from(value: &[u8; RecordProof::SIZE]) -> Self {
-        // SAFETY: `RecordProof` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordProof` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -881,7 +886,7 @@ impl From<&[u8; RecordProof::SIZE]> for &RecordProof {
 impl From<&mut RecordProof> for &mut [u8; RecordProof::SIZE] {
     #[inline]
     fn from(value: &mut RecordProof) -> Self {
-        // SAFETY: `RecordProof` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordProof` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -890,7 +895,7 @@ impl From<&mut RecordProof> for &mut [u8; RecordProof::SIZE] {
 impl From<&mut [u8; RecordProof::SIZE]> for &mut RecordProof {
     #[inline]
     fn from(value: &mut [u8; RecordProof::SIZE]) -> Self {
-        // SAFETY: `RecordProof` is `#[repr(transparent)]` and guaranteed to have the same
+        // SAFETY: `RecordProof` is `#[repr(C)]` and guaranteed to have the same
         // memory layout
         unsafe { mem::transmute(value) }
     }
@@ -910,7 +915,7 @@ impl RecordProof {
 /// root and a proof proving this piece belongs to can be used to verify that a piece belongs to
 /// the actual archival history of the blockchain.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, DerefMut, AsRef, AsMut)]
-#[repr(transparent)]
+#[repr(C)]
 pub struct PieceArray([u8; PieceArray::SIZE]);
 
 impl fmt::Debug for PieceArray {
@@ -946,7 +951,7 @@ impl AsMut<[u8]> for PieceArray {
 impl From<&PieceArray> for &[u8; PieceArray::SIZE] {
     #[inline]
     fn from(value: &PieceArray) -> Self {
-        // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // SAFETY: `PieceArray` is `#[repr(C)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
@@ -955,7 +960,7 @@ impl From<&PieceArray> for &[u8; PieceArray::SIZE] {
 impl From<&[u8; PieceArray::SIZE]> for &PieceArray {
     #[inline]
     fn from(value: &[u8; PieceArray::SIZE]) -> Self {
-        // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // SAFETY: `PieceArray` is `#[repr(C)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
@@ -964,7 +969,7 @@ impl From<&[u8; PieceArray::SIZE]> for &PieceArray {
 impl From<&mut PieceArray> for &mut [u8; PieceArray::SIZE] {
     #[inline]
     fn from(value: &mut PieceArray) -> Self {
-        // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // SAFETY: `PieceArray` is `#[repr(C)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
@@ -973,7 +978,7 @@ impl From<&mut PieceArray> for &mut [u8; PieceArray::SIZE] {
 impl From<&mut [u8; PieceArray::SIZE]> for &mut PieceArray {
     #[inline]
     fn from(value: &mut [u8; PieceArray::SIZE]) -> Self {
-        // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // SAFETY: `PieceArray` is `#[repr(C)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
@@ -1117,7 +1122,7 @@ impl PieceArray {
     /// purposes.
     #[inline]
     pub fn slice_to_repr(value: &[Self]) -> &[[u8; Self::SIZE]] {
-        // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // SAFETY: `PieceArray` is `#[repr(C)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
@@ -1126,7 +1131,7 @@ impl PieceArray {
     /// purposes.
     #[inline]
     pub fn slice_from_repr(value: &[[u8; Self::SIZE]]) -> &[Self] {
-        // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // SAFETY: `PieceArray` is `#[repr(C)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
@@ -1135,7 +1140,7 @@ impl PieceArray {
     /// efficiency purposes.
     #[inline]
     pub fn slice_mut_to_repr(value: &mut [Self]) -> &mut [[u8; Self::SIZE]] {
-        // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // SAFETY: `PieceArray` is `#[repr(C)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }
@@ -1144,7 +1149,7 @@ impl PieceArray {
     /// efficiency purposes.
     #[inline]
     pub fn slice_mut_from_repr(value: &mut [[u8; Self::SIZE]]) -> &mut [Self] {
-        // SAFETY: `PieceArray` is `#[repr(transparent)]` and guaranteed to have the same memory
+        // SAFETY: `PieceArray` is `#[repr(C)]` and guaranteed to have the same memory
         // layout
         unsafe { mem::transmute(value) }
     }

--- a/crates/shared/ab-core-primitives/src/pos.rs
+++ b/crates/shared/ab-core-primitives/src/pos.rs
@@ -1,6 +1,7 @@
 //! Proof of space-related data structures.
 
 use crate::hashes::{Blake3Hash, blake3_hash};
+use ab_io_type::trivial_type::TrivialType;
 use core::fmt;
 use derive_more::{Deref, DerefMut, From, Into};
 #[cfg(feature = "scale-codec")]
@@ -33,11 +34,12 @@ impl PosSeed {
 }
 
 /// Proof of space proof bytes.
-#[derive(Copy, Clone, Eq, PartialEq, Deref, DerefMut, From, Into)]
+#[derive(Copy, Clone, Eq, PartialEq, Deref, DerefMut, From, Into, TrivialType)]
 #[cfg_attr(
     feature = "scale-codec",
     derive(Encode, Decode, TypeInfo, MaxEncodedLen)
 )]
+#[repr(C)]
 pub struct PosProof([u8; PosProof::SIZE]);
 
 impl fmt::Debug for PosProof {

--- a/crates/shared/ab-core-primitives/src/solutions.rs
+++ b/crates/shared/ab-core-primitives/src/solutions.rs
@@ -432,12 +432,6 @@ pub trait SolutionPotVerifier {
 pub struct Solution {
     /// Public key of the farmer that created the solution
     pub public_key_hash: Blake3Hash,
-    /// Index of the sector where the solution was found
-    pub sector_index: SectorIndex,
-    /// Size of the blockchain history at the time of sector creation
-    pub history_size: Unaligned<HistorySize>,
-    /// Pieces offset within sector
-    pub piece_offset: PieceOffset,
     /// Record root that can use used to verify that piece was included in blockchain history
     pub record_root: RecordRoot,
     /// Proof for above record root
@@ -448,6 +442,12 @@ pub struct Solution {
     pub chunk_proof: ChunkProof,
     /// Proof of space for piece offset
     pub proof_of_space: PosProof,
+    /// Size of the blockchain history at the time of sector creation
+    pub history_size: Unaligned<HistorySize>,
+    /// Index of the sector where the solution was found
+    pub sector_index: SectorIndex,
+    /// Pieces offset within sector
+    pub piece_offset: PieceOffset,
 }
 
 impl Solution {
@@ -455,14 +455,14 @@ impl Solution {
     pub fn genesis_solution() -> Self {
         Self {
             public_key_hash: Blake3Hash::default(),
-            sector_index: SectorIndex::ZERO,
-            history_size: HistorySize::from(SegmentIndex::ZERO).into(),
-            piece_offset: PieceOffset::default(),
             record_root: RecordRoot::default(),
             record_proof: RecordProof::default(),
             chunk: RecordChunk::default(),
             chunk_proof: ChunkProof::default(),
             proof_of_space: PosProof::default(),
+            history_size: HistorySize::from(SegmentIndex::ZERO).into(),
+            sector_index: SectorIndex::ZERO,
+            piece_offset: PieceOffset::default(),
         }
     }
 

--- a/crates/shared/ab-io-type/Cargo.toml
+++ b/crates/shared/ab-io-type/Cargo.toml
@@ -12,6 +12,18 @@ include = [
 
 [dependencies]
 ab-trivial-type-derive = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["bytes", "derive", "max-encoded-len"], optional = true }
+scale-info = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+
+[features]
+scale-codec = [
+    "dep:parity-scale-codec",
+    "dep:scale-info",
+]
+serde = [
+    "dep:serde",
+]
 
 [lints]
 workspace = true

--- a/crates/shared/ab-io-type/src/lib.rs
+++ b/crates/shared/ab-io-type/src/lib.rs
@@ -7,6 +7,7 @@ pub mod fixed_capacity_string;
 pub mod maybe_data;
 pub mod metadata;
 pub mod trivial_type;
+pub mod unaligned;
 pub mod variable_bytes;
 pub mod variable_elements;
 

--- a/crates/shared/ab-io-type/src/maybe_data.rs
+++ b/crates/shared/ab-io-type/src/maybe_data.rs
@@ -140,7 +140,7 @@ where
     //
     // `impl Deref` is used to tie lifetime of returned value to inputs, but still treat it as a
     // shared reference for most practical purposes.
-    pub const fn from_buffer(data: Option<&'_ Data>) -> impl Deref<Target = Self> + '_ {
+    pub const fn from_ref(data: Option<&'_ Data>) -> impl Deref<Target = Self> + '_ {
         let (data, size) = if let Some(data) = data {
             (NonNull::from_ref(data), &Data::SIZE)
         } else {
@@ -164,7 +164,7 @@ where
     // `impl DerefMut` is used to tie lifetime of returned value to inputs, but still treat it as an
     // exclusive reference for most practical purposes.
     #[track_caller]
-    pub fn from_buffer_mut<'a>(
+    pub fn from_mut<'a>(
         buffer: &'a mut Data,
         size: &'a mut u32,
     ) -> impl DerefMut<Target = Self> + 'a {

--- a/crates/shared/ab-io-type/src/metadata.rs
+++ b/crates/shared/ab-io-type/src/metadata.rs
@@ -262,19 +262,19 @@ pub enum IoTypeMetadataKind {
     ///
     /// Encoded as follows:
     /// * 1 byte number of elements
-    /// * Recursive metadata of contained type
+    /// * Recursive metadata of a contained type
     Array8b,
     /// Array `[T; N]` with up to 2^16 elements.
     ///
     /// Encoded as follows:
     /// * 2 bytes number of elements (little-endian)
-    /// * Recursive metadata of contained type
+    /// * Recursive metadata of a contained type
     Array16b,
     /// Array `[T; N]` with up to 2^32 elements.
     ///
     /// Encoded as follows:
     /// * 4 bytes number of elements (little-endian)
-    /// * Recursive metadata of contained type
+    /// * Recursive metadata of a contained type
     Array32b,
     /// Compact alias for `[u8; 8]`
     ArrayU8x8,
@@ -341,18 +341,24 @@ pub enum IoTypeMetadataKind {
     ///
     /// Encoded as follows:
     /// * 1 byte recommended allocation in bytes
+    /// * Recursive metadata of a contained type
     VariableElements8b,
     /// Variable elements with up to 2^16 elements recommended allocation.
     ///
     /// Encoded as follows:
     /// * 2 bytes recommended allocation in elements (little-endian)
+    /// * Recursive metadata of a contained type
     VariableElements16b,
     /// Variable elements with up to 2^32 elements recommended allocation.
     ///
     /// Encoded as follows:
     /// * 4 bytes recommended allocation in elements (little-endian)
+    /// * Recursive metadata of a contained type
     VariableElements32b,
     /// Compact alias [`VariableElements<0, T>`](crate::variable_elements::VariableElements)
+    ///
+    /// Encoded as follows:
+    /// * Recursive metadata of a contained type
     VariableElements0,
     /// Fixed capacity bytes with up to 2^8 bytes capacity.
     ///
@@ -380,6 +386,13 @@ pub enum IoTypeMetadataKind {
     /// Encoded as follows:
     /// * 2 bytes capacity (little-endian)
     FixedCapacityString16b,
+    /// Unaligned wrapper over another [`TrivialType`].
+    ///
+    /// [`TrivialType`]: crate::trivial_type::TrivialType
+    ///
+    /// Encoded as follows:
+    /// * Recursive metadata of a contained type
+    Unaligned,
     /// Address of a contract.
     ///
     /// Internally `u128` with `8` byte alignment
@@ -490,6 +503,7 @@ impl IoTypeMetadataKind {
             91 => Self::FixedCapacityBytes16b,
             92 => Self::FixedCapacityString8b,
             93 => Self::FixedCapacityString16b,
+            94 => Self::Unaligned,
             128 => Self::Address,
             129 => Self::Balance,
             _ => {

--- a/crates/shared/ab-io-type/src/metadata/compact.rs
+++ b/crates/shared/ab-io-type/src/metadata/compact.rs
@@ -275,7 +275,7 @@ pub(super) const fn compact_metadata<'i, 'o>(
         | IoTypeMetadataKind::VariableBytes262144
         | IoTypeMetadataKind::VariableBytes524288
         | IoTypeMetadataKind::VariableBytes1048576 => copy_n_bytes(input, output, 1),
-        IoTypeMetadataKind::VariableElements0 => {
+        IoTypeMetadataKind::VariableElements0 | IoTypeMetadataKind::Unaligned => {
             (input, output) = forward_option!(copy_n_bytes(input, output, 1));
             compact_metadata(input, output)
         }

--- a/crates/shared/ab-io-type/src/metadata/tests.rs
+++ b/crates/shared/ab-io-type/src/metadata/tests.rs
@@ -97,6 +97,7 @@ fn check_repr() {
         (IoTypeMetadataKind::FixedCapacityBytes16b, 91),
         (IoTypeMetadataKind::FixedCapacityString8b, 92),
         (IoTypeMetadataKind::FixedCapacityString16b, 93),
+        (IoTypeMetadataKind::Unaligned, 94),
         (IoTypeMetadataKind::Address, 128),
         (IoTypeMetadataKind::Balance, 129),
     ];

--- a/crates/shared/ab-io-type/src/metadata/type_details.rs
+++ b/crates/shared/ab-io-type/src/metadata/type_details.rs
@@ -276,6 +276,19 @@ pub(super) const fn decode_type_details(mut metadata: &[u8]) -> Option<(IoTypeDe
                 metadata,
             ))
         }
+        IoTypeMetadataKind::Unaligned => {
+            if metadata.is_empty() {
+                return None;
+            }
+
+            let type_details;
+            (type_details, metadata) = forward_option!(decode_type_details(metadata));
+
+            Some((
+                IoTypeDetails::bytes(type_details.recommended_capacity),
+                metadata,
+            ))
+        }
         IoTypeMetadataKind::Address | IoTypeMetadataKind::Balance => Some((
             IoTypeDetails {
                 recommended_capacity: 16,

--- a/crates/shared/ab-io-type/src/metadata/type_name.rs
+++ b/crates/shared/ab-io-type/src/metadata/type_name.rs
@@ -130,6 +130,7 @@ pub(super) const fn type_name(mut metadata: &[u8]) -> Option<&[u8]> {
         IoTypeMetadataKind::FixedCapacityString8b | IoTypeMetadataKind::FixedCapacityString16b => {
             b"FixedCapacityString"
         }
+        IoTypeMetadataKind::Unaligned => b"Unaligned",
         IoTypeMetadataKind::Address => b"Address",
         IoTypeMetadataKind::Balance => b"Balance",
     })

--- a/crates/shared/ab-io-type/src/unaligned.rs
+++ b/crates/shared/ab-io-type/src/unaligned.rs
@@ -1,0 +1,126 @@
+use crate::metadata::{IoTypeMetadataKind, MAX_METADATA_CAPACITY, concat_metadata_sources};
+use crate::trivial_type::TrivialType;
+use core::fmt;
+#[cfg(feature = "scale-codec")]
+use parity_scale_codec::{Decode, Encode, EncodeLike, MaxEncodedLen, Output};
+#[cfg(feature = "scale-codec")]
+use scale_info::TypeInfo;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize, Serializer};
+
+/// Wrapper type for `Data` that is the same size, but doesn't need to be aligned/has alignment of
+/// one byte.
+///
+/// This is similar to `#[repr(packed)]`, but makes sure to only expose safe API when dealing with
+/// the contents. For example, if `Data` is unaligned and has fields, it is not sounds having
+/// references to its fields. This data structure prevents such invalid invariants.
+#[derive(Debug, Default, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "scale-codec", derive(Decode, MaxEncodedLen, TypeInfo))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[repr(C, packed)]
+pub struct Unaligned<Data>(Data)
+where
+    Data: TrivialType;
+
+impl<Data> From<Data> for Unaligned<Data>
+where
+    Data: TrivialType,
+{
+    #[inline(always)]
+    fn from(value: Data) -> Self {
+        Self(value)
+    }
+}
+
+impl<Data> fmt::Display for Unaligned<Data>
+where
+    Data: TrivialType + fmt::Display,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let inner = self.0;
+        inner.fmt(f)
+    }
+}
+
+unsafe impl<Data> TrivialType for Unaligned<Data>
+where
+    Data: TrivialType,
+{
+    const METADATA: &[u8] = {
+        const fn metadata(inner_metadata: &[u8]) -> ([u8; MAX_METADATA_CAPACITY], usize) {
+            concat_metadata_sources(&[&[IoTypeMetadataKind::Unaligned as u8], inner_metadata])
+        }
+
+        // Strange syntax to allow Rust to extend the lifetime of metadata scratch automatically
+        metadata(Data::METADATA)
+            .0
+            .split_at(metadata(Data::METADATA).1)
+            .0
+    };
+}
+
+#[cfg(feature = "scale-codec")]
+impl<Data> Encode for Unaligned<Data>
+where
+    Data: TrivialType + Encode,
+{
+    #[inline(always)]
+    fn size_hint(&self) -> usize {
+        let inner = self.0;
+        inner.size_hint()
+    }
+
+    #[inline(always)]
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        let inner = self.0;
+        inner.encode_to(dest)
+    }
+
+    #[inline(always)]
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        let inner = self.0;
+        inner.using_encoded(f)
+    }
+}
+
+#[cfg(feature = "scale-codec")]
+impl<Data> EncodeLike for Unaligned<Data> where Data: TrivialType + Encode {}
+
+#[cfg(feature = "serde")]
+impl<Data> Serialize for Unaligned<Data>
+where
+    Data: TrivialType + Serialize,
+{
+    #[inline(always)]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let inner = self.0;
+        inner.serialize(serializer)
+    }
+}
+
+impl<Data> Unaligned<Data>
+where
+    Data: TrivialType,
+{
+    /// Create a new instance
+    #[inline(always)]
+    pub const fn new(inner: Data) -> Self {
+        Self(inner)
+    }
+
+    /// Get inner value
+    #[inline(always)]
+    pub const fn as_inner(&self) -> Data {
+        self.0
+    }
+
+    /// Replace inner value
+    pub const fn replace(&mut self, value: Data) {
+        self.0 = value;
+    }
+}

--- a/crates/shared/ab-merkle-tree/src/unbalanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/src/unbalanced_hashed.rs
@@ -15,7 +15,7 @@ use core::mem::MaybeUninit;
 /// [`BalancedHashedMerkleTree`]: crate::balanced_hashed::BalancedHashedMerkleTree
 ///
 /// The unbalanced tree is not padded, it is created the same way Merkle Mountain Range would be:
-/// ```ignore
+/// ```text
 ///               Root
 ///         /--------------\
 ///        H3              H4

--- a/crates/shared/ab-merkle-tree/src/unbalanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/src/unbalanced_hashed.rs
@@ -301,8 +301,6 @@ impl UnbalancedHashedMerkleTree {
 
     /// Verify a Merkle proof for a leaf at the given index
     #[inline]
-    // TODO: Make `num_leaves` optional in case the leaf is trusted (like just hashed from another
-    //  value and guaranteed not to use the same keyed hash as used here)
     pub fn verify(
         root: &[u8; OUT_LEN],
         proof: &[[u8; OUT_LEN]],

--- a/crates/shared/ab-trivial-type-derive/src/lib.rs
+++ b/crates/shared/ab-trivial-type-derive/src/lib.rs
@@ -80,7 +80,9 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
                             ::core::mem::size_of::<#type_name>()
                             #(- ::core::mem::size_of::<#field_types>() )*
                         ),
-                        "Struct must not have implicit padding"
+                        "Struct must not have implicit padding. Add `padding: [u8; N]` field where \
+                        necessary or use `Unaligned<T>` wrapper for types with larger alignment to \
+                        reduce it to one byte."
                     );
 
                     // Assert that type doesn't exceed 32-bit size limit
@@ -141,7 +143,9 @@ pub fn trivial_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenS
                             - ::core::mem::size_of::<::core::primitive::#repr_numeric>()
                             #(- ::core::mem::size_of::<#field_types>() )*
                         ),
-                        "Enum must not have implicit padding"
+                        "Enum must not have implicit padding. Add `padding: [u8; N]` field where \
+                        necessary or use `Unaligned<T>` wrapper for types with larger alignment to \
+                        reduce it to one byte."
                     );
                 }
             });

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -63,6 +63,9 @@ name = "ab-io-type"
 version = "0.0.1"
 dependencies = [
  "ab-trivial-type-derive",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
 ]
 
 [[package]]

--- a/subspace/crates/pallet-subspace/src/lib.rs
+++ b/subspace/crates/pallet-subspace/src/lib.rs
@@ -490,7 +490,7 @@ impl<T: Config> Pallet<T> {
     pub fn history_size() -> HistorySize {
         // Chain starts with one segment plotted, even if it is not recorded in the runtime yet
         let number_of_segments = u64::from(SegmentRoot::<T>::count()).max(1);
-        HistorySize::from(NonZeroU64::new(number_of_segments).expect("Not zero; qed"))
+        HistorySize::new(NonZeroU64::new(number_of_segments).expect("Not zero; qed"))
     }
 
     fn do_initialize(block_number: BlockNumberFor<T>) {

--- a/subspace/crates/pallet-subspace/src/lib.rs
+++ b/subspace/crates/pallet-subspace/src/lib.rs
@@ -751,10 +751,10 @@ impl<T: Config> Pallet<T> {
         );
 
         for segment_header in segment_headers {
-            SegmentRoot::<T>::insert(segment_header.segment_index, segment_header.segment_root);
+            SegmentRoot::<T>::insert(segment_header.segment_index(), segment_header.segment_root);
             // Deposit global randomness data such that light client can validate blocks later.
             frame_system::Pallet::<T>::deposit_log(DigestItem::segment_root(
-                segment_header.segment_index,
+                segment_header.segment_index(),
                 segment_header.segment_root,
             ));
             Self::deposit_event(Event::SegmentHeaderStored { segment_header });
@@ -910,21 +910,21 @@ fn check_segment_headers<T: Config>(
     };
 
     // Segment in segment headers should monotonically increase
-    if first_segment_header.segment_index > SegmentIndex::ZERO
-        && !SegmentRoot::<T>::contains_key(first_segment_header.segment_index - SegmentIndex::ONE)
+    if first_segment_header.segment_index() > SegmentIndex::ZERO
+        && !SegmentRoot::<T>::contains_key(first_segment_header.segment_index() - SegmentIndex::ONE)
     {
         return Err(InvalidTransaction::BadMandatory.into());
     }
 
     // Segment headers should never repeat
-    if SegmentRoot::<T>::contains_key(first_segment_header.segment_index) {
+    if SegmentRoot::<T>::contains_key(first_segment_header.segment_index()) {
         return Err(InvalidTransaction::BadMandatory.into());
     }
 
-    let mut last_segment_index = first_segment_header.segment_index;
+    let mut last_segment_index = first_segment_header.segment_index();
 
     for segment_header in segment_headers_iter {
-        let segment_index = segment_header.segment_index;
+        let segment_index = segment_header.segment_index();
 
         // Segment in segment headers should monotonically increase
         if segment_index != last_segment_index + SegmentIndex::ONE {

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -158,13 +158,12 @@ pub fn new_test_ext() -> TestExternalities {
 
 pub fn create_segment_header(segment_index: SegmentIndex) -> SegmentHeader {
     SegmentHeader {
-        segment_index,
+        segment_index: segment_index.into(),
         segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),
         last_archived_block: LastArchivedBlock {
-            number: BlockNumber::ZERO,
+            number: BlockNumber::ZERO.into(),
             archived_progress: ArchivedBlockProgress::new_complete(),
-            padding: [0; _],
         },
     }
 }

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -101,14 +101,14 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: SlotNumber) {
         slot,
         Solution {
             public_key_hash: PublicKey::from(keypair.public.to_bytes()).hash(),
-            sector_index: SectorIndex::ZERO,
-            history_size: HistorySize::from(SegmentIndex::ZERO).into(),
-            piece_offset: PieceOffset::default(),
             record_root: Default::default(),
             record_proof: Default::default(),
             chunk,
             chunk_proof: Default::default(),
             proof_of_space: Default::default(),
+            history_size: HistorySize::from(SegmentIndex::ZERO).into(),
+            sector_index: SectorIndex::ZERO,
+            piece_offset: PieceOffset::default(),
         },
     );
 

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -102,7 +102,7 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: SlotNumber) {
         Solution {
             public_key_hash: PublicKey::from(keypair.public.to_bytes()).hash(),
             sector_index: SectorIndex::ZERO,
-            history_size: HistorySize::from(SegmentIndex::ZERO),
+            history_size: HistorySize::from(SegmentIndex::ZERO).into(),
             piece_offset: PieceOffset::default(),
             record_root: Default::default(),
             record_proof: Default::default(),

--- a/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -545,7 +545,7 @@ where
                     acknowledgement_sender,
                 } = archived_segment_notification;
 
-                let segment_index = archived_segment.segment_header.segment_index;
+                let segment_index = archived_segment.segment_header.segment_index();
 
                 // Store acknowledgment sender so that we can retrieve it when acknowledgement
                 // comes from the farmer, but only if unsafe APIs are allowed
@@ -701,7 +701,8 @@ where
             }
         };
 
-        if requested_piece_index.segment_index() == archived_segment.segment_header.segment_index {
+        if requested_piece_index.segment_index() == archived_segment.segment_header.segment_index()
+        {
             return Ok(archived_segment
                 .pieces
                 .pieces()

--- a/subspace/crates/sc-consensus-subspace/src/archiver.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver.rs
@@ -179,7 +179,7 @@ where
         // Check all input segment headers to see which ones are not stored yet and verifying that segment indices are
         // monotonically increasing
         for segment_header in segment_headers {
-            let segment_index = segment_header.segment_index;
+            let segment_index = segment_header.segment_index();
             match maybe_last_segment_index {
                 Some(last_segment_index) => {
                     if segment_index <= last_segment_index {
@@ -276,7 +276,7 @@ where
                 .expect("Segment headers are stored in monotonically increasing order; qed");
 
             // The block immediately after the archived segment adding the confirmation depth
-            let target_block_number = current_segment_header.last_archived_block.number
+            let target_block_number = current_segment_header.last_archived_block.number()
                 + BlockNumber::ONE
                 + self.confirmation_depth_k;
             if target_block_number == block_number {
@@ -419,7 +419,7 @@ where
         .rev()
         .filter_map(|segment_index| segment_headers_store.get_segment_header(segment_index))
     {
-        let last_archived_block_number = segment_header.last_archived_block.number;
+        let last_archived_block_number = segment_header.last_archived_block.number();
 
         if last_archived_block_number > best_block_to_archive {
             // Last archived block in segment header is too high for current state of the chain
@@ -969,7 +969,7 @@ where
                 .last_segment_header()
                 .expect("Exists after archiver initialization; qed")
                 .last_archived_block
-                .number;
+                .number();
             let create_mappings =
                 create_object_mappings.is_enabled_for_block(last_archived_block_number);
             trace!(
@@ -1064,7 +1064,7 @@ where
                     .and_then(|segment_index| {
                         segment_headers_store.get_segment_header(segment_index)
                     })
-                    .map(|segment_header| segment_header.last_archived_block.number)
+                    .map(|segment_header| segment_header.last_archived_block.number())
                     // Make sure not to finalize block number that does not yet exist (segment
                     // headers store may contain future blocks during initial sync)
                     .map(|block_number| block_number_to_archive.min(block_number))

--- a/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
+++ b/subspace/crates/sc-consensus-subspace/src/archiver/tests.rs
@@ -57,57 +57,52 @@ fn segment_headers_store_block_number_queries_work() {
     // Several starting segments from gemini-3h
 
     let segment_header0 = SegmentHeader {
-        segment_index: SegmentIndex::ZERO,
+        segment_index: SegmentIndex::ZERO.into(),
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
-            number: BlockNumber::new(0),
+            number: BlockNumber::new(0).into(),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
-            padding: [0; _],
         },
     };
 
     let segment_header1 = SegmentHeader {
-        segment_index: SegmentIndex::ONE,
+        segment_index: SegmentIndex::ONE.into(),
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
-            number: BlockNumber::new(652),
+            number: BlockNumber::new(652).into(),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
-            padding: [0; _],
         },
     };
 
     let segment_header2 = SegmentHeader {
-        segment_index: SegmentIndex::from(2),
+        segment_index: SegmentIndex::from(2).into(),
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
-            number: BlockNumber::new(752),
+            number: BlockNumber::new(752).into(),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
-            padding: [0; _],
         },
     };
 
     let segment_header3 = SegmentHeader {
-        segment_index: SegmentIndex::from(3),
+        segment_index: SegmentIndex::from(3).into(),
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
-            number: BlockNumber::new(806),
+            number: BlockNumber::new(806).into(),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
-            padding: [0; _],
         },
     };
 
     let segment_header4 = SegmentHeader {
-        segment_index: SegmentIndex::from(4),
+        segment_index: SegmentIndex::from(4).into(),
         segment_root: Default::default(),
         prev_segment_header_hash: Default::default(),
         last_archived_block: LastArchivedBlock {
-            number: BlockNumber::new(806),
+            number: BlockNumber::new(806).into(),
             archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::new(5).unwrap()),
-            padding: [0; _],
         },
     };
 

--- a/subspace/crates/sc-consensus-subspace/src/block_import.rs
+++ b/subspace/crates/sc-consensus-subspace/src/block_import.rs
@@ -428,7 +428,7 @@ where
         let sector_id = SectorId::new(
             &pre_digest.solution.public_key_hash,
             pre_digest.solution.sector_index,
-            pre_digest.solution.history_size,
+            pre_digest.solution.history_size(),
         );
 
         let max_pieces_in_sector = self
@@ -437,7 +437,7 @@ where
             .max_pieces_in_sector(parent_hash)?;
         let piece_index = sector_id.derive_piece_index(
             pre_digest.solution.piece_offset,
-            pre_digest.solution.history_size,
+            pre_digest.solution.history_size(),
             max_pieces_in_sector,
             chain_constants.recent_segments(),
             chain_constants.recent_history_fraction(),
@@ -456,7 +456,7 @@ where
                 subspace_digest_items
                     .pre_digest
                     .solution
-                    .history_size
+                    .history_size()
                     .sector_expiration_check(chain_constants.min_sector_lifetime())
                     .ok_or(Error::InvalidHistorySize)?
                     .segment_index(),

--- a/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
+++ b/subspace/crates/sc-consensus-subspace/src/slot_worker.rs
@@ -500,7 +500,7 @@ where
             let sector_id = SectorId::new(
                 &solution.public_key_hash,
                 solution.sector_index,
-                solution.history_size,
+                solution.history_size(),
             );
 
             let history_size = runtime_api.history_size(parent_hash).ok()?;
@@ -509,7 +509,7 @@ where
             let segment_index = sector_id
                 .derive_piece_index(
                     solution.piece_offset,
-                    solution.history_size,
+                    solution.history_size(),
                     max_pieces_in_sector,
                     chain_constants.recent_segments(),
                     chain_constants.recent_history_fraction(),
@@ -532,7 +532,7 @@ where
                 }
             };
             let sector_expiration_check_segment_index = match solution
-                .history_size
+                .history_size()
                 .sector_expiration_check(chain_constants.min_sector_lifetime())
             {
                 Some(sector_expiration_check) => sector_expiration_check.segment_index(),

--- a/subspace/crates/subspace-farmer-components/benches/auditing.rs
+++ b/subspace/crates/subspace-farmer-components/benches/auditing.rs
@@ -64,14 +64,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .unwrap();
 
     let farmer_protocol_info = FarmerProtocolInfo {
-        history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
+        history_size: HistorySize::new(NonZeroU64::new(1).unwrap()),
         max_pieces_in_sector: pieces_in_sector,
-        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_segments: HistorySize::new(NonZeroU64::new(5).unwrap()),
         recent_history_fraction: (
-            HistorySize::from(NonZeroU64::new(1).unwrap()),
-            HistorySize::from(NonZeroU64::new(10).unwrap()),
+            HistorySize::new(NonZeroU64::new(1).unwrap()),
+            HistorySize::new(NonZeroU64::new(10).unwrap()),
         ),
-        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
+        min_sector_lifetime: HistorySize::new(NonZeroU64::new(4).unwrap()),
     };
     let global_challenge = &Blake3Hash::default();
     let solution_range = SolutionRange::MAX;

--- a/subspace/crates/subspace-farmer-components/benches/plotting.rs
+++ b/subspace/crates/subspace-farmer-components/benches/plotting.rs
@@ -53,14 +53,14 @@ fn criterion_benchmark(c: &mut Criterion) {
         .unwrap();
 
     let farmer_protocol_info = FarmerProtocolInfo {
-        history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
+        history_size: HistorySize::new(NonZeroU64::new(1).unwrap()),
         max_pieces_in_sector: pieces_in_sector,
-        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_segments: HistorySize::new(NonZeroU64::new(5).unwrap()),
         recent_history_fraction: (
-            HistorySize::from(NonZeroU64::new(1).unwrap()),
-            HistorySize::from(NonZeroU64::new(10).unwrap()),
+            HistorySize::new(NonZeroU64::new(1).unwrap()),
+            HistorySize::new(NonZeroU64::new(10).unwrap()),
         ),
-        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
+        min_sector_lifetime: HistorySize::new(NonZeroU64::new(4).unwrap()),
     };
 
     let sector_size = sector_size(pieces_in_sector);

--- a/subspace/crates/subspace-farmer-components/benches/proving.rs
+++ b/subspace/crates/subspace-farmer-components/benches/proving.rs
@@ -72,14 +72,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .unwrap();
 
     let farmer_protocol_info = FarmerProtocolInfo {
-        history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
+        history_size: HistorySize::new(NonZeroU64::new(1).unwrap()),
         max_pieces_in_sector: pieces_in_sector,
-        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_segments: HistorySize::new(NonZeroU64::new(5).unwrap()),
         recent_history_fraction: (
-            HistorySize::from(NonZeroU64::new(1).unwrap()),
-            HistorySize::from(NonZeroU64::new(10).unwrap()),
+            HistorySize::new(NonZeroU64::new(1).unwrap()),
+            HistorySize::new(NonZeroU64::new(10).unwrap()),
         ),
-        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
+        min_sector_lifetime: HistorySize::new(NonZeroU64::new(4).unwrap()),
     };
     let solution_range = SolutionRange::MAX;
 

--- a/subspace/crates/subspace-farmer-components/benches/reading.rs
+++ b/subspace/crates/subspace-farmer-components/benches/reading.rs
@@ -64,14 +64,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .unwrap();
 
     let farmer_protocol_info = FarmerProtocolInfo {
-        history_size: HistorySize::from(NonZeroU64::new(1).unwrap()),
+        history_size: HistorySize::new(NonZeroU64::new(1).unwrap()),
         max_pieces_in_sector: pieces_in_sector,
-        recent_segments: HistorySize::from(NonZeroU64::new(5).unwrap()),
+        recent_segments: HistorySize::new(NonZeroU64::new(5).unwrap()),
         recent_history_fraction: (
-            HistorySize::from(NonZeroU64::new(1).unwrap()),
-            HistorySize::from(NonZeroU64::new(10).unwrap()),
+            HistorySize::new(NonZeroU64::new(1).unwrap()),
+            HistorySize::new(NonZeroU64::new(10).unwrap()),
         ),
-        min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
+        min_sector_lifetime: HistorySize::new(NonZeroU64::new(4).unwrap()),
     };
 
     let sector_size = sector_size(pieces_in_sector);

--- a/subspace/crates/subspace-farmer-components/src/proving.rs
+++ b/subspace/crates/subspace-farmer-components/src/proving.rs
@@ -278,14 +278,14 @@ where
 
             Solution {
                 public_key_hash: *self.public_key_hash,
-                sector_index: self.sector_metadata.sector_index,
-                history_size: self.sector_metadata.history_size.into(),
-                piece_offset,
                 record_root: record_metadata.root,
                 record_proof: record_metadata.proof,
                 chunk,
                 chunk_proof: ChunkProof::from(chunk_proof),
                 proof_of_space,
+                history_size: self.sector_metadata.history_size.into(),
+                sector_index: self.sector_metadata.sector_index,
+                piece_offset,
             }
         };
 

--- a/subspace/crates/subspace-farmer-components/src/proving.rs
+++ b/subspace/crates/subspace-farmer-components/src/proving.rs
@@ -279,7 +279,7 @@ where
             Solution {
                 public_key_hash: *self.public_key_hash,
                 sector_index: self.sector_metadata.sector_index,
-                history_size: self.sector_metadata.history_size,
+                history_size: self.sector_metadata.history_size.into(),
                 piece_offset,
                 record_root: record_metadata.root,
                 record_proof: record_metadata.proof,

--- a/subspace/crates/subspace-farmer/src/cluster/controller.rs
+++ b/subspace/crates/subspace-farmer/src/cluster/controller.rs
@@ -557,7 +557,7 @@ impl NodeClient for ClusterNodeClient {
 
                 move |broadcast| {
                     let archived_segment_header = broadcast.archived_segment_header;
-                    let segment_index = archived_segment_header.segment_index;
+                    let segment_index = archived_segment_header.segment_index();
 
                     let maybe_archived_segment_header = if let Some(last_archived_segment_index) =
                         last_archived_segment_index
@@ -772,7 +772,7 @@ where
         );
 
         node_client
-            .acknowledge_archived_segment_header(archived_segment_header.segment_index)
+            .acknowledge_archived_segment_header(archived_segment_header.segment_index())
             .await
             .map_err(|error| anyhow!("Failed to acknowledge archived segment header: {error}"))?;
 

--- a/subspace/crates/subspace-farmer/src/farmer_cache.rs
+++ b/subspace/crates/subspace-farmer/src/farmer_cache.rs
@@ -688,7 +688,7 @@ where
     ) where
         PG: PieceGetter,
     {
-        let segment_index = segment_header.segment_index;
+        let segment_index = segment_header.segment_index();
         debug!(%segment_index, "Starting to process newly archived segment");
 
         if *last_segment_index_internal < segment_index {

--- a/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -290,13 +290,12 @@ async fn basic() {
         // finished
         {
             let segment_header = SegmentHeader {
-                segment_index: SegmentIndex::ONE,
+                segment_index: SegmentIndex::ONE.into(),
                 segment_root: Default::default(),
                 prev_segment_header_hash: [0; 32].into(),
                 last_archived_block: LastArchivedBlock {
-                    number: BlockNumber::ZERO,
+                    number: BlockNumber::ZERO.into(),
                     archived_progress: Default::default(),
-                    padding: [0; _],
                 },
             };
 
@@ -351,13 +350,12 @@ async fn basic() {
         // pieces for it to store)
         for segment_index in [2, 3] {
             let segment_header = SegmentHeader {
-                segment_index: SegmentIndex::from(segment_index),
+                segment_index: SegmentIndex::from(segment_index).into(),
                 segment_root: Default::default(),
                 prev_segment_header_hash: [0; 32].into(),
                 last_archived_block: LastArchivedBlock {
-                    number: BlockNumber::ZERO,
+                    number: BlockNumber::ZERO.into(),
                     archived_progress: Default::default(),
-                    padding: [0; _],
                 },
             };
 

--- a/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
+++ b/subspace/crates/subspace-farmer/src/farmer_cache/tests.rs
@@ -51,10 +51,10 @@ impl NodeClient for MockNodeClient {
                 max_pieces_in_sector: 0,
                 recent_segments: HistorySize::from(SegmentIndex::ZERO),
                 recent_history_fraction: (
-                    HistorySize::from(NonZeroU64::new(1).unwrap()),
-                    HistorySize::from(NonZeroU64::new(10).unwrap()),
+                    HistorySize::new(NonZeroU64::new(1).unwrap()),
+                    HistorySize::new(NonZeroU64::new(10).unwrap()),
                 ),
-                min_sector_lifetime: HistorySize::from(NonZeroU64::new(4).unwrap()),
+                min_sector_lifetime: HistorySize::new(NonZeroU64::new(4).unwrap()),
             },
         })
     }

--- a/subspace/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
+++ b/subspace/crates/subspace-farmer/src/node_client/caching_proxy_node_client.rs
@@ -30,7 +30,8 @@ struct SegmentHeaders {
 
 impl SegmentHeaders {
     fn push(&mut self, archived_segment_header: SegmentHeader) {
-        if self.segment_headers.len() == u64::from(archived_segment_header.segment_index) as usize {
+        if self.segment_headers.len() == u64::from(archived_segment_header.segment_index()) as usize
+        {
             self.segment_headers.push(archived_segment_header);
         }
     }
@@ -167,7 +168,7 @@ where
                 while let Some(archived_segment_header) =
                     archived_segments_notifications.next().await
                 {
-                    let segment_index = archived_segment_header.segment_index;
+                    let segment_index = archived_segment_header.segment_index();
                     trace!(
                         ?archived_segment_header,
                         "New archived archived segment header notification"

--- a/subspace/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/subspace/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -792,7 +792,7 @@ where
     while let Some(segment_header) = archived_segments_notifications.next().await {
         debug!(?segment_header, "New archived segment");
         if let Err(error) = node_client
-            .acknowledge_archived_segment_header(segment_header.segment_index)
+            .acknowledge_archived_segment_header(segment_header.segment_index())
             .await
         {
             debug!(%error, "Failed to acknowledge segment header");
@@ -859,7 +859,9 @@ where
     let mut sectors_to_replot = Vec::with_capacity(usize::from(target_sector_count) / 10);
 
     loop {
-        let segment_index = archived_segments_receiver.borrow_and_update().segment_index;
+        let segment_index = archived_segments_receiver
+            .borrow_and_update()
+            .segment_index();
         trace!(%segment_index, "New archived segment received");
 
         let sectors_metadata = sectors_metadata.read().await;

--- a/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
+++ b/subspace/crates/subspace-service/src/sync_from_dsn/import_blocks.rs
@@ -84,7 +84,7 @@ where
             .get_segment_header(segment_index)
             .expect("Statically guaranteed to exist, see checks above; qed");
 
-        let last_archived_maybe_partial_block_number = segment_header.last_archived_block.number;
+        let last_archived_maybe_partial_block_number = segment_header.last_archived_block.number();
         let last_archived_block_partial = segment_header
             .last_archived_block
             .archived_progress

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/segment_header.rs
@@ -32,13 +32,12 @@ const BLOCK_CONTINUATION_VARIANT: u8 = 3;
 #[inline]
 pub fn segment_header_encoded_size() -> usize {
     let min_segment_header = SegmentHeader {
-        segment_index: 0.into(),
+        segment_index: SegmentIndex::ZERO.into(),
         segment_root: SegmentRoot::default(),
         prev_segment_header_hash: Blake3Hash::default(),
         last_archived_block: LastArchivedBlock {
-            number: BlockNumber::ZERO,
+            number: BlockNumber::ZERO.into(),
             archived_progress: ArchivedBlockProgress::new_complete(),
-            padding: [0; _],
         },
     };
 

--- a/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
+++ b/subspace/shared/subspace-data-retrieval/src/object_fetcher/tests.rs
@@ -87,13 +87,12 @@ fn write_segment_header(mut piece: &mut Piece, remaining_len: usize) -> Vec<u8> 
         let segment_variants = [4_u8];
         // SegmentHeader
         let segment_header = SegmentHeader {
-            segment_index: u64::MAX.into(),
+            segment_index: SegmentIndex::new(u64::MAX).into(),
             segment_root: SegmentRoot::default(),
             prev_segment_header_hash: Blake3Hash::default(),
             last_archived_block: LastArchivedBlock {
-                number: BlockNumber::MAX,
+                number: BlockNumber::MAX.into(),
                 archived_progress: ArchivedBlockProgress::new_partial(NonZeroU32::MAX),
-                padding: [0; _],
             },
         }
         .encode();

--- a/subspace/shared/subspace-data-retrieval/src/piece_getter.rs
+++ b/subspace/shared/subspace-data-retrieval/src/piece_getter.rs
@@ -54,7 +54,7 @@ where
 #[async_trait]
 impl PieceGetter for NewArchivedSegment {
     async fn get_piece(&self, piece_index: PieceIndex) -> anyhow::Result<Option<Piece>> {
-        if piece_index.segment_index() == self.segment_header.segment_index {
+        if piece_index.segment_index() == self.segment_header.segment_index() {
             return Ok(Some(
                 self.pieces
                     .pieces()


### PR DESCRIPTION
This primarily introduces `Unaligned` wrapper that implements `TrivialType`. While using unaligned data structures is not as efficient, it is worth doing in some cases.

This PR uses `Unaligned` in a few places and does other minor cleanups.