### PR TITLE
Extend `no-panic` usage in crates where it was used already, other CI improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,25 +85,32 @@ jobs:
                 continue
               fi
               crate="$(basename -- $crate_path)"
+              echo "Checking \`$feature\` in \`$crate\`"
               cargo -Zgitoxide -Zgit clippy --all-targets --package $crate --features $crate/$feature -- -D warnings
             done
           done
 
           # Ensure `clippy` is happy with `guest` feature
-          echo "Checking `guest` in contracts"
+          echo "Checking \`guest\` in contracts"
           for contract_path in crates/contracts/{example,system}/*; do
             contract="$(basename -- $contract_path)"
+            echo "Checking \`guest\` in \`$contract\`"
             cargo -Zgitoxide -Zgit clippy --all-targets --package $contract --features $contract/guest -- -D warnings
           done
+          for crate_path in crates/contracts/core/*; do
+            # Not all crates have this feature
+            if ! grep --no-messages --quiet "^guest =" "$crate_path/Cargo.toml"; then
+              continue
+            fi
+            crate="$(basename -- $crate_path)"
+            echo "Checking \`guest\` in \`$crate\`"
+            cargo -Zgitoxide -Zgit clippy --all-targets --package $crate --features $crate/guest -- -D warnings
+          done
 
-          # TODO: Would be nice to have these as job matrix later
-          cargo -Zgitoxide -Zgit clippy --all-targets --package ab-contracts-common --features ab-contracts-common/guest -- -D warnings
+          echo "Checking \`executor\` in \`ab-contracts-common\`"
           cargo -Zgitoxide -Zgit clippy --all-targets --package ab-contracts-common --features ab-contracts-common/executor -- -D warnings
 
-          cargo -Zgitoxide -Zgit clippy --all-targets --package ab-contracts-macros --features ab-contracts-macros/guest -- -D warnings
-
-          cargo -Zgitoxide -Zgit clippy --all-targets --package ab-contracts-standards --features ab-contracts-standards/guest -- -D warnings
-
+          echo "Checking \`payload-builder\` in \`ab-system-contract-simple-wallet-base\`"
           cargo -Zgitoxide -Zgit clippy --all-targets --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder -- -D warnings
         if: runner.os == 'Linux'
 
@@ -145,29 +152,47 @@ jobs:
           cargo -Zgitoxide -Zgit nextest run --locked
 
       - name: cargo test (various features)
+        shell: bash
         run: |
           for feature in alloc parallel scale-codec serde; do
-            echo "Testing with feature: $feature"
             for crate_path in crates/{execution,node,shared}/*; do
               # Not all crates have this feature
               if ! grep --no-messages --quiet "^$feature =" "$crate_path/Cargo.toml"; then
                 continue
               fi
               crate="$(basename -- $crate_path)"
+              echo "Testing \`$feature\` in \`$crate\`"
               cargo -Zgitoxide -Zgit nextest run --no-tests pass --package $crate --features $crate/$feature
             done
           done
 
+          echo "Checking \`executor\` in \`ab-contracts-common\`"
+          cargo -Zgitoxide -Zgit nextest run --package ab-contracts-common --features ab-contracts-common/executor
+
+          echo "Testing \`payload-builder\` in \`ab-system-contract-simple-wallet-base\`"
+          cargo -Zgitoxide -Zgit nextest run --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
+
+      - name: cargo nextest run (guest feature)
+        shell: bash
+        run: |
           # Ensure tests pass with `guest` feature
-          echo "Testing `guest` in contracts"
           for contract_path in crates/contracts/{example,system}/*; do
             contract="$(basename -- $contract_path)"
+            echo "Testing \`guest\` in \`$contract\`"
             cargo -Zgitoxide -Zgit nextest run --no-tests pass --package $contract --features $contract/guest
           done
-
-          cargo -Zgitoxide -Zgit nextest run --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
+          for create_path in crates/contracts/core/*; do
+            # Not all crates have this feature
+            if ! grep --no-messages --quiet "^guest =" "$crate_path/Cargo.toml"; then
+              continue
+            fi
+            crate="$(basename -- $create_path)"
+            echo "Testing \`guest\` in \`$crate\`"
+            cargo -Zgitoxide -Zgit nextest run --no-tests pass --package $crate --features $crate/guest
+          done
         if: runner.os == 'Linux'
 
+  # TODO: All these miri commands are otherwise identical to regular testing, think about de-duplicating them
   cargo-miri-test:
     strategy:
       matrix:
@@ -206,21 +231,44 @@ jobs:
           cargo -Zgitoxide -Zgit miri nextest run
 
       - name: cargo miri nextest run (various features)
+        shell: bash
         run: |
           for feature in alloc parallel scale-codec serde; do
-            echo "Testing with feature: $feature"
             for crate_path in crates/{execution,node,shared}/*; do
               # Not all crates have this feature
               if ! grep --no-messages --quiet "^$feature =" "$crate_path/Cargo.toml"; then
                 continue
               fi
               crate="$(basename -- $crate_path)"
+              echo "Testing \`$feature\` in \`$crate\`"
               cargo -Zgitoxide -Zgit miri nextest run --no-tests pass --package $crate --features $crate/$feature
             done
           done
 
-          echo "Testing the rest"
+          echo "Checking \`executor\` in \`ab-contracts-common\`"
+          cargo -Zgitoxide -Zgit miri nextest run --package ab-contracts-common --features ab-contracts-common/executor
+
+          echo "Testing \`payload-builder\` in \`ab-system-contract-simple-wallet-base\`"
           cargo -Zgitoxide -Zgit miri nextest run --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
+
+      - name: cargo miri nextest run (guest feature)
+        shell: bash
+        run: |
+          # Ensure tests pass with `guest` feature
+          for contract_path in crates/contracts/{example,system}/*; do
+            contract="$(basename -- $contract_path)"
+            echo "Testing \`guest\` in \`$contract\`"
+            cargo -Zgitoxide -Zgit miri nextest run --no-tests pass --package $contract --features $contract/guest
+          done
+          for create_path in crates/contracts/core/*; do
+            # Not all crates have this feature
+            if ! grep --no-messages --quiet "^guest =" "$crate_path/Cargo.toml"; then
+              continue
+            fi
+            crate="$(basename -- $create_path)"
+            echo "Testing \`guest\` in \`$crate\`"
+            cargo -Zgitoxide -Zgit miri nextest run --no-tests pass --package $crate --features $crate/guest
+          done
         if: runner.os == 'Linux'
 
   no-panic:
@@ -230,8 +278,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-24.04-arm
           - macos-15
-          # TODO: Windows is pain, add it at some point if possible, but generally other platforms should be sufficient
-          # - windows-2025
+          - windows-2025
 
     runs-on: ${{ matrix.os }}
 
@@ -256,29 +303,32 @@ jobs:
         env:
           # Increase inlining threshold to make sure the compiler can see that some functions do not panic
           # Native CPU and LTO to allow compiler to apply more optimizations and prove lack of panics in more cases
-          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=3000 -C embed-bitcode -C lto=fat -Z dylib-lto -C target-cpu=native
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=5000 -C embed-bitcode -C lto -Z dylib-lto -C target-cpu=native
+        shell: bash
         run: |
-          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic
+          # TODO: This doesn't seem to work for now: https://users.rust-lang.org/t/compiler-optimizations-are-different-for-crate-itself-vs-dependency/130187?u=nazar-pc
+          # So we end up building individual crates instead, which is unfortunate
+          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic
+
+          # Ensure no panics in various crates
+          for crate_path in crates/{contracts/{core,example,system},execution,node,shared}/*; do
+            # Not all crates have this feature yet
+            if ! grep --no-messages --quiet '^no-panic =' "$crate_path/Cargo.toml"; then
+              continue
+            fi
+            crate="$(basename -- $crate_path)"
+            echo "Checking \`$crate\`"
+            cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package $crate
+          done
 
       - name: Ensure no panics in annotated code (various features)
         env:
           # Increase inlining threshold to make sure the compiler can see that some functions do not panic
           # Native CPU and LTO to allow compiler to apply more optimizations and prove lack of panics in more cases
-          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=3000 -C embed-bitcode -C lto=fat -Z dylib-lto -C target-cpu=native
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Cllvm-args=--inline-threshold=5000 -C embed-bitcode -C lto -Z dylib-lto -C target-cpu=native
+        shell: bash
         run: |
-          # Ensure no panics with `guest` feature
-          echo "Checking `no-panic` in contracts"
-          for contract_path in crates/contracts/{example,system}/*; do
-            # Not all contracts have this feature yet
-            if ! grep --no-messages --quiet '^no-panic =' "$contract_path/Cargo.toml"; then
-              continue
-            fi
-            contract="$(basename -- $contract_path)"
-            cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package $contract --features $contract/guest
-          done
-
           # Ensure no panics with `alloc` feature
-          echo "Checking `no-panic` with `alloc`"
           for crate_path in crates/{execution,node,shared}/*; do
             # Not all crates have this feature yet
             if ! grep --no-messages --quiet '^no-panic =' "$crate_path/Cargo.toml" || \
@@ -286,21 +336,37 @@ jobs:
               continue
             fi
             crate="$(basename -- $crate_path)"
+            echo "Checking \`alloc\` in \`$crate\`"
             cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package $crate --features $crate/alloc
           done
 
-          echo "Checking `no-panic` with others"
-
-          # TODO: Would be nice to have these as job matrix later
-          # TODO: Unlock commented-out crates once they have the feature
-          cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-contracts-common --features ab-contracts-common/guest
+          echo "Checking \`executor\` in \`ab-contracts-common\`"
           cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-contracts-common --features ab-contracts-common/executor
 
-          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-contracts-macros --features ab-contracts-macros/guest
-
-          # cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-contracts-standards --features ab-contracts-standards/guest
-
+          echo "Checking \`payload-builder\` in \`ab-system-contract-simple-wallet-base\`"
           cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package ab-system-contract-simple-wallet-base --features ab-system-contract-simple-wallet-base/payload-builder
+      - name: Ensure no panics in annotated code (guest feature)
+        run: |
+          # Ensure no panics with `guest` feature
+          for contract_path in crates/contracts/{example,system}/*; do
+            # Not all contracts have this feature yet
+            if ! grep --no-messages --quiet '^no-panic =' "$contract_path/Cargo.toml"; then
+              continue
+            fi
+            contract="$(basename -- $contract_path)"
+            echo "Checking \`guest\` in \`$contract\`"
+            cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package $contract --features $contract/guest
+          done
+          for contract_path in crates/contracts/core/*; do
+            # Not all contracts have this feature yet
+            if ! grep --no-messages --quiet '^no-panic =' "$crate_path/Cargo.toml" || \
+               ! grep --no-messages --quiet '^guest =' "$crate_path/Cargo.toml"; then
+              continue
+            fi
+            contract="$(basename -- $contract_path)"
+            echo "Checking \`guest\` in \`$contract\`"
+            cargo -Zgitoxide -Zgit build --release --all-targets --features no-panic --package $contract --features $contract/guest
+          done
         if: runner.os == 'Linux'
 
   contracts:
@@ -319,15 +385,12 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-        # Cache on Windows is so slow, it is faster without it, see many reports like
-        # https://github.com/actions/runner-images/issues/7320
-        if: runner.os != 'Windows'
 
       - name: Ensure contracts compile for a custom target
         run: |
           for contract_path in crates/contracts/{example,system}/*; do
             contract="$(basename -- $contract_path)"
+            echo "Checking \`$contract\`"
             # TODO: This uses x86-64-based target, but will have to change to riscv64e-based target eventually
             cargo -Zgitoxide -Zgit rustc -Z build-std=core --crate-type cdylib --profile contract --target crates/contracts/x86_64-unknown-none-abundance.json --package $contract --features $contract/guest
           done
-        if: runner.os == 'Linux'

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/lib.rs
@@ -104,6 +104,7 @@ pub struct SimpleWalletBase;
 impl SimpleWalletBase {
     /// Returns initial state with a provided public key
     #[view]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn initialize(#[input] &public_key: &[u8; 32]) -> Result<WalletState, ContractError> {
         // TODO: Storing some lower-level representation of the public key might reduce the cost of
         //  verification in `Self::authorize()` method
@@ -118,6 +119,7 @@ impl SimpleWalletBase {
 
     /// Reads state of `owner` and returns `Ok(())` if authorization succeeds
     #[view]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn authorize(
         #[input] state: &WalletState,
         #[input] header: &TransactionHeader,
@@ -160,6 +162,7 @@ impl SimpleWalletBase {
     ///
     /// The caller must set themselves as a context or else error will be returned.
     #[update]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn execute(
         #[env] env: &mut Env<'_>,
         #[input] header: &TransactionHeader,
@@ -205,6 +208,7 @@ impl SimpleWalletBase {
 
     /// Returns state with increased nonce
     #[view]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn increase_nonce(#[input] state: &WalletState) -> Result<WalletState, ContractError> {
         let nonce = state.nonce.checked_add(1).ok_or(ContractError::Forbidden)?;
 
@@ -216,6 +220,7 @@ impl SimpleWalletBase {
 
     /// Returns a new state with a changed public key
     #[view]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn change_public_key(
         #[input] state: &WalletState,
         #[input] &public_key: &[u8; 32],

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder.rs
@@ -58,6 +58,7 @@ pub struct TransactionPayloadBuilder {
 }
 
 impl Default for TransactionPayloadBuilder {
+    #[inline]
     fn default() -> Self {
         Self {
             payload: Vec::with_capacity(1024),
@@ -73,6 +74,7 @@ impl TransactionPayloadBuilder {
     /// `slot_output_index` and `input_output_index` are used for referencing earlier outputs as
     /// slots or inputs of this method, its values are optional, see [`TransactionInput`] for more
     /// details.
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn with_method_call<Args>(
         &mut self,
         contract: &Address,
@@ -110,6 +112,7 @@ impl TransactionPayloadBuilder {
         clippy::too_many_arguments,
         reason = "Only exceeds the limit due to being untyped, while above typed version is not"
     )]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub unsafe fn with_method_call_untyped<'a>(
         &mut self,
         contract: &Address,
@@ -311,6 +314,7 @@ impl TransactionPayloadBuilder {
     ///
     /// [`TransactionSlotType::Address`]: crate::payload::TransactionSlotType::Address
     /// [`TransactionInputType::Value`]: crate::payload::TransactionInputType::Value
+    // TODO: Figure out how sand make it possible to apply `no-panic` here
     pub fn into_aligned_bytes(mut self) -> Vec<u128> {
         // Fill bytes to make it multiple of `u128` before creating `u128`-based vector
         self.ensure_alignment(usize::from(MAX_ALIGNMENT));
@@ -333,12 +337,14 @@ impl TransactionPayloadBuilder {
         output
     }
 
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     fn extend_payload_with_alignment(&mut self, bytes: &[u8], alignment: usize) {
         self.ensure_alignment(alignment);
 
         self.payload.extend_from_slice(bytes);
     }
 
+    // TODO: Figure out how sand make it possible to apply `no-panic` here
     fn ensure_alignment(&mut self, alignment: usize) {
         debug_assert!(alignment <= usize::from(MAX_ALIGNMENT));
 
@@ -352,6 +358,7 @@ impl TransactionPayloadBuilder {
         }
     }
 
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     fn push_payload_byte(&mut self, byte: u8) {
         self.payload.push(byte);
     }

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/seal.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/seal.rs
@@ -12,6 +12,7 @@ use schnorrkel::{Keypair, PublicKey, Signature};
 /// Create transaction hash used for signing with [`sign()`].
 ///
 /// [`hash_and_sign()`] helper function exists that combines this method with [`sign()`].
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn hash_transaction(
     header: &TransactionHeader,
     read_slots: &[TransactionSlot],
@@ -39,12 +40,14 @@ pub fn hash_transaction(
 ///
 /// [`hash_and_sign()`] helper function exists that combines this method with
 /// [`hash_transaction()`].
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn sign(keypair: &Keypair, tx_hash: &[u8; OUT_LEN]) -> Signature {
     let signing_context = SigningContext::new(SIGNING_CONTEXT);
     keypair.sign(signing_context.bytes(tx_hash))
 }
 
 /// Combines [`hash_transaction()`] and [`sign()`] and returns [`Seal`]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn hash_and_sign(
     keypair: &Keypair,
     header: &TransactionHeader,
@@ -81,8 +84,8 @@ pub fn verify(
         .map_err(|_error| ContractError::Forbidden)
 }
 
-// TODO: Add guarantees that this does not panic
 /// Combines [`hash_transaction()`] and [`verify()`]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn hash_and_verify(
     public_key: &PublicKey,
     expected_nonce: u64,

--- a/crates/shared/ab-proof-of-time/src/aes/aarch64.rs
+++ b/crates/shared/ab-proof-of-time/src/aes/aarch64.rs
@@ -44,8 +44,7 @@ pub(super) fn create(
 /// Verification mimics `create` function, but also has decryption half for better performance
 #[target_feature(enable = "aes")]
 #[inline]
-// TODO: Enable on all platforms once it works
-#[cfg_attr(all(feature = "no-panic", target_os = "linux"), no_panic::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub(super) fn verify_sequential_aes(
     seed: &[u8; 16],
     key: &[u8; 16],

--- a/crates/shared/ab-proof-of-time/src/lib.rs
+++ b/crates/shared/ab-proof-of-time/src/lib.rs
@@ -29,8 +29,7 @@ pub enum PotError {
 /// Run PoT proving and produce checkpoints.
 ///
 /// Returns error if `iterations` is not a multiple of checkpoints times two.
-// TODO: un-comment once https://github.com/RustCrypto/block-ciphers/issues/481 is resolved
-// #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn prove(seed: PotSeed, iterations: NonZeroU32) -> Result<PotCheckpoints, PotError> {
     if iterations.get() % u32::from(PotCheckpoints::NUM_CHECKPOINTS.get() * 2) != 0 {
         return Err(PotError::NotMultipleOfCheckpoints {
@@ -50,8 +49,11 @@ pub fn prove(seed: PotSeed, iterations: NonZeroU32) -> Result<PotCheckpoints, Po
 /// Verify checkpoint, number of iterations is set across uniformly distributed checkpoints.
 ///
 /// Returns error if `iterations` is not a multiple of checkpoints times two.
-// TODO: un-comment once https://github.com/RustCrypto/block-ciphers/issues/481 is resolved
-// #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+// TODO: Figure out what is wrong with macOS here
+#[cfg_attr(
+    all(feature = "no-panic", not(target_os = "macos")),
+    no_panic::no_panic
+)]
 pub fn verify(
     seed: PotSeed,
     iterations: NonZeroU32,


### PR DESCRIPTION
With updated `RUSTFLAGS` more code can be checked, but crucially heap allocations seem to block some of the usage (likely due to `Vec`) and it is not clear if it can be resolved since heap allocations are inherently fallible on hardware level and most often not handled at all on application level.

UPD: After countless attempts managed to enable Windows, extend various tests and even improve logging.