### PR TITLE
Switch reward signature from Sr25519 to Ed25519

### DIFF
--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "blake3",
  "bytes",
  "derive_more 2.0.1",
+ "ed25519-zebra",
  "hex",
  "parity-scale-codec",
  "rayon",
@@ -9022,14 +9023,12 @@ dependencies = [
  "sc-proof-of-time",
  "sc-telemetry",
  "sc-utils",
- "schnorrkel",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
  "sp-consensus-subspace",
- "sp-core",
  "sp-inherents",
  "sp-runtime",
  "subspace-proof-of-space",
@@ -9062,7 +9061,6 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-subspace",
- "sp-core",
  "sp-runtime",
  "subspace-farmer-components",
  "subspace-networking",
@@ -11462,6 +11460,7 @@ dependencies = [
  "clap",
  "criterion",
  "derive_more 1.0.0",
+ "ed25519-zebra",
  "event-listener 5.3.1",
  "event-listener-primitives",
  "fdlimit",
@@ -11479,7 +11478,6 @@ dependencies = [
  "prometheus-client",
  "rand 0.8.5",
  "rayon",
- "schnorrkel",
  "serde",
  "serde_json",
  "ss58-registry",
@@ -11493,7 +11491,6 @@ dependencies = [
  "subspace-proof-of-space-gpu",
  "subspace-rpc-primitives",
  "subspace-verification",
- "substrate-bip39",
  "tempfile",
  "thiserror 2.0.12",
  "thread-priority",
@@ -11525,7 +11522,6 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "rayon",
- "schnorrkel",
  "serde",
  "static_assertions",
  "subspace-data-retrieval",
@@ -11784,7 +11780,6 @@ dependencies = [
  "sc-tracing",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
- "schnorrkel",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
@@ -11801,7 +11796,6 @@ dependencies = [
  "subspace-networking",
  "subspace-proof-of-space",
  "subspace-runtime-primitives",
- "subspace-verification",
  "substrate-prometheus-endpoint",
  "thiserror 2.0.12",
  "tokio",
@@ -11814,10 +11808,10 @@ version = "0.1.0"
 dependencies = [
  "ab-core-primitives",
  "derive_more 1.0.0",
+ "ed25519-zebra",
  "hex",
  "parity-scale-codec",
  "scale-info",
- "schnorrkel",
  "serde",
  "serde-big-array",
 ]
@@ -11825,8 +11819,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
+source = "git+https://github.com/subspace/polkadot-sdk?rev=d7b75f3d002f5f9bcd04da31cc8197d3a733de35#d7b75f3d002f5f9bcd04da31cc8197d3a733de35"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",

--- a/subspace/Cargo.toml
+++ b/subspace/Cargo.toml
@@ -32,6 +32,7 @@ clap = "4.5.18"
 core_affinity = "0.8.1"
 criterion = { version = "0.5.1", default-features = false }
 derive_more = { version = "1.0.0", default-features = false }
+ed25519-zebra = { version = "4.0.3", default-features = false }
 event-listener = "5.3.1"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.3.0"
@@ -144,7 +145,6 @@ subspace-runtime = { version = "0.1.0", path = "crates/subspace-runtime" }
 subspace-runtime-primitives = { version = "0.1.0", path = "crates/subspace-runtime-primitives", default-features = false }
 subspace-service = { version = "0.1.0", path = "crates/subspace-service" }
 subspace-verification = { version = "0.1.0", path = "crates/subspace-verification", default-features = false }
-substrate-bip39 = "0.6.0"
 substrate-build-script-utils = { git = "https://github.com/subspace/polkadot-sdk", rev = "d7b75f3d002f5f9bcd04da31cc8197d3a733de35" }
 substrate-prometheus-endpoint = { git = "https://github.com/subspace/polkadot-sdk", rev = "d7b75f3d002f5f9bcd04da31cc8197d3a733de35" }
 substrate-wasm-builder = { git = "https://github.com/subspace/polkadot-sdk", rev = "d7b75f3d002f5f9bcd04da31cc8197d3a733de35" }
@@ -225,10 +225,6 @@ panic = "unwind"
 [profile.production]
 inherits = "release"
 lto = "fat"
-
-[patch."https://github.com/subspace/polkadot-sdk.git"]
-# De-duplicate extra copy that comes from Substrate repo
-substrate-bip39 = "0.6.0"
 
 [patch.crates-io]
 # TODO: Remove once https://github.com/KokaKiwi/rust-hex/pull/58 is released (0.4.4+)

--- a/subspace/crates/pallet-subspace/src/mock.rs
+++ b/subspace/crates/pallet-subspace/src/mock.rs
@@ -20,7 +20,7 @@ use sp_runtime::testing::{Digest, DigestItem, TestXt};
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use subspace_runtime_primitives::ConsensusEventSegmentSize;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 type Balance = u128;
@@ -100,7 +100,7 @@ pub fn go_to_block(keypair: &Keypair, block: u64, slot: SlotNumber) {
     let pre_digest = make_pre_digest(
         slot,
         Solution {
-            public_key_hash: PublicKey::from(keypair.public.to_bytes()).hash(),
+            public_key_hash: Ed25519PublicKey::from(keypair.public.to_bytes()).hash(),
             record_root: Default::default(),
             record_proof: Default::default(),
             chunk,

--- a/subspace/crates/sc-consensus-subspace-rpc/Cargo.toml
+++ b/subspace/crates/sc-consensus-subspace-rpc/Cargo.toml
@@ -32,7 +32,6 @@ sp-api = { workspace = true }
 sp-consensus = { workspace = true }
 sp-consensus-subspace = { workspace = true }
 sp-blockchain = { workspace = true }
-sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 subspace-farmer-components = { workspace = true }
 subspace-networking = { workspace = true }

--- a/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
+++ b/subspace/crates/sc-consensus-subspace-rpc/src/lib.rs
@@ -4,6 +4,7 @@
 
 use ab_archiving::archiver::NewArchivedSegment;
 use ab_core_primitives::block::BlockRoot;
+use ab_core_primitives::hashes::Blake3Hash;
 use ab_core_primitives::pieces::{Piece, PieceIndex};
 use ab_core_primitives::pot::SlotNumber;
 use ab_core_primitives::segments::{HistorySize, SegmentHeader, SegmentIndex};
@@ -33,7 +34,6 @@ use sp_api::{ApiError, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_consensus::SyncOracle;
 use sp_consensus_subspace::{ChainConstants, SubspaceApi};
-use sp_core::H256;
 use sp_runtime::traits::Block as BlockT;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -146,7 +146,7 @@ struct ArchivedSegmentHeaderAcknowledgementSenders {
 
 #[derive(Default)]
 struct BlockSignatureSenders {
-    current_hash: H256,
+    current_hash: Blake3Hash,
     senders: Vec<async_oneshot::Sender<RewardSignatureResponse>>,
 }
 
@@ -487,7 +487,7 @@ where
 
                 // This will be sent to the farmer
                 RewardSigningInfo {
-                    hash: hash.into(),
+                    hash,
                     public_key_hash,
                 }
             },
@@ -515,7 +515,7 @@ where
         //  multiple (https://github.com/paritytech/jsonrpsee/issues/452)
         let mut reward_signature_senders = reward_signature_senders.lock();
 
-        if reward_signature_senders.current_hash == reward_signature.hash.into()
+        if reward_signature_senders.current_hash == reward_signature.hash
             && let Some(mut sender) = reward_signature_senders.senders.pop()
         {
             let _ = sender.send(reward_signature);

--- a/subspace/crates/sc-consensus-subspace/Cargo.toml
+++ b/subspace/crates/sc-consensus-subspace/Cargo.toml
@@ -23,7 +23,6 @@ parking_lot = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
-schnorrkel = { workspace = true }
 sc-client-api = { workspace = true }
 sc-consensus = { workspace = true }
 sc-consensus-slots = { workspace = true }
@@ -36,7 +35,6 @@ sp-block-builder = { workspace = true, features = ["std"] }
 sp-consensus = { workspace = true }
 sp-consensus-subspace = { workspace = true, features = ["std"] }
 sp-consensus-slots = { workspace = true }
-sp-core = { workspace = true }
 sp-inherents = { workspace = true }
 sp-runtime = { workspace = true }
 subspace-proof-of-space = { workspace = true }

--- a/subspace/crates/sp-consensus-subspace/src/digests.rs
+++ b/subspace/crates/sp-consensus-subspace/src/digests.rs
@@ -13,7 +13,7 @@ use log::trace;
 use parity_scale_codec::{Decode, Encode};
 use sp_runtime::DigestItem;
 use sp_runtime::traits::{Header as HeaderT, One, Zero};
-use subspace_verification::sr25519::RewardSignature;
+use subspace_verification::ed25519::RewardSignature;
 
 /// A Subspace pre-runtime digest. This contains all data required to validate a block and for the
 /// Subspace runtime module.

--- a/subspace/crates/subspace-farmer-components/Cargo.toml
+++ b/subspace/crates/subspace-farmer-components/Cargo.toml
@@ -62,6 +62,5 @@ winapi = "0.3.9"
 [dev-dependencies]
 criterion = { workspace = true }
 futures = { workspace = true }
-schnorrkel = { workspace = true }
 subspace-proof-of-space = { workspace = true }
 subspace-verification = { workspace = true }

--- a/subspace/crates/subspace-farmer-components/benches/auditing.rs
+++ b/subspace/crates/subspace-farmer-components/benches/auditing.rs
@@ -23,7 +23,7 @@ use subspace_farmer_components::sector::{
 };
 use subspace_proof_of_space::Table;
 use subspace_proof_of_space::chia::ChiaTable;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 
 type PosTable = ChiaTable;
 
@@ -44,7 +44,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .map(|sectors_count| sectors_count.parse().unwrap())
         .unwrap_or(10);
 
-    let public_key = &PublicKey::default();
+    let public_key = &Ed25519PublicKey::default();
     let public_key_hash = &public_key.hash();
     let sector_index = SectorIndex::ZERO;
     let mut input = RecordedHistorySegment::new_boxed();

--- a/subspace/crates/subspace-farmer-components/benches/plotting.rs
+++ b/subspace/crates/subspace-farmer-components/benches/plotting.rs
@@ -12,7 +12,7 @@ use subspace_farmer_components::plotting::{CpuRecordsEncoder, PlotSectorOptions,
 use subspace_farmer_components::sector::sector_size;
 use subspace_proof_of_space::Table;
 use subspace_proof_of_space::chia::ChiaTable;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 
 type PosTable = ChiaTable;
 
@@ -24,7 +24,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         .map(|base_path| base_path.parse().unwrap())
         .unwrap_or_else(|_error| MAX_PIECES_IN_SECTOR);
 
-    let public_key = PublicKey::default();
+    let public_key = Ed25519PublicKey::default();
     let public_key_hash = &public_key.hash();
     let sector_index = SectorIndex::ZERO;
     let mut input = RecordedHistorySegment::new_boxed();

--- a/subspace/crates/subspace-farmer-components/benches/proving.rs
+++ b/subspace/crates/subspace-farmer-components/benches/proving.rs
@@ -11,7 +11,6 @@ use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, cr
 use futures::executor::block_on;
 use parking_lot::Mutex;
 use rand::prelude::*;
-use schnorrkel::Keypair;
 use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -29,7 +28,7 @@ use subspace_farmer_components::sector::{
 };
 use subspace_proof_of_space::chia::ChiaTable;
 use subspace_proof_of_space::{Table, TableGenerator};
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 
 type PosTable = ChiaTable;
 
@@ -50,8 +49,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .map(|sectors_count| sectors_count.parse().unwrap())
         .unwrap_or(10);
 
-    let keypair = Keypair::from_bytes(&[0; 96]).unwrap();
-    let public_key = &PublicKey::from(keypair.public.to_bytes());
+    let public_key = &Ed25519PublicKey::default();
     let public_key_hash = &public_key.hash();
     let sector_index = SectorIndex::ZERO;
     let mut input = RecordedHistorySegment::new_boxed();

--- a/subspace/crates/subspace-farmer-components/benches/reading.rs
+++ b/subspace/crates/subspace-farmer-components/benches/reading.rs
@@ -23,7 +23,7 @@ use subspace_farmer_components::sector::{
 use subspace_farmer_components::{FarmerProtocolInfo, ReadAt, ReadAtSync};
 use subspace_proof_of_space::Table;
 use subspace_proof_of_space::chia::ChiaTable;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 
 type PosTable = ChiaTable;
 
@@ -44,7 +44,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .map(|sectors_count| sectors_count.parse().unwrap())
         .unwrap_or(10);
 
-    let public_key = PublicKey::default();
+    let public_key = Ed25519PublicKey::default();
     let public_key_hash = &public_key.hash();
     let sector_index = SectorIndex::ZERO;
     let mut input = RecordedHistorySegment::new_boxed();

--- a/subspace/crates/subspace-farmer/Cargo.toml
+++ b/subspace/crates/subspace-farmer/Cargo.toml
@@ -31,6 +31,7 @@ bytesize = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 criterion = { workspace = true, features = ["rayon", "async"], optional = true }
 derive_more = { workspace = true, features = ["full"] }
+ed25519-zebra = { workspace = true }
 event-listener = { workspace = true }
 event-listener-primitives = { workspace = true }
 fdlimit = { workspace = true, optional = true }
@@ -48,7 +49,6 @@ pin-project = { workspace = true }
 prometheus-client = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-schnorrkel = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
@@ -62,7 +62,6 @@ subspace-proof-of-space = { workspace = true }
 subspace-proof-of-space-gpu = { workspace = true, optional = true }
 subspace-rpc-primitives = { workspace = true }
 subspace-verification = { workspace = true }
-substrate-bip39 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 thread-priority = { workspace = true }

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/controller.rs
@@ -125,7 +125,7 @@ pub(super) async fn controller(
 
     let identity = Identity::open_or_create(&base_path)
         .map_err(|error| anyhow!("Failed to open or create identity: {error}"))?;
-    let keypair = derive_libp2p_keypair(identity.secret_key());
+    let keypair = derive_libp2p_keypair(&identity);
     let peer_id = keypair.public().to_peer_id();
     let instance = peer_id.to_string();
 

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -33,7 +33,7 @@ use subspace_farmer::utils::{
 };
 use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_proof_of_space::Table;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 use tracing::{Instrument, error, info, info_span, warn};
 
 const FARM_ERROR_PRINT_INTERVAL: Duration = Duration::from_secs(30);
@@ -60,7 +60,7 @@ pub(super) struct FarmerArgs {
     disk_farms: Vec<DiskFarm>,
     /// Address for farming rewards
     #[arg(long, value_parser = parse_ss58_reward_address)]
-    reward_address: Option<PublicKey>,
+    reward_address: Option<Ed25519PublicKey>,
     /// Sets some flags that are convenient during development, currently `--reward-address` (if
     /// not specified explicitly)
     #[arg(long)]
@@ -158,7 +158,7 @@ where
         None => {
             if dev {
                 // `//Alice`
-                PublicKey::from([
+                Ed25519PublicKey::from([
                     0xd4, 0x35, 0x93, 0xc7, 0x15, 0xfd, 0xd3, 0x1c, 0x61, 0x14, 0x1a, 0xbd, 0x04,
                     0xa9, 0x9f, 0xd6, 0x82, 0x2c, 0x85, 0x58, 0x85, 0x4c, 0xcd, 0xe3, 0x9a, 0x56,
                     0x84, 0xe7, 0xa5, 0x6d, 0xa2, 0x7d,

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -51,7 +51,7 @@ use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_metrics::{RegistryAdapter, start_prometheus_metrics_server};
 use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_proof_of_space::Table;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 use tracing::{Instrument, error, info, info_span, warn};
 
 /// Get piece retry attempts number.
@@ -202,7 +202,7 @@ pub(crate) struct FarmingArgs {
     node_rpc_url: String,
     /// Address for farming rewards
     #[arg(long, value_parser = parse_ss58_reward_address)]
-    reward_address: Option<PublicKey>,
+    reward_address: Option<Ed25519PublicKey>,
     /// Percentage of allocated space dedicated for caching purposes, 99% max
     #[arg(long, default_value = "1", value_parser = cache_percentage_parser)]
     cache_percentage: NonZeroU8,
@@ -343,7 +343,7 @@ where
         None => {
             if dev {
                 // `//Alice`
-                PublicKey::from([
+                Ed25519PublicKey::from([
                     0xd4, 0x35, 0x93, 0xc7, 0x15, 0xfd, 0xd3, 0x1c, 0x61, 0x14, 0x1a, 0xbd, 0x04,
                     0xa9, 0x9f, 0xd6, 0x82, 0x2c, 0x85, 0x58, 0x85, 0x4c, 0xcd, 0xe3, 0x9a, 0x56,
                     0x84, 0xe7, 0xa5, 0x6d, 0xa2, 0x7d,
@@ -416,7 +416,7 @@ where
                 )
             })?
     };
-    let keypair = derive_libp2p_keypair(identity.secret_key());
+    let keypair = derive_libp2p_keypair(&identity);
     let peer_id = keypair.public().to_peer_id();
 
     let mut registry = Registry::with_prefix("subspace_farmer");

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared.rs
@@ -5,11 +5,11 @@ use clap::Parser;
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
+use subspace_farmer::single_disk_farm::identity::Identity;
 use subspace_farmer::single_disk_farm::{SingleDiskFarm, SingleDiskFarmSummary};
 use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_networking::libp2p::identity::{Keypair, ed25519};
 use thread_priority::ThreadPriority;
-use zeroize::Zeroizing;
 
 /// Plotting thread priority
 #[derive(Debug, Parser, Copy, Clone)]
@@ -133,11 +133,9 @@ impl FromStr for DiskFarm {
     }
 }
 
-pub(in super::super) fn derive_libp2p_keypair(schnorrkel_sk: &schnorrkel::SecretKey) -> Keypair {
-    let mut secret_bytes = Zeroizing::new(schnorrkel_sk.to_ed25519_bytes());
-
+pub(in super::super) fn derive_libp2p_keypair(identity: &Identity) -> Keypair {
     let keypair = ed25519::Keypair::from(
-        ed25519::SecretKey::try_from_bytes(&mut secret_bytes.as_mut()[..32])
+        ed25519::SecretKey::try_from_bytes(&mut identity.secret_key())
             .expect("Secret key is exactly 32 bytes in size; qed"),
     );
 

--- a/subspace/crates/subspace-farmer/src/cluster/plotter.rs
+++ b/subspace/crates/subspace-farmer/src/cluster/plotter.rs
@@ -33,7 +33,7 @@ use std::time::{Duration, Instant};
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::sector::sector_size;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time::MissedTickBehavior;
 use tracing::{Instrument, debug, info, info_span, trace, warn};
@@ -107,7 +107,7 @@ enum ClusterSectorPlottingProgress {
 /// Request to plot sector from plotter
 #[derive(Debug, Clone, Encode, Decode)]
 struct ClusterPlotterPlotSectorRequest {
-    public_key: PublicKey,
+    public_key: Ed25519PublicKey,
     sector_index: SectorIndex,
     farmer_protocol_info: FarmerProtocolInfo,
     pieces_in_sector: u16,
@@ -120,7 +120,7 @@ impl GenericStreamRequest for ClusterPlotterPlotSectorRequest {
 
 #[derive(Default, Debug)]
 struct Handlers {
-    plotting_progress: Handler3<PublicKey, SectorIndex, SectorPlottingProgress>,
+    plotting_progress: Handler3<Ed25519PublicKey, SectorIndex, SectorPlottingProgress>,
 }
 
 /// Cluster plotter
@@ -155,7 +155,7 @@ impl Plotter for ClusterPlotter {
 
     async fn plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -207,7 +207,7 @@ impl Plotter for ClusterPlotter {
 
     async fn try_plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -287,7 +287,7 @@ impl ClusterPlotter {
     /// Subscribe to plotting progress notifications
     pub fn on_plotting_progress(
         &self,
-        callback: HandlerFn3<PublicKey, SectorIndex, SectorPlottingProgress>,
+        callback: HandlerFn3<Ed25519PublicKey, SectorIndex, SectorPlottingProgress>,
     ) -> HandlerId {
         self.handlers.plotting_progress.add(callback)
     }
@@ -297,7 +297,7 @@ impl ClusterPlotter {
         &self,
         start: Instant,
         sector_encoding_permit: OwnedSemaphorePermit,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -686,7 +686,7 @@ where
 }
 
 struct ProgressUpdater {
-    public_key: PublicKey,
+    public_key: Ed25519PublicKey,
     sector_index: SectorIndex,
     handlers: Arc<Handlers>,
 }

--- a/subspace/crates/subspace-farmer/src/plotter.rs
+++ b/subspace/crates/subspace-farmer/src/plotter.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_farmer_components::plotting::PlottedSector;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 
 /// Sector plotting progress
 pub enum SectorPlottingProgress {
@@ -90,7 +90,7 @@ pub trait Plotter: fmt::Debug {
     /// Future returns once plotting is successfully scheduled (for backpressure purposes).
     async fn plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -104,7 +104,7 @@ pub trait Plotter: fmt::Debug {
     /// plotting immediately.
     async fn try_plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -126,7 +126,7 @@ where
     #[inline]
     async fn plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -148,7 +148,7 @@ where
     #[inline]
     async fn try_plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,

--- a/subspace/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/subspace/crates/subspace-farmer/src/plotter/cpu.rs
@@ -34,7 +34,7 @@ use subspace_farmer_components::plotting::{
     encode_sector, write_sector,
 };
 use subspace_proof_of_space::Table;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 use tokio::task::yield_now;
 use tracing::{Instrument, warn};
 
@@ -44,7 +44,7 @@ type Handler3<A, B, C> = Bag<HandlerFn3<A, B, C>, A, B, C>;
 
 #[derive(Default, Debug)]
 struct Handlers {
-    plotting_progress: Handler3<PublicKey, SectorIndex, SectorPlottingProgress>,
+    plotting_progress: Handler3<Ed25519PublicKey, SectorIndex, SectorPlottingProgress>,
 }
 
 /// CPU plotter
@@ -90,7 +90,7 @@ where
 
     async fn plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -118,7 +118,7 @@ where
 
     async fn try_plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -219,7 +219,7 @@ where
     /// Subscribe to plotting progress notifications
     pub fn on_plotting_progress(
         &self,
-        callback: HandlerFn3<PublicKey, SectorIndex, SectorPlottingProgress>,
+        callback: HandlerFn3<Ed25519PublicKey, SectorIndex, SectorPlottingProgress>,
     ) -> HandlerId {
         self.handlers.plotting_progress.add(callback)
     }
@@ -229,7 +229,7 @@ where
         &self,
         start: Instant,
         downloading_permit: SemaphoreGuardArc,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -459,7 +459,7 @@ where
 }
 
 struct ProgressUpdater {
-    public_key: PublicKey,
+    public_key: Ed25519PublicKey,
     sector_index: SectorIndex,
     handlers: Arc<Handlers>,
     metrics: Option<Arc<CpuPlotterMetrics>>,

--- a/subspace/crates/subspace-farmer/src/plotter/gpu.rs
+++ b/subspace/crates/subspace-farmer/src/plotter/gpu.rs
@@ -36,7 +36,7 @@ use subspace_farmer_components::plotting::{
     DownloadSectorOptions, EncodeSectorOptions, PlottingError, RecordsEncoder, download_sector,
     encode_sector, write_sector,
 };
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 use tokio::task::yield_now;
 use tracing::{Instrument, warn};
 
@@ -46,7 +46,7 @@ type Handler3<A, B, C> = Bag<HandlerFn3<A, B, C>, A, B, C>;
 
 #[derive(Default, Debug)]
 struct Handlers {
-    plotting_progress: Handler3<PublicKey, SectorIndex, SectorPlottingProgress>,
+    plotting_progress: Handler3<Ed25519PublicKey, SectorIndex, SectorPlottingProgress>,
 }
 
 /// GPU-specific [`RecordsEncoder`] with extra APIs
@@ -100,7 +100,7 @@ where
 
     async fn plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -127,7 +127,7 @@ where
 
     async fn try_plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -226,7 +226,7 @@ where
     /// Subscribe to plotting progress notifications
     pub fn on_plotting_progress(
         &self,
-        callback: HandlerFn3<PublicKey, SectorIndex, SectorPlottingProgress>,
+        callback: HandlerFn3<Ed25519PublicKey, SectorIndex, SectorPlottingProgress>,
     ) -> HandlerId {
         self.handlers.plotting_progress.add(callback)
     }
@@ -236,7 +236,7 @@ where
         &self,
         start: Instant,
         downloading_permit: SemaphoreGuardArc,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -447,7 +447,7 @@ where
 }
 
 struct ProgressUpdater {
-    public_key: PublicKey,
+    public_key: Ed25519PublicKey,
     sector_index: SectorIndex,
     handlers: Arc<Handlers>,
     metrics: Option<Arc<GpuPlotterMetrics>>,

--- a/subspace/crates/subspace-farmer/src/plotter/pool.rs
+++ b/subspace/crates/subspace-farmer/src/plotter/pool.rs
@@ -10,7 +10,7 @@ use std::any::type_name_of_val;
 use std::pin::pin;
 use std::time::Duration;
 use subspace_farmer_components::FarmerProtocolInfo;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 use tracing::{error, trace};
 
 /// Pool plotter.
@@ -50,7 +50,7 @@ impl Plotter for PoolPlotter {
 
     async fn plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,
@@ -89,7 +89,7 @@ impl Plotter for PoolPlotter {
 
     async fn try_plot_sector(
         &self,
-        public_key: PublicKey,
+        public_key: Ed25519PublicKey,
         sector_index: SectorIndex,
         farmer_protocol_info: FarmerProtocolInfo,
         pieces_in_sector: u16,

--- a/subspace/crates/subspace-farmer/src/single_disk_farm/farming.rs
+++ b/subspace/crates/subspace-farmer/src/single_disk_farm/farming.rs
@@ -33,7 +33,7 @@ use subspace_farmer_components::reading::ReadSectorRecordChunksMode;
 use subspace_farmer_components::sector::{SectorMetadata, SectorMetadataChecksummed};
 use subspace_proof_of_space::{Table, TableGenerator};
 use subspace_rpc_primitives::{SlotInfo, SolutionResponse};
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 use tracing::{Span, debug, error, info, trace, warn};
 
 /// How many non-fatal errors should happen in a row before farm is considered non-operational
@@ -197,7 +197,7 @@ pub(super) struct FarmingOptions<NC, PlotAudit> {
         dead_code,
         reason = "Reward address was removed from `Solution` and will need to be re-introduced later"
     )]
-    pub(super) reward_address: PublicKey,
+    pub(super) reward_address: Ed25519PublicKey,
     pub(super) node_client: NC,
     pub(super) plot_audit: PlotAudit,
     pub(super) sectors_metadata: Arc<AsyncRwLock<Vec<SectorMetadataChecksummed>>>,

--- a/subspace/crates/subspace-farmer/src/single_disk_farm/plotting.rs
+++ b/subspace/crates/subspace-farmer/src/single_disk_farm/plotting.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 use subspace_farmer_components::file_ext::FileExt;
 use subspace_farmer_components::plotting::PlottedSector;
 use subspace_farmer_components::sector::SectorMetadataChecksummed;
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 use thiserror::Error;
 use tokio::sync::watch;
 use tokio::task;
@@ -84,7 +84,7 @@ pub enum PlottingError {
 }
 
 pub(super) struct SectorPlottingOptions<'a, NC> {
-    pub(super) public_key: PublicKey,
+    pub(super) public_key: Ed25519PublicKey,
     pub(super) node_client: &'a NC,
     pub(super) pieces_in_sector: u16,
     pub(super) sector_size: usize,

--- a/subspace/crates/subspace-node/src/chain_spec.rs
+++ b/subspace/crates/subspace-node/src/chain_spec.rs
@@ -14,7 +14,7 @@ use subspace_runtime::{
     SudoConfig, SystemConfig, WASM_BINARY,
 };
 use subspace_runtime_primitives::{AccountId, Balance, SLOT_PROBABILITY, SSC};
-use subspace_verification::sr25519::PublicKey;
+use subspace_verification::ed25519::Ed25519PublicKey;
 
 // We assume initial plot size starts with a single sector.
 const INITIAL_SOLUTION_RANGE: SolutionRange = SolutionRange::from_pieces(1000, SLOT_PROBABILITY);
@@ -57,7 +57,7 @@ pub fn mainnet_compiled() -> Result<GenericChainSpec, String> {
             balances,
             GenesisParams {
                 allow_authoring_by: AllowAuthoringBy::RootFarmer(
-                    PublicKey::from(hex_literal::hex!(
+                    Ed25519PublicKey::from(hex_literal::hex!(
                         "e6a489dab63b650cf475431fc46649f4256167443fea241fca0bb3f86b29837a"
                     ))
                     .hash(),

--- a/subspace/crates/subspace-rpc-primitives/src/lib.rs
+++ b/subspace/crates/subspace-rpc-primitives/src/lib.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use subspace_farmer_components::FarmerProtocolInfo;
 use subspace_networking::libp2p::Multiaddr;
-use subspace_verification::sr25519::RewardSignature;
+use subspace_verification::ed25519::RewardSignature;
 
 /// Defines a limit for number of segments that can be requested over RPC
 pub const MAX_SEGMENT_HEADERS_PER_REQUEST: usize = 1000;
@@ -122,8 +122,7 @@ pub struct SolutionResponse {
 #[serde(rename_all = "camelCase")]
 pub struct RewardSigningInfo {
     /// Hash to be signed.
-    #[serde(with = "hex")]
-    pub hash: [u8; 32],
+    pub hash: Blake3Hash,
     /// Public key hash of the plot identity that should create signature.
     pub public_key_hash: Blake3Hash,
 }
@@ -133,8 +132,7 @@ pub struct RewardSigningInfo {
 #[serde(rename_all = "camelCase")]
 pub struct RewardSignatureResponse {
     /// Hash that was signed.
-    #[serde(with = "hex")]
-    pub hash: [u8; 32],
+    pub hash: Blake3Hash,
     /// Pre-header or vote hash signature.
     pub signature: Option<RewardSignature>,
 }

--- a/subspace/crates/subspace-service/Cargo.toml
+++ b/subspace/crates/subspace-service/Cargo.toml
@@ -47,7 +47,6 @@ sc-service = { workspace = true }
 sc-tracing = { workspace = true }
 sc-transaction-pool = { workspace = true }
 sc-transaction-pool-api = { workspace = true }
-schnorrkel = { workspace = true }
 sp-api = { workspace = true }
 sp-blockchain = { workspace = true }
 sp-block-builder = { workspace = true }
@@ -64,7 +63,6 @@ subspace-data-retrieval = { workspace = true }
 subspace-networking = { workspace = true }
 subspace-proof-of-space = { workspace = true }
 subspace-runtime-primitives = { workspace = true }
-subspace-verification = { workspace = true }
 sc-subspace-sync-common = { workspace = true }
 substrate-prometheus-endpoint = { workspace = true }
 thiserror = { workspace = true }

--- a/subspace/crates/subspace-service/src/lib.rs
+++ b/subspace/crates/subspace-service/src/lib.rs
@@ -82,7 +82,6 @@ use subspace_networking::utils::piece_provider::PieceProvider;
 use subspace_proof_of_space::Table;
 use subspace_runtime_primitives::opaque::Block;
 use subspace_runtime_primitives::{AccountId, Balance, Nonce};
-use subspace_verification::sr25519::REWARD_SIGNING_CONTEXT;
 use tokio::sync::broadcast;
 use tracing::{Instrument, debug, error, info};
 pub use utils::wait_for_block_import;
@@ -331,7 +330,6 @@ where
     let verifier = SubspaceVerifier::<PosTable, _, _>::new(SubspaceVerifierOptions {
         client: client.clone(),
         chain_constants,
-        reward_signing_context: schnorrkel::context::signing_context(REWARD_SIGNING_CONTEXT),
         sync_target_block_number: Arc::clone(&sync_target_block_number),
         is_authoring_blocks: config.role.is_authority(),
         pot_verifier: pot_verifier.clone(),

--- a/subspace/crates/subspace-verification/Cargo.toml
+++ b/subspace/crates/subspace-verification/Cargo.toml
@@ -16,10 +16,10 @@ include = [
 [dependencies]
 ab-core-primitives = { workspace = true }
 derive_more = { workspace = true, features = ["deref", "from", "into"] }
+ed25519-zebra = { workspace = true }
 hex = { workspace = true, optional = true }
 parity-scale-codec = { workspace = true, features = ["bytes", "derive", "max-encoded-len"], optional = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }
-schnorrkel = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde-big-array = { workspace = true }
 

--- a/subspace/crates/subspace-verification/src/ed25519.rs
+++ b/subspace/crates/subspace-verification/src/ed25519.rs
@@ -12,15 +12,12 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde")]
 use serde_big_array::BigArray;
 
-/// Signing context used for creating reward signatures by farmers.
-pub const REWARD_SIGNING_CONTEXT: &[u8] = b"subspace_reward";
-
-/// A Ristretto Schnorr public key as bytes produced by `schnorrkel` crate.
+/// Ed25519 public key
 #[derive(Default, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Deref, From, Into)]
 #[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
-pub struct PublicKey([u8; PublicKey::SIZE]);
+pub struct Ed25519PublicKey([u8; Ed25519PublicKey::SIZE]);
 
-impl fmt::Debug for PublicKey {
+impl fmt::Debug for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.0 {
             write!(f, "{byte:02x}")?;
@@ -32,44 +29,44 @@ impl fmt::Debug for PublicKey {
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct PublicKeyBinary([u8; PublicKey::SIZE]);
+struct Ed25519PublicKeyBinary([u8; Ed25519PublicKey::SIZE]);
 
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct PublicKeyHex(#[serde(with = "hex")] [u8; PublicKey::SIZE]);
+struct Ed25519PublicKeyHex(#[serde(with = "hex")] [u8; Ed25519PublicKey::SIZE]);
 
 #[cfg(feature = "serde")]
-impl Serialize for PublicKey {
+impl Serialize for Ed25519PublicKey {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            PublicKeyHex(self.0).serialize(serializer)
+            Ed25519PublicKeyHex(self.0).serialize(serializer)
         } else {
-            PublicKeyBinary(self.0).serialize(serializer)
+            Ed25519PublicKeyBinary(self.0).serialize(serializer)
         }
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for PublicKey {
+impl<'de> Deserialize<'de> for Ed25519PublicKey {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(Self(if deserializer.is_human_readable() {
-            PublicKeyHex::deserialize(deserializer)?.0
+            Ed25519PublicKeyHex::deserialize(deserializer)?.0
         } else {
-            PublicKeyBinary::deserialize(deserializer)?.0
+            Ed25519PublicKeyBinary::deserialize(deserializer)?.0
         }))
     }
 }
 
-impl fmt::Display for PublicKey {
+impl fmt::Display for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.0 {
             write!(f, "{byte:02x}")?;
@@ -78,14 +75,14 @@ impl fmt::Display for PublicKey {
     }
 }
 
-impl AsRef<[u8]> for PublicKey {
+impl AsRef<[u8]> for Ed25519PublicKey {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl PublicKey {
+impl Ed25519PublicKey {
     /// Public key size in bytes
     pub const SIZE: usize = 32;
 
@@ -95,18 +92,18 @@ impl PublicKey {
     }
 }
 
-/// A Ristretto Schnorr signature as bytes produced by `schnorrkel` crate.
+/// Ed25519 signature
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Deref, From, Into)]
 #[cfg_attr(feature = "scale-codec", derive(Encode, Decode, TypeInfo))]
-pub struct Signature([u8; Signature::SIZE]);
+pub struct Ed25519Signature([u8; Ed25519Signature::SIZE]);
 
-impl Default for Signature {
+impl Default for Ed25519Signature {
     fn default() -> Self {
         Self([0; Self::SIZE])
     }
 }
 
-impl fmt::Debug for Signature {
+impl fmt::Debug for Ed25519Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.0 {
             write!(f, "{byte:02x}")?;
@@ -118,44 +115,44 @@ impl fmt::Debug for Signature {
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct SignatureBinary(#[serde(with = "BigArray")] [u8; Signature::SIZE]);
+struct Ed25519SignatureBinary(#[serde(with = "BigArray")] [u8; Ed25519Signature::SIZE]);
 
 #[cfg(feature = "serde")]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-struct SignatureHex(#[serde(with = "hex")] [u8; Signature::SIZE]);
+struct Ed25519SignatureHex(#[serde(with = "hex")] [u8; Ed25519Signature::SIZE]);
 
 #[cfg(feature = "serde")]
-impl Serialize for Signature {
+impl Serialize for Ed25519Signature {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            SignatureHex(self.0).serialize(serializer)
+            Ed25519SignatureHex(self.0).serialize(serializer)
         } else {
-            SignatureBinary(self.0).serialize(serializer)
+            Ed25519SignatureBinary(self.0).serialize(serializer)
         }
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for Signature {
+impl<'de> Deserialize<'de> for Ed25519Signature {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(Self(if deserializer.is_human_readable() {
-            SignatureHex::deserialize(deserializer)?.0
+            Ed25519SignatureHex::deserialize(deserializer)?.0
         } else {
-            SignatureBinary::deserialize(deserializer)?.0
+            Ed25519SignatureBinary::deserialize(deserializer)?.0
         }))
     }
 }
 
-impl fmt::Display for Signature {
+impl fmt::Display for Ed25519Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.0 {
             write!(f, "{byte:02x}")?;
@@ -164,14 +161,14 @@ impl fmt::Display for Signature {
     }
 }
 
-impl AsRef<[u8]> for Signature {
+impl AsRef<[u8]> for Ed25519Signature {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl Signature {
+impl Ed25519Signature {
     /// Signature size in bytes
     pub const SIZE: usize = 64;
 }
@@ -183,12 +180,12 @@ impl Signature {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RewardSignature {
     /// Public key that signature corresponds to
-    pub public_key: PublicKey,
+    pub public_key: Ed25519PublicKey,
     /// Signature itself
-    pub signature: Signature,
+    pub signature: Ed25519Signature,
 }
 
 impl RewardSignature {
     /// Reward signature size in bytes
-    pub const SIZE: usize = PublicKey::SIZE + Signature::SIZE;
+    pub const SIZE: usize = Ed25519PublicKey::SIZE + Ed25519Signature::SIZE;
 }


### PR DESCRIPTION
Use case of reward signature is simple and doesn't benefit from Sr25519, while using more common crypto should help with signing and verification in the future