### PR TITLE
Address formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "ab-aligned-buffer",
  "ab-io-type",
  "ab-merkle-tree",
+ "bech32",
  "blake3",
  "bytes",
  "derive_more 2.0.1",
@@ -361,6 +362,12 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "blake3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ab-system-contract-native-token = { version = "0.0.1", path = "crates/contracts/
 ab-system-contract-simple-wallet-base = { version = "0.0.1", path = "crates/contracts/system/ab-system-contract-simple-wallet-base" }
 ab-system-contract-state = { version = "0.0.1", path = "crates/contracts/system/ab-system-contract-state" }
 ab-trivial-type-derive = { version = "0.0.1", path = "crates/shared/ab-trivial-type-derive" }
+bech32 = { version = "0.11.0", default-features = false }
 blake3 = { version = "1.8.2", default-features = false }
 bytes = { version = "1.10.1", default-features = false }
 const-sha1 = { version = "0.3.0", default-features = false }

--- a/crates/contracts/system/ab-system-contract-address-allocator/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-address-allocator/src/lib.rs
@@ -23,8 +23,7 @@ impl AddressAllocator {
     pub fn new(#[env] env: &Env<'_>) -> Self {
         let shard_index = env.shard_index();
 
-        let expected_self_address =
-            u128::from(shard_index.as_u32()) * ShardIndex::MAX_ADDRESSES_PER_SHARD.get();
+        let expected_self_address = u128::from(Address::system_address_allocator(shard_index));
         debug_assert_eq!(
             env.own_address(),
             Address::from(expected_self_address),
@@ -33,7 +32,7 @@ impl AddressAllocator {
 
         Self {
             next_address: expected_self_address + 1,
-            max_address: expected_self_address + ShardIndex::MAX_ADDRESSES_PER_SHARD.get() - 1,
+            max_address: expected_self_address + (ShardIndex::MAX_ADDRESSES_PER_SHARD.get() - 1),
         }
     }
 

--- a/crates/execution/ab-executor-native/src/context.rs
+++ b/crates/execution/ab-executor-native/src/context.rs
@@ -66,7 +66,7 @@ impl<'a> ExecutorContext for NativeExecutorContext<'a> {
             caller: previous_env_state.own_address,
         };
 
-        let span = info_span!("NativeExecutorContext", %contract);
+        let span = info_span!("NativeExecutorContext", ?contract);
         let _span_guard = span.enter();
 
         let method_details = {

--- a/crates/execution/ab-executor-slots/src/lib.rs
+++ b/crates/execution/ab-executor-slots/src/lib.rs
@@ -178,7 +178,7 @@ impl Slots {
         let new_contracts = &mut self.0.new_contracts;
 
         if new_contracts.contains(&owner) {
-            debug!(%owner, "Not adding new contract duplicate");
+            debug!(?owner, "Not adding new contract duplicate");
             return false;
         }
 
@@ -388,14 +388,14 @@ impl<'a> NestedSlots<'a> {
     #[inline(always)]
     pub fn add_new_contract(&mut self, owner: Address) -> bool {
         let Some(inner) = self.inner_rw() else {
-            debug!(%owner, "`add_new_contract` access violation");
+            debug!(?owner, "`add_new_contract` access violation");
             return false;
         };
 
         let new_contracts = &mut inner.new_contracts;
 
         if new_contracts.contains(&owner) {
-            debug!(%owner, "Not adding new contract duplicate");
+            debug!(?owner, "Not adding new contract duplicate");
             return false;
         }
 
@@ -414,7 +414,7 @@ impl<'a> NestedSlots<'a> {
         let result = self.get_code_internal(owner);
 
         if result.is_none() {
-            debug!(%owner, "`get_code` access violation");
+            debug!(?owner, "`get_code` access violation");
         }
 
         result

--- a/crates/shared/ab-core-primitives/Cargo.toml
+++ b/crates/shared/ab-core-primitives/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 ab-aligned-buffer = { workspace = true, optional = true }
 ab-io-type = { workspace = true }
 ab-merkle-tree = { workspace = true }
+bech32 = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["full"] }

--- a/crates/shared/ab-core-primitives/src/address.rs
+++ b/crates/shared/ab-core-primitives/src/address.rs
@@ -3,9 +3,81 @@
 use crate::shard::ShardIndex;
 use ab_io_type::metadata::IoTypeMetadataKind;
 use ab_io_type::trivial_type::TrivialType;
+use bech32::primitives::decode::CheckedHrpstring;
+use bech32::{Bech32m, ByteIterExt, Fe32IterExt, Hrp};
 use core::cmp::Ordering;
 use core::mem::MaybeUninit;
+use core::ops::Deref;
 use core::{fmt, ptr};
+use derive_more::Deref;
+
+/// Formatted address
+#[derive(Copy, Clone)]
+pub struct FormattedAddress {
+    buffer:
+        [u8; ShortHrp::MAX_HRP_LENGTH + FormattedAddress::MAX_ENCODING_WITHOUT_HRP_WITH_SEPARATOR],
+    length: usize,
+}
+
+impl fmt::Debug for FormattedAddress {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl fmt::Display for FormattedAddress {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl Deref for FormattedAddress {
+    type Target = str;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl FormattedAddress {
+    const MAX_ENCODING_WITHOUT_HRP_NO_SEPARATOR: usize = 33;
+    const MAX_ENCODING_WITHOUT_HRP_WITH_SEPARATOR: usize = 39;
+
+    /// Get internal string representation
+    #[inline(always)]
+    pub const fn as_str(&self) -> &str {
+        // SAFETY: Guaranteed by formatting constructor
+        unsafe { str::from_utf8_unchecked(self.buffer.split_at_unchecked(self.length).0) }
+    }
+}
+
+/// Short human-readable address part
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Deref)]
+pub struct ShortHrp(Hrp);
+
+impl ShortHrp {
+    /// Maximum length of the human-readable part of the address
+    pub const MAX_HRP_LENGTH: usize = 5;
+    /// Mainnet human-readable part
+    pub const MAINNET: Self = Self(Hrp::parse_unchecked("abc"));
+    /// Testnet human-readable part
+    pub const TESTNET: Self = Self(Hrp::parse_unchecked("xyz"));
+
+    /// Create a new instance.
+    ///
+    /// Returns `None` if length of human-readable part is longer than [`Self::MAX_HRP_LENGTH`].
+    // TODO: `const fn` once https://github.com/rust-bitcoin/rust-bech32/issues/216 is resolved
+    pub fn new(hrp: Hrp) -> Option<Self> {
+        if hrp.len() > Self::MAX_HRP_LENGTH {
+            return None;
+        }
+
+        Some(Self(hrp))
+    }
+}
 
 /// Logically the same as `u128`, but aligned to `8` bytes instead of `16`.
 ///
@@ -23,7 +95,7 @@ unsafe impl TrivialType for Address {
     const METADATA: &[u8] = &[IoTypeMetadataKind::Address as u8];
 }
 
-// Ensure this never mismatches with code in `ab-io-type` despite being in different crate
+// Ensure this never mismatches with code in `ab-io-type` despite being in a different crate
 const _: () = {
     let (type_details, _metadata) = IoTypeMetadataKind::type_details(Address::METADATA)
         .expect("Statically correct metadata; qed");
@@ -34,13 +106,6 @@ const _: () = {
 impl fmt::Debug for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Address").field(&self.as_u128()).finish()
-    }
-}
-
-impl fmt::Display for Address {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Human-readable formatting rather than a huge number
-        self.as_u128().fmt(f)
     }
 }
 
@@ -103,6 +168,21 @@ impl Address {
     /// System simple wallet base contract that can be used by end user wallets
     pub const SYSTEM_SIMPLE_WALLET_BASE: Self = Self::new(10);
 
+    // Formatting-related constants
+    const FORMAT_SEPARATOR_INTERVAL: [usize; 7] = [
+        // `1` + shard ID
+        1 + 4,
+        4,
+        3,
+        4,
+        4,
+        3,
+        4,
+    ];
+    const FORMAT_SEPARATOR: u8 = b'-';
+    const FORMAT_ALL_ZEROES: u8 = b'q';
+    const FORMAT_CHECKSUM_LENGTH: usize = 6;
+
     /// Create a value from `u128`
     #[inline(always)]
     const fn new(n: u128) -> Self {
@@ -112,6 +192,167 @@ impl Address {
             result.as_mut_ptr().cast::<u128>().write_unaligned(n);
             result.assume_init()
         }
+    }
+
+    /// Parse address from a string formatted using [`Self::format()`].
+    ///
+    /// Returns `None` if address is formatted incorrectly.
+    pub fn parse(s: &str) -> Option<(ShortHrp, Self)> {
+        let (hrp, other) = s.split_once('1')?;
+        if hrp.len() > ShortHrp::MAX_HRP_LENGTH {
+            return None;
+        }
+
+        let mut scratch = FormattedAddress {
+            buffer: [Self::FORMAT_ALL_ZEROES; _],
+            length: 0,
+        };
+
+        // Copy human-readable part + `1`
+        scratch.buffer[..hrp.len() + 1].copy_from_slice(&s.as_bytes()[..hrp.len() + 1]);
+        // Set length to full
+        scratch.length = hrp.len() + FormattedAddress::MAX_ENCODING_WITHOUT_HRP_NO_SEPARATOR;
+
+        let mut chunks = other.rsplit(char::from(Self::FORMAT_SEPARATOR));
+        // Copy checksum into target location
+        {
+            let checksum = chunks.next()?;
+
+            if checksum.len() != Self::FORMAT_CHECKSUM_LENGTH {
+                return None;
+            }
+            scratch.buffer[..scratch.length][scratch.length - Self::FORMAT_CHECKSUM_LENGTH..]
+                .copy_from_slice(checksum.as_bytes());
+        }
+
+        {
+            let mut buffer = &mut scratch.buffer[..scratch.length - Self::FORMAT_CHECKSUM_LENGTH];
+            let mut iterator = chunks
+                .zip(Self::FORMAT_SEPARATOR_INTERVAL.into_iter().rev())
+                .peekable();
+            while let Some((chunk, max_chunk_length)) = iterator.next() {
+                let chunk = chunk.as_bytes();
+
+                if iterator.peek().is_none() {
+                    // Finish with shard index
+                    buffer[hrp.len() + 1..][..chunk.len()].copy_from_slice(chunk);
+                    break;
+                }
+
+                if chunk.len() > max_chunk_length {
+                    return None;
+                }
+
+                let target_chunk;
+                (buffer, target_chunk) = buffer.split_at_mut(buffer.len() - max_chunk_length);
+
+                target_chunk[max_chunk_length - chunk.len()..].copy_from_slice(chunk);
+            }
+        }
+
+        let checked_hrp_string = CheckedHrpstring::new::<Bech32m>(&scratch).ok()?;
+        let short_hrp = ShortHrp::new(checked_hrp_string.hrp())?;
+
+        let mut address_bytes = 0u128.to_be_bytes();
+        // Must decode the expected number of bytes
+        {
+            let mut address_bytes = address_bytes.as_mut_slice();
+            for byte in checked_hrp_string.byte_iter() {
+                if address_bytes.is_empty() {
+                    return None;
+                }
+
+                address_bytes[0] = byte;
+
+                address_bytes = &mut address_bytes[1..];
+            }
+
+            if !address_bytes.is_empty() {
+                return None;
+            }
+        }
+        let address = Address::from(u128::from_be_bytes(address_bytes));
+
+        Some((short_hrp, address))
+    }
+
+    /// Format address for presentation purposes
+    #[inline]
+    pub fn format(&self, hrp: &ShortHrp) -> FormattedAddress {
+        let mut scratch = FormattedAddress {
+            buffer: [0; _],
+            length: 0,
+        };
+
+        for char in self
+            .as_u128()
+            .to_be_bytes()
+            .into_iter()
+            .bytes_to_fes()
+            .with_checksum::<Bech32m>(hrp)
+            .bytes()
+        {
+            scratch.buffer[scratch.length] = char;
+            scratch.length += 1;
+        }
+
+        let (prefix_with_shard, other) = scratch
+            .as_str()
+            .split_at(hrp.len() + Self::FORMAT_SEPARATOR_INTERVAL[0]);
+        let (mut address_within_shard, checksum) =
+            other.split_at(Self::FORMAT_SEPARATOR_INTERVAL[1..].iter().sum());
+
+        let mut formatted_address = FormattedAddress {
+            buffer: [0; _],
+            length: 0,
+        };
+
+        // Shard index
+        {
+            let prefix_with_shard = prefix_with_shard
+                .trim_end_matches(char::from(Self::FORMAT_ALL_ZEROES))
+                .as_bytes();
+
+            formatted_address.buffer[..prefix_with_shard.len()].copy_from_slice(prefix_with_shard);
+            formatted_address.length = prefix_with_shard.len();
+
+            formatted_address.buffer[prefix_with_shard.len()] = Self::FORMAT_SEPARATOR;
+            formatted_address.length += 1;
+        }
+        // Address within shard
+        {
+            let mut finished_trimming = false;
+
+            for &chunk_size in Self::FORMAT_SEPARATOR_INTERVAL[1..].iter() {
+                let mut chunk;
+                (chunk, address_within_shard) = address_within_shard.split_at(chunk_size);
+
+                if !finished_trimming {
+                    chunk = chunk.trim_start_matches(char::from(Self::FORMAT_ALL_ZEROES));
+
+                    if chunk.is_empty() {
+                        continue;
+                    }
+
+                    finished_trimming = true;
+                }
+
+                formatted_address.buffer[formatted_address.length..][..chunk.len()]
+                    .copy_from_slice(chunk.as_bytes());
+                formatted_address.length += chunk.len();
+
+                formatted_address.buffer[formatted_address.length] = Self::FORMAT_SEPARATOR;
+                formatted_address.length += 1;
+            }
+        }
+        // Checksum
+        {
+            formatted_address.buffer[formatted_address.length..][..checksum.len()]
+                .copy_from_slice(checksum.as_bytes());
+            formatted_address.length += checksum.len();
+        }
+
+        formatted_address
     }
 
     /// Turn value into `u128`

--- a/crates/shared/ab-core-primitives/src/address.rs
+++ b/crates/shared/ab-core-primitives/src/address.rs
@@ -9,7 +9,12 @@ use core::{fmt, ptr};
 
 /// Logically the same as `u128`, but aligned to `8` bytes instead of `16`.
 ///
-/// Byte layout is the same as `u128`, just alignment is different
+/// Byte layout is the same as `u128`, just alignment is different.
+///
+/// The first 20 bits correspond to the shard index (big endian), and the remaining 108 bits
+/// (little endian) are an address allocated within that shard. This way an address will have a
+/// bunch of zeroes in the middle that is shrinking as more shards are added and more addresses are
+/// allocated.
 #[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
 #[repr(C)]
 pub struct Address(u64, u64);
@@ -122,6 +127,6 @@ impl Address {
         // Shard `0` doesn't have its own allocator because there are no user-deployable contracts
         // there, so address `0` is `NULL`, the rest up to `ShardIndex::MAX_SHARD_INDEX` correspond
         // to address allocators of respective shards
-        Self::new(shard_index.as_u32() as u128 * ShardIndex::MAX_ADDRESSES_PER_SHARD.get())
+        Self::new((shard_index.as_u32() as u128).reverse_bits())
     }
 }

--- a/crates/shared/ab-core-primitives/src/shard.rs
+++ b/crates/shared/ab-core-primitives/src/shard.rs
@@ -16,8 +16,7 @@ impl ShardIndex {
     pub const MAX_SHARDS: NonZeroU32 = NonZeroU32::new(2u32.pow(20)).expect("Not zero; qed");
     /// Max possible number of addresses per shard
     pub const MAX_ADDRESSES_PER_SHARD: NonZeroU128 =
-        NonZeroU128::new((u128::MAX / 2 + 1) / (Self::MAX_SHARDS.get() as u128 / 2))
-            .expect("Not zero; qed");
+        NonZeroU128::new(2u128.pow(108)).expect("Not zero; qed");
 
     // TODO: Remove once traits work in const environment and `From` could be used
     /// Create shard index from `u32`.

--- a/crates/shared/ab-core-primitives/tests/address.rs
+++ b/crates/shared/ab-core-primitives/tests/address.rs
@@ -1,0 +1,58 @@
+use ab_core_primitives::address::{Address, ShortHrp};
+use ab_core_primitives::shard::ShardIndex;
+
+#[test]
+fn format() {
+    let test_vectors = [
+        // Fully collapsed
+        (Address::NULL, &ShortHrp::MAINNET, "abc1-ldnky6"),
+        // Shard part fully collapsed and most of the address
+        (Address::SYSTEM_CODE, &ShortHrp::MAINNET, "abc1-y-s83stq"),
+        // Shard part collapsed partially and address part collapsed fully
+        (
+            Address::system_address_allocator(ShardIndex::new(1).unwrap()),
+            &ShortHrp::MAINNET,
+            "abc1s-x5j6vw",
+        ),
+        // Shard part collapsed partially and several address sections collapsed
+        (
+            Address::from(u128::from_be_bytes([
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42, 0, 0, 0, 42,
+            ])),
+            &ShortHrp::MAINNET,
+            "abc1qy-4-qqq-qq9g-mzcrt4",
+        ),
+        // Full length
+        (
+            Address::from(668134116173567166818323700814383461),
+            &ShortHrp::MAINNET,
+            "abc1qzq2-mr3r-nsr-wcka-6fk6-sdz-cfv5-ygv5w7",
+        ),
+        // Max address
+        (
+            Address::from(u128::MAX),
+            &ShortHrp::MAINNET,
+            "abc1llll-llll-lll-llll-llll-lll-lllu-9vt6a6",
+        ),
+    ];
+
+    for (address, hrp, s) in test_vectors {
+        assert_eq!(address.format(hrp).as_str(), s, "{address:?}, {hrp:?}");
+        assert_eq!(
+            Address::parse(s),
+            Some((*hrp, address)),
+            "{address:?}, {hrp:?}"
+        );
+
+        // Corrupted
+        {
+            let mut s = s.to_string();
+            unsafe {
+                s.as_bytes_mut()[5] = b'k';
+                s.as_bytes_mut()[6] = b'l';
+                s.as_bytes_mut()[7] = b'm';
+            }
+            assert!(Address::parse(&s).is_none(), "{address:?}, {hrp:?}");
+        }
+    }
+}

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "ab-aligned-buffer",
  "ab-io-type",
  "ab-merkle-tree",
+ "bech32",
  "blake3",
  "bytes",
  "derive_more 2.0.1",
@@ -1129,6 +1130,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "beef"


### PR DESCRIPTION
This implements address formatting.

The format is based on Bech32m from [BIP-350](https://github.com/bitcoin/bips/blob/60ac0e8feccb07f891fd984e4ed76105d2898609/bip-0350.mediawiki) with better readability thanks to built-in separators and more compact representation in many cases.

The first step is to treat `u128` inside `Address` as big-endian sequence of bytes that will be encoded with Bech32m. First 20 bits correspond to shard index, the remaining 108 bits are allocated addresses within that shard.

The first step is to simply encode an address with Bech32m, for `Address::NULL` it'll look like this:
```
abc1qqqqqqqqqqqqqqqqqqqqqqqqqqldnky6
```

Next step is to visually separate the address into sections. The first 4 characters after `1` correspond to shard index (each character encodes 5 bytes, so 4*5=20 bits), then we split the rest into groups of 4-3-4-4-3-4 characters, last 6 are checksum:
```
abc1qqqq-qqqq-qqq-qqqq-qqqq-qqq-qqqq-ldnky6
```

Now note that when we have a bunch of zeroes, they encode as `q`, so we can collapse all `q` to the right of the shard index and to the left of the other side, including separators, so it becomes just this:
```
abc1-ldnky6
```

In more realistic example it looks something like this:
```
abc1qyqq-qqqq-qqq-qqqq-qqq4-qqq-qq9g-mzcrt4 -> abc1qy-4-qqq-qq9g-mzcrt4
```

The longest possible address looks like this, but should not really happen often in practice and even then it is substantially shorter than Bitcoin addresses despite address separator:
```
abc1qzq2-mr3r-nsr-wcka-6fk6-sdz-cfv5-ygv5w7
```

Decoding of the address consists of stripping separators and adding back missing `q`, after which regular Bech32m decoding can be done.