### PR TITLE
Block infrastructure improvements

### DIFF
--- a/crates/node/ab-client-api/src/lib.rs
+++ b/crates/node/ab-client-api/src/lib.rs
@@ -1,7 +1,7 @@
 //! Client API
 
-/// Global chain info
-pub trait ChainInfo: Clone + Send + Sync + 'static {
+/// Chain sync status
+pub trait ChainSyncStatus: Clone + Send + Sync + 'static {
     /// Returns `true` if the chain is currently syncing
     fn is_syncing(&self) -> bool;
 

--- a/crates/shared/ab-core-primitives/src/block/body/owned.rs
+++ b/crates/shared/ab-core-primitives/src/block/body/owned.rs
@@ -1,8 +1,8 @@
 //! Data structures related to the owned version of [`BlockBody`]
 
 use crate::block::body::{
-    BeaconChainBody, BlockBody, IntermediateShardBlockInfo, IntermediateShardBody,
-    LeafShardBlockInfo, LeafShardBody,
+    BeaconChainBody, BlockBody, GenericBlockBody, IntermediateShardBlockInfo,
+    IntermediateShardBody, LeafShardBlockInfo, LeafShardBody,
 };
 use crate::block::header::owned::{
     OwnedIntermediateShardHeader, OwnedIntermediateShardHeaderError, OwnedLeafShardHeader,
@@ -16,6 +16,17 @@ use ab_aligned_buffer::{OwnedAlignedBuffer, SharedAlignedBuffer};
 use ab_io_type::trivial_type::TrivialType;
 use core::iter::TrustedLen;
 use derive_more::From;
+
+/// Generic owned block body
+pub trait GenericOwnedBlockBody {
+    /// Block body
+    type Body<'a>: GenericBlockBody<'a>
+    where
+        Self: 'a;
+
+    /// Get regular block body out of the owned version
+    fn body(&self) -> Self::Body<'_>;
+}
 
 /// Transaction addition error
 #[derive(Debug, thiserror::Error)]
@@ -206,6 +217,15 @@ pub enum OwnedBeaconChainBodyError {
 #[derive(Debug, Clone)]
 pub struct OwnedBeaconChainBody {
     buffer: SharedAlignedBuffer,
+}
+
+impl GenericOwnedBlockBody for OwnedBeaconChainBody {
+    type Body<'a> = BeaconChainBody<'a>;
+
+    #[inline(always)]
+    fn body(&self) -> Self::Body<'_> {
+        self.body()
+    }
 }
 
 impl OwnedBeaconChainBody {
@@ -437,6 +457,15 @@ pub struct OwnedIntermediateShardBody {
     buffer: SharedAlignedBuffer,
 }
 
+impl GenericOwnedBlockBody for OwnedIntermediateShardBody {
+    type Body<'a> = IntermediateShardBody<'a>;
+
+    #[inline(always)]
+    fn body(&self) -> Self::Body<'_> {
+        self.body()
+    }
+}
+
 impl OwnedIntermediateShardBody {
     /// Initialize building of [`OwnedIntermediateShardBody`]
     pub fn init<'a, LSB>(
@@ -651,6 +680,15 @@ pub struct OwnedLeafShardBody {
     buffer: SharedAlignedBuffer,
 }
 
+impl GenericOwnedBlockBody for OwnedLeafShardBody {
+    type Body<'a> = LeafShardBody<'a>;
+
+    #[inline(always)]
+    fn body(&self) -> Self::Body<'_> {
+        self.body()
+    }
+}
+
 impl OwnedLeafShardBody {
     /// Initialize building of [`OwnedLeafShardBody`]
     pub fn init(
@@ -773,6 +811,15 @@ pub enum OwnedBlockBody {
     IntermediateShard(OwnedIntermediateShardBody),
     /// Block body corresponds to a leaf shard
     LeafShard(OwnedLeafShardBody),
+}
+
+impl GenericOwnedBlockBody for OwnedBlockBody {
+    type Body<'a> = BlockBody<'a>;
+
+    #[inline(always)]
+    fn body(&self) -> Self::Body<'_> {
+        self.body()
+    }
 }
 
 impl OwnedBlockBody {

--- a/crates/shared/ab-core-primitives/src/block/header.rs
+++ b/crates/shared/ab-core-primitives/src/block/header.rs
@@ -136,7 +136,7 @@ pub struct BlockHeaderFixedConsensusParameters {
     ///
     /// Corresponds to the slot that is right after the parent block's slot.
     /// It can change before the slot of this block (see [`PotParametersChange`]).
-    pub pot_slot_iterations: NonZeroU32,
+    pub slot_iterations: NonZeroU32,
 }
 
 impl BlockHeaderFixedConsensusParameters {
@@ -164,18 +164,18 @@ impl BlockHeaderFixedConsensusParameters {
         ]);
 
         let pot_slot_iterations = bytes.split_off(..size_of::<u32>())?;
-        let pot_slot_iterations = u32::from_le_bytes([
+        let slot_iterations = u32::from_le_bytes([
             pot_slot_iterations[0],
             pot_slot_iterations[1],
             pot_slot_iterations[2],
             pot_slot_iterations[3],
         ]);
-        let pot_slot_iterations = NonZeroU32::new(pot_slot_iterations)?;
+        let slot_iterations = NonZeroU32::new(slot_iterations)?;
 
         Some((
             Self {
                 solution_range,
-                pot_slot_iterations,
+                slot_iterations,
             },
             bytes,
         ))
@@ -350,13 +350,13 @@ impl<'a> BlockHeaderBeaconChainParameters<'a> {
         } = self;
         let BlockHeaderFixedConsensusParameters {
             solution_range,
-            pot_slot_iterations,
+            slot_iterations,
         } = fixed_parameters;
 
         // TODO: Keyed hash
         let mut hasher = blake3::Hasher::new();
         hasher.update(solution_range.as_bytes());
-        hasher.update(&pot_slot_iterations.get().to_le_bytes());
+        hasher.update(&slot_iterations.get().to_le_bytes());
 
         if let Some(super_segment_root) = super_segment_root {
             hasher.update(super_segment_root.as_bytes());

--- a/crates/shared/ab-core-primitives/src/block/header/owned.rs
+++ b/crates/shared/ab-core-primitives/src/block/header/owned.rs
@@ -196,14 +196,14 @@ impl OwnedBeaconChainHeader {
     #[inline]
     pub fn from_header(header: BeaconChainHeader<'_>) -> Result<Self, OwnedBeaconChainHeaderError> {
         let unsealed = Self::from_parts(
-            header.generic.prefix,
-            header.generic.result,
-            header.generic.consensus_info,
+            header.shared.prefix,
+            header.shared.result,
+            header.shared.consensus_info,
             &header.child_shard_blocks,
             header.consensus_parameters,
         )?;
 
-        Ok(unsealed.with_seal(header.generic.seal))
+        Ok(unsealed.with_seal(header.shared.seal))
     }
 
     /// Create owned header from a buffer
@@ -367,14 +367,14 @@ impl OwnedIntermediateShardHeader {
         header: IntermediateShardHeader<'_>,
     ) -> Result<Self, OwnedIntermediateShardHeaderError> {
         let unsealed = Self::from_parts(
-            header.generic.prefix,
-            header.generic.result,
-            header.generic.consensus_info,
+            header.shared.prefix,
+            header.shared.result,
+            header.shared.consensus_info,
             header.beacon_chain_info,
             &header.child_shard_blocks,
         )?;
 
-        Ok(unsealed.with_seal(header.generic.seal))
+        Ok(unsealed.with_seal(header.shared.seal))
     }
 
     /// Create owned header from a buffer
@@ -493,13 +493,13 @@ impl OwnedLeafShardHeader {
     #[inline]
     pub fn from_header(header: LeafShardHeader<'_>) -> Self {
         let unsealed = Self::from_parts(
-            header.generic.prefix,
-            header.generic.result,
-            header.generic.consensus_info,
+            header.shared.prefix,
+            header.shared.result,
+            header.shared.consensus_info,
             header.beacon_chain_info,
         );
 
-        unsealed.with_seal(header.generic.seal)
+        unsealed.with_seal(header.shared.seal)
     }
 
     /// Create owned header from a buffer

--- a/crates/shared/ab-core-primitives/src/block/header/owned.rs
+++ b/crates/shared/ab-core-primitives/src/block/header/owned.rs
@@ -135,7 +135,7 @@ impl OwnedBeaconChainHeader {
             let true = buffer.append(
                 &consensus_parameters
                     .fixed_parameters
-                    .pot_slot_iterations
+                    .slot_iterations
                     .get()
                     .to_le_bytes(),
             ) else {

--- a/subspace/crates/subspace-service/src/rpc.rs
+++ b/subspace/crates/subspace-service/src/rpc.rs
@@ -6,7 +6,7 @@
 
 #![warn(missing_docs)]
 
-use ab_client_api::ChainInfo;
+use ab_client_api::ChainSyncStatus;
 use ab_erasure_coding::ErasureCoding;
 use jsonrpsee::RpcModule;
 use sc_client_api::{AuxStore, BlockBackend};
@@ -23,7 +23,7 @@ use subspace_networking::libp2p::Multiaddr;
 use subspace_runtime_primitives::opaque::Block;
 
 /// Full client dependencies.
-pub struct FullDeps<C, CI, AS> {
+pub struct FullDeps<C, CSS, AS> {
     /// The client instance to use.
     pub client: Arc<C>,
     /// Executor to drive the subscription manager in the Grandpa RPC handler.
@@ -40,15 +40,15 @@ pub struct FullDeps<C, CI, AS> {
     pub dsn_bootstrap_nodes: Vec<Multiaddr>,
     /// Segment header provider.
     pub segment_headers_store: SegmentHeadersStore<AS>,
-    /// Chain info
-    pub chain_info: CI,
+    /// Chain sync status
+    pub chain_sync_status: CSS,
     /// Erasure coding instance.
     pub erasure_coding: ErasureCoding,
 }
 
 /// Instantiate all full RPC extensions.
-pub fn create_full<C, CI, AS>(
-    deps: FullDeps<C, CI, AS>,
+pub fn create_full<C, CSS, AS>(
+    deps: FullDeps<C, CSS, AS>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
     C: ProvideRuntimeApi<Block>
@@ -58,7 +58,7 @@ where
         + Sync
         + 'static,
     C::Api: SubspaceApi<Block>,
-    CI: ChainInfo,
+    CSS: ChainSyncStatus,
     AS: AuxStore + Send + Sync + 'static,
 {
     let FullDeps {
@@ -69,7 +69,7 @@ where
         archived_segment_notification_stream,
         dsn_bootstrap_nodes,
         segment_headers_store,
-        chain_info,
+        chain_sync_status,
         erasure_coding,
     } = deps;
 
@@ -83,7 +83,7 @@ where
             archived_segment_notification_stream,
             dsn_bootstrap_nodes,
             segment_headers_store,
-            chain_info,
+            chain_sync_status,
             erasure_coding,
         })?
         .into_rpc(),


### PR DESCRIPTION
Extracted from local branch more block-related infrastructure, primarily introducing `Generic{,Owned}Block{,Header,Body}` traits that make it possible to reason about blocks in generic way. Some of it is quite painful to use due to the state of generics in Rust (even nightly), but it is a sufficient foundation for now.