### PR TITLE
Improve pos vectorization and pipelining

### DIFF
--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -28,7 +28,6 @@ use spin::Mutex;
 
 pub(super) const COMPUTE_F1_SIMD_FACTOR: usize = 8;
 pub(super) const FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR: usize = 8;
-pub(super) const HAS_MATCH_UNROLL_FACTOR: usize = 8;
 
 /// Compute the size of `y` in bits
 pub(super) const fn y_size_bits(k: u8) -> usize {
@@ -341,27 +340,11 @@ pub(super) fn has_match(left_y: Y, right_y: Y) -> bool {
     let parity = (u32::from(left_y) / u32::from(PARAM_BC)) % 2;
     let left_r = u32::from(left_y) % u32::from(PARAM_BC);
 
-    const _: () = {
-        assert!(PARAM_M as usize % HAS_MATCH_UNROLL_FACTOR == 0);
-    };
+    let r_targets = array::from_fn::<_, { PARAM_M as usize }, _>(|i| {
+        calculate_left_target_on_demand(parity, left_r, i as u32)
+    });
 
-    for m in 0..u32::from(PARAM_M) / HAS_MATCH_UNROLL_FACTOR as u32 {
-        let _: [(); HAS_MATCH_UNROLL_FACTOR] = seq!(N in 0..8 {
-            [
-            #(
-            {
-                #[allow(clippy::identity_op)]
-                let r_target = calculate_left_target_on_demand(parity, left_r, m * HAS_MATCH_UNROLL_FACTOR as u32 + N);
-                if r_target == right_r {
-                    return true;
-                }
-            },
-            )*
-            ]
-        });
-    }
-
-    false
+    r_targets.contains(&right_r)
 }
 
 pub(super) fn compute_fn<const K: u8, const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
@@ -44,7 +44,7 @@ fn test_compute_f1_k25() {
         let mut partial_ys = [0; K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize];
         partial_ys.view_bits_mut::<Msb0>()[..usize::from(K)]
             .copy_from_bitslice(&partial_y.view_bits()[partial_y_offset..][..usize::from(K)]);
-        let y = compute_f1_simd::<K>([x; COMPUTE_F1_SIMD_FACTOR], &partial_ys);
+        let y = compute_f1_simd::<K>([x.into(); COMPUTE_F1_SIMD_FACTOR], &partial_ys);
         assert_eq!(y[0], Y::from(expected_y));
     }
 }
@@ -70,7 +70,7 @@ fn test_compute_f1_k22() {
         let mut partial_ys = [0; K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize];
         partial_ys.view_bits_mut::<Msb0>()[..usize::from(K)]
             .copy_from_bitslice(&partial_y.view_bits()[partial_y_offset..][..usize::from(K)]);
-        let y = compute_f1_simd::<K>([x; COMPUTE_F1_SIMD_FACTOR], &partial_ys);
+        let y = compute_f1_simd::<K>([x.into(); COMPUTE_F1_SIMD_FACTOR], &partial_ys);
         assert_eq!(y[0], Y::from(expected_y));
     }
 }

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/types.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/types.rs
@@ -80,6 +80,13 @@ impl Y {
     pub(in super::super) const fn first_k_bits<const K: u8>(self) -> u32 {
         self.0 >> PARAM_EXT as usize
     }
+
+    #[inline(always)]
+    pub(super) const fn array_from_repr<const N: usize>(array: [u32; N]) -> [Self; N] {
+        // TODO: Should have been transmute, but https://github.com/rust-lang/rust/issues/61956
+        // SAFETY: `T` is `#[repr(C)]` and guaranteed to have the same memory layout
+        unsafe { mem::transmute_copy(&array) }
+    }
 }
 
 #[derive(


### PR DESCRIPTION
Before:
```
chia/table/single       time:   [1.0668 s 1.0756 s 1.0862 s]
chia/table/parallel/8x  time:   [905.01 ms 919.11 ms 933.34 ms]
chia/verification       time:   [11.094 µs 11.533 µs 11.985 µs]
```

After:
```
chia/table/single       time:   [1.0245 s 1.0329 s 1.0432 s]
chia/table/parallel/8x  time:   [830.37 ms 843.37 ms 855.47 ms]
chia/verification       time:   [8.9454 µs 8.9612 µs 8.9726 µs]
```

Also less code and a bit easier to read.

I had some other tweaks locally, but at least until https://github.com/BLAKE3-team/BLAKE3/issues/478 is available it hurts more than helps.