### PR TITLE
Implement PoT verification optimized for AVX2+VAES and AES+SSE4.1

### DIFF
--- a/crates/shared/ab-proof-of-time/src/aes.rs
+++ b/crates/shared/ab-proof-of-time/src/aes.rs
@@ -64,7 +64,20 @@ pub(crate) fn verify_sequential(
         if has_avx512f_vaes::get() {
             // SAFETY: Checked `avx512f` and `vaes` features
             return unsafe {
-                x86_64::verify_sequential_avx512f(&seed, &key, checkpoints, checkpoint_iterations)
+                x86_64::verify_sequential_avx512f_vaes(
+                    &seed,
+                    &key,
+                    checkpoints,
+                    checkpoint_iterations,
+                )
+            };
+        }
+
+        cpufeatures::new!(has_avx2_vaes, "avx2", "vaes");
+        if has_avx2_vaes::get() {
+            // SAFETY: Checked `avx2` and `vaes` features
+            return unsafe {
+                x86_64::verify_sequential_avx2_vaes(&seed, &key, checkpoints, checkpoint_iterations)
             };
         }
     }
@@ -123,6 +136,51 @@ mod tests {
     ];
     const BAD_CIPHER: [u8; 16] = [22; 16];
 
+    fn verify_test(
+        seed: PotSeed,
+        key: PotKey,
+        checkpoints: &PotCheckpoints,
+        checkpoint_iterations: u32,
+    ) -> bool {
+        let sequential = verify_sequential(seed, key, checkpoints, checkpoint_iterations);
+        let sequential_generic =
+            verify_sequential_generic(seed, key, checkpoints, checkpoint_iterations);
+        assert_eq!(sequential, sequential_generic);
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            cpufeatures::new!(has_avx512f_vaes, "avx512f", "vaes");
+            if has_avx512f_vaes::get() {
+                // SAFETY: Checked `avx512f` and `vaes` features
+                let avx512f_vaes = unsafe {
+                    x86_64::verify_sequential_avx512f_vaes(
+                        &seed,
+                        &key,
+                        checkpoints,
+                        checkpoint_iterations,
+                    )
+                };
+                assert_eq!(sequential, avx512f_vaes);
+            }
+
+            cpufeatures::new!(has_avx2_vaes, "avx2", "vaes");
+            if has_avx2_vaes::get() {
+                // SAFETY: Checked `avx2` and `vaes` features
+                let avx2_vaes = unsafe {
+                    x86_64::verify_sequential_avx2_vaes(
+                        &seed,
+                        &key,
+                        checkpoints,
+                        checkpoint_iterations,
+                    )
+                };
+                assert_eq!(sequential, avx2_vaes);
+            }
+        }
+
+        sequential
+    }
+
     #[test]
     fn test_create_verify() {
         let seed = PotSeed::from(SEED);
@@ -136,29 +194,12 @@ mod tests {
             assert_eq!(checkpoints, generic_checkpoints);
         }
 
-        assert!(verify_sequential(
-            seed,
-            key,
-            &checkpoints,
-            checkpoint_iterations,
-        ));
-        assert!(verify_sequential_generic(
-            seed,
-            key,
-            &checkpoints,
-            checkpoint_iterations,
-        ));
+        assert!(verify_test(seed, key, &checkpoints, checkpoint_iterations,));
 
         // Decryption of invalid cipher text fails.
         let mut checkpoints_1 = checkpoints;
         checkpoints_1[0] = PotOutput::from(BAD_CIPHER);
-        assert!(!verify_sequential(
-            seed,
-            key,
-            &checkpoints_1,
-            checkpoint_iterations,
-        ));
-        assert!(!verify_sequential_generic(
+        assert!(!verify_test(
             seed,
             key,
             &checkpoints_1,
@@ -166,25 +207,13 @@ mod tests {
         ));
 
         // Decryption with wrong number of iterations fails.
-        assert!(!verify_sequential(
+        assert!(!verify_test(
             seed,
             key,
             &checkpoints,
             checkpoint_iterations + 2,
         ));
-        assert!(!verify_sequential_generic(
-            seed,
-            key,
-            &checkpoints,
-            checkpoint_iterations + 2,
-        ));
-        assert!(!verify_sequential(
-            seed,
-            key,
-            &checkpoints,
-            checkpoint_iterations - 2,
-        ));
-        assert!(!verify_sequential_generic(
+        assert!(!verify_test(
             seed,
             key,
             &checkpoints,
@@ -192,13 +221,7 @@ mod tests {
         ));
 
         // Decryption with wrong seed fails.
-        assert!(!verify_sequential(
-            PotSeed::from(SEED_1),
-            key,
-            &checkpoints,
-            checkpoint_iterations,
-        ));
-        assert!(!verify_sequential_generic(
+        assert!(!verify_test(
             PotSeed::from(SEED_1),
             key,
             &checkpoints,
@@ -206,13 +229,7 @@ mod tests {
         ));
 
         // Decryption with wrong key fails.
-        assert!(!verify_sequential(
-            seed,
-            PotKey::from(KEY_1),
-            &checkpoints,
-            checkpoint_iterations,
-        ));
-        assert!(!verify_sequential_generic(
+        assert!(!verify_test(
             seed,
             PotKey::from(KEY_1),
             &checkpoints,

--- a/crates/shared/ab-proof-of-time/src/aes.rs
+++ b/crates/shared/ab-proof-of-time/src/aes.rs
@@ -80,6 +80,14 @@ pub(crate) fn verify_sequential(
                 x86_64::verify_sequential_avx2_vaes(&seed, &key, checkpoints, checkpoint_iterations)
             };
         }
+
+        cpufeatures::new!(has_aes_sse41, "aes", "sse4.1");
+        if has_aes_sse41::get() {
+            // SAFETY: Checked `aes` and `sse4.1` features
+            return unsafe {
+                x86_64::verify_sequential_aes_sse41(&seed, &key, checkpoints, checkpoint_iterations)
+            };
+        }
     }
 
     verify_sequential_generic(seed, key, checkpoints, checkpoint_iterations)
@@ -175,6 +183,20 @@ mod tests {
                     )
                 };
                 assert_eq!(sequential, avx2_vaes);
+            }
+
+            cpufeatures::new!(has_aes_sse41, "aes", "sse4.1");
+            if has_aes_sse41::get() {
+                // SAFETY: Checked `aes` and `sse4.1` features
+                let aes = unsafe {
+                    x86_64::verify_sequential_aes_sse41(
+                        &seed,
+                        &key,
+                        checkpoints,
+                        checkpoint_iterations,
+                    )
+                };
+                assert_eq!(sequential, aes);
             }
         }
 

--- a/crates/shared/ab-proof-of-time/src/aes/x86_64.rs
+++ b/crates/shared/ab-proof-of-time/src/aes/x86_64.rs
@@ -1,7 +1,7 @@
 use ab_core_primitives::pot::{PotCheckpoints, PotOutput};
 use core::arch::x86_64::*;
 use core::array;
-use core::simd::{u8x16, u8x64};
+use core::simd::{u8x16, u8x32, u8x64};
 
 const NUM_ROUND_KEYS: usize = 11;
 
@@ -42,10 +42,125 @@ pub(super) fn create(
 }
 
 /// Verification mimics `create` function, but also has decryption half for better performance
+#[target_feature(enable = "avx2,vaes")]
+#[inline]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub(super) fn verify_sequential_avx2_vaes(
+    seed: &[u8; 16],
+    key: &[u8; 16],
+    checkpoints: &PotCheckpoints,
+    checkpoint_iterations: u32,
+) -> bool {
+    let checkpoints = PotOutput::repr_from_slice(checkpoints.as_slice());
+
+    let keys = expand_key(key);
+    let xor_key = _mm_xor_si128(keys[10], keys[0]);
+    let xor_key_256 = _mm256_broadcastsi128_si256(xor_key);
+
+    // Invert keys for decryption, the first and last element is not used below, hence they are
+    // copied as is from encryption keys (otherwise the first and last element would need to be
+    // swapped)
+    let mut inv_keys = keys;
+    for i in 1..10 {
+        inv_keys[i] = _mm_aesimc_si128(keys[10 - i]);
+    }
+
+    let keys_256 = array::from_fn::<_, NUM_ROUND_KEYS, _>(|i| _mm256_broadcastsi128_si256(keys[i]));
+    let inv_keys_256 =
+        array::from_fn::<_, NUM_ROUND_KEYS, _>(|i| _mm256_broadcastsi128_si256(inv_keys[i]));
+
+    let mut input_0 = [[0u8; 16]; 2];
+    input_0[0] = *seed;
+    input_0[1] = checkpoints[0];
+    let mut input_0 = __m256i::from(u8x32::from_slice(input_0.as_flattened()));
+
+    let mut input_1 = __m256i::from(u8x32::from_slice(checkpoints[1..3].as_flattened()));
+    let mut input_2 = __m256i::from(u8x32::from_slice(checkpoints[3..5].as_flattened()));
+    let mut input_3 = __m256i::from(u8x32::from_slice(checkpoints[5..7].as_flattened()));
+
+    let mut output_0 = __m256i::from(u8x32::from_slice(checkpoints[0..2].as_flattened()));
+    let mut output_1 = __m256i::from(u8x32::from_slice(checkpoints[2..4].as_flattened()));
+    let mut output_2 = __m256i::from(u8x32::from_slice(checkpoints[4..6].as_flattened()));
+    let mut output_3 = __m256i::from(u8x32::from_slice(checkpoints[6..8].as_flattened()));
+
+    input_0 = _mm256_xor_si256(input_0, keys_256[0]);
+    input_1 = _mm256_xor_si256(input_1, keys_256[0]);
+    input_2 = _mm256_xor_si256(input_2, keys_256[0]);
+    input_3 = _mm256_xor_si256(input_3, keys_256[0]);
+
+    output_0 = _mm256_xor_si256(output_0, keys_256[10]);
+    output_1 = _mm256_xor_si256(output_1, keys_256[10]);
+    output_2 = _mm256_xor_si256(output_2, keys_256[10]);
+    output_3 = _mm256_xor_si256(output_3, keys_256[10]);
+
+    for _ in 0..checkpoint_iterations / 2 {
+        // TODO: Shouldn't be unsafe: https://github.com/rust-lang/rust/issues/141718
+        unsafe {
+            for i in 1..10 {
+                input_0 = _mm256_aesenc_epi128(input_0, keys_256[i]);
+                input_1 = _mm256_aesenc_epi128(input_1, keys_256[i]);
+                input_2 = _mm256_aesenc_epi128(input_2, keys_256[i]);
+                input_3 = _mm256_aesenc_epi128(input_3, keys_256[i]);
+
+                output_0 = _mm256_aesdec_epi128(output_0, inv_keys_256[i]);
+                output_1 = _mm256_aesdec_epi128(output_1, inv_keys_256[i]);
+                output_2 = _mm256_aesdec_epi128(output_2, inv_keys_256[i]);
+                output_3 = _mm256_aesdec_epi128(output_3, inv_keys_256[i]);
+            }
+
+            input_0 = _mm256_aesenclast_epi128(input_0, xor_key_256);
+            input_1 = _mm256_aesenclast_epi128(input_1, xor_key_256);
+            input_2 = _mm256_aesenclast_epi128(input_2, xor_key_256);
+            input_3 = _mm256_aesenclast_epi128(input_3, xor_key_256);
+
+            output_0 = _mm256_aesdeclast_epi128(output_0, xor_key_256);
+            output_1 = _mm256_aesdeclast_epi128(output_1, xor_key_256);
+            output_2 = _mm256_aesdeclast_epi128(output_2, xor_key_256);
+            output_3 = _mm256_aesdeclast_epi128(output_3, xor_key_256);
+        }
+    }
+
+    // Code below is a more efficient version of this:
+    // input_0 = _mm256_xor_si256(input_0, keys_256[0]);
+    // input_1 = _mm256_xor_si256(input_1, keys_256[0]);
+    // input_2 = _mm256_xor_si256(input_2, keys_256[0]);
+    // input_3 = _mm256_xor_si256(input_3, keys_256[0]);
+    // output_0 = _mm256_xor_si256(output_0, keys_256[10]);
+    // output_1 = _mm256_xor_si256(output_1, keys_256[10]);
+    // output_2 = _mm256_xor_si256(output_2, keys_256[10]);
+    // output_3 = _mm256_xor_si256(output_3, keys_256[10]);
+    //
+    // let mask_0 = _mm256_cmpeq_epi64(input_0, output_0);
+    // let mask_1 = _mm256_cmpeq_epi64(input_1, output_1);
+    // let mask_2 = _mm256_cmpeq_epi64(input_2, output_1);
+    // let mask_3 = _mm256_cmpeq_epi64(input_3, output_1);
+
+    let diff_0 = _mm256_xor_si256(input_0, output_0);
+    let diff_1 = _mm256_xor_si256(input_1, output_1);
+    let diff_2 = _mm256_xor_si256(input_2, output_2);
+    let diff_3 = _mm256_xor_si256(input_3, output_3);
+
+    let mask_0 = _mm256_cmpeq_epi64(diff_0, xor_key_256);
+    let mask_1 = _mm256_cmpeq_epi64(diff_1, xor_key_256);
+    let mask_2 = _mm256_cmpeq_epi64(diff_2, xor_key_256);
+    let mask_3 = _mm256_cmpeq_epi64(diff_3, xor_key_256);
+
+    // All bits set
+    let all_ones = _mm256_set1_epi64x(-1);
+
+    let match_0 = _mm256_testc_si256(mask_0, all_ones) != 0;
+    let match_1 = _mm256_testc_si256(mask_1, all_ones) != 0;
+    let match_2 = _mm256_testc_si256(mask_2, all_ones) != 0;
+    let match_3 = _mm256_testc_si256(mask_3, all_ones) != 0;
+
+    match_0 && match_1 && match_2 && match_3
+}
+
+/// Verification mimics `create` function, but also has decryption half for better performance
 #[target_feature(enable = "avx512f,vaes")]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
-pub(super) fn verify_sequential_avx512f(
+pub(super) fn verify_sequential_avx512f_vaes(
     seed: &[u8; 16],
     key: &[u8; 16],
     checkpoints: &PotCheckpoints,
@@ -109,17 +224,17 @@ pub(super) fn verify_sequential_avx512f(
     // output_0 = _mm512_xor_si512(output_0, keys_512[10]);
     // output_1 = _mm512_xor_si512(output_1, keys_512[10]);
     //
-    // let mask0 = _mm512_cmpeq_epu64_mask(input_0, output_0);
-    // let mask1 = _mm512_cmpeq_epu64_mask(input_1, output_1);
+    // let mask_0 = _mm512_cmpeq_epu64_mask(input_0, output_0);
+    // let mask_1 = _mm512_cmpeq_epu64_mask(input_1, output_1);
 
     let diff_0 = _mm512_xor_si512(input_0, output_0);
     let diff_1 = _mm512_xor_si512(input_1, output_1);
 
-    let mask0 = _mm512_cmpeq_epu64_mask(diff_0, xor_key_512);
-    let mask1 = _mm512_cmpeq_epu64_mask(diff_1, xor_key_512);
+    let mask_0 = _mm512_cmpeq_epu64_mask(diff_0, xor_key_512);
+    let mask_1 = _mm512_cmpeq_epu64_mask(diff_1, xor_key_512);
 
     // All inputs match outputs
-    (mask0 & mask1) == u8::MAX
+    (mask_0 & mask_1) == u8::MAX
 }
 
 // Below code copied with minor changes from the following place under MIT/Apache-2.0 license by


### PR DESCRIPTION
There are CPUs with VAES that do not support AVX512F, which requires a special version of code to make it work with AVX2 and narrower registers