### PR TITLE
Improve Merkle Tree implementation

### DIFF
--- a/crates/shared/ab-core-primitives/src/block/body.rs
+++ b/crates/shared/ab-core-primitives/src/block/body.rs
@@ -92,7 +92,7 @@ impl IntermediateShardBlockInfo<'_> {
             *compute_segments_root(self.child_segment_roots),
         ];
 
-        let root = UnbalancedHashedMerkleTree::compute_root_only::<MAX_N, _, _>(leaves)
+        let root = UnbalancedHashedMerkleTree::compute_root_only::<{ MAX_N as u64 }, _, _>(leaves)
             .expect("The list is not empty; qed");
 
         Blake3Hash::new(root)
@@ -276,18 +276,17 @@ impl<'a> IntermediateShardBlocksInfo<'a> {
     /// Returns default value for an empty collection of shard blocks.
     #[inline]
     pub fn headers_root(&self) -> Blake3Hash {
-        let root =
-            UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as usize + 1 }, _, _>(
-                // TODO: Keyed hash
-                self.iter().map(|shard_block_info| {
-                    // Hash the root again so we can prove it, otherwise headers root is
-                    // indistinguishable from individual block roots and can be used to confuse
-                    // verifier
+        let root = UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as u64 + 1 }, _, _>(
+            // TODO: Keyed hash
+            self.iter().map(|shard_block_info| {
+                // Hash the root again so we can prove it, otherwise headers root is
+                // indistinguishable from individual block roots and can be used to confuse
+                // verifier
 
-                    blake3::hash(shard_block_info.header.root().as_ref())
-                }),
-            )
-            .unwrap_or_default();
+                blake3::hash(shard_block_info.header.root().as_ref())
+            }),
+        )
+        .unwrap_or_default();
 
         Blake3Hash::new(root)
     }
@@ -297,11 +296,10 @@ impl<'a> IntermediateShardBlocksInfo<'a> {
     /// Returns default value for an empty collection of shard blocks.
     #[inline]
     pub fn root(&self) -> Blake3Hash {
-        let root =
-            UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as usize + 1 }, _, _>(
-                self.iter().map(|shard_block_info| shard_block_info.root()),
-            )
-            .unwrap_or_default();
+        let root = UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as u64 + 1 }, _, _>(
+            self.iter().map(|shard_block_info| shard_block_info.root()),
+        )
+        .unwrap_or_default();
 
         Blake3Hash::new(root)
     }
@@ -662,17 +660,16 @@ impl<'a> LeafShardBlocksInfo<'a> {
     /// Returns default value for an empty collection of shard blocks.
     #[inline]
     pub fn headers_root(&self) -> Blake3Hash {
-        let root =
-            UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as usize + 1 }, _, _>(
-                self.iter().map(|shard_block_info| {
-                    // Hash the root again so we can prove it, otherwise headers root is
-                    // indistinguishable from individual block roots and can be used to confuse
-                    // verifier
+        let root = UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as u64 + 1 }, _, _>(
+            self.iter().map(|shard_block_info| {
+                // Hash the root again so we can prove it, otherwise headers root is
+                // indistinguishable from individual block roots and can be used to confuse
+                // verifier
 
-                    blake3::hash(shard_block_info.header.root().as_ref())
-                }),
-            )
-            .unwrap_or_default();
+                blake3::hash(shard_block_info.header.root().as_ref())
+            }),
+        )
+        .unwrap_or_default();
 
         Blake3Hash::new(root)
     }
@@ -901,16 +898,15 @@ impl<'a> Transactions<'a> {
     /// Returns default value for an empty collection of shard blocks.
     #[inline]
     pub fn root(&self) -> Blake3Hash {
-        let root =
-            UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as usize + 1 }, _, _>(
-                self.iter().map(|transaction| {
-                    // Hash the hash again so we can prove it, otherwise transactions root is
-                    // indistinguishable from individual transaction roots and can be used to
-                    // confuse verifier
-                    blake3::hash(transaction.hash().as_ref())
-                }),
-            )
-            .unwrap_or_default();
+        let root = UnbalancedHashedMerkleTree::compute_root_only::<{ u16::MAX as u64 + 1 }, _, _>(
+            self.iter().map(|transaction| {
+                // Hash the hash again so we can prove it, otherwise transactions root is
+                // indistinguishable from individual transaction roots and can be used to
+                // confuse verifier
+                blake3::hash(transaction.hash().as_ref())
+            }),
+        )
+        .unwrap_or_default();
 
         Blake3Hash::new(root)
     }

--- a/crates/shared/ab-core-primitives/src/block/header.rs
+++ b/crates/shared/ab-core-primitives/src/block/header.rs
@@ -495,7 +495,7 @@ impl<'a> BlockHeaderChildShardBlocks<'a> {
     ///
     /// `None` is returned if there are no child shard blocks.
     pub fn root(&self) -> Option<Blake3Hash> {
-        let root = UnbalancedHashedMerkleTree::compute_root_only::<'_, { u32::MAX as usize }, _, _>(
+        let root = UnbalancedHashedMerkleTree::compute_root_only::<'_, { u32::MAX as u64 }, _, _>(
             // TODO: Keyed hash
             self.child_shard_blocks
                 .iter()
@@ -878,8 +878,9 @@ impl<'a> BeaconChainHeader<'a> {
             child_shard_blocks.root().unwrap_or_default(),
             consensus_parameters.hash(),
         ];
-        let block_root = UnbalancedHashedMerkleTree::compute_root_only::<MAX_N, _, _>(leaves)
-            .expect("The list is not empty; qed");
+        let block_root =
+            UnbalancedHashedMerkleTree::compute_root_only::<{ MAX_N as u64 }, _, _>(leaves)
+                .expect("The list is not empty; qed");
 
         BlockRoot::new(Blake3Hash::new(block_root))
     }
@@ -1091,8 +1092,9 @@ impl<'a> IntermediateShardHeader<'a> {
             beacon_chain_info.hash(),
             child_shard_blocks.root().unwrap_or_default(),
         ];
-        let block_root = UnbalancedHashedMerkleTree::compute_root_only::<MAX_N, _, _>(leaves)
-            .expect("The list is not empty; qed");
+        let block_root =
+            UnbalancedHashedMerkleTree::compute_root_only::<{ MAX_N as u64 }, _, _>(leaves)
+                .expect("The list is not empty; qed");
 
         BlockRoot::new(Blake3Hash::new(block_root))
     }
@@ -1288,8 +1290,9 @@ impl<'a> LeafShardHeader<'a> {
             seal.hash(),
             beacon_chain_info.hash(),
         ];
-        let block_root = UnbalancedHashedMerkleTree::compute_root_only::<MAX_N, _, _>(leaves)
-            .expect("The list is not empty; qed");
+        let block_root =
+            UnbalancedHashedMerkleTree::compute_root_only::<{ MAX_N as u64 }, _, _>(leaves)
+                .expect("The list is not empty; qed");
 
         BlockRoot::new(Blake3Hash::new(block_root))
     }

--- a/crates/shared/ab-merkle-tree/src/balanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/src/balanced_hashed.rs
@@ -140,26 +140,18 @@ where
 
         // Stack of intermediate nodes per tree level
         let mut stack = [[0u8; OUT_LEN]; N.ilog2() as usize + 1];
-        // Bitmask: bit `i = 1` if level `i` is active
-        let mut active_levels = 0_u32;
 
-        for &hash in leaves {
+        for (num_leaves, &hash) in leaves.iter().enumerate() {
             let mut current = hash;
-            let mut level = 0;
 
-            // Check if level is active by testing bit (active_levels & (1 << level))
-            while active_levels & (1 << level) != 0 {
-                current = hash_pair(&stack[level], &current);
-
-                // Clear the current level
-                active_levels &= !(1 << level);
-                level += 1;
+            // Every bit set to `1` corresponds to an active Merkle Tree level
+            let lowest_active_levels = num_leaves.trailing_ones() as usize;
+            for item in stack.iter().take(lowest_active_levels) {
+                current = hash_pair(item, &current);
             }
 
             // Place the current hash at the first inactive level
-            stack[level] = current;
-            // Set bit for level
-            active_levels |= 1 << level;
+            stack[lowest_active_levels] = current;
         }
 
         stack[N.ilog2() as usize]

--- a/crates/shared/ab-merkle-tree/src/unbalanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/src/unbalanced_hashed.rs
@@ -50,56 +50,50 @@ impl UnbalancedHashedMerkleTree {
     {
         // Stack of intermediate nodes per tree level
         let mut stack = [[0u8; OUT_LEN]; MAX_N.ilog2() as usize + 1];
-        // Bitmask: bit `i = 1` if level `i` is active
-        let mut active_levels = 0_u64;
+        let mut num_leaves = 0_u64;
 
         for hash in leaves {
-            // Active leaves is effectively the number of leaves
-            if active_levels >= MAX_N as u64 {
+            // How many leaves were processed so far
+            if num_leaves >= MAX_N as u64 {
                 return None;
             }
 
             let mut current = hash.into();
-            let mut level = 0;
 
-            // Check if level is active by testing bit (active_levels & (1 << level))
-            while (active_levels & (1 << level)) != 0 {
-                current = hash_pair(&stack[level], &current);
-
-                // Clear the current level
-                active_levels &= !(1 << level);
-                level += 1;
+            // Every bit set to `1` corresponds to an active Merkle Tree level
+            let lowest_active_levels = num_leaves.trailing_ones() as usize;
+            for item in stack.iter().take(lowest_active_levels) {
+                current = hash_pair(item, &current);
             }
 
             // Place the current hash at the first inactive level
-            stack[level] = current;
-            // Set bit for level
-            active_levels |= 1 << level;
+            stack[lowest_active_levels] = current;
+            num_leaves += 1;
         }
 
-        if active_levels == 0 {
+        if num_leaves == 0 {
             // If no leaves were provided
             return None;
         }
 
         {
-            let lowest_active_level = active_levels.trailing_zeros() as usize;
+            let lowest_active_level = num_leaves.trailing_zeros() as usize;
             // Reuse `stack[0]` for resulting value
             stack[0] = stack[lowest_active_level];
             // Clear lowest active level
-            active_levels &= !(1 << lowest_active_level);
+            num_leaves &= !(1 << lowest_active_level);
         }
 
         // Hash remaining peaks (if any) of the potentially unbalanced tree together
         loop {
-            let lowest_active_level = active_levels.trailing_zeros() as usize;
+            let lowest_active_level = num_leaves.trailing_zeros() as usize;
 
             if lowest_active_level == u64::BITS as usize {
                 break;
             }
 
             // Clear lowest active level
-            active_levels &= !(1 << lowest_active_level);
+            num_leaves &= !(1 << lowest_active_level);
 
             stack[0] = hash_pair(&stack[lowest_active_level], &stack[0]);
         }
@@ -186,56 +180,42 @@ impl UnbalancedHashedMerkleTree {
         Iter: IntoIterator<Item = Item> + 'a,
     {
         let mut proof_length = 0;
-        let mut active_levels = 0_u64;
+        let mut num_leaves = 0_u64;
 
         let mut current_target_level = None;
         let mut position = target_index;
 
         for (current_index, hash) in leaves.into_iter().enumerate() {
-            // Active leaves is effectively the number of leaves
-            if active_levels >= MAX_N as u64 {
+            // How many leaves were processed so far
+            if num_leaves >= MAX_N as u64 {
                 return None;
             }
 
             let mut current = hash.into();
-            let mut level = 0;
+
+            // Every bit set to `1` corresponds to an active Merkle Tree level
+            let lowest_active_levels = num_leaves.trailing_ones() as usize;
 
             if current_index == target_index {
-                // Check if level is active by testing bit (active_levels & (1 << level))
-                while (active_levels & (1 << level)) != 0 {
+                for item in stack.iter().take(lowest_active_levels) {
                     // If at the target leaf index, need to collect the proof
                     // SAFETY: Method signature guarantees upper bound of the proof length
-                    unsafe { proof.get_unchecked_mut(proof_length) }.write(stack[level]);
+                    unsafe { proof.get_unchecked_mut(proof_length) }.write(*item);
                     proof_length += 1;
 
-                    current = hash_pair(&stack[level], &current);
-
-                    // Clear the current level
-                    active_levels &= !(1 << level);
-                    level += 1;
+                    current = hash_pair(item, &current);
 
                     // Move up the tree
                     position /= 2;
                 }
 
-                current_target_level = Some(level);
-
-                // Place the current hash at the first inactive level
-                stack[level] = current;
-                // Set bit for level
-                active_levels |= 1 << level;
+                current_target_level = Some(lowest_active_levels);
             } else {
-                // If at the target leaf index, need to collect the proof
-                while (active_levels & (1 << level)) != 0 {
+                for (level, item) in stack.iter().enumerate().take(lowest_active_levels) {
                     if current_target_level == Some(level) {
                         // SAFETY: Method signature guarantees upper bound of the proof length
-                        unsafe { proof.get_unchecked_mut(proof_length) }.write(
-                            if position % 2 == 0 {
-                                current
-                            } else {
-                                stack[level]
-                            },
-                        );
+                        unsafe { proof.get_unchecked_mut(proof_length) }
+                            .write(if position % 2 == 0 { current } else { *item });
                         proof_length += 1;
 
                         current_target_level = Some(level + 1);
@@ -244,22 +224,17 @@ impl UnbalancedHashedMerkleTree {
                         position /= 2;
                     }
 
-                    current = hash_pair(&stack[level], &current);
-
-                    // Clear the current level
-                    active_levels &= !(1 << level);
-                    level += 1;
+                    current = hash_pair(item, &current);
                 }
-
-                // Place the current hash at the first inactive level
-                stack[level] = current;
-                // Set bit for level
-                active_levels |= 1 << level;
             }
+
+            // Place the current hash at the first inactive level
+            stack[lowest_active_levels] = current;
+            num_leaves += 1;
         }
 
         // `active_levels` here contains the number of leaves after above loop
-        if target_index >= active_levels as usize {
+        if target_index >= num_leaves as usize {
             // If no leaves were provided
             return None;
         }
@@ -270,25 +245,25 @@ impl UnbalancedHashedMerkleTree {
         };
 
         {
-            let lowest_active_level = active_levels.trailing_zeros() as usize;
+            let lowest_active_level = num_leaves.trailing_zeros() as usize;
             // Reuse `stack[0]` for resulting value
             stack[0] = stack[lowest_active_level];
             // Clear lowest active level
-            active_levels &= !(1 << lowest_active_level);
+            num_leaves &= !(1 << lowest_active_level);
         }
 
         // Hash remaining peaks (if any) of the potentially unbalanced tree together and collect
         // proof hashes
         let mut merged_peaks = false;
         loop {
-            let lowest_active_level = active_levels.trailing_zeros() as usize;
+            let lowest_active_level = num_leaves.trailing_zeros() as usize;
 
             if lowest_active_level == u64::BITS as usize {
                 break;
             }
 
             // Clear lowest active level
-            active_levels &= !(1 << lowest_active_level);
+            num_leaves &= !(1 << lowest_active_level);
 
             if lowest_active_level > current_target_level
                 || (lowest_active_level == current_target_level

--- a/crates/shared/ab-merkle-tree/src/unbalanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/src/unbalanced_hashed.rs
@@ -40,7 +40,7 @@ impl UnbalancedHashedMerkleTree {
     ///
     /// Returns `None` for an empty list of leaves.
     #[inline]
-    pub fn compute_root_only<'a, const MAX_N: usize, Item, Iter>(
+    pub fn compute_root_only<'a, const MAX_N: u64, Item, Iter>(
         leaves: Iter,
     ) -> Option<[u8; OUT_LEN]>
     where
@@ -54,7 +54,7 @@ impl UnbalancedHashedMerkleTree {
 
         for hash in leaves {
             // How many leaves were processed so far
-            if num_leaves >= MAX_N as u64 {
+            if num_leaves >= MAX_N {
                 return None;
             }
 
@@ -109,7 +109,7 @@ impl UnbalancedHashedMerkleTree {
     /// usage.
     #[inline]
     #[cfg(feature = "alloc")]
-    pub fn compute_root_and_proof<'a, const MAX_N: usize, Item, Iter>(
+    pub fn compute_root_and_proof<'a, const MAX_N: u64, Item, Iter>(
         leaves: Iter,
         target_index: usize,
     ) -> Option<([u8; OUT_LEN], Vec<[u8; OUT_LEN]>)>
@@ -147,7 +147,7 @@ impl UnbalancedHashedMerkleTree {
     /// `MAX_N` generic constant defines the maximum number of elements supported and controls stack
     /// usage.
     #[inline]
-    pub fn compute_root_and_proof_in<'a, 'proof, const MAX_N: usize, Item, Iter>(
+    pub fn compute_root_and_proof_in<'a, 'proof, const MAX_N: u64, Item, Iter>(
         leaves: Iter,
         target_index: usize,
         proof: &'proof mut [MaybeUninit<[u8; OUT_LEN]>; MAX_N.ilog2() as usize + 1],
@@ -168,7 +168,7 @@ impl UnbalancedHashedMerkleTree {
         Some((root, proof))
     }
 
-    fn compute_root_and_proof_inner<'a, const MAX_N: usize, Item, Iter>(
+    fn compute_root_and_proof_inner<'a, const MAX_N: u64, Item, Iter>(
         leaves: Iter,
         target_index: usize,
         stack: &mut [[u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
@@ -187,7 +187,7 @@ impl UnbalancedHashedMerkleTree {
 
         for (current_index, hash) in leaves.into_iter().enumerate() {
             // How many leaves were processed so far
-            if num_leaves >= MAX_N as u64 {
+            if num_leaves >= MAX_N {
                 return None;
             }
 
@@ -298,9 +298,9 @@ impl UnbalancedHashedMerkleTree {
     pub fn verify(
         root: &[u8; OUT_LEN],
         proof: &[[u8; OUT_LEN]],
-        leaf_index: usize,
+        leaf_index: u64,
         leaf: [u8; OUT_LEN],
-        num_leaves: usize,
+        num_leaves: u64,
     ) -> bool {
         if leaf_index >= num_leaves {
             return false;

--- a/crates/shared/ab-merkle-tree/tests/unbalanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/tests/unbalanced_hashed.rs
@@ -207,6 +207,42 @@ fn mt_unbalanced_15_leaves() {
 }
 
 #[test]
+fn mt_unbalanced_too_many_leaves() {
+    const NUM_LEAVES: usize = 3;
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+
+    let leaves = {
+        let mut leaves = vec![[0u8; OUT_LEN]; NUM_LEAVES + 1];
+        for hash in &mut leaves {
+            rng.fill_bytes(hash);
+        }
+        leaves
+    };
+
+    assert!(
+        UnbalancedHashedMerkleTree::compute_root_only::<NUM_LEAVES, _, _>(leaves.iter().copied())
+            .is_none()
+    );
+    let proof_buffer = &mut [MaybeUninit::uninit(); _];
+    assert!(
+        UnbalancedHashedMerkleTree::compute_root_and_proof_in::<NUM_LEAVES, _, _>(
+            leaves.iter().copied(),
+            0,
+            proof_buffer
+        )
+        .is_none()
+    );
+    #[cfg(feature = "alloc")]
+    assert!(
+        UnbalancedHashedMerkleTree::compute_root_and_proof::<NUM_LEAVES, _, _>(
+            leaves.iter().copied(),
+            0
+        )
+        .is_none()
+    );
+}
+
+#[test]
 #[cfg_attr(miri, ignore)]
 fn mt_unbalanced_large_range() {
     for number_of_leaves in 2..MAX_N {

--- a/crates/shared/ab-merkle-tree/tests/unbalanced_hashed.rs
+++ b/crates/shared/ab-merkle-tree/tests/unbalanced_hashed.rs
@@ -10,7 +10,7 @@ use rand_core::{RngCore, SeedableRng};
 use std::mem;
 use std::mem::MaybeUninit;
 
-const MAX_N: usize = 100;
+const MAX_N: u64 = 100;
 
 /// A simplified version that is easier to audit to verify the main optimized version against
 struct SimpleUnbalancedMerkleTree;
@@ -208,11 +208,11 @@ fn mt_unbalanced_15_leaves() {
 
 #[test]
 fn mt_unbalanced_too_many_leaves() {
-    const NUM_LEAVES: usize = 3;
+    const NUM_LEAVES: u64 = 3;
     let mut rng = ChaCha8Rng::from_seed(Default::default());
 
     let leaves = {
-        let mut leaves = vec![[0u8; OUT_LEN]; NUM_LEAVES + 1];
+        let mut leaves = vec![[0u8; OUT_LEN]; NUM_LEAVES as usize + 1];
         for hash in &mut leaves {
             rng.fill_bytes(hash);
         }
@@ -250,11 +250,11 @@ fn mt_unbalanced_large_range() {
     }
 }
 
-fn test_basic(number_of_leaves: usize) {
+fn test_basic(number_of_leaves: u64) {
     let mut rng = ChaCha8Rng::from_seed(Default::default());
 
     let leaves = {
-        let mut leaves = vec![[0u8; OUT_LEN]; number_of_leaves];
+        let mut leaves = vec![[0u8; OUT_LEN]; number_of_leaves as usize];
         for hash in &mut leaves {
             rng.fill_bytes(hash);
         }
@@ -330,7 +330,13 @@ fn test_basic(number_of_leaves: usize) {
             "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
         );
         assert!(
-            UnbalancedHashedMerkleTree::verify(&root, &proof, leaf_index, leaf, leaves.len()),
+            UnbalancedHashedMerkleTree::verify(
+                &root,
+                &proof,
+                leaf_index as u64,
+                leaf,
+                leaves.len() as u64
+            ),
             "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
         );
 
@@ -348,9 +354,9 @@ fn test_basic(number_of_leaves: usize) {
             !UnbalancedHashedMerkleTree::verify(
                 &root,
                 &random_proof,
-                leaf_index,
+                leaf_index as u64,
                 leaf,
-                leaves.len()
+                leaves.len() as u64
             ),
             "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
         );
@@ -370,9 +376,9 @@ fn test_basic(number_of_leaves: usize) {
                 !UnbalancedHashedMerkleTree::verify(
                     &root,
                     &proof,
-                    bad_leaf_index,
+                    bad_leaf_index as u64,
                     leaf,
-                    leaves.len()
+                    leaves.len() as u64
                 ),
                 "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
             );
@@ -383,7 +389,13 @@ fn test_basic(number_of_leaves: usize) {
             "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
         );
         assert!(
-            !UnbalancedHashedMerkleTree::verify(&root, &proof, leaf_index + 1, leaf, leaves.len()),
+            !UnbalancedHashedMerkleTree::verify(
+                &root,
+                &proof,
+                leaf_index as u64 + 1,
+                leaf,
+                leaves.len() as u64
+            ),
             "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
         );
 
@@ -401,9 +413,9 @@ fn test_basic(number_of_leaves: usize) {
             !UnbalancedHashedMerkleTree::verify(
                 &root,
                 &proof,
-                leaf_index,
+                leaf_index as u64,
                 random_hash,
-                leaves.len()
+                leaves.len() as u64
             ),
             "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
         );
@@ -436,5 +448,5 @@ fn test_basic(number_of_leaves: usize) {
         .is_none()
     );
     #[cfg(feature = "alloc")]
-    assert!(UnbalancedHashedMerkleTree::compute_root_and_proof::<MAX_N, _, _>(empty, 0,).is_none());
+    assert!(UnbalancedHashedMerkleTree::compute_root_and_proof::<MAX_N, _, _>(empty, 0).is_none());
 }


### PR DESCRIPTION
I first noticed that unbalanced implementation could panic if `MAX_N` was specified incorrectly.

I then looked closer into `active_levels` and it became clear that it is just a number of leaves, so decided to simplify the implementation. Especially balanced implementation is very elegant now.

There are no dedicated Merkle Tree benchmarks yet, but archiving that uses it shows clear and non-negligible improvement.

```
Before:
segment-archiving-whole-segment
                        time:   [1.9043 s 1.9133 s 1.9230 s]
After:
segment-archiving-whole-segment
                        time:   [1.8101 s 1.8152 s 1.8202 s]
```