### PR TITLE
Update `chacha20` with API that writes keystream without XORing it

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,9 +22,9 @@ jobs:
           submodules: 'true'
 
       - name: Install mdbook with extra preprocessors
-        uses: taiki-e/install-action@acd25891978b4cdaebd139d3efef606d26513b14 # 2.47.0
+        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb # 2.53.2
         with:
-          tool: mdbook@0.4,mdbook-alerts@0.7.0,mdbook-d2@0.3.3
+          tool: mdbook@0.4,mdbook-alerts@0.7.0,mdbook-d2@0.3.4
 
       - name: D2 CLI
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -143,7 +143,7 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # 2.47.0
+        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb # 2.53.2
         with:
           tool: cargo-nextest
 
@@ -222,7 +222,7 @@ jobs:
         if: runner.os != 'Windows'
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # 2.47.0
+        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb # 2.53.2
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -226,6 +226,12 @@ jobs:
         with:
           tool: cargo-nextest
 
+      # TODO: This is a workaround for https://github.com/RustCrypto/stream-ciphers/issues/426
+      - name: Miri aarch64 workaround
+        run: |
+          echo "RUSTFLAGS=${{ env.RUSTFLAGS }} -C target-feature=-neon" >> $GITHUB_ENV
+        if: matrix.os == 'ubuntu-24.04-arm' || matrix.os == 'macos-15'
+
       - name: cargo miri nextest run
         run: |
           cargo -Zgitoxide -Zgit miri nextest run

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,7 +81,7 @@ jobs:
             echo "Check clippy with feature: $feature"
             for crate_path in crates/{execution,farmer,node,shared}/*; do
               # Not all crates have this feature
-              if ! grep --no-messages --quiet "^$feature = [" "$crate_path/Cargo.toml"; then
+              if ! grep --no-messages --quiet "^$feature = \[" "$crate_path/Cargo.toml"; then
                 continue
               fi
               crate="$(basename -- $crate_path)"
@@ -99,7 +99,7 @@ jobs:
           done
           for crate_path in crates/contracts/core/*; do
             # Not all crates have this feature
-            if ! grep --no-messages --quiet "^guest = [" "$crate_path/Cargo.toml"; then
+            if ! grep --no-messages --quiet "^guest = \[" "$crate_path/Cargo.toml"; then
               continue
             fi
             crate="$(basename -- $crate_path)"
@@ -157,7 +157,7 @@ jobs:
           for feature in alloc parallel scale-codec serde; do
             for crate_path in crates/{execution,farmer,node,shared}/*; do
               # Not all crates have this feature
-              if ! grep --no-messages --quiet "^$feature = [" "$crate_path/Cargo.toml"; then
+              if ! grep --no-messages --quiet "^$feature = \[" "$crate_path/Cargo.toml"; then
                 continue
               fi
               crate="$(basename -- $crate_path)"
@@ -183,7 +183,7 @@ jobs:
           done
           for create_path in crates/contracts/core/*; do
             # Not all crates have this feature
-            if ! grep --no-messages --quiet "^guest = [" "$crate_path/Cargo.toml"; then
+            if ! grep --no-messages --quiet "^guest = \[" "$crate_path/Cargo.toml"; then
               continue
             fi
             crate="$(basename -- $create_path)"
@@ -242,7 +242,7 @@ jobs:
           for feature in alloc parallel scale-codec serde; do
             for crate_path in crates/{execution,farmer,node,shared}/*; do
               # Not all crates have this feature
-              if ! grep --no-messages --quiet "^$feature = [" "$crate_path/Cargo.toml"; then
+              if ! grep --no-messages --quiet "^$feature = \[" "$crate_path/Cargo.toml"; then
                 continue
               fi
               crate="$(basename -- $crate_path)"
@@ -268,7 +268,7 @@ jobs:
           done
           for create_path in crates/contracts/core/*; do
             # Not all crates have this feature
-            if ! grep --no-messages --quiet "^guest = [" "$crate_path/Cargo.toml"; then
+            if ! grep --no-messages --quiet "^guest = \[" "$crate_path/Cargo.toml"; then
               continue
             fi
             crate="$(basename -- $create_path)"
@@ -319,7 +319,7 @@ jobs:
           # Ensure no panics in various crates
           for crate_path in crates/{contracts/{core,example,system},execution,farmer,node,shared}/*; do
             # Not all crates have this feature yet
-            if ! grep --no-messages --quiet '^no-panic = [' "$crate_path/Cargo.toml"; then
+            if ! grep --no-messages --quiet '^no-panic = \[' "$crate_path/Cargo.toml"; then
               continue
             fi
             crate="$(basename -- $crate_path)"
@@ -337,8 +337,8 @@ jobs:
           # Ensure no panics with `alloc` feature
           for crate_path in crates/{execution,farmer,node,shared}/*; do
             # Not all crates have this feature yet
-            if ! grep --no-messages --quiet '^no-panic = [' "$crate_path/Cargo.toml" || \
-               ! grep --no-messages --quiet '^alloc = [' "$crate_path/Cargo.toml"; then
+            if ! grep --no-messages --quiet '^no-panic = \[' "$crate_path/Cargo.toml" || \
+               ! grep --no-messages --quiet '^alloc = \[' "$crate_path/Cargo.toml"; then
               continue
             fi
             crate="$(basename -- $crate_path)"
@@ -356,7 +356,7 @@ jobs:
           # Ensure no panics with `guest` feature
           for contract_path in crates/contracts/{example,system}/*; do
             # Not all contracts have this feature yet
-            if ! grep --no-messages --quiet '^no-panic = [' "$contract_path/Cargo.toml"; then
+            if ! grep --no-messages --quiet '^no-panic = \[' "$contract_path/Cargo.toml"; then
               continue
             fi
             contract="$(basename -- $contract_path)"
@@ -365,8 +365,8 @@ jobs:
           done
           for contract_path in crates/contracts/core/*; do
             # Not all contracts have this feature yet
-            if ! grep --no-messages --quiet '^no-panic = [' "$crate_path/Cargo.toml" || \
-               ! grep --no-messages --quiet '^guest = [' "$crate_path/Cargo.toml"; then
+            if ! grep --no-messages --quiet '^no-panic = \[' "$crate_path/Cargo.toml" || \
+               ! grep --no-messages --quiet '^guest = \[' "$crate_path/Cargo.toml"; then
               continue
             fi
             contract="$(basename -- $contract_path)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,12 +524,12 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-pre.3"
+version = "0.9.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e4da00d9978020ddaa556c1747cfcafc3f375cfadb109acfe8b752cfc373bf"
+checksum = "cd4838e4ad37bb032dea137f441d5f71c16c26c068af512e64c5bc13a88cdfc7"
 dependencies = [
  "cfg-if",
- "cipher 0.5.0-pre.8",
+ "cipher",
  "cpufeatures",
 ]
 
@@ -696,15 +696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,12 +739,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "6e057d7ab0331b90074df7ca698b3361860c20a1d8c8e28f49c01f526e3f3958"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures",
 ]
 
@@ -786,22 +777,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+version = "0.5.0-rc.0"
+source = "git+https://github.com/RustCrypto/traits?rev=57aea511ffc6e8122ef4abced5135ea29473ef8d#57aea511ffc6e8122ef4abced5135ea29473ef8d"
 dependencies = [
- "crypto-common 0.1.6",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
-version = "0.5.0-pre.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276974d2acb7cf592603150941fc1ff6442acdeb1dc653ac2825928f4703c131"
-dependencies = [
- "crypto-common 0.2.0-rc.2",
- "inout 0.2.0-rc.4",
+ "crypto-common 0.2.0-rc.3",
+ "inout",
 ]
 
 [[package]]
@@ -974,9 +954,8 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170d71b5b14dec99db7739f6fc7d6ec2db80b78c3acb77db48392ccc3d8a9ea0"
+version = "0.2.0-rc.3"
+source = "git+https://github.com/RustCrypto/traits?rev=57aea511ffc6e8122ef4abced5135ea29473ef8d#57aea511ffc6e8122ef4abced5135ea29473ef8d"
 dependencies = [
  "hybrid-array",
 ]
@@ -1373,16 +1352,6 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "block-padding",
- "generic-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ab-system-contract-native-token = { version = "0.0.1", path = "crates/contracts/
 ab-system-contract-simple-wallet-base = { version = "0.0.1", path = "crates/contracts/system/ab-system-contract-simple-wallet-base" }
 ab-system-contract-state = { version = "0.0.1", path = "crates/contracts/system/ab-system-contract-state" }
 ab-trivial-type-derive = { version = "0.0.1", path = "crates/shared/ab-trivial-type-derive" }
-aes = "0.9.0-pre.3"
+aes = "0.9.0-rc.0"
 anyhow = { version = "1.0.98", default-features = false }
 async-lock = { version = "3.4.0", default-features = false }
 async-trait = "0.1.88"
@@ -50,7 +50,7 @@ bech32 = { version = "0.11.0", default-features = false }
 bitvec = "1.0.1"
 blake3 = { version = "1.8.2", default-features = false }
 bytes = { version = "1.10.1", default-features = false }
-chacha20 = { version = "0.9.1", default-features = false }
+chacha20 = { version = "0.10.0-rc.0", default-features = false }
 const-sha1 = { version = "0.3.0", default-features = false }
 const_format = "0.2.34"
 core_affinity = "0.8.3"
@@ -117,3 +117,7 @@ lto = "fat"
 [profile.contract]
 inherits = "production"
 strip = "symbols"
+
+[patch.crates-io]
+# TODO: Remove once 0.5.0-rc.1+ is released to include https://github.com/RustCrypto/traits/pull/1907
+cipher = { version = "0.5.0-rc.0", git = "https://github.com/RustCrypto/traits", rev = "57aea511ffc6e8122ef4abced5135ea29473ef8d" }

--- a/crates/shared/ab-proof-of-space/Cargo.toml
+++ b/crates/shared/ab-proof-of-space/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 [dependencies]
 ab-core-primitives = { workspace = true }
 blake3 = { workspace = true }
-chacha20 = { workspace = true }
+chacha20 = { workspace = true, features = ["cipher"] }
 derive_more = { workspace = true, features = ["full"] }
 parking_lot = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
@@ -44,7 +44,6 @@ default = []
 alloc = []
 std = [
     "alloc",
-    "chacha20/std",
     "derive_more/std",
     # In no-std environment we use `spin`
     "parking_lot",

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -13,8 +13,8 @@ use crate::chiapos::utils::EvaluatableUsize;
 use alloc::vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use chacha20::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
-use chacha20::{ChaCha8, Key, Nonce};
+use chacha20::cipher::{Iv, KeyIvInit, StreamCipher, StreamCipherSeek};
+use chacha20::{ChaCha8, Key};
 use core::array;
 use core::simd::Simd;
 use core::simd::num::SimdUint;
@@ -60,11 +60,11 @@ fn partial_ys<const K: u8>(seed: Seed) -> Vec<u8> {
     let mut output = vec![0; output_len_bits.div_ceil(u8::BITS as usize)];
 
     let key = Key::from(seed);
-    let nonce = Nonce::default();
+    let iv = Iv::<ChaCha8>::default();
 
-    let mut cipher = ChaCha8::new(&key, &nonce);
+    let mut cipher = ChaCha8::new(&key, &iv);
 
-    cipher.apply_keystream(&mut output);
+    cipher.write_keystream(&mut output);
 
     output
 }
@@ -83,12 +83,12 @@ pub(super) fn partial_y<const K: u8>(
     let mut output = [0; (K as usize * 2).div_ceil(u8::BITS as usize)];
 
     let key = Key::from(seed);
-    let nonce = Nonce::default();
+    let iv = Iv::<ChaCha8>::default();
 
-    let mut cipher = ChaCha8::new(&key, &nonce);
+    let mut cipher = ChaCha8::new(&key, &iv);
 
     cipher.seek(skip_bytes);
-    cipher.apply_keystream(&mut output);
+    cipher.write_keystream(&mut output);
 
     (output, skip_bits)
 }

--- a/subspace/.github/workflows/rust.yml
+++ b/subspace/.github/workflows/rust.yml
@@ -270,7 +270,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@07a34f8347b1eeb5f5469cdfa451b0a5db2ae4e8 # 2.38.4
+        uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb # 2.53.2
         with:
           tool: cargo-nextest
 

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.0"
 dependencies = [
  "ab-core-primitives",
  "blake3",
- "chacha20",
+ "chacha20 0.10.0-rc.0",
  "derive_more 2.0.1",
  "rayon",
  "seq-macro",
@@ -169,7 +169,7 @@ name = "ab-proof-of-time"
 version = "0.1.0"
 dependencies = [
  "ab-core-primitives",
- "aes 0.9.0-pre.3",
+ "aes 0.9.0-rc.0",
  "cpufeatures",
  "thiserror 2.0.12",
 ]
@@ -406,12 +406,12 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-pre.3"
+version = "0.9.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e4da00d9978020ddaa556c1747cfcafc3f375cfadb109acfe8b752cfc373bf"
+checksum = "cd4838e4ad37bb032dea137f441d5f71c16c26c068af512e64c5bc13a88cdfc7"
 dependencies = [
  "cfg-if",
- "cipher 0.5.0-pre.8",
+ "cipher 0.5.0-rc.0",
  "cpufeatures",
 ]
 
@@ -1530,13 +1530,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e057d7ab0331b90074df7ca698b3361860c20a1d8c8e28f49c01f526e3f3958"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.0-rc.0",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher 0.4.4",
  "poly1305",
  "zeroize",
@@ -1631,11 +1642,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0-pre.8"
+version = "0.5.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276974d2acb7cf592603150941fc1ff6442acdeb1dc653ac2825928f4703c131"
+checksum = "bd4ef774202f1749465fc7cf88d70fc30620e8cacd5429268f4bff7d003bd976"
 dependencies = [
- "crypto-common 0.2.0-rc.2",
+ "crypto-common 0.2.0-rc.3",
  "inout 0.2.0-rc.4",
 ]
 
@@ -2090,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170d71b5b14dec99db7739f6fc7d6ec2db80b78c3acb77db48392ccc3d8a9ea0"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
 ]


### PR DESCRIPTION
This also updates `aes` crate to a similar version