### PR TITLE
Cache block's root after first call with `alloc` feature or for OS target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "derive_more 2.0.1",
  "ed25519-zebra",
  "hex",
+ "once_cell",
  "parity-scale-codec",
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ hex = { version = "0.4.3", default-features = false }
 ident_case = "1.0.1"
 libc = "0.2.174"
 no-panic = "0.1.35"
+once_cell = { version = "1.21.3", default-features = false }
 parity-scale-codec = { version = "3.7.5", default-features = false }
 parking_lot = "0.12.3"
 proc-macro2 = "1.0.95"

--- a/crates/node/ab-client-block-authoring/src/slot_worker.rs
+++ b/crates/node/ab-client-block-authoring/src/slot_worker.rs
@@ -462,9 +462,9 @@ where
             let best_beacon_chain_header = best_beacon_chain_header.header();
             let best_header = self.chain_info.best_header();
             let best_header = best_header.header();
-            let best_root = best_header.root();
+            let best_root = &*best_header.root();
 
-            self.on_new_slot(slot, checkpoints, &best_root, best_beacon_chain_header);
+            self.on_new_slot(slot, checkpoints, best_root, best_beacon_chain_header);
 
             if self.chain_sync_status.is_syncing() {
                 debug!(%slot, "Skipping proposal slot due to sync");
@@ -482,7 +482,7 @@ where
             let Some(block) = self
                 .produce_block(
                     slot_to_claim,
-                    &best_root,
+                    best_root,
                     best_header,
                     best_beacon_chain_header,
                 )
@@ -629,11 +629,10 @@ where
             }
         };
 
-        let header = block.header();
-        let header = header.header();
+        let header = block.header().header();
         info!(
             number = %header.prefix.number,
-            root = %header.root(),
+            root = %&*header.root(),
             "🔖 Built new block",
         );
 

--- a/crates/shared/ab-core-primitives/Cargo.toml
+++ b/crates/shared/ab-core-primitives/Cargo.toml
@@ -23,6 +23,7 @@ bytes = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["full"] }
 ed25519-zebra = { workspace = true }
 hex = { workspace = true }
+once_cell = { workspace = true, features = ["alloc"], optional = true }
 parity-scale-codec = { workspace = true, features = ["bytes", "derive", "max-encoded-len"], optional = true }
 rayon = { workspace = true, optional = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }
@@ -39,6 +40,7 @@ rand_chacha = { workspace = true }
 alloc = [
     "dep:ab-aligned-buffer",
     "dep:bytes",
+    "dep:once_cell",
     "serde?/alloc",
 ]
 scale-codec = [

--- a/crates/shared/ab-core-primitives/src/block.rs
+++ b/crates/shared/ab-core-primitives/src/block.rs
@@ -219,7 +219,7 @@ impl BlockRoot {
 /// Generic block
 pub trait GenericBlock<'a>
 where
-    Self: Copy + fmt::Debug,
+    Self: Clone + fmt::Debug,
 {
     /// Block header type
     type Header: GenericBlockHeader<'a>;
@@ -243,7 +243,7 @@ where
 }
 
 /// Block that corresponds to the beacon chain
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 // Prevent creation of potentially broken invariants externally
 #[non_exhaustive]
 pub struct BeaconChainBlock<'a> {
@@ -296,7 +296,7 @@ impl<'a> BeaconChainBlock<'a> {
                 .iter()
                 .zip(self.body.intermediate_shard_blocks().iter())
                 .all(|(child_shard_block_root, intermediate_shard_block)| {
-                    child_shard_block_root == &intermediate_shard_block.header.root()
+                    child_shard_block_root == &*intermediate_shard_block.header.root()
                         && intermediate_shard_block
                             .header
                             .prefix
@@ -351,7 +351,7 @@ impl<'a> GenericBlock<'a> for BeaconChainBlock<'a> {
 }
 
 /// Block that corresponds to an intermediate shard
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 // Prevent creation of potentially broken invariants externally
 #[non_exhaustive]
 pub struct IntermediateShardBlock<'a> {
@@ -404,7 +404,7 @@ impl<'a> IntermediateShardBlock<'a> {
                 .iter()
                 .zip(self.body.leaf_shard_blocks().iter())
                 .all(|(child_shard_block_root, leaf_shard_block)| {
-                    child_shard_block_root == &leaf_shard_block.header.root()
+                    child_shard_block_root == &*leaf_shard_block.header.root()
                         && leaf_shard_block
                             .header
                             .prefix
@@ -459,7 +459,7 @@ impl<'a> GenericBlock<'a> for IntermediateShardBlock<'a> {
 }
 
 /// Block that corresponds to a leaf shard
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 // Prevent creation of potentially broken invariants externally
 #[non_exhaustive]
 pub struct LeafShardBlock<'a> {
@@ -556,7 +556,7 @@ impl<'a> GenericBlock<'a> for LeafShardBlock<'a> {
 ///
 /// [`BlockHeader`]: crate::block::header::BlockHeader
 /// [`BlockBody`]: crate::block::body::BlockBody
-#[derive(Debug, Copy, Clone, From)]
+#[derive(Debug, Clone, From)]
 pub enum Block<'a> {
     /// Block corresponds to the beacon chain
     BeaconChain(BeaconChainBlock<'a>),

--- a/crates/shared/ab-core-primitives/src/block/body.rs
+++ b/crates/shared/ab-core-primitives/src/block/body.rs
@@ -68,7 +68,7 @@ where
 }
 
 /// Information about intermediate shard block
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct IntermediateShardBlockInfo<'a> {
     /// Block header that corresponds to an intermediate shard
     pub header: IntermediateShardHeader<'a>,
@@ -87,7 +87,7 @@ impl IntermediateShardBlockInfo<'_> {
         // TODO: Keyed hash
         const MAX_N: usize = 3;
         let leaves: [_; MAX_N] = [
-            **self.header.root(),
+            ***self.header.root(),
             *compute_segments_root(self.own_segment_roots),
             *compute_segments_root(self.child_segment_roots),
         ];
@@ -531,7 +531,7 @@ impl<'a> BeaconChainBody<'a> {
 }
 
 /// Information about leaf shard block
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct LeafShardBlockInfo<'a> {
     /// Block header that corresponds to an intermediate shard
     pub header: LeafShardHeader<'a>,

--- a/crates/shared/ab-core-primitives/src/block/header/owned.rs
+++ b/crates/shared/ab-core-primitives/src/block/header/owned.rs
@@ -620,11 +620,13 @@ impl OwnedBlockHeader {
     #[inline]
     pub fn header(&self) -> BlockHeader<'_> {
         match self {
-            Self::BeaconChain(owned_header) => BlockHeader::BeaconChain(*owned_header.header()),
-            Self::IntermediateShard(owned_header) => {
-                BlockHeader::IntermediateShard(*owned_header.header())
+            Self::BeaconChain(owned_header) => {
+                BlockHeader::BeaconChain(owned_header.header().clone())
             }
-            Self::LeafShard(owned_header) => BlockHeader::LeafShard(*owned_header.header()),
+            Self::IntermediateShard(owned_header) => {
+                BlockHeader::IntermediateShard(owned_header.header().clone())
+            }
+            Self::LeafShard(owned_header) => BlockHeader::LeafShard(owned_header.header().clone()),
         }
     }
 }

--- a/crates/shared/ab-core-primitives/src/block/owned.rs
+++ b/crates/shared/ab-core-primitives/src/block/owned.rs
@@ -38,10 +38,10 @@ pub trait GenericOwnedBlock {
         Self: 'a;
 
     /// Block header
-    fn header(&self) -> Self::Header;
+    fn header(&self) -> &Self::Header;
 
     /// Block body
-    fn body(&self) -> Self::Body;
+    fn body(&self) -> &Self::Body;
 
     /// Get regular block out of the owned version
     fn block(&self) -> Self::Block<'_>;
@@ -67,13 +67,13 @@ impl GenericOwnedBlock for OwnedBeaconChainBlock {
     type Block<'a> = BeaconChainBlock<'a>;
 
     #[inline(always)]
-    fn header(&self) -> Self::Header {
-        self.header.clone()
+    fn header(&self) -> &Self::Header {
+        &self.header
     }
 
     #[inline(always)]
-    fn body(&self) -> Self::Body {
-        self.body.clone()
+    fn body(&self) -> &Self::Body {
+        &self.body
     }
 
     #[inline(always)]
@@ -121,7 +121,7 @@ impl OwnedBeaconChainBlock {
     /// Get [`BeaconChainBlock`] out of [`OwnedBeaconChainBlock`]
     pub fn block(&self) -> BeaconChainBlock<'_> {
         BeaconChainBlock {
-            header: *self.header.header(),
+            header: self.header.header().clone(),
             body: *self.body.body(),
         }
     }
@@ -154,7 +154,7 @@ impl OwnedBeaconChainBlockBuilder {
                 .body()
                 .intermediate_shard_blocks()
                 .iter()
-                .map(|block| block.header.root())
+                .map(|block| *block.header.root())
                 .collect::<Vec<_>>(),
             consensus_parameters,
         )?;
@@ -219,13 +219,13 @@ impl GenericOwnedBlock for OwnedIntermediateShardBlock {
     type Block<'a> = IntermediateShardBlock<'a>;
 
     #[inline(always)]
-    fn header(&self) -> Self::Header {
-        self.header.clone()
+    fn header(&self) -> &Self::Header {
+        &self.header
     }
 
     #[inline(always)]
-    fn body(&self) -> Self::Body {
-        self.body.clone()
+    fn body(&self) -> &Self::Body {
+        &self.body
     }
 
     #[inline(always)]
@@ -268,7 +268,7 @@ impl OwnedIntermediateShardBlock {
     /// Get [`IntermediateShardBlock`] out of [`OwnedIntermediateShardBlock`]
     pub fn block(&self) -> IntermediateShardBlock<'_> {
         IntermediateShardBlock {
-            header: *self.header.header(),
+            header: self.header.header().clone(),
             body: *self.body.body(),
         }
     }
@@ -302,7 +302,7 @@ impl OwnedIntermediateShardBlockBuilder {
                 .body()
                 .leaf_shard_blocks()
                 .iter()
-                .map(|block| block.header.root())
+                .map(|block| *block.header.root())
                 .collect::<Vec<_>>(),
         )?;
 
@@ -355,13 +355,13 @@ impl GenericOwnedBlock for OwnedLeafShardBlock {
     type Block<'a> = LeafShardBlock<'a>;
 
     #[inline(always)]
-    fn header(&self) -> Self::Header {
-        self.header.clone()
+    fn header(&self) -> &Self::Header {
+        &self.header
     }
 
     #[inline(always)]
-    fn body(&self) -> Self::Body {
-        self.body.clone()
+    fn body(&self) -> &Self::Body {
+        &self.body
     }
 
     #[inline(always)]
@@ -402,7 +402,7 @@ impl OwnedLeafShardBlock {
     /// Get [`LeafShardBlock`] out of [`OwnedLeafShardBlock`]
     pub fn block(&self) -> LeafShardBlock<'_> {
         LeafShardBlock {
-            header: *self.header.header(),
+            header: self.header.header().clone(),
             body: *self.body.body(),
         }
     }
@@ -493,11 +493,11 @@ impl OwnedBlock {
     #[inline(always)]
     pub fn header(&self) -> BlockHeader<'_> {
         match self {
-            Self::BeaconChain(block) => BlockHeader::BeaconChain(*block.header.header()),
+            Self::BeaconChain(block) => BlockHeader::BeaconChain(block.header.header().clone()),
             Self::IntermediateShard(block) => {
-                BlockHeader::IntermediateShard(*block.header.header())
+                BlockHeader::IntermediateShard(block.header.header().clone())
             }
-            Self::LeafShard(block) => BlockHeader::LeafShard(*block.header.header()),
+            Self::LeafShard(block) => BlockHeader::LeafShard(block.header.header().clone()),
         }
     }
 

--- a/crates/shared/ab-core-primitives/src/lib.rs
+++ b/crates/shared/ab-core-primitives/src/lib.rs
@@ -1,6 +1,6 @@
 //! Core primitives for the protocol
 
-#![no_std]
+#![cfg_attr(target_os = "none", no_std)]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
 #![feature(
     array_chunks,
@@ -33,7 +33,7 @@ pub mod shard;
 pub mod solutions;
 pub mod transaction;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", not(target_os = "none")))]
 extern crate alloc;
 
 const _: () = {

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "derive_more 2.0.1",
  "ed25519-zebra 4.0.3 (git+https://github.com/ZcashFoundation/ed25519-zebra?rev=dbb5610b818a6b54ebd347c27f8c8d3d6af89648)",
  "hex",
+ "once_cell",
  "parity-scale-codec",
  "rayon",
  "scale-info",


### PR DESCRIPTION
This will make block root access much less expensive