### PR TITLE
Faster PoT verification for CPUs that support AVX512F+VAES

### DIFF
--- a/crates/shared/ab-proof-of-time/src/aes/x86_64.rs
+++ b/crates/shared/ab-proof-of-time/src/aes/x86_64.rs
@@ -1,6 +1,6 @@
-use ab_core_primitives::pot::PotCheckpoints;
+use ab_core_primitives::pot::{PotCheckpoints, PotOutput};
 use core::arch::x86_64::*;
-use core::mem;
+use core::{array, mem};
 
 /// Create PoT proof with checkpoints
 #[target_feature(enable = "aes")]
@@ -32,22 +32,97 @@ pub(super) unsafe fn create(
             }
 
             let checkpoint_reg = _mm_xor_si128(seed_reg, keys_reg[0]);
-            _mm_storeu_si128(
-                checkpoint.as_mut().as_mut_ptr() as *mut __m128i,
-                checkpoint_reg,
-            );
+            _mm_storeu_si128(checkpoint.as_mut_ptr() as *mut __m128i, checkpoint_reg);
         }
     }
 
     checkpoints
 }
 
+/// Verification mimics `create` function, but also has decryption half for better performance
+#[target_feature(enable = "avx512f,vaes")]
+#[inline]
+pub(super) unsafe fn verify_sequential_avx512f(
+    seed: &[u8; 16],
+    key: &[u8; 16],
+    checkpoints: &PotCheckpoints,
+    checkpoint_iterations: u32,
+) -> bool {
+    let checkpoints = PotOutput::repr_from_slice(checkpoints.as_slice());
+
+    unsafe {
+        let keys_reg = expand_key(key);
+        let xor_key = _mm_xor_si128(keys_reg[10], keys_reg[0]);
+        let xor_key_512 = _mm512_broadcast_i32x4(xor_key);
+
+        // Invert keys for decryption
+        let mut inv_keys = keys_reg;
+        for i in 1..10 {
+            inv_keys[i] = _mm_aesimc_si128(keys_reg[10 - i]);
+        }
+
+        let keys_512 = array::from_fn::<_, NUM_ROUNDS, _>(|i| _mm512_broadcast_i32x4(keys_reg[i]));
+        let inv_keys_512 =
+            array::from_fn::<_, NUM_ROUNDS, _>(|i| _mm512_broadcast_i32x4(inv_keys[i]));
+
+        let mut input_0 = [[0u8; 16]; 4];
+        input_0[0] = *seed;
+        input_0[1..].copy_from_slice(&checkpoints[..3]);
+        let mut input_0 = _mm512_loadu_si512(input_0.as_ptr() as *const __m512i);
+        let mut input_1 = _mm512_loadu_si512(checkpoints[3..7].as_ptr() as *const __m512i);
+
+        let mut output_0 = _mm512_loadu_si512(checkpoints[0..4].as_ptr() as *const __m512i);
+        let mut output_1 = _mm512_loadu_si512(checkpoints[4..8].as_ptr() as *const __m512i);
+
+        input_0 = _mm512_xor_si512(input_0, keys_512[0]);
+        input_1 = _mm512_xor_si512(input_1, keys_512[0]);
+
+        output_0 = _mm512_xor_si512(output_0, keys_512[10]);
+        output_1 = _mm512_xor_si512(output_1, keys_512[10]);
+
+        for _ in 0..checkpoint_iterations / 2 {
+            for i in 1..10 {
+                input_0 = _mm512_aesenc_epi128(input_0, keys_512[i]);
+                input_1 = _mm512_aesenc_epi128(input_1, keys_512[i]);
+
+                output_0 = _mm512_aesdec_epi128(output_0, inv_keys_512[i]);
+                output_1 = _mm512_aesdec_epi128(output_1, inv_keys_512[i]);
+            }
+
+            input_0 = _mm512_aesenclast_epi128(input_0, xor_key_512);
+            input_1 = _mm512_aesenclast_epi128(input_1, xor_key_512);
+
+            output_0 = _mm512_aesdeclast_epi128(output_0, xor_key_512);
+            output_1 = _mm512_aesdeclast_epi128(output_1, xor_key_512);
+        }
+
+        // Code below is a more efficient version of this:
+        // input_0 = _mm512_xor_si512(input_0, keys_512[0]);
+        // input_1 = _mm512_xor_si512(input_1, keys_512[0]);
+        // output_0 = _mm512_xor_si512(output_0, keys_512[10]);
+        // output_1 = _mm512_xor_si512(output_1, keys_512[10]);
+        //
+        // let mask0 = _mm512_cmpeq_epu64_mask(input_0, output_0);
+        // let mask1 = _mm512_cmpeq_epu64_mask(input_1, output_1);
+
+        let diff_0 = _mm512_xor_si512(input_0, output_0);
+        let diff_1 = _mm512_xor_si512(input_1, output_1);
+
+        let mask0 = _mm512_cmpeq_epu64_mask(diff_0, xor_key_512);
+        let mask1 = _mm512_cmpeq_epu64_mask(diff_1, xor_key_512);
+
+        // All inputs match outputs
+        (mask0 & mask1) == u8::MAX
+    }
+}
+
 // Below code copied with minor changes from following place under MIT/Apache-2.0 license by Artyom
 // Pavlov:
 // https://github.com/RustCrypto/block-ciphers/blob/9413fcadd28d53854954498c0589b747d8e4ade2/aes/src/ni/aes128.rs
 
+const NUM_ROUNDS: usize = 11;
 /// AES-128 round keys
-type RoundKeys = [__m128i; 11];
+type RoundKeys = [__m128i; NUM_ROUNDS];
 
 macro_rules! expand_round {
     ($keys:expr, $pos:expr, $round:expr) => {

--- a/crates/shared/ab-proof-of-time/src/lib.rs
+++ b/crates/shared/ab-proof-of-time/src/lib.rs
@@ -1,5 +1,6 @@
 //! Proof of time implementation.
 
+#![cfg_attr(target_arch = "x86_64", feature(stdarch_x86_avx512))]
 #![no_std]
 
 mod aes;
@@ -34,6 +35,7 @@ pub fn prove(seed: PotSeed, iterations: NonZeroU32) -> Result<PotCheckpoints, Po
         });
     }
 
+    // TODO: Is there a point in having both values derived from the same source?
     Ok(aes::create(
         seed,
         seed.key(),


### PR DESCRIPTION
Another 2x performance improvement on Zen 4.

Before:
```
verify                  time:   [204.92 ms 205.10 ms 205.30 ms]
```
After:
```
verify                  time:   [102.38 ms 102.43 ms 102.53 ms]
```

On this particular CPU verification is 16x faster than proving, which matches expected dual AES units per CPU core with 0.5 clocks per instruction:
```
2 AES units * 4 blocks at a time / 0.5 CPI = 16
```

:muscle: 