### PR TITLE
Block layout

### DIFF
--- a/crates/shared/ab-core-primitives/src/block.rs
+++ b/crates/shared/ab-core-primitives/src/block.rs
@@ -1,6 +1,16 @@
 //! Block-related primitives
 
+pub mod body;
+pub mod header;
+
+use crate::block::body::{
+    BeaconChainBlockBody, BlockBody, IntermediateShardBlockBody, LeafShardBlockBody,
+};
+use crate::block::header::{
+    BeaconChainBlockHeader, BlockHeader, IntermediateShardBlockHeader, LeafShardBlockHeader,
+};
 use crate::hashes::Blake3Hash;
+use crate::shard::ShardKind;
 #[cfg(feature = "serde")]
 use ::serde::{Deserialize, Serialize};
 use ab_io_type::trivial_type::TrivialType;
@@ -43,17 +53,17 @@ use scale_info::TypeInfo;
 pub struct BlockNumber(u64);
 
 impl Step for BlockNumber {
-    #[inline]
+    #[inline(always)]
     fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
         u64::steps_between(&start.0, &end.0)
     }
 
-    #[inline]
+    #[inline(always)]
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
         u64::forward_checked(start.0, count).map(Self)
     }
 
-    #[inline]
+    #[inline(always)]
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         u64::backward_checked(start.0, count).map(Self)
     }
@@ -70,7 +80,7 @@ impl BlockNumber {
     pub const MAX: BlockNumber = BlockNumber(u64::MAX);
 
     /// Create new instance
-    #[inline]
+    #[inline(always)]
     pub const fn new(n: u64) -> Self {
         Self(n)
     }
@@ -82,18 +92,19 @@ impl BlockNumber {
     }
 
     /// Create block number from bytes
-    #[inline]
+    #[inline(always)]
     pub const fn from_bytes(bytes: [u8; Self::SIZE]) -> Self {
         Self(u64::from_le_bytes(bytes))
     }
 
     /// Convert block number to bytes
-    #[inline]
+    #[inline(always)]
     pub const fn to_bytes(self) -> [u8; Self::SIZE] {
         self.0.to_le_bytes()
     }
 
     /// Checked subtraction, returns `None` on underflow
+    #[inline(always)]
     pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
         if let Some(n) = self.0.checked_sub(rhs.0) {
             Some(Self(n))
@@ -103,6 +114,7 @@ impl BlockNumber {
     }
 
     /// Saturating subtraction
+    #[inline(always)]
     pub const fn saturating_sub(self, rhs: Self) -> Self {
         Self(self.0.saturating_sub(rhs.0))
     }
@@ -127,21 +139,24 @@ impl BlockNumber {
     DerefMut,
     TrivialType,
 )]
-#[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[repr(C)]
 pub struct BlockHash(Blake3Hash);
 
 impl AsRef<[u8]> for BlockHash {
-    #[inline]
+    #[inline(always)]
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
 impl AsMut<[u8]> for BlockHash {
-    #[inline]
+    #[inline(always)]
     fn as_mut(&mut self) -> &mut [u8] {
         self.0.as_mut()
     }
@@ -152,9 +167,294 @@ impl BlockHash {
     pub const SIZE: usize = Blake3Hash::SIZE;
 
     /// Create new instance
-    #[inline]
+    #[inline(always)]
     pub const fn new(hash: Blake3Hash) -> Self {
         Self(hash)
+    }
+}
+
+/// Block that corresponds to the beacon chain
+#[derive(Debug, Copy, Clone)]
+pub struct BeaconChainBlock<'a> {
+    /// Block header
+    pub header: BeaconChainBlockHeader<'a>,
+    /// Block body
+    pub body: BeaconChainBlockBody<'a>,
+}
+
+impl<'a> BeaconChainBlock<'a> {
+    /// Try to create a new instance from provided bytes for provided shard index.
+    ///
+    /// `bytes` should be 8-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        let (header, remainder) = BeaconChainBlockHeader::try_from_bytes(bytes)?;
+        let remainder = align_to_and_ensure_zero_padding::<u128>(remainder)?;
+        let (body, remainder) = BeaconChainBlockBody::try_from_bytes(remainder)?;
+
+        let block = Self { header, body };
+
+        // Check internal consistency
+        if !block.is_internally_consistent() {
+            return None;
+        }
+
+        Some((block, remainder))
+    }
+
+    /// Check block's internal consistency
+    #[inline]
+    pub fn is_internally_consistent(&self) -> bool {
+        self.body.is_internally_consistent()
+            && self.body.root() == self.header.result.body_root
+            && self.header.child_shard_blocks.len() == self.body.intermediate_shard_blocks.len()
+            && self
+                .header
+                .child_shard_blocks
+                .iter()
+                .zip(self.body.intermediate_shard_blocks.iter())
+                .all(|(child_shard_block, intermediate_shard_block)| {
+                    child_shard_block.shard_index
+                        == intermediate_shard_block.header.prefix.shard_index
+                        && child_shard_block.block_hash == intermediate_shard_block.header.hash()
+                        && intermediate_shard_block
+                            .header
+                            .prefix
+                            .shard_index
+                            .is_child_of(self.header.prefix.shard_index)
+                })
+    }
+
+    /// The same as [`Self::try_from_bytes()`], but for trusted input that skips some consistency
+    /// checks
+    #[inline]
+    pub fn try_from_bytes_unchecked(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        let (header, remainder) = BeaconChainBlockHeader::try_from_bytes(bytes)?;
+        let remainder = align_to_and_ensure_zero_padding::<u128>(remainder)?;
+        let (body, remainder) = BeaconChainBlockBody::try_from_bytes(remainder)?;
+
+        Some((Self { header, body }, remainder))
+    }
+}
+
+/// Block that corresponds to an intermediate shard
+#[derive(Debug, Copy, Clone)]
+pub struct IntermediateShardBlock<'a> {
+    /// Block header
+    pub header: IntermediateShardBlockHeader<'a>,
+    /// Block body
+    pub body: IntermediateShardBlockBody<'a>,
+}
+
+impl<'a> IntermediateShardBlock<'a> {
+    /// Try to create a new instance from provided bytes for provided shard index.
+    ///
+    /// `bytes` should be 8-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        let (header, remainder) = IntermediateShardBlockHeader::try_from_bytes(bytes)?;
+        let remainder = align_to_and_ensure_zero_padding::<u128>(remainder)?;
+        let (body, remainder) = IntermediateShardBlockBody::try_from_bytes(remainder)?;
+
+        let block = Self { header, body };
+
+        // Check internal consistency
+        if !block.is_internally_consistent() {
+            return None;
+        }
+
+        Some((block, remainder))
+    }
+
+    /// Check block's internal consistency
+    #[inline]
+    pub fn is_internally_consistent(&self) -> bool {
+        self.body.is_internally_consistent()
+            && self.body.root() == self.header.result.body_root
+            && self.header.child_shard_blocks.len() == self.body.leaf_shard_blocks.len()
+            && self
+                .header
+                .child_shard_blocks
+                .iter()
+                .zip(self.body.leaf_shard_blocks.iter())
+                .all(|(child_shard_block, leaf_shard_block)| {
+                    child_shard_block.shard_index == leaf_shard_block.header.prefix.shard_index
+                        && child_shard_block.block_hash == leaf_shard_block.header.hash()
+                        && leaf_shard_block
+                            .header
+                            .prefix
+                            .shard_index
+                            .is_child_of(self.header.prefix.shard_index)
+                })
+    }
+
+    /// The same as [`Self::try_from_bytes()`], but for trusted input that skips some consistency
+    /// checks
+    #[inline]
+    pub fn try_from_bytes_unchecked(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        let (header, remainder) = IntermediateShardBlockHeader::try_from_bytes(bytes)?;
+        let remainder = align_to_and_ensure_zero_padding::<u128>(remainder)?;
+        let (body, remainder) = IntermediateShardBlockBody::try_from_bytes(remainder)?;
+
+        Some((Self { header, body }, remainder))
+    }
+}
+
+/// Block that corresponds to a leaf shard
+#[derive(Debug, Copy, Clone)]
+pub struct LeafShardBlock<'a> {
+    /// Block header
+    pub header: LeafShardBlockHeader<'a>,
+    /// Block body
+    pub body: LeafShardBlockBody<'a>,
+}
+
+impl<'a> LeafShardBlock<'a> {
+    /// Try to create a new instance from provided bytes for provided shard index.
+    ///
+    /// `bytes` should be 8-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        let (header, remainder) = LeafShardBlockHeader::try_from_bytes(bytes)?;
+        let remainder = align_to_and_ensure_zero_padding::<u128>(remainder)?;
+        let (body, remainder) = LeafShardBlockBody::try_from_bytes(remainder)?;
+
+        let block = Self { header, body };
+
+        // Check internal consistency
+        if !block.is_internally_consistent() {
+            return None;
+        }
+
+        Some((block, remainder))
+    }
+
+    /// Check block's internal consistency
+    #[inline]
+    pub fn is_internally_consistent(&self) -> bool {
+        self.body.is_internally_consistent() && self.body.root() == self.header.result.body_root
+    }
+
+    /// The same as [`Self::try_from_bytes()`], but for trusted input that skips some consistency
+    /// checks
+    #[inline]
+    pub fn try_from_bytes_unchecked(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        let (header, remainder) = LeafShardBlockHeader::try_from_bytes(bytes)?;
+        let remainder = align_to_and_ensure_zero_padding::<u128>(remainder)?;
+        let (body, remainder) = LeafShardBlockBody::try_from_bytes(remainder)?;
+
+        Some((Self { header, body }, remainder))
+    }
+}
+
+/// Block that contains [`BlockHeader`] and [`BlockBody`]
+#[derive(Debug, Copy, Clone, From)]
+pub enum Block<'a> {
+    /// Block corresponds to the beacon chain
+    BeaconChain(BeaconChainBlock<'a>),
+    /// Block corresponds to an intermediate shard
+    IntermediateShard(IntermediateShardBlock<'a>),
+    /// Block corresponds to a leaf shard
+    LeafShard(LeafShardBlock<'a>),
+}
+
+impl<'a> Block<'a> {
+    /// Try to create a new instance from provided bytes.
+    ///
+    /// `bytes` should be 16-byte aligned.
+    ///
+    /// Header and body will be checked for basic internal consistencies body and that they match
+    /// each other, but no consensus verification is done.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8], shard_kind: ShardKind) -> Option<(Self, &'a [u8])> {
+        match shard_kind {
+            ShardKind::BeaconChain => {
+                let (block_header, remainder) = BeaconChainBlock::try_from_bytes(bytes)?;
+                Some((Self::BeaconChain(block_header), remainder))
+            }
+            ShardKind::IntermediateShard => {
+                let (block_header, remainder) = IntermediateShardBlock::try_from_bytes(bytes)?;
+                Some((Self::IntermediateShard(block_header), remainder))
+            }
+            ShardKind::LeafShard => {
+                let (block_header, remainder) = LeafShardBlock::try_from_bytes(bytes)?;
+                Some((Self::LeafShard(block_header), remainder))
+            }
+            ShardKind::Phantom | ShardKind::Invalid => {
+                // Blocks for such shards do not exist
+                None
+            }
+        }
+    }
+
+    /// Check block's internal consistency
+    #[inline]
+    pub fn is_internally_consistent(&self) -> bool {
+        match self {
+            Self::BeaconChain(body) => body.is_internally_consistent(),
+            Self::IntermediateShard(body) => body.is_internally_consistent(),
+            Self::LeafShard(body) => body.is_internally_consistent(),
+        }
+    }
+
+    /// The same as [`Self::try_from_bytes()`], but for trusted input that skips some consistency
+    /// checks
+    #[inline]
+    pub fn try_from_bytes_unchecked(
+        bytes: &'a [u8],
+        shard_kind: ShardKind,
+    ) -> Option<(Self, &'a [u8])> {
+        match shard_kind {
+            ShardKind::BeaconChain => {
+                let (block_header, remainder) = BeaconChainBlock::try_from_bytes_unchecked(bytes)?;
+                Some((Self::BeaconChain(block_header), remainder))
+            }
+            ShardKind::IntermediateShard => {
+                let (block_header, remainder) =
+                    IntermediateShardBlock::try_from_bytes_unchecked(bytes)?;
+                Some((Self::IntermediateShard(block_header), remainder))
+            }
+            ShardKind::LeafShard => {
+                let (block_header, remainder) = LeafShardBlock::try_from_bytes_unchecked(bytes)?;
+                Some((Self::LeafShard(block_header), remainder))
+            }
+            ShardKind::Phantom | ShardKind::Invalid => {
+                // Blocks for such shards do not exist
+                None
+            }
+        }
+    }
+
+    /// Get block header
+    #[inline(always)]
+    pub fn header(&self) -> BlockHeader<'a> {
+        match self {
+            Self::BeaconChain(block) => BlockHeader::BeaconChain(block.header),
+            Self::IntermediateShard(block) => BlockHeader::IntermediateShard(block.header),
+            Self::LeafShard(block) => BlockHeader::LeafShard(block.header),
+        }
+    }
+
+    /// Get block body
+    #[inline(always)]
+    pub fn body(&self) -> BlockBody<'a> {
+        match self {
+            Self::BeaconChain(block) => BlockBody::BeaconChain(block.body),
+            Self::IntermediateShard(block) => BlockBody::IntermediateShard(block.body),
+            Self::LeafShard(block) => BlockBody::LeafShard(block.body),
+        }
     }
 }
 
@@ -196,7 +496,7 @@ impl BlockWeight {
     pub const MAX: BlockWeight = BlockWeight(u128::MAX);
 
     /// Create new instance
-    #[inline]
+    #[inline(always)]
     pub const fn new(n: u128) -> Self {
         Self(n)
     }
@@ -206,4 +506,17 @@ impl BlockWeight {
     pub const fn as_u128(self) -> u128 {
         self.0
     }
+}
+
+/// Aligns bytes to `T` and ensures that all padding bytes (if any) are zero
+fn align_to_and_ensure_zero_padding<T>(bytes: &[u8]) -> Option<&[u8]> {
+    // SAFETY: We do not read `T`, so the contents don't really matter
+    let padding = unsafe { bytes.align_to::<T>() }.0;
+
+    // Padding must be zero
+    if padding.iter().any(|&byte| byte != 0) {
+        return None;
+    }
+
+    Some(&bytes[padding.len()..])
 }

--- a/crates/shared/ab-core-primitives/src/block/body.rs
+++ b/crates/shared/ab-core-primitives/src/block/body.rs
@@ -1,0 +1,879 @@
+//! Block body primitives
+
+use crate::block::align_to_and_ensure_zero_padding;
+use crate::block::header::{IntermediateShardBlockHeader, LeafShardBlockHeader};
+use crate::hashes::Blake3Hash;
+use crate::pot::PotCheckpoints;
+use crate::segments::SegmentRoot;
+use crate::shard::ShardKind;
+use crate::transaction::Transaction;
+use ab_io_type::trivial_type::TrivialType;
+use ab_merkle_tree::balanced_hashed::BalancedHashedMerkleTree;
+use ab_merkle_tree::unbalanced_hashed::UnbalancedHashedMerkleTree;
+use core::iter::TrustedLen;
+use core::slice;
+use derive_more::From;
+
+/// Calculates a Merkle Tree root for a provided list of segment roots
+#[inline]
+pub fn compute_segments_root<Item, Iter>(segment_roots: Iter) -> Blake3Hash
+where
+    Item: AsRef<[u8]>,
+    Iter: IntoIterator<Item = Item>,
+{
+    // TODO: This is a workaround for https://github.com/rust-lang/rust/issues/139866 that
+    //  allows the code to compile. Constant 16 is hardcoded here and in `if` branch below
+    //  for compilation to succeed
+    const _: () = {
+        assert!(u32::MAX == 4294967295);
+    };
+    // TODO: Keyed hash
+    let root = UnbalancedHashedMerkleTree::compute_root_only::<4294967295, _, _>(
+        segment_roots.into_iter().map(|segment_root| {
+            // Hash the root again so we can prove it, otherwise segments root is indistinguishable
+            // from individual segment roots and can be used to confuse verifier
+            blake3::hash(segment_root.as_ref())
+        }),
+    );
+
+    Blake3Hash::new(root.unwrap_or_default())
+}
+
+/// Information about intermediate shard block
+#[derive(Debug, Copy, Clone)]
+pub struct IntermediateShardBlockInfo<'a> {
+    /// Block header that corresponds to an intermediate shard
+    pub header: IntermediateShardBlockHeader<'a>,
+    /// Segment roots proof if there are segment roots in the corresponding block
+    pub segment_roots_proof: Option<&'a [u8; 32]>,
+    /// Segment roots produced by this shard
+    pub own_segment_roots: &'a [SegmentRoot],
+    /// Segment roots produced by child shard
+    pub child_segment_roots: &'a [SegmentRoot],
+}
+
+impl IntermediateShardBlockInfo<'_> {
+    /// Compute the root of the intermediate shard block info
+    #[inline]
+    pub fn root(&self) -> Blake3Hash {
+        // TODO: Keyed hash
+        const MAX_N: usize = 3;
+        let leaves: [_; MAX_N] = [
+            **self.header.hash(),
+            *compute_segments_root(self.own_segment_roots),
+            *compute_segments_root(self.child_segment_roots),
+        ];
+
+        let root = UnbalancedHashedMerkleTree::compute_root_only::<MAX_N, _, _>(leaves)
+            .expect("The list is not empty; qed");
+
+        Blake3Hash::new(root)
+    }
+}
+
+/// Information about a collection of intermediate shard blocks
+#[derive(Debug, Copy, Clone)]
+pub struct IntermediateShardBlocksInfo<'a> {
+    num_blocks: usize,
+    bytes: &'a [u8],
+}
+
+impl<'a> IntermediateShardBlocksInfo<'a> {
+    /// Create an instance from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * number of blocks: u16 as unaligned little-endian bytes
+        // * for each block:
+        //   * number of own segment roots: u8
+        //   * number of child segment roots: u16 as unaligned little-endian bytes
+        // * padding to 8-bytes boundary (if needed)
+        // * for each block:
+        //   * block header: IntermediateShardBlockHeader
+        //   * padding to 8-bytes boundary (if needed)
+        //   * segment roots proof (if there is at least one segment root)
+        //   * concatenated own segment roots
+        //   * concatenated child segment roots
+
+        let num_blocks = bytes.split_off(..size_of::<u16>())?;
+        let num_blocks = usize::from(u16::from_le_bytes([num_blocks[1], num_blocks[2]]));
+
+        let bytes_start = bytes;
+
+        let mut counts = bytes.split_off(..num_blocks * (size_of::<u8>() + size_of::<u16>()))?;
+
+        let mut remainder = align_to_and_ensure_zero_padding::<u64>(bytes)?;
+
+        for _ in 0..num_blocks {
+            let num_own_segment_roots = usize::from(counts[0]);
+            let num_child_segment_roots = usize::from(u16::from_le_bytes([counts[1], counts[2]]));
+            counts = &counts[3..];
+
+            (_, remainder) = IntermediateShardBlockHeader::try_from_bytes(remainder)?;
+
+            remainder = align_to_and_ensure_zero_padding::<u64>(remainder)?;
+
+            if num_own_segment_roots + num_child_segment_roots > 0 {
+                let _segment_roots_proof = remainder.split_off(..SegmentRoot::SIZE)?;
+            }
+
+            let _segment_roots = remainder.split_off(
+                ..(num_own_segment_roots + num_child_segment_roots) * SegmentRoot::SIZE,
+            )?;
+        }
+
+        Some((
+            Self {
+                num_blocks,
+                bytes: &bytes_start[..bytes_start.len() - remainder.len()],
+            },
+            remainder,
+        ))
+    }
+
+    /// Iterator over intermediate shard blocks in a collection
+    #[inline]
+    pub fn iter(
+        &self,
+    ) -> impl ExactSizeIterator<Item = IntermediateShardBlockInfo<'a>> + TrustedLen + 'a {
+        // SAFETY: Checked in constructor
+        let (mut counts, mut remainder) = unsafe {
+            self.bytes
+                .split_at_unchecked(self.num_blocks * (size_of::<u8>() + size_of::<u16>()))
+        };
+
+        (0..self.num_blocks).map(move |_| {
+            let num_own_segment_roots = usize::from(counts[0]);
+            let num_child_segment_roots = usize::from(u16::from_le_bytes([counts[1], counts[2]]));
+            counts = &counts[3..];
+
+            // TODO: Unchecked method would have been helpful here
+            let header;
+            (header, remainder) = IntermediateShardBlockHeader::try_from_bytes(remainder)
+                .expect("Already checked in constructor; qed");
+
+            remainder = align_to_and_ensure_zero_padding::<u64>(remainder)
+                .expect("Already checked in constructor; qed");
+
+            let segment_roots_proof = if num_own_segment_roots + num_child_segment_roots > 0 {
+                let segment_roots_proof;
+                // SAFETY: Checked in constructor
+                (segment_roots_proof, remainder) =
+                    unsafe { remainder.split_at_unchecked(SegmentRoot::SIZE) };
+                // SAFETY: Valid pointer and size, no alignment requirements
+                Some(unsafe {
+                    segment_roots_proof
+                        .as_ptr()
+                        .cast::<[u8; SegmentRoot::SIZE]>()
+                        .as_ref_unchecked()
+                })
+            } else {
+                None
+            };
+
+            let own_segment_roots;
+            // SAFETY: Checked in constructor
+            (own_segment_roots, remainder) =
+                unsafe { remainder.split_at_unchecked(num_own_segment_roots * SegmentRoot::SIZE) };
+            // SAFETY: Valid pointer and size, no alignment requirements
+            let own_segment_roots = unsafe {
+                slice::from_raw_parts(
+                    own_segment_roots.as_ptr().cast::<[u8; SegmentRoot::SIZE]>(),
+                    num_own_segment_roots,
+                )
+            };
+            let own_segment_roots = SegmentRoot::slice_from_repr(own_segment_roots);
+
+            let child_segment_roots;
+            // SAFETY: Checked in constructor
+            (child_segment_roots, remainder) = unsafe {
+                remainder.split_at_unchecked(num_child_segment_roots * SegmentRoot::SIZE)
+            };
+            // SAFETY: Valid pointer and size, no alignment requirements
+            let child_segment_roots = unsafe {
+                slice::from_raw_parts(
+                    child_segment_roots
+                        .as_ptr()
+                        .cast::<[u8; SegmentRoot::SIZE]>(),
+                    num_child_segment_roots,
+                )
+            };
+            let child_segment_roots = SegmentRoot::slice_from_repr(child_segment_roots);
+
+            IntermediateShardBlockInfo {
+                header,
+                segment_roots_proof,
+                own_segment_roots,
+                child_segment_roots,
+            }
+        })
+    }
+
+    /// Number of intermediate shard blocks
+    #[inline(always)]
+    pub const fn len(&self) -> usize {
+        self.num_blocks
+    }
+
+    /// Returns `true` if there are no intermediate shard blocks
+    #[inline(always)]
+    pub const fn is_empty(&self) -> bool {
+        self.num_blocks == 0
+    }
+
+    /// Compute the segments root of the intermediate shard blocks info.
+    ///
+    /// Returns default value for an empty collection of segment roots.
+    #[inline]
+    pub fn segments_root(&self) -> Blake3Hash {
+        compute_segments_root(
+            self.iter()
+                .flat_map(|shard_block_info| {
+                    [
+                        shard_block_info.own_segment_roots,
+                        shard_block_info.child_segment_roots,
+                    ]
+                })
+                .flatten(),
+        )
+    }
+
+    /// Compute the headers root of the intermediate shard blocks info.
+    ///
+    /// Returns default value for an empty collection of shard blocks.
+    #[inline]
+    pub fn headers_root(&self) -> Blake3Hash {
+        let root =
+            UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as usize + 1 }, _, _>(
+                self.iter().map(|shard_block_info| {
+                    // Hash the hash again so we can prove it, otherwise headers root is
+                    // indistinguishable from individual block hashes and can be used to confuse
+                    // verifier
+
+                    blake3::hash(shard_block_info.header.hash().as_ref())
+                }),
+            )
+            .unwrap_or_default();
+
+        Blake3Hash::new(root)
+    }
+
+    /// Compute the root of the intermediate shard blocks info.
+    ///
+    /// Returns default value for an empty collection of shard blocks.
+    #[inline]
+    pub fn root(&self) -> Blake3Hash {
+        let root =
+            UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as usize + 1 }, _, _>(
+                self.iter().map(|shard_block_info| shard_block_info.root()),
+            )
+            .unwrap_or_default();
+
+        Blake3Hash::new(root)
+    }
+}
+
+/// Block body that corresponds to the beacon chain
+#[derive(Debug, Copy, Clone)]
+pub struct BeaconChainBlockBody<'a> {
+    /// Segment roots produced by this shard
+    pub own_segment_roots: &'a [SegmentRoot],
+    /// Intermediate shard blocks
+    pub intermediate_shard_blocks: IntermediateShardBlocksInfo<'a>,
+    /// Proof of time checkpoints from after future proof of time of the parent block to current
+    /// block's future proof of time (inclusive)
+    pub pot_checkpoints: &'a [PotCheckpoints],
+}
+
+impl<'a> BeaconChainBlockBody<'a> {
+    /// Create an instance from provided correctly aligned bytes.
+    ///
+    /// `bytes` should be 4-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * number of PoT checkpoints: u32 as aligned little-endian bytes
+        // * number of own segment roots: u8
+        // * concatenated own segment roots
+        // * intermediate shard blocks: IntermediateShardBlocksInfo
+        // * concatenated PoT checkpoints
+
+        let num_pot_checkpoints = bytes.split_off(..size_of::<u16>())?;
+        // SAFETY: All bit patterns are valid
+        let num_pot_checkpoints =
+            *unsafe { <u32 as TrivialType>::from_bytes(num_pot_checkpoints) }? as usize;
+
+        if num_pot_checkpoints == 0 {
+            return None;
+        }
+
+        let num_own_segment_roots = bytes.split_off(..size_of::<u8>())?;
+        let num_own_segment_roots = usize::from(num_own_segment_roots[0]);
+
+        let own_segment_roots = bytes.split_off(..num_own_segment_roots * SegmentRoot::SIZE)?;
+        // SAFETY: Valid pointer and size, no alignment requirements
+        let own_segment_roots = unsafe {
+            slice::from_raw_parts(
+                own_segment_roots.as_ptr().cast::<[u8; SegmentRoot::SIZE]>(),
+                num_own_segment_roots,
+            )
+        };
+        let own_segment_roots = SegmentRoot::slice_from_repr(own_segment_roots);
+
+        let (intermediate_shard_blocks, remainder) =
+            IntermediateShardBlocksInfo::try_from_bytes(bytes)?;
+
+        let pot_checkpoints = bytes.split_off(..num_pot_checkpoints * PotCheckpoints::SIZE)?;
+        // SAFETY: Valid pointer and size, no alignment requirements
+        let pot_checkpoints = unsafe {
+            slice::from_raw_parts(
+                pot_checkpoints
+                    .as_ptr()
+                    .cast::<[u8; PotCheckpoints::SIZE]>(),
+                num_pot_checkpoints,
+            )
+        };
+        let pot_checkpoints = PotCheckpoints::slice_from_bytes(pot_checkpoints);
+
+        Some((
+            Self {
+                pot_checkpoints,
+                own_segment_roots,
+                intermediate_shard_blocks,
+            },
+            remainder,
+        ))
+    }
+
+    /// Check block body's internal consistency
+    #[inline]
+    pub fn is_internally_consistent(&self) -> bool {
+        self.intermediate_shard_blocks
+            .iter()
+            .all(|intermediate_shard_block| {
+                let Some(&segment_roots_proof) = intermediate_shard_block.segment_roots_proof
+                else {
+                    return true;
+                };
+
+                BalancedHashedMerkleTree::<2>::verify(
+                    &intermediate_shard_block.header.result.body_root,
+                    &[segment_roots_proof],
+                    0,
+                    BalancedHashedMerkleTree::compute_root_only(&[
+                        *compute_segments_root(intermediate_shard_block.own_segment_roots),
+                        *compute_segments_root(intermediate_shard_block.child_segment_roots),
+                    ]),
+                )
+            })
+    }
+
+    /// Compute block body root
+    #[inline]
+    pub fn root(&self) -> Blake3Hash {
+        let root = BalancedHashedMerkleTree::compute_root_only(&[
+            *compute_segments_root(self.own_segment_roots),
+            *self.intermediate_shard_blocks.segments_root(),
+            *self.intermediate_shard_blocks.headers_root(),
+            blake3::hash(PotCheckpoints::bytes_from_slice(self.pot_checkpoints).as_flattened())
+                .into(),
+        ]);
+
+        Blake3Hash::new(root)
+    }
+}
+
+/// Information about leaf shard block
+#[derive(Debug, Copy, Clone)]
+pub struct LeafShardBlockInfo<'a> {
+    /// Block header that corresponds to an intermediate shard
+    pub header: LeafShardBlockHeader<'a>,
+    /// Segment roots proof if there are segment roots in the corresponding block
+    pub segment_roots_proof: Option<&'a [u8; 32]>,
+    /// Segment roots produced by this shard
+    pub own_segment_roots: &'a [SegmentRoot],
+}
+
+/// Information about a collection of leaf shard blocks
+#[derive(Debug, Copy, Clone)]
+pub struct LeafShardBlocksInfo<'a> {
+    num_blocks: usize,
+    bytes: &'a [u8],
+}
+
+impl<'a> LeafShardBlocksInfo<'a> {
+    /// Create an instance from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * number of blocks: u16 as unaligned little-endian bytes
+        // * for each block:
+        //   * number of own segment roots: u8
+        // * padding to 8-bytes boundary (if needed)
+        // * for each block:
+        //   * block header
+        //   * padding to 8-bytes boundary (if needed)
+        //   * segment roots proof (if there is at least one segment root)
+        //   * concatenated own segment roots
+
+        let num_blocks = bytes.split_off(..size_of::<u16>())?;
+        let num_blocks = usize::from(u16::from_le_bytes([num_blocks[0], num_blocks[1]]));
+
+        let bytes_start = bytes;
+
+        let mut counts = bytes.split_off(..num_blocks * size_of::<u8>())?;
+
+        let mut remainder = align_to_and_ensure_zero_padding::<u64>(bytes)?;
+
+        for _ in 0..num_blocks {
+            let num_own_segment_roots = usize::from(counts[0]);
+            counts = &counts[1..];
+
+            (_, remainder) = LeafShardBlockHeader::try_from_bytes(remainder)?;
+
+            remainder = align_to_and_ensure_zero_padding::<u64>(remainder)?;
+
+            if num_own_segment_roots > 0 {
+                let _segment_roots_proof = remainder.split_off(..SegmentRoot::SIZE)?;
+            }
+
+            let _own_segment_roots =
+                remainder.split_off(..num_own_segment_roots * SegmentRoot::SIZE)?;
+        }
+
+        Some((
+            Self {
+                num_blocks,
+                bytes: &bytes_start[..bytes_start.len() - remainder.len()],
+            },
+            remainder,
+        ))
+    }
+
+    /// Iterator over leaf shard blocks in a collection
+    #[inline]
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = LeafShardBlockInfo<'a>> + TrustedLen + 'a {
+        // SAFETY: Checked in constructor
+        let (mut counts, mut remainder) = unsafe {
+            self.bytes
+                .split_at_unchecked(self.num_blocks * size_of::<u8>())
+        };
+
+        (0..self.num_blocks).map(move |_| {
+            let num_own_segment_roots = usize::from(counts[0]);
+            counts = &counts[1..];
+
+            // TODO: Unchecked method would have been helpful here
+            let header;
+            (header, remainder) = LeafShardBlockHeader::try_from_bytes(remainder)
+                .expect("Already checked in constructor; qed");
+
+            remainder = align_to_and_ensure_zero_padding::<u64>(remainder)
+                .expect("Already checked in constructor; qed");
+
+            let segment_roots_proof = if num_own_segment_roots > 0 {
+                let segment_roots_proof;
+                // SAFETY: Checked in constructor
+                (segment_roots_proof, remainder) =
+                    unsafe { remainder.split_at_unchecked(SegmentRoot::SIZE) };
+                // SAFETY: Valid pointer and size, no alignment requirements
+                Some(unsafe {
+                    segment_roots_proof
+                        .as_ptr()
+                        .cast::<[u8; SegmentRoot::SIZE]>()
+                        .as_ref_unchecked()
+                })
+            } else {
+                None
+            };
+
+            let own_segment_roots;
+            // SAFETY: Checked in constructor
+            (own_segment_roots, remainder) =
+                unsafe { remainder.split_at_unchecked(num_own_segment_roots * SegmentRoot::SIZE) };
+            // SAFETY: Valid pointer and size, no alignment requirements
+            let own_segment_roots = unsafe {
+                slice::from_raw_parts(
+                    own_segment_roots.as_ptr().cast::<[u8; SegmentRoot::SIZE]>(),
+                    num_own_segment_roots,
+                )
+            };
+            let own_segment_roots = SegmentRoot::slice_from_repr(own_segment_roots);
+
+            LeafShardBlockInfo {
+                header,
+                segment_roots_proof,
+                own_segment_roots,
+            }
+        })
+    }
+
+    /// Number of leaf shard blocks
+    #[inline(always)]
+    pub const fn len(&self) -> usize {
+        self.num_blocks
+    }
+
+    /// Returns `true` if there are no leaf shard blocks
+    #[inline(always)]
+    pub const fn is_empty(&self) -> bool {
+        self.num_blocks == 0
+    }
+
+    /// Compute the segments root of the leaf shard blocks info.
+    ///
+    /// Returns default value for an empty collection of segment roots.
+    #[inline]
+    pub fn segments_root(&self) -> Blake3Hash {
+        compute_segments_root(
+            self.iter()
+                .flat_map(|shard_block_info| shard_block_info.own_segment_roots),
+        )
+    }
+
+    /// Compute the headers root of the leaf shard blocks info.
+    ///
+    /// Returns default value for an empty collection of shard blocks.
+    #[inline]
+    pub fn headers_root(&self) -> Blake3Hash {
+        let root =
+            UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as usize + 1 }, _, _>(
+                self.iter().map(|shard_block_info| {
+                    // Hash the hash again so we can prove it, otherwise headers root is
+                    // indistinguishable from individual block hashes and can be used to confuse
+                    // verifier
+
+                    blake3::hash(shard_block_info.header.hash().as_ref())
+                }),
+            )
+            .unwrap_or_default();
+
+        Blake3Hash::new(root)
+    }
+}
+
+/// Collection of transactions
+#[derive(Debug, Copy, Clone)]
+pub struct Transactions<'a> {
+    num_transactions: usize,
+    bytes: &'a [u8],
+}
+
+impl<'a> Transactions<'a> {
+    /// Create an instance from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * number of transactions: u32 as unaligned little-endian bytes
+        // * padding to 16-bytes boundary (if needed)
+        // * for each transaction
+        //   * transaction: Transaction
+        //   * padding to 16-bytes boundary (if needed)
+
+        let num_transactions = bytes.split_off(..size_of::<u32>())?;
+        let num_transactions = u32::from_le_bytes([
+            num_transactions[0],
+            num_transactions[1],
+            num_transactions[2],
+            num_transactions[3],
+        ]) as usize;
+
+        let mut remainder = align_to_and_ensure_zero_padding::<u128>(bytes)?;
+        let bytes_start = remainder;
+
+        for _ in 0..num_transactions {
+            (_, remainder) = Transaction::try_from_bytes(bytes)?;
+            remainder = align_to_and_ensure_zero_padding::<u128>(remainder)?;
+        }
+
+        Some((
+            Self {
+                num_transactions,
+                bytes: &bytes_start[..bytes_start.len() - remainder.len()],
+            },
+            remainder,
+        ))
+    }
+
+    /// Iterator over transactions in a collection
+    #[inline]
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = Transaction<'a>> + TrustedLen + 'a {
+        let mut remainder = self.bytes;
+
+        (0..self.num_transactions).map(move |_| {
+            // SAFETY: Checked in constructor
+            let transaction = unsafe { Transaction::from_bytes_unchecked(remainder) };
+
+            remainder = &remainder[transaction.encoded_size()..];
+            remainder = align_to_and_ensure_zero_padding::<u128>(remainder)
+                .expect("Already checked in constructor; qed");
+
+            transaction
+        })
+    }
+
+    /// Compute the root of the leaf shard blocks info.
+    ///
+    /// Returns default value for an empty collection of shard blocks.
+    #[inline]
+    pub fn root(&self) -> Blake3Hash {
+        let root =
+            UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as usize + 1 }, _, _>(
+                self.iter().map(|transaction| {
+                    // Hash the hash again so we can prove it, otherwise transactions root is
+                    // indistinguishable from individual transaction roots and can be used to
+                    // confuse verifier
+                    blake3::hash(transaction.hash().as_ref())
+                }),
+            )
+            .unwrap_or_default();
+
+        Blake3Hash::new(root)
+    }
+}
+
+/// Block body that corresponds to an intermediate shard
+#[derive(Debug, Copy, Clone)]
+pub struct IntermediateShardBlockBody<'a> {
+    /// Segment roots produced by this shard
+    pub own_segment_roots: &'a [SegmentRoot],
+    /// Leaf shard blocks
+    pub leaf_shard_blocks: LeafShardBlocksInfo<'a>,
+    /// User transactions
+    pub transactions: Transactions<'a>,
+}
+
+impl<'a> IntermediateShardBlockBody<'a> {
+    /// Create an instance from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * number of own segment roots: u8
+        // * concatenated own segment roots
+        // * leaf shard blocks: LeafShardBlocksInfo
+        // * transactions: Transactions
+
+        let num_own_segment_roots = bytes.split_off(..size_of::<u8>())?;
+        let num_own_segment_roots = usize::from(num_own_segment_roots[0]);
+
+        let own_segment_roots = bytes.split_off(..num_own_segment_roots * SegmentRoot::SIZE)?;
+        // SAFETY: Valid pointer and size, no alignment requirements
+        let own_segment_roots = unsafe {
+            slice::from_raw_parts(
+                own_segment_roots.as_ptr().cast::<[u8; SegmentRoot::SIZE]>(),
+                num_own_segment_roots,
+            )
+        };
+        let own_segment_roots = SegmentRoot::slice_from_repr(own_segment_roots);
+
+        let (leaf_shard_blocks, remainder) = LeafShardBlocksInfo::try_from_bytes(bytes)?;
+
+        let (transactions, remainder) = Transactions::try_from_bytes(remainder)?;
+
+        Some((
+            Self {
+                own_segment_roots,
+                leaf_shard_blocks,
+                transactions,
+            },
+            remainder,
+        ))
+    }
+
+    /// Check block body's internal consistency
+    #[inline]
+    pub fn is_internally_consistent(&self) -> bool {
+        self.leaf_shard_blocks.iter().all(|leaf_shard_block| {
+            let Some(&segment_roots_proof) = leaf_shard_block.segment_roots_proof else {
+                return true;
+            };
+
+            BalancedHashedMerkleTree::<2>::verify(
+                &leaf_shard_block.header.result.body_root,
+                &[segment_roots_proof],
+                0,
+                *compute_segments_root(leaf_shard_block.own_segment_roots),
+            )
+        })
+    }
+
+    /// Proof for segment roots included in the body
+    #[inline]
+    pub fn segment_roots_proof(&self) -> [u8; 32] {
+        // Merkle Tree is recursive. First two leafs (own and leaf shards record roots) are one
+        // subtree, the second subtree is the proof needed to verify them both.
+        BalancedHashedMerkleTree::compute_root_only(&[
+            *self.leaf_shard_blocks.headers_root(),
+            *self.transactions.root(),
+        ])
+    }
+
+    /// Compute block body root
+    #[inline]
+    pub fn root(&self) -> Blake3Hash {
+        let root = BalancedHashedMerkleTree::compute_root_only(&[
+            *compute_segments_root(self.own_segment_roots),
+            *self.leaf_shard_blocks.segments_root(),
+            *self.leaf_shard_blocks.headers_root(),
+            *self.transactions.root(),
+        ]);
+
+        Blake3Hash::new(root)
+    }
+}
+
+/// Block body that corresponds to a leaf shard
+#[derive(Debug, Copy, Clone)]
+pub struct LeafShardBlockBody<'a> {
+    /// Segment roots produced by this shard
+    pub own_segment_roots: &'a [SegmentRoot],
+    /// User transactions
+    pub transactions: Transactions<'a>,
+}
+
+impl<'a> LeafShardBlockBody<'a> {
+    /// Create an instance from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * number of own segment roots: u8
+        // * concatenated own segment roots
+        // * transactions: Transactions
+
+        let num_own_segment_roots = bytes.split_off(..size_of::<u8>())?;
+        let num_own_segment_roots = usize::from(num_own_segment_roots[0]);
+
+        let own_segment_roots = bytes.split_off(..num_own_segment_roots * SegmentRoot::SIZE)?;
+        // SAFETY: Valid pointer and size, no alignment requirements
+        let own_segment_roots = unsafe {
+            slice::from_raw_parts(
+                own_segment_roots.as_ptr().cast::<[u8; SegmentRoot::SIZE]>(),
+                num_own_segment_roots,
+            )
+        };
+        let own_segment_roots = SegmentRoot::slice_from_repr(own_segment_roots);
+
+        let (transactions, remainder) = Transactions::try_from_bytes(bytes)?;
+
+        Some((
+            Self {
+                own_segment_roots,
+                transactions,
+            },
+            remainder,
+        ))
+    }
+
+    /// Check block body's internal consistency
+    #[inline]
+    pub fn is_internally_consistent(&self) -> bool {
+        // Nothing to check here
+        true
+    }
+
+    /// Proof for segment roots included in the body
+    #[inline]
+    pub fn segment_roots_proof(&self) -> [u8; 32] {
+        *self.transactions.root()
+    }
+
+    /// Compute block body root
+    #[inline]
+    pub fn root(&self) -> Blake3Hash {
+        let root = BalancedHashedMerkleTree::compute_root_only(&[
+            *compute_segments_root(self.own_segment_roots),
+            *self.transactions.root(),
+        ]);
+
+        Blake3Hash::new(root)
+    }
+}
+
+/// Block body that together with [`BlockHeader`] form a [`Block`]
+///
+/// [`BlockHeader`]: crate::block::header::BlockHeader
+/// [`Block`]: crate::block::Block
+#[derive(Debug, Copy, Clone, From)]
+pub enum BlockBody<'a> {
+    /// Block body corresponds to the beacon chain
+    BeaconChain(BeaconChainBlockBody<'a>),
+    /// Block body corresponds to an intermediate shard
+    IntermediateShard(IntermediateShardBlockBody<'a>),
+    /// Block body corresponds to a leaf shard
+    LeafShard(LeafShardBlockBody<'a>),
+}
+
+impl<'a> BlockBody<'a> {
+    /// Try to create a new instance from provided bytes for provided shard index.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8], shard_kind: ShardKind) -> Option<(Self, &'a [u8])> {
+        match shard_kind {
+            ShardKind::BeaconChain => {
+                let (body, remainder) = BeaconChainBlockBody::try_from_bytes(bytes)?;
+                Some((Self::BeaconChain(body), remainder))
+            }
+            ShardKind::IntermediateShard => {
+                let (body, remainder) = IntermediateShardBlockBody::try_from_bytes(bytes)?;
+                Some((Self::IntermediateShard(body), remainder))
+            }
+            ShardKind::LeafShard => {
+                let (body, remainder) = LeafShardBlockBody::try_from_bytes(bytes)?;
+                Some((Self::LeafShard(body), remainder))
+            }
+            ShardKind::Phantom | ShardKind::Invalid => {
+                // Blocks for such shards do not exist
+                None
+            }
+        }
+    }
+
+    /// Check block body's internal consistency
+    #[inline]
+    pub fn is_internally_consistent(&self) -> bool {
+        match self {
+            Self::BeaconChain(body) => body.is_internally_consistent(),
+            Self::IntermediateShard(body) => body.is_internally_consistent(),
+            Self::LeafShard(body) => body.is_internally_consistent(),
+        }
+    }
+
+    /// Compute block body hash.
+    ///
+    /// Block body hash is actually a Merkle Tree Root. The leaves are derived from individual
+    /// fields this enum in the declaration order.
+    #[inline]
+    pub fn hash(&self) -> Blake3Hash {
+        match self {
+            Self::BeaconChain(body) => body.root(),
+            Self::IntermediateShard(body) => body.root(),
+            Self::LeafShard(body) => body.root(),
+        }
+    }
+}

--- a/crates/shared/ab-core-primitives/src/block/header.rs
+++ b/crates/shared/ab-core-primitives/src/block/header.rs
@@ -1,0 +1,988 @@
+//! Block header primitives
+
+use crate::block::{BlockHash, BlockNumber};
+use crate::hashes::Blake3Hash;
+use crate::pot::{PotOutput, PotParametersChange, SlotNumber};
+use crate::segments::SuperSegmentRoot;
+use crate::shard::{ShardIndex, ShardKind};
+use crate::solutions::{Solution, SolutionRange};
+#[cfg(feature = "serde")]
+use ::serde::{Deserialize, Serialize};
+use ab_io_type::trivial_type::TrivialType;
+use ab_merkle_tree::unbalanced_hashed::UnbalancedHashedMerkleTree;
+use core::num::NonZeroU32;
+use core::ops::Deref;
+use derive_more::{Deref, From};
+#[cfg(feature = "scale-codec")]
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+#[cfg(feature = "scale-codec")]
+use scale_info::TypeInfo;
+#[cfg(feature = "serde")]
+use serde_big_array::BigArray;
+
+/// Block header prefix.
+///
+/// The prefix contains generic information known about the block before block creation starts.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, TrivialType)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[repr(C)]
+pub struct BlockHeaderPrefix {
+    /// Block version
+    pub version: u64,
+    /// Block number
+    pub number: BlockNumber,
+    /// Shard index
+    pub shard_index: ShardIndex,
+    /// Padding for data structure alignment
+    pub padding: [u8; 4],
+    /// Unix timestamp in ms
+    // TODO: New type?
+    pub timestamp: u64,
+    /// Hash of the parent block
+    pub parent_hash: BlockHash,
+    /// MMR root of all block hashes, including `parent_hash`
+    // TODO: New type?
+    pub mmr_root: Blake3Hash,
+}
+
+impl BlockHeaderPrefix {
+    /// The only supported block version right now
+    pub const BLOCK_VERSION: u64 = 0;
+
+    /// Hash of the block header prefix, part of the eventual block hash
+    pub fn hash(&self) -> Blake3Hash {
+        // TODO: Keyed hash
+        Blake3Hash::from(blake3::hash(self.as_bytes()))
+    }
+}
+
+/// Consensus information in block header
+#[derive(Debug, Copy, Clone, Eq, PartialEq, TrivialType)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[repr(C)]
+pub struct BlockHeaderConsensusInfo {
+    /// Slot number
+    pub slot: SlotNumber,
+    /// Proof of time for this slot
+    pub proof_of_time: PotOutput,
+    /// Future proof of time
+    pub future_proof_of_time: PotOutput,
+    /// Solution
+    pub solution: Solution,
+}
+
+impl BlockHeaderConsensusInfo {
+    /// Hash of the consensus info, part of the eventual block hash
+    pub fn hash(&self) -> Blake3Hash {
+        // TODO: Keyed hash
+        Blake3Hash::from(blake3::hash(self.as_bytes()))
+    }
+}
+
+/// Beacon chain info
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, TrivialType)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[repr(C)]
+pub struct BlockHeaderBeaconChainInfo {
+    /// Beacon chain block number
+    pub number: BlockNumber,
+    /// Beacon chain block hash
+    pub hash: BlockHash,
+}
+
+impl BlockHeaderBeaconChainInfo {
+    /// Hash of the beacon chain info, part of the eventual block hash
+    pub fn hash(&self) -> Blake3Hash {
+        // TODO: Keyed hash
+        Blake3Hash::from(blake3::hash(self.as_bytes()))
+    }
+}
+
+/// Consensus parameters (on the beacon chain)
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct BlockHeaderFixedConsensusParameters {
+    /// Solution range for this block/era
+    pub solution_range: SolutionRange,
+    /// The number of iterations for proof of time per slot.
+    ///
+    /// Corresponds to the slot that is right after the parent block's slot.
+    /// It can change before the slot of this block (see [`PotParametersChange`]).
+    pub pot_slot_iterations: NonZeroU32,
+}
+
+impl BlockHeaderFixedConsensusParameters {
+    /// Create an instance from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &[u8]) -> Option<(Self, &[u8])> {
+        // Layout here is as follows:
+        // * solution range: SolutionRange as unaligned bytes
+        // * PoT slot iterations: NonZeroU32 as unaligned little-endian bytes
+
+        let solution_range = bytes.split_off(..size_of::<SolutionRange>())?;
+        let solution_range = SolutionRange::from_bytes([
+            solution_range[0],
+            solution_range[1],
+            solution_range[2],
+            solution_range[3],
+            solution_range[4],
+            solution_range[5],
+            solution_range[6],
+            solution_range[7],
+        ]);
+
+        let pot_slot_iterations = bytes.split_off(..size_of::<u32>())?;
+        let pot_slot_iterations = u32::from_le_bytes([
+            pot_slot_iterations[0],
+            pot_slot_iterations[1],
+            pot_slot_iterations[2],
+            pot_slot_iterations[3],
+        ]);
+        let pot_slot_iterations = NonZeroU32::new(pot_slot_iterations)?;
+
+        Some((
+            Self {
+                solution_range,
+                pot_slot_iterations,
+            },
+            bytes,
+        ))
+    }
+}
+
+/// A mirror of [`PotParametersChange`] for block header purposes.
+///
+/// Use [`From`] or [`Into`] for converting into [`PotParametersChange`] before use.
+#[derive(Debug, Copy, Clone)]
+#[repr(C, packed)]
+pub struct BlockHeaderPotParametersChange {
+    // TODO: Reduce this to `u16` or even `u8` since it is always an offset relatively to current
+    //  block's slot number
+    /// At which slot change of parameters takes effect
+    slot: SlotNumber,
+    /// New number of slot iterations
+    slot_iterations: NonZeroU32,
+    /// Entropy that should be injected at this time
+    entropy: Blake3Hash,
+}
+
+impl From<BlockHeaderPotParametersChange> for PotParametersChange {
+    #[inline(always)]
+    fn from(value: BlockHeaderPotParametersChange) -> Self {
+        let BlockHeaderPotParametersChange {
+            slot,
+            slot_iterations,
+            entropy,
+        } = value;
+
+        PotParametersChange {
+            slot,
+            slot_iterations,
+            entropy,
+        }
+    }
+}
+
+impl BlockHeaderPotParametersChange {
+    /// Get instance reference from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &[u8]) -> Option<(&Self, &[u8])> {
+        // Layout here is as follows:
+        // * slot number: SlotNumber as unaligned bytes
+        // * slot iterations: NonZeroU32 as unaligned little-endian bytes
+        // * entropy: Blake3Hash
+
+        let _slot = bytes.split_off(..size_of::<SlotNumber>())?;
+
+        let slot_iterations = bytes.split_off(..size_of::<u32>())?;
+        if slot_iterations == [0, 0, 0, 0] {
+            return None;
+        }
+        let _entropy = bytes.split_off(..size_of::<Blake3Hash>())?;
+
+        // SAFETY: Not null, packed, bit pattern for `NonZeroU32` checked above
+        let pot_parameters_change = unsafe { bytes.as_ptr().cast::<Self>().as_ref_unchecked() };
+
+        Some((pot_parameters_change, bytes))
+    }
+}
+
+/// Consensus parameters (on the beacon chain)
+#[derive(Debug, Copy, Clone)]
+pub struct BlockHeaderBeaconChainParameters<'a> {
+    /// Consensus parameters that are always present
+    pub fixed_parameters: BlockHeaderFixedConsensusParameters,
+    /// Super segment root
+    pub super_segment_root: Option<&'a SuperSegmentRoot>,
+    /// Solution range for the next block/era (if any)
+    pub next_solution_range: Option<SolutionRange>,
+    /// Change of parameters to apply to the proof of time chain (if any)
+    pub pot_parameters_change: Option<&'a BlockHeaderPotParametersChange>,
+}
+
+impl<'a> BlockHeaderBeaconChainParameters<'a> {
+    /// Bitmask for presence of `super_segment_root` field
+    pub const SUPER_SEGMENT_ROOT_MASK: u8 = 0b_0000_0001;
+    /// Bitmask for presence of `next_solution_range` field
+    pub const NEXT_SOLUTION_RANGE_MASK: u8 = 0b_0000_0010;
+    /// Bitmask for presence of `pot_parameters_change` field
+    pub const POT_PARAMETERS_CHANGE_MASK: u8 = 0b_0000_0100;
+
+    /// Create an instance from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // Layout here is as follows:
+        // * fixed parameters: BlockHeaderFixedConsensusParameters
+        // * bitflags: u8
+        // * (optional, depends on bitflags) super segment root: SuperSegmentRoot
+        // * (optional, depends on bitflags) next solution range: SolutionRange as unaligned bytes
+        // * (optional, depends on bitflags) PoT parameters change: BlockHeaderPotParametersChange
+
+        let (fixed_parameters, mut remainder) =
+            BlockHeaderFixedConsensusParameters::try_from_bytes(bytes)?;
+
+        let bitflags = remainder.split_off(..size_of::<u8>())?;
+        let bitflags = bitflags[0];
+
+        let super_segment_root = if bitflags & Self::SUPER_SEGMENT_ROOT_MASK != 0 {
+            let super_segment_root = remainder.split_off(..size_of::<SuperSegmentRoot>())?;
+            // SAFETY: All bit patterns are valid
+            let super_segment_root = unsafe { SuperSegmentRoot::from_bytes(super_segment_root) }?;
+
+            Some(super_segment_root)
+        } else {
+            None
+        };
+
+        let next_solution_range = if bitflags & Self::NEXT_SOLUTION_RANGE_MASK != 0 {
+            let next_solution_range = remainder.split_off(..size_of::<SolutionRange>())?;
+            // Not guaranteed to be aligned
+            let next_solution_range = SolutionRange::from_bytes([
+                next_solution_range[0],
+                next_solution_range[1],
+                next_solution_range[2],
+                next_solution_range[3],
+                next_solution_range[4],
+                next_solution_range[5],
+                next_solution_range[6],
+                next_solution_range[7],
+            ]);
+
+            Some(next_solution_range)
+        } else {
+            None
+        };
+
+        let pot_parameters_change = if bitflags & Self::POT_PARAMETERS_CHANGE_MASK != 0 {
+            let pot_parameters_change;
+            (pot_parameters_change, remainder) =
+                BlockHeaderPotParametersChange::try_from_bytes(remainder)?;
+
+            Some(pot_parameters_change)
+        } else {
+            None
+        };
+
+        Some((
+            Self {
+                super_segment_root,
+                fixed_parameters,
+                next_solution_range,
+                pot_parameters_change,
+            },
+            remainder,
+        ))
+    }
+
+    /// Hash of the block consensus parameters, part of the eventual block hash
+    pub fn hash(&self) -> Blake3Hash {
+        let Self {
+            super_segment_root,
+            fixed_parameters,
+            next_solution_range,
+            pot_parameters_change,
+        } = self;
+        let BlockHeaderFixedConsensusParameters {
+            solution_range,
+            pot_slot_iterations,
+        } = fixed_parameters;
+
+        // TODO: Keyed hash
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(solution_range.as_bytes());
+        hasher.update(&pot_slot_iterations.get().to_le_bytes());
+
+        if let Some(super_segment_root) = super_segment_root {
+            hasher.update(super_segment_root.as_bytes());
+        }
+        if let Some(next_solution_range) = next_solution_range {
+            hasher.update(next_solution_range.as_bytes());
+        }
+        if let Some(pot_parameters_change) = pot_parameters_change.copied() {
+            let BlockHeaderPotParametersChange {
+                slot,
+                slot_iterations,
+                entropy,
+            } = pot_parameters_change;
+            hasher.update(slot.as_bytes());
+            hasher.update(&slot_iterations.get().to_le_bytes());
+            hasher.update(entropy.as_bytes());
+        }
+
+        Blake3Hash::from(hasher.finalize())
+    }
+}
+
+/// Information about child shard block
+#[derive(Debug, Copy, Clone, TrivialType)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[repr(C)]
+pub struct BlockHeaderChildShardBlock {
+    /// Shard index
+    pub shard_index: ShardIndex,
+    // TODO: Is block number also needed?
+    /// Block hash
+    pub block_hash: BlockHash,
+}
+
+/// Information about child shard blocks
+#[derive(Debug, Copy, Clone, Deref)]
+pub struct BlockHeaderChildShardBlocks<'a> {
+    /// Child shards blocks
+    pub child_shard_blocks: &'a [BlockHeaderChildShardBlock],
+}
+
+impl<'a> BlockHeaderChildShardBlocks<'a> {
+    /// Create an instance from provided correctly aligned bytes.
+    ///
+    /// `bytes` should be 4-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // Layout here is as follows:
+        // * number of blocks: u16 as aligned little-endian bytes
+        // * padding: [0u8; 2]
+        // * for each block:
+        //   * child shard block: BlockHeaderChildShardBlock
+
+        let length = bytes.split_off(..size_of::<u16>())?;
+        // SAFETY: All bit patterns are valid
+        let length = *unsafe { <u16 as TrivialType>::from_bytes(length) }?;
+
+        let padding = bytes.split_off(..size_of::<[u8; 2]>())?;
+
+        // Padding must be zero
+        if padding != [0, 0] {
+            return None;
+        }
+
+        let child_shard_blocks = bytes.split_off(
+            ..usize::from(length).saturating_mul(BlockHeaderBeaconChainInfo::SIZE as usize),
+        )?;
+
+        // SAFETY: All bit patterns are valid for this data structure
+        let (before, child_shard_blocks, after) =
+            unsafe { child_shard_blocks.align_to::<BlockHeaderChildShardBlock>() };
+        let is_valid = before.is_empty()
+            && after.is_empty()
+            && child_shard_blocks
+                .iter()
+                .all(|item| item.shard_index.as_u32() <= ShardIndex::MAX_SHARD_INDEX);
+        if !is_valid {
+            return None;
+        }
+
+        Some((Self { child_shard_blocks }, bytes))
+    }
+
+    /// Compute Merkle Tree with child shard blocks, part of the eventual block hash.
+    ///
+    /// `None` is returned if there are no child shard blocks.
+    pub fn root(&self) -> Option<Blake3Hash> {
+        let root = UnbalancedHashedMerkleTree::compute_root_only::<'_, { u32::MAX as usize }, _, _>(
+            // TODO: Keyed hash
+            self.child_shard_blocks
+                .iter()
+                .map(|child_shard_block| blake3::hash(child_shard_block.as_bytes())),
+        )?;
+        Some(Blake3Hash::new(root))
+    }
+}
+
+/// Block header result.
+///
+/// The result contains information that can only be computed after the block was created.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, TrivialType)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[repr(C)]
+pub struct BlockHeaderResult {
+    /// Root of the block body
+    // TODO: New type
+    pub body_root: Blake3Hash,
+    /// Root of the state tree
+    // TODO: New type?
+    pub state_root: Blake3Hash,
+}
+
+impl BlockHeaderResult {
+    /// Hash of the block header result, part of the eventual block hash
+    pub fn hash(&self) -> Blake3Hash {
+        // TODO: Keyed hash
+        Blake3Hash::from(blake3::hash(self.as_bytes()))
+    }
+}
+
+/// Block header seal type
+#[derive(Debug, Copy, Clone, Eq, PartialEq, TrivialType)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[repr(u8)]
+pub enum BlockHeaderSealType {
+    /// Sr25519 signature
+    #[cfg_attr(feature = "scale-codec", codec(index = 0))]
+    Sr25519 = 0,
+}
+
+impl BlockHeaderSealType {
+    /// Create an instance from bytes if valid
+    #[inline(always)]
+    pub const fn try_from_byte(byte: u8) -> Option<Self> {
+        if byte == Self::Sr25519 as u8 {
+            Some(Self::Sr25519)
+        } else {
+            None
+        }
+    }
+}
+
+/// Sr25519 seal
+#[derive(Debug, Copy, Clone, Eq, PartialEq, TrivialType)]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(Encode, Decode, TypeInfo, MaxEncodedLen)
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[repr(C)]
+pub struct BlockHeaderSr25519Seal {
+    /// Sr25519 public key
+    /// TODO: Probably use constant from `schnorrkel`
+    pub public_key: [u8; 32],
+    /// Sr25519 signature
+    /// TODO: Probably use constant from `schnorrkel`
+    #[cfg_attr(feature = "serde", serde(with = "BigArray"))]
+    pub signature: [u8; 64],
+}
+
+/// Block header seal
+#[derive(Debug, Copy, Clone)]
+pub enum BlockHeaderSeal<'a> {
+    /// Sr25519 seal
+    Sr25519(&'a BlockHeaderSr25519Seal),
+}
+
+impl<'a> BlockHeaderSeal<'a> {
+    /// Create an instance from provided bytes.
+    ///
+    /// `bytes` do not need to be aligned.
+    ///
+    /// Returns an instance and remaining bytes on success.
+    #[inline]
+    pub fn try_from_bytes(mut bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * seal type: u8
+        // * seal (depends on a seal type): BlockHeaderSr25519Seal
+
+        let seal_type = bytes.split_off(..size_of::<u8>())?;
+        let seal_type = BlockHeaderSealType::try_from_byte(seal_type[0])?;
+
+        match seal_type {
+            BlockHeaderSealType::Sr25519 => {
+                let seal = bytes.split_off(..size_of::<BlockHeaderSr25519Seal>())?;
+                // SAFETY: All bit patterns are valid
+                let seal = unsafe { BlockHeaderSr25519Seal::from_bytes(seal) }?;
+                Some((Self::Sr25519(seal), bytes))
+            }
+        }
+    }
+
+    /// Hash of the block header seal, part of the eventual block hash
+    pub fn hash(&self) -> Blake3Hash {
+        match self {
+            BlockHeaderSeal::Sr25519(seal) => {
+                // TODO: Keyed hash
+                let mut hasher = blake3::Hasher::new();
+                hasher.update(&[BlockHeaderSealType::Sr25519 as u8]);
+                hasher.update(seal.as_bytes());
+
+                Blake3Hash::from(hasher.finalize())
+            }
+        }
+    }
+}
+
+/// Generic block header, shared for different kinds of shards
+#[derive(Debug, Copy, Clone)]
+pub struct GenericBlockHeader<'a> {
+    /// Block header prefix
+    pub prefix: &'a BlockHeaderPrefix,
+    /// Block header result
+    pub result: &'a BlockHeaderResult,
+    /// Consensus information
+    pub consensus_info: &'a BlockHeaderConsensusInfo,
+    /// Block header seal
+    pub seal: BlockHeaderSeal<'a>,
+}
+
+/// Block header that corresponds to the beacon chain
+#[derive(Debug, Copy, Clone)]
+pub struct BeaconChainBlockHeader<'a> {
+    /// Generic block header
+    pub generic: GenericBlockHeader<'a>,
+    /// Information about child shard blocks
+    pub child_shard_blocks: BlockHeaderChildShardBlocks<'a>,
+    /// Consensus parameters (on the beacon chain)
+    pub consensus_parameters: BlockHeaderBeaconChainParameters<'a>,
+}
+
+impl<'a> Deref for BeaconChainBlockHeader<'a> {
+    type Target = GenericBlockHeader<'a>;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.generic
+    }
+}
+
+impl<'a> BeaconChainBlockHeader<'a> {
+    /// Try to create a new instance from provided bytes.
+    ///
+    /// `bytes` should be 8-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * block header prefix: BlockHeaderPrefix
+        // * block header result: BlockHeaderResult
+        // * consensus info: BlockHeaderConsensusInfo
+        // * child shard blocks: BlockHeaderChildShardBlocks
+        // * beacon chain parameters: BlockHeaderBeaconChainParameters
+        // * block header seal: BlockHeaderSeal
+
+        let (prefix, consensus_info, result, remainder) =
+            BlockHeader::try_from_bytes_shared(bytes)?;
+
+        let (child_shard_blocks, remainder) =
+            BlockHeaderChildShardBlocks::try_from_bytes(remainder)?;
+
+        let (consensus_parameters, remainder) =
+            BlockHeaderBeaconChainParameters::try_from_bytes(remainder)?;
+
+        let (seal, remainder) = BlockHeaderSeal::try_from_bytes(remainder)?;
+
+        let generic = GenericBlockHeader {
+            prefix,
+            result,
+            consensus_info,
+            seal,
+        };
+
+        Some((
+            Self {
+                generic,
+                child_shard_blocks,
+                consensus_parameters,
+            },
+            remainder,
+        ))
+    }
+
+    /// Compute block hash out of this header.
+    ///
+    /// Block hash is actually a Merkle Tree Root. The leaves are derived from individual fields in
+    /// [`GenericBlockHeader`] and other fields of this enum in the declaration order.
+    ///
+    /// Note that this method does a bunch of hashing and if hash is needed often, should be cached.
+    // TODO: Cache hash internally
+    #[inline]
+    pub fn hash(&self) -> BlockHash {
+        let Self {
+            generic,
+            child_shard_blocks,
+            consensus_parameters,
+        } = self;
+        let GenericBlockHeader {
+            prefix,
+            result,
+            consensus_info,
+            seal,
+        } = generic;
+
+        const MAX_N: usize = 6;
+        let leaves: [_; MAX_N] = [
+            prefix.hash(),
+            result.hash(),
+            consensus_info.hash(),
+            seal.hash(),
+            child_shard_blocks.root().unwrap_or_default(),
+            consensus_parameters.hash(),
+        ];
+        let block_hash = UnbalancedHashedMerkleTree::compute_root_only::<MAX_N, _, _>(leaves)
+            .expect("The list is not empty; qed");
+
+        BlockHash::new(Blake3Hash::new(block_hash))
+    }
+}
+
+/// Block header that corresponds to an intermediate shard
+#[derive(Debug, Copy, Clone)]
+pub struct IntermediateShardBlockHeader<'a> {
+    /// Generic block header
+    pub generic: GenericBlockHeader<'a>,
+    /// Beacon chain info
+    pub beacon_chain_info: &'a BlockHeaderBeaconChainInfo,
+    /// Information about child shard blocks
+    pub child_shard_blocks: BlockHeaderChildShardBlocks<'a>,
+}
+
+impl<'a> Deref for IntermediateShardBlockHeader<'a> {
+    type Target = GenericBlockHeader<'a>;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.generic
+    }
+}
+
+impl<'a> IntermediateShardBlockHeader<'a> {
+    /// Try to create a new instance from provided bytes.
+    ///
+    /// `bytes` should be 8-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * block header prefix: BlockHeaderPrefix
+        // * block header result: BlockHeaderResult
+        // * consensus info: BlockHeaderConsensusInfo
+        // * beacon chain: BlockHeaderBeaconChainInfo
+        // * child shard blocks: BlockHeaderBeaconChainInfo
+        // * block header seal: BlockHeaderSeal
+
+        let (prefix, consensus_info, result, mut remainder) =
+            BlockHeader::try_from_bytes_shared(bytes)?;
+
+        let beacon_chain_info = remainder.split_off(..size_of::<BlockHeaderBeaconChainInfo>())?;
+        // SAFETY: All bit patterns are valid
+        let beacon_chain_info =
+            unsafe { BlockHeaderBeaconChainInfo::from_bytes(beacon_chain_info) }?;
+
+        let (child_shard_blocks, remainder) =
+            BlockHeaderChildShardBlocks::try_from_bytes(remainder)?;
+
+        let (seal, remainder) = BlockHeaderSeal::try_from_bytes(remainder)?;
+
+        let generic = GenericBlockHeader {
+            prefix,
+            result,
+            consensus_info,
+            seal,
+        };
+
+        Some((
+            Self {
+                generic,
+                beacon_chain_info,
+                child_shard_blocks,
+            },
+            remainder,
+        ))
+    }
+
+    /// Compute block hash out of this header.
+    ///
+    /// Block hash is actually a Merkle Tree Root. The leaves are derived from individual fields in
+    /// [`GenericBlockHeader`] and other fields of this enum in the declaration order.
+    ///
+    /// Note that this method does a bunch of hashing and if hash is needed often, should be cached.
+    // TODO: Cache hash internally
+    #[inline]
+    pub fn hash(&self) -> BlockHash {
+        let Self {
+            generic,
+            beacon_chain_info,
+            child_shard_blocks,
+        } = self;
+        let GenericBlockHeader {
+            prefix,
+            result,
+            consensus_info,
+            seal,
+        } = generic;
+
+        const MAX_N: usize = 6;
+        let leaves: [_; MAX_N] = [
+            prefix.hash(),
+            result.hash(),
+            consensus_info.hash(),
+            seal.hash(),
+            beacon_chain_info.hash(),
+            child_shard_blocks.root().unwrap_or_default(),
+        ];
+        let block_hash = UnbalancedHashedMerkleTree::compute_root_only::<MAX_N, _, _>(leaves)
+            .expect("The list is not empty; qed");
+
+        BlockHash::new(Blake3Hash::new(block_hash))
+    }
+}
+
+/// Block header that corresponds to a leaf shard
+#[derive(Debug, Copy, Clone)]
+pub struct LeafShardBlockHeader<'a> {
+    /// Generic block header
+    pub generic: GenericBlockHeader<'a>,
+    /// Beacon chain info
+    pub beacon_chain_info: &'a BlockHeaderBeaconChainInfo,
+}
+
+impl<'a> Deref for LeafShardBlockHeader<'a> {
+    type Target = GenericBlockHeader<'a>;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.generic
+    }
+}
+
+impl<'a> LeafShardBlockHeader<'a> {
+    /// Try to create a new instance from provided bytes.
+    ///
+    /// `bytes` should be 8-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<(Self, &'a [u8])> {
+        // The layout here is as follows:
+        // * block header result: BlockHeaderResult
+        // * block header prefix: BlockHeaderPrefix
+        // * consensus info: BlockHeaderConsensusInfo
+        // * beacon chain: BlockHeaderBeaconChainInfo
+        // * block header seal: BlockHeaderSeal
+
+        let (prefix, consensus_info, result, mut remainder) =
+            BlockHeader::try_from_bytes_shared(bytes)?;
+
+        let beacon_chain_info = remainder.split_off(..size_of::<BlockHeaderBeaconChainInfo>())?;
+        // SAFETY: All bit patterns are valid
+        let beacon_chain_info =
+            unsafe { BlockHeaderBeaconChainInfo::from_bytes(beacon_chain_info) }?;
+
+        let (seal, remainder) = BlockHeaderSeal::try_from_bytes(remainder)?;
+
+        let generic = GenericBlockHeader {
+            prefix,
+            result,
+            consensus_info,
+            seal,
+        };
+
+        Some((
+            Self {
+                generic,
+                beacon_chain_info,
+            },
+            remainder,
+        ))
+    }
+
+    /// Compute block hash out of this header.
+    ///
+    /// Block hash is actually a Merkle Tree Root. The leaves are derived from individual fields in
+    /// [`GenericBlockHeader`] and other fields of this enum in the declaration order.
+    ///
+    /// Note that this method does a bunch of hashing and if hash is needed often, should be cached.
+    // TODO: Cache hash internally
+    #[inline]
+    pub fn hash(&self) -> BlockHash {
+        let Self {
+            generic,
+            beacon_chain_info,
+        } = self;
+        let GenericBlockHeader {
+            prefix,
+            result,
+            consensus_info,
+            seal,
+        } = generic;
+
+        const MAX_N: usize = 5;
+        let leaves: [_; MAX_N] = [
+            prefix.hash(),
+            result.hash(),
+            consensus_info.hash(),
+            seal.hash(),
+            beacon_chain_info.hash(),
+        ];
+        let block_hash = UnbalancedHashedMerkleTree::compute_root_only::<MAX_N, _, _>(leaves)
+            .expect("The list is not empty; qed");
+
+        BlockHash::new(Blake3Hash::new(block_hash))
+    }
+}
+
+/// Block header that together with [`BlockBody`] form a [`Block`]
+///
+/// [`BlockBody`]: crate::block::body::BlockBody
+/// [`Block`]: crate::block::Block
+#[derive(Debug, Copy, Clone, From)]
+pub enum BlockHeader<'a> {
+    /// Block header corresponds to the beacon chain
+    BeaconChain(BeaconChainBlockHeader<'a>),
+    /// Block header corresponds to an intermediate shard
+    IntermediateShard(IntermediateShardBlockHeader<'a>),
+    /// Block header corresponds to a leaf shard
+    LeafShard(LeafShardBlockHeader<'a>),
+}
+
+impl<'a> Deref for BlockHeader<'a> {
+    type Target = GenericBlockHeader<'a>;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::BeaconChain(header) => header,
+            Self::IntermediateShard(header) => header,
+            Self::LeafShard(header) => header,
+        }
+    }
+}
+
+impl<'a> BlockHeader<'a> {
+    /// Try to create a new instance from provided bytes for provided shard index.
+    ///
+    /// `bytes` should be 8-bytes aligned.
+    ///
+    /// Returns an instance and remaining bytes on success, `None` if too few bytes were given,
+    /// bytes are not properly aligned or input is otherwise invalid.
+    #[inline]
+    pub fn try_from_bytes(bytes: &'a [u8], shard_kind: ShardKind) -> Option<(Self, &'a [u8])> {
+        match shard_kind {
+            ShardKind::BeaconChain => {
+                let (header, remainder) = BeaconChainBlockHeader::try_from_bytes(bytes)?;
+                Some((Self::BeaconChain(header), remainder))
+            }
+            ShardKind::IntermediateShard => {
+                let (header, remainder) = IntermediateShardBlockHeader::try_from_bytes(bytes)?;
+                Some((Self::IntermediateShard(header), remainder))
+            }
+            ShardKind::LeafShard => {
+                let (header, remainder) = LeafShardBlockHeader::try_from_bytes(bytes)?;
+                Some((Self::LeafShard(header), remainder))
+            }
+            ShardKind::Phantom | ShardKind::Invalid => {
+                // Blocks for such shards do not exist
+                None
+            }
+        }
+    }
+
+    #[inline]
+    fn try_from_bytes_shared(
+        mut bytes: &'a [u8],
+    ) -> Option<(
+        &'a BlockHeaderPrefix,
+        &'a BlockHeaderConsensusInfo,
+        &'a BlockHeaderResult,
+        &'a [u8],
+    )> {
+        let prefix = bytes.split_off(..size_of::<BlockHeaderPrefix>())?;
+        // SAFETY: All bit patterns are valid
+        let prefix = unsafe { BlockHeaderPrefix::from_bytes(prefix) }?;
+
+        if prefix.version != BlockHeaderPrefix::BLOCK_VERSION || prefix.padding != [0; _] {
+            return None;
+        }
+
+        let result = bytes.split_off(..size_of::<BlockHeaderResult>())?;
+        // SAFETY: All bit patterns are valid
+        let result = unsafe { BlockHeaderResult::from_bytes(result) }?;
+
+        let consensus_info = bytes.split_off(..size_of::<BlockHeaderConsensusInfo>())?;
+        // SAFETY: All bit patterns are valid
+        let consensus_info = unsafe { BlockHeaderConsensusInfo::from_bytes(consensus_info) }?;
+
+        if consensus_info.solution.padding != [0; _] {
+            return None;
+        }
+
+        Some((prefix, consensus_info, result, bytes))
+    }
+
+    /// Compute block hash out of this header.
+    ///
+    /// Block hash is actually a Merkle Tree Root. The leaves are derived from individual fields in
+    /// [`GenericBlockHeader`] and other fields of this enum in the declaration order.
+    ///
+    /// Note that this method does a bunch of hashing and if hash is needed often, should be cached.
+    #[inline]
+    pub fn hash(&self) -> BlockHash {
+        // TODO: Should unique keyed hash be used for different kinds of shards?
+        match self {
+            Self::BeaconChain(header) => header.hash(),
+            Self::IntermediateShard(header) => header.hash(),
+            Self::LeafShard(header) => header.hash(),
+        }
+    }
+}

--- a/crates/shared/ab-core-primitives/src/lib.rs
+++ b/crates/shared/ab-core-primitives/src/lib.rs
@@ -9,7 +9,8 @@
     generic_arg_infer,
     portable_simd,
     ptr_as_ref_unchecked,
-    step_trait
+    step_trait,
+    trusted_len
 )]
 #![cfg_attr(feature = "alloc", feature(new_zeroed_alloc))]
 #![expect(incomplete_features, reason = "generic_const_exprs")]

--- a/crates/shared/ab-core-primitives/src/shard.rs
+++ b/crates/shared/ab-core-primitives/src/shard.rs
@@ -10,6 +10,49 @@ use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// A kind of shard.
+///
+/// Schematically, the hierarchy of shards is as follows:
+/// ```text
+///                          Beacon chain
+///                          /          \
+///      Intermediate shard 1            Intermediate shard 2
+///              /  \                            /  \
+/// Leaf shard 11   Leaf shard 12   Leaf shard 22   Leaf shard 22
+/// ```
+///
+/// Beacon chain has index 0, intermediate shards indices 1..=1023. Leaf shards share the same least
+/// significant 10 bits as their respective intermediate shards, so leaf shards of intermediate
+/// shard 1 have indices like 1025,2049,3097,etc.
+///
+/// If represented as least significant bits first (as it will be in the formatted address):
+/// ```text
+/// Intermediate shard bits
+///     \            /
+///      1000_0000_0001_0000_0000
+///                 /            \
+///                Leaf shard bits
+/// ```
+///
+/// Note that shards that have 10 least significant bits set to 0 (corresponds to the beacon chain)
+/// are not leaf shards, in fact, they are not even physical shards that have nodes in general. The
+/// meaning of these shards is TBD, currently they are called "phantom" shards and may end up
+/// containing some system contracts with special meaning, but no blocks will ever exist for such
+/// shards.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum ShardKind {
+    /// Beacon chain shard
+    BeaconChain,
+    /// Intermediate shard directly below the beacon chain that has child shards
+    IntermediateShard,
+    /// Leaf shard, doesn't have child shards
+    LeafShard,
+    /// TODO
+    Phantom,
+    /// Invalid shard kind (if decoded from invalid bit pattern)
+    Invalid,
+}
+
 /// Shard index
 #[derive(Debug, Display, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, TrivialType)]
 #[cfg_attr(
@@ -53,5 +96,72 @@ impl ShardIndex {
     #[inline(always)]
     pub const fn as_u32(self) -> u32 {
         self.0
+    }
+
+    /// Whether the shard index corresponds to the beacon chain
+    #[inline(always)]
+    pub const fn is_beacon_chain(&self) -> bool {
+        self.0 == Self::BEACON_CHAIN.0
+    }
+
+    /// Whether the shard index corresponds to an intermediate shard
+    #[inline(always)]
+    pub const fn is_intermediate_shard(&self) -> bool {
+        self.0 >= 1 && self.0 <= 1023
+    }
+
+    /// Whether the shard index corresponds to an intermediate shard
+    #[inline(always)]
+    pub const fn is_leaf_shard(&self) -> bool {
+        if self.0 <= 1023 || self.0 > Self::MAX_SHARD_INDEX {
+            return false;
+        }
+
+        self.0 & 0b11_1111_1111 != 0
+    }
+
+    /// Whether the shard index corresponds to a phantom shard
+    #[inline(always)]
+    pub const fn is_phantom_shard(&self) -> bool {
+        if self.0 <= 1023 || self.0 > Self::MAX_SHARD_INDEX {
+            return false;
+        }
+
+        self.0 & 0b11_1111_1111 == 0
+    }
+
+    /// Check if this shard is a child shard of `parent`
+    #[inline]
+    pub const fn is_child_of(self, parent: Self) -> bool {
+        match self.shard_kind() {
+            ShardKind::BeaconChain => false,
+            ShardKind::IntermediateShard | ShardKind::Phantom => parent.is_beacon_chain(),
+            ShardKind::LeafShard => {
+                // Check that least significant bits match
+                self.0 & 0b11_1111_1111 == parent.0 & 0b11_1111_1111
+            }
+            ShardKind::Invalid => false,
+        }
+    }
+
+    /// Get shard kind
+    #[inline(always)]
+    pub const fn shard_kind(&self) -> ShardKind {
+        match self.0 {
+            0 => ShardKind::BeaconChain,
+            1..=1023 => ShardKind::IntermediateShard,
+            shard_index => {
+                if shard_index > Self::MAX_SHARD_INDEX {
+                    return ShardKind::Invalid;
+                }
+
+                // Check if least significant bits correspond to the beacon chain
+                if shard_index & 0b11_1111_1111 == 0 {
+                    ShardKind::Phantom
+                } else {
+                    ShardKind::LeafShard
+                }
+            }
+        }
     }
 }

--- a/crates/shared/ab-core-primitives/src/solutions.rs
+++ b/crates/shared/ab-core-primitives/src/solutions.rs
@@ -7,7 +7,6 @@ use crate::pos::{PosProof, PosSeed};
 use crate::pot::{PotOutput, SlotNumber};
 use crate::sectors::{SectorId, SectorIndex, SectorSlotChallenge};
 use crate::segments::{HistorySize, SegmentIndex, SegmentRoot};
-use crate::shard::ShardIndex;
 use ab_io_type::trivial_type::TrivialType;
 use ab_merkle_tree::balanced_hashed::BalancedHashedMerkleTree;
 use blake3::OUT_LEN;
@@ -448,13 +447,12 @@ pub struct Solution {
     pub proof_of_space: PosProof,
     /// Size of the blockchain history at the time of sector creation
     pub history_size: HistorySize,
-    // TODO: This might be the wrong type/field
-    /// Index of a shard for which sector was created
-    pub shard_index: ShardIndex,
     /// Index of the sector where the solution was found
     pub sector_index: SectorIndex,
     /// Pieces offset within sector
     pub piece_offset: PieceOffset,
+    /// Padding for data structure alignment
+    pub padding: [u8; 4],
 }
 
 impl Solution {
@@ -467,10 +465,10 @@ impl Solution {
             chunk: RecordChunk::default(),
             chunk_proof: ChunkProof::default(),
             proof_of_space: PosProof::default(),
-            shard_index: ShardIndex::BEACON_CHAIN,
             history_size: HistorySize::from(SegmentIndex::ZERO),
             sector_index: SectorIndex::ZERO,
             piece_offset: PieceOffset::default(),
+            padding: [0; _],
         }
     }
 

--- a/crates/shared/ab-core-primitives/src/transaction/owned/builder_buffer.rs
+++ b/crates/shared/ab-core-primitives/src/transaction/owned/builder_buffer.rs
@@ -1,4 +1,4 @@
-use crate::transaction::owned::{OwnedTransactionBuilderError, OwnedTransactionLengths};
+use crate::transaction::owned::{OwnedTransactionBuilderError, SerializedTransactionLengths};
 use crate::transaction::{TransactionHeader, TransactionSlot};
 use ab_aligned_buffer::OwnedAlignedBuffer;
 use ab_io_type::trivial_type::TrivialType;
@@ -13,24 +13,26 @@ impl BuilderBuffer {
     pub(super) fn new(header: &TransactionHeader) -> Self {
         const _: () = {
             // Writing `OwnedTransactionLengths` after `TransactionHeader` must be aligned
-            assert!(size_of::<TransactionHeader>() % align_of::<OwnedTransactionLengths>() == 0);
+            assert!(
+                size_of::<TransactionHeader>() % align_of::<SerializedTransactionLengths>() == 0
+            );
         };
         let mut buffer = OwnedAlignedBuffer::with_capacity(
-            TransactionHeader::SIZE + OwnedTransactionLengths::SIZE,
+            TransactionHeader::SIZE + SerializedTransactionLengths::SIZE,
         );
         // Always fits into `u32`
         let _: bool = buffer.append(header.as_bytes());
         // Always fits into `u32`
-        let _: bool = buffer.append(OwnedTransactionLengths::default().as_bytes());
+        let _: bool = buffer.append(SerializedTransactionLengths::default().as_bytes());
         Self { buffer }
     }
 
-    fn get_lengths(&mut self) -> &mut OwnedTransactionLengths {
+    fn get_lengths(&mut self) -> &mut SerializedTransactionLengths {
         unsafe {
             self.buffer
                 .as_mut_ptr()
                 .add(size_of::<TransactionHeader>())
-                .cast::<OwnedTransactionLengths>()
+                .cast::<SerializedTransactionLengths>()
                 .as_mut_unchecked()
         }
     }
@@ -55,7 +57,7 @@ impl BuilderBuffer {
             // Writing `TransactionSlot` after `OwnedTransactionLengths` and `TransactionHeader`
             // must be aligned
             assert!(
-                (size_of::<TransactionHeader>() + size_of::<OwnedTransactionLengths>())
+                (size_of::<TransactionHeader>() + size_of::<SerializedTransactionLengths>())
                     % align_of::<TransactionSlot>()
                     == 0
             );
@@ -91,7 +93,7 @@ impl BuilderBuffer {
             // Writing `TransactionSlot` after `OwnedTransactionLengths` and `TransactionHeader`
             // must be aligned
             assert!(
-                (size_of::<TransactionHeader>() + size_of::<OwnedTransactionLengths>())
+                (size_of::<TransactionHeader>() + size_of::<SerializedTransactionLengths>())
                     % align_of::<TransactionSlot>()
                     == 0
             );
@@ -127,13 +129,13 @@ impl BuilderBuffer {
             // Writing after `OwnedTransactionLengths`, `TransactionHeader` and (optionally)
             // `TransactionSlot` must be aligned to `u128`
             assert!(
-                (size_of::<TransactionHeader>() + size_of::<OwnedTransactionLengths>())
+                (size_of::<TransactionHeader>() + size_of::<SerializedTransactionLengths>())
                     % align_of::<u128>()
                     == 0
             );
             assert!(
                 (size_of::<TransactionHeader>()
-                    + size_of::<OwnedTransactionLengths>()
+                    + size_of::<SerializedTransactionLengths>()
                     + size_of::<TransactionSlot>())
                     % align_of::<u128>()
                     == 0
@@ -166,13 +168,13 @@ impl BuilderBuffer {
             // Writing after `OwnedTransactionLengths`, `TransactionHeader` and (optionally)
             // `TransactionSlot` must be aligned to `u128`
             assert!(
-                (size_of::<TransactionHeader>() + size_of::<OwnedTransactionLengths>())
+                (size_of::<TransactionHeader>() + size_of::<SerializedTransactionLengths>())
                     % align_of::<u128>()
                     == 0
             );
             assert!(
                 (size_of::<TransactionHeader>()
-                    + size_of::<OwnedTransactionLengths>()
+                    + size_of::<SerializedTransactionLengths>()
                     + size_of::<TransactionSlot>())
                     % align_of::<u128>()
                     == 0

--- a/crates/shared/ab-merkle-tree/src/balanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/src/balanced_hashed.rs
@@ -125,7 +125,7 @@ where
         }
     }
 
-    /// Compute Merkle Tree Root.
+    /// Compute Merkle Tree root.
     ///
     /// This is functionally equivalent to creating an instance first and calling [`Self::root()`]
     /// method, but is faster and avoids heap allocation when root is the only thing that is needed.

--- a/crates/shared/ab-merkle-tree/src/lib.rs
+++ b/crates/shared/ab-merkle-tree/src/lib.rs
@@ -21,6 +21,8 @@
 )]
 #![no_std]
 
+// TODO: Consider domains-specific internal node separator and inclusion of tree size into hashing
+//  key
 pub mod balanced_hashed;
 pub mod unbalanced_hashed;
 

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -9,7 +9,6 @@ use ab_core_primitives::sectors::SectorIndex;
 use ab_core_primitives::segments::{
     ArchivedBlockProgress, HistorySize, LastArchivedBlock, SegmentHeader, SegmentIndex, SegmentRoot,
 };
-use ab_core_primitives::shard::ShardIndex;
 use ab_core_primitives::solutions::{Solution, SolutionRange};
 use frame_support::traits::{ConstU128, OnInitialize};
 use frame_support::{derive_impl, parameter_types};
@@ -108,9 +107,9 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: SlotNumber) {
             chunk_proof: Default::default(),
             proof_of_space: Default::default(),
             history_size: HistorySize::from(SegmentIndex::ZERO),
-            shard_index: ShardIndex::BEACON_CHAIN,
             sector_index: SectorIndex::ZERO,
             piece_offset: PieceOffset::default(),
+            padding: [0; _],
         },
     );
 

--- a/subspace/crates/subspace-farmer-components/src/proving.rs
+++ b/subspace/crates/subspace-farmer-components/src/proving.rs
@@ -16,7 +16,6 @@ use ab_core_primitives::hashes::Blake3Hash;
 use ab_core_primitives::pieces::{PieceOffset, Record, RecordChunk};
 use ab_core_primitives::pos::PosSeed;
 use ab_core_primitives::sectors::{SBucket, SectorId};
-use ab_core_primitives::shard::ShardIndex;
 use ab_core_primitives::solutions::{ChunkProof, Solution, SolutionDistance};
 use ab_erasure_coding::ErasureCoding;
 use ab_merkle_tree::balanced_hashed::BalancedHashedMerkleTree;
@@ -285,10 +284,9 @@ where
                 chunk_proof: ChunkProof::from(chunk_proof),
                 proof_of_space,
                 history_size: self.sector_metadata.history_size,
-                // TODO: Set correct value
-                shard_index: ShardIndex::BEACON_CHAIN,
                 sector_index: self.sector_metadata.sector_index,
                 piece_offset,
+                padding: [0; _],
             }
         };
 


### PR DESCRIPTION
First few commits are preparation, the last one implements `Block`, `BlockHeader` and `BlockBody` that to the best of my knowledge right now, implement most of the things needed for hierarchical consensus.

Those data structures only provide the shape and ability to decode data structures from bytes. Builders and owned versions of the data structures will be added separately.

In general there are 4 flavors of each data structure:
* beacon chain
* intermediate shard
* leaf shard
* wrapper enum with 3 variants that correspond to above variants

Block header contains everything that might be needed by a light client for consensus verification. Block body contains PoT checkpoints, segment roots and child shards information alongside user transactions.

Information about child shards includes header, segment roots and a proof that confirms segment roots actually correspond to the header. I think this is about as much as we can check in that situation.

Both block header and body are actually Merkle Trees of Merkle Trees and hashes. This allows us to recursively prove and verify inclusion of things in the hierarchy. I was trying to structure the information in a way that will minimize proof size for common situations.

There are consistency checks for both block body and block as a whole, checking that certain internal properties (like child blocks in the header and in the body) match each other.

There is some inline documentation explaining the layout of various data structures, but not for layout of the proofs.

---

The only major thing missing right now is the information for non-happy path, but I don't have enough information to model that yet.

---

Naming-wise I'm wondering if `BlockHash` should be `BlockRoot` since it is not a plain hash anymore or would that be too weird? @adlrocha any opinion here?