### PR TITLE
Enable ed25519 verification unconditionally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,15 +937,13 @@ dependencies = [
 [[package]]
 name = "ed25519-zebra"
 version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
+source = "git+https://github.com/ZcashFoundation/ed25519-zebra?rev=dbb5610b818a6b54ebd347c27f8c8d3d6af89648#dbb5610b818a6b54ebd347c27f8c8d3d6af89648"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "hashbrown 0.14.5",
- "hex",
  "rand_core 0.6.4",
  "sha2",
+ "subtle",
  "zeroize",
 ]
 
@@ -1148,16 +1146,6 @@ name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ criterion = { version = "0.6.0", default-features = false }
 derive_more = { version = "2.0.1", default-features = false }
 # TODO: Switch to ed25519-dalek with RFC8032 / NIST validation criteria instead once
 #  https://github.com/dalek-cryptography/curve25519-dalek/issues/626 is resolved
-ed25519-zebra = { version = "4.0.3", default-features = false }
+# TODO: Switch to offical 4.0.4+ is released with https://github.com/ZcashFoundation/ed25519-zebra/pull/174
+ed25519-zebra = { version = "4.0.3", git = "https://github.com/ZcashFoundation/ed25519-zebra", rev = "dbb5610b818a6b54ebd347c27f8c8d3d6af89648", default-features = false }
 futures = { version = "0.3.31", default-features = false }
 halfbrown = "0.3.0"
 hex = { version = "0.4.3", default-features = false }

--- a/crates/shared/ab-core-primitives/Cargo.toml
+++ b/crates/shared/ab-core-primitives/Cargo.toml
@@ -21,8 +21,7 @@ bech32 = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["full"] }
-# TODO: Make non-optional once https://github.com/ZcashFoundation/ed25519-zebra/issues/160 is resolved
-ed25519-zebra = { workspace = true, optional = true }
+ed25519-zebra = { workspace = true }
 hex = { workspace = true }
 parity-scale-codec = { workspace = true, features = ["bytes", "derive", "max-encoded-len"], optional = true }
 rayon = { workspace = true, optional = true }
@@ -42,11 +41,6 @@ alloc = [
     "dep:bytes",
     "hex/alloc",
     "serde/alloc",
-]
-# TODO: Remove once https://github.com/ZcashFoundation/ed25519-zebra/issues/160 is resolved
-ed25519-verify = [
-    "alloc",
-    "dep:ed25519-zebra",
 ]
 scale-codec = [
     "dep:parity-scale-codec",

--- a/crates/shared/ab-core-primitives/src/ed25519.rs
+++ b/crates/shared/ab-core-primitives/src/ed25519.rs
@@ -4,7 +4,6 @@ use crate::hashes::Blake3Hash;
 use ab_io_type::trivial_type::TrivialType;
 use core::fmt;
 use derive_more::{Deref, From, Into};
-#[cfg(feature = "ed25519-verify")]
 use ed25519_zebra::{Error, Signature, VerificationKey};
 #[cfg(feature = "scale-codec")]
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
@@ -26,7 +25,6 @@ use serde_big_array::BigArray;
 #[repr(C)]
 pub struct Ed25519PublicKey([u8; Ed25519PublicKey::SIZE]);
 
-#[cfg(feature = "ed25519-verify")]
 impl From<VerificationKey> for Ed25519PublicKey {
     #[inline(always)]
     fn from(verification_key: VerificationKey) -> Self {
@@ -109,7 +107,6 @@ impl Ed25519PublicKey {
     }
 
     /// Verify Ed25519 signature
-    #[cfg(feature = "ed25519-verify")]
     #[inline]
     pub fn verify(&self, signature: &Ed25519Signature, msg: &[u8]) -> Result<(), Error> {
         VerificationKey::try_from(self.0)?.verify(&Signature::from_bytes(signature), msg)
@@ -125,7 +122,6 @@ impl Ed25519PublicKey {
 #[repr(C)]
 pub struct Ed25519Signature([u8; Ed25519Signature::SIZE]);
 
-#[cfg(feature = "ed25519-verify")]
 impl From<Signature> for Ed25519Signature {
     #[inline(always)]
     fn from(signature: Signature) -> Self {

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "blake3",
  "bytes",
  "derive_more 2.0.1",
- "ed25519-zebra",
+ "ed25519-zebra 4.0.3 (git+https://github.com/ZcashFoundation/ed25519-zebra?rev=dbb5610b818a6b54ebd347c27f8c8d3d6af89648)",
  "hex",
  "parity-scale-codec",
  "rayon",
@@ -2526,6 +2526,19 @@ dependencies = [
  "hex",
  "rand_core 0.6.4",
  "sha2 0.10.8",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-zebra"
+version = "4.0.3"
+source = "git+https://github.com/ZcashFoundation/ed25519-zebra?rev=dbb5610b818a6b54ebd347c27f8c8d3d6af89648#dbb5610b818a6b54ebd347c27f8c8d3d6af89648"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "sha2 0.10.8",
+ "subtle 2.6.1",
  "zeroize",
 ]
 
@@ -9251,7 +9264,7 @@ dependencies = [
  "bounded-collections",
  "bs58",
  "dyn-clonable",
- "ed25519-zebra",
+ "ed25519-zebra 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "hash-db",
  "hash256-std-hasher",
@@ -9926,7 +9939,7 @@ dependencies = [
  "clap",
  "criterion",
  "derive_more 1.0.0",
- "ed25519-zebra",
+ "ed25519-zebra 4.0.3 (git+https://github.com/ZcashFoundation/ed25519-zebra?rev=dbb5610b818a6b54ebd347c27f8c8d3d6af89648)",
  "event-listener 5.3.1",
  "event-listener-primitives",
  "fdlimit",

--- a/subspace/Cargo.toml
+++ b/subspace/Cargo.toml
@@ -34,7 +34,8 @@ clap = "4.5.18"
 core_affinity = "0.8.1"
 criterion = { version = "0.6.0", default-features = false }
 derive_more = { version = "1.0.0", default-features = false }
-ed25519-zebra = { version = "4.0.3", default-features = false }
+# TODO: Switch to offical 4.0.4+ is released with https://github.com/ZcashFoundation/ed25519-zebra/pull/174
+ed25519-zebra = { version = "4.0.3", git = "https://github.com/ZcashFoundation/ed25519-zebra", rev = "dbb5610b818a6b54ebd347c27f8c8d3d6af89648", default-features = false }
 event-listener = "5.3.1"
 event-listener-primitives = "2.0.1"
 fdlimit = "0.3.0"

--- a/subspace/crates/sp-consensus-subspace/src/digests.rs
+++ b/subspace/crates/sp-consensus-subspace/src/digests.rs
@@ -1,7 +1,6 @@
 //! Private implementation details of Subspace consensus digests.
 
 use crate::{ConsensusLog, PotParametersChange, SUBSPACE_ENGINE_ID};
-use ab_core_primitives::block::BlockNumber;
 use ab_core_primitives::hashes::Blake3Hash;
 use ab_core_primitives::pot::{PotOutput, SlotNumber};
 use ab_core_primitives::segments::{SegmentIndex, SegmentRoot};

--- a/subspace/crates/subspace-verification/Cargo.toml
+++ b/subspace/crates/subspace-verification/Cargo.toml
@@ -14,7 +14,7 @@ include = [
 ]
 
 [dependencies]
-ab-core-primitives = { workspace = true, features = ["ed25519-verify"] }
+ab-core-primitives = { workspace = true }
 parity-scale-codec = { workspace = true, features = ["bytes", "derive", "max-encoded-len"], optional = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }


### PR DESCRIPTION
With https://github.com/ZcashFoundation/ed25519-zebra/pull/161 and https://github.com/ZcashFoundation/ed25519-zebra/pull/174 `alloc` is no longer needed. Using upstream `main` for now until they have a new release.

Also included some refactoring to seal check from local branch.