### PR TITLE
Block MMR verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ name = "ab-client-api"
 version = "0.0.1"
 dependencies = [
  "ab-core-primitives",
+ "ab-merkle-tree",
  "thiserror",
 ]
 

--- a/crates/farmer/ab-farmer-components/src/proving.rs
+++ b/crates/farmer/ab-farmer-components/src/proving.rs
@@ -245,8 +245,8 @@ where
             drop(sector_record_chunks);
 
             // TODO: This is a workaround for https://github.com/rust-lang/rust/issues/139866 that
-            //  allows the code to compile. Constant 16 is hardcoded here and in `if` branch below
-            //  for compilation to succeed
+            //  allows the code to compile. Constant 65536 is hardcoded here and below for
+            //  compilation to succeed.
             const _: () = {
                 assert!(Record::NUM_S_BUCKETS == 65536);
             };

--- a/crates/node/ab-client-api/Cargo.toml
+++ b/crates/node/ab-client-api/Cargo.toml
@@ -15,6 +15,7 @@ all-features = true
 
 [dependencies]
 ab-core-primitives = { workspace = true, features = ["alloc"] }
+ab-merkle-tree = { workspace = true }
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/node/ab-client-api/src/lib.rs
+++ b/crates/node/ab-client-api/src/lib.rs
@@ -1,7 +1,23 @@
 //! Client API
 
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+// TODO: This feature is not actually used in this crate, but is added as a workaround for
+//  https://github.com/rust-lang/rust/issues/141492
+#![feature(generic_const_exprs)]
+
 use ab_core_primitives::block::owned::GenericOwnedBlock;
 use ab_core_primitives::block::{BlockNumber, BlockRoot};
+use ab_merkle_tree::mmr::MerkleMountainRange;
+use std::sync::Arc;
+
+// TODO: This is a workaround for https://github.com/rust-lang/rust/issues/139866 that allows the
+//  code to compile. Constant 4294967295 is hardcoded here and below for compilation to succeed.
+const _: () = {
+    assert!(u32::MAX == 4294967295);
+};
+
+/// Type alias for Merkle Mountain Range with block roots
+pub type BlockMerkleMountainRange = MerkleMountainRange<4294967295>;
 
 // TODO: Probably move it elsewhere
 /// Origin
@@ -13,6 +29,12 @@ pub enum BlockOrigin {
     Sync,
     /// Broadcast on the network during normal operation (not sync)
     Broadcast,
+}
+
+/// Error for [`ChainInfoWrite::persist_block()`]
+#[derive(Debug, thiserror::Error)]
+pub enum PersistBlockError {
+    // TODO
 }
 
 // TODO: Split this into different more narrow traits
@@ -44,6 +66,22 @@ where
 
     /// Block header
     fn header(&self, block_root: &BlockRoot) -> Option<Block::Header>;
+
+    /// Merkle Mountain Range with block
+    fn mmr_with_block(&self, block_root: &BlockRoot) -> Option<Arc<BlockMerkleMountainRange>>;
+}
+
+/// [`ChainInfo`] extension for writing information
+pub trait ChainInfoWrite<Block>: ChainInfo<Block>
+where
+    Block: GenericOwnedBlock,
+{
+    /// Persist newly imported block
+    fn persist_block(
+        &self,
+        block: Block,
+        mmr_with_block: Arc<BlockMerkleMountainRange>,
+    ) -> impl Future<Output = Result<(), PersistBlockError>> + Send;
 }
 
 /// Chain sync status

--- a/crates/node/ab-client-block-import/Cargo.toml
+++ b/crates/node/ab-client-block-import/Cargo.toml
@@ -19,7 +19,7 @@ ab-client-block-verification = { workspace = true }
 ab-core-primitives = { workspace = true, features = ["alloc"] }
 ab-proof-of-space = { workspace = true }
 anyhow = { workspace = true }
-async-lock = { workspace = true }
+async-lock = { workspace = true, features = ["std"] }
 parking_lot = { workspace = true }
 send-future = { workspace = true }
 stable_deref_trait = { workspace = true }

--- a/crates/node/ab-client-block-import/src/lib.rs
+++ b/crates/node/ab-client-block-import/src/lib.rs
@@ -1,9 +1,13 @@
 #![feature(map_try_insert)]
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+// TODO: This feature is not actually used in this crate, but is added as a workaround for
+//  https://github.com/rust-lang/rust/issues/141492
+#![feature(generic_const_exprs)]
 
 pub mod beacon_chain;
 mod importing_blocks;
 
-use ab_client_api::BlockOrigin;
+use ab_client_api::{BlockOrigin, PersistBlockError};
 use ab_core_primitives::block::BlockRoot;
 
 /// Error for [`BlockImport`]
@@ -21,9 +25,27 @@ pub enum BlockImportError {
         // Block root that was not found
         block_root: BlockRoot,
     },
+    /// Parent block MMR missing; this is an implementation bug and must never happen
+    #[error("Parent block MMR missing; this is an implementation bug and must never happen")]
+    ParentBlockMmrMissing,
+    /// Invalid parent MMR; this is an implementation bug and must never happen
+    #[error("Invalid parent MMR; this is an implementation bug and must never happen")]
+    ParentBlockMmrInvalid,
+    /// Can't extend MMR, too many blocks; this is an implementation bug and must never happen
+    #[error(
+        "Can't extend MMR, too many blocks; this is an implementation bug and must never happen"
+    )]
+    CantExtendMmr,
     /// Parent block import failed
     #[error("Parent block import failed")]
     ParentBlockImportFailed,
+    /// Block persisting error
+    #[error("Block persisting error: {error}")]
+    PersistBlockError {
+        /// Block persisting error
+        #[from]
+        error: PersistBlockError,
+    },
     /// Custom import error
     #[error("Custom import error: {error}")]
     Custom {

--- a/crates/node/ab-client-block-verification/src/lib.rs
+++ b/crates/node/ab-client-block-verification/src/lib.rs
@@ -6,6 +6,7 @@ use ab_client_api::BlockOrigin;
 use ab_core_primitives::block::body::owned::GenericOwnedBlockBody;
 use ab_core_primitives::block::header::owned::GenericOwnedBlockHeader;
 use ab_core_primitives::block::owned::GenericOwnedBlock;
+use ab_core_primitives::hashes::Blake3Hash;
 use ab_core_primitives::segments::SegmentRoot;
 
 type GenericHeader<'a, Block> =
@@ -20,7 +21,7 @@ pub enum BlockVerificationError {
     #[error("Block is below archiving point")]
     BelowArchivingPoint,
     /// Invalid header prefix
-    #[error("Invalid heder prefix")]
+    #[error("Invalid header prefix")]
     InvalidHeaderPrefix,
     /// Invalid seal
     #[error("Invalid seal")]
@@ -67,6 +68,7 @@ where
     fn verify(
         &self,
         parent_header: &GenericHeader<'_, Block>,
+        parent_block_mmr_root: &Blake3Hash,
         header: &GenericHeader<'_, Block>,
         body: &GenericBody<'_, Block>,
         origin: BlockOrigin,

--- a/crates/shared/ab-core-primitives/src/block/body.rs
+++ b/crates/shared/ab-core-primitives/src/block/body.rs
@@ -49,9 +49,9 @@ where
     Item: AsRef<[u8]>,
     Iter: IntoIterator<Item = Item>,
 {
-    // TODO: This is a workaround for https://github.com/rust-lang/rust/issues/139866 that
-    //  allows the code to compile. Constant 16 is hardcoded here and in `if` branch below
-    //  for compilation to succeed
+    // TODO: This is a workaround for https://github.com/rust-lang/rust/issues/139866 that allows
+    //  the code to compile. Constant 4294967295 is hardcoded here and below for compilation to
+    //  succeed.
     const _: () = {
         assert!(u32::MAX == 4294967295);
     };

--- a/crates/shared/ab-core-primitives/src/block/body/owned.rs
+++ b/crates/shared/ab-core-primitives/src/block/body/owned.rs
@@ -14,6 +14,7 @@ use crate::transaction::Transaction;
 use crate::transaction::owned::{OwnedTransaction, OwnedTransactionError};
 use ab_aligned_buffer::{OwnedAlignedBuffer, SharedAlignedBuffer};
 use ab_io_type::trivial_type::TrivialType;
+use alloc::sync::Arc;
 use core::fmt;
 use core::iter::TrustedLen;
 use derive_more::From;
@@ -218,7 +219,7 @@ pub enum OwnedBeaconChainBodyError {
 /// efficiently or storing in memory or on disk.
 #[derive(Debug, Clone)]
 pub struct OwnedBeaconChainBody {
-    inner: Yoke<BeaconChainBody<'static>, SharedAlignedBuffer>,
+    inner: Arc<Yoke<BeaconChainBody<'static>, SharedAlignedBuffer>>,
 }
 
 impl GenericOwnedBlockBody for OwnedBeaconChainBody {
@@ -381,7 +382,9 @@ impl OwnedBeaconChainBody {
         })
         .map_err(move |()| buffer)?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
 
     /// Inner buffer with block body contents
@@ -426,7 +429,7 @@ pub enum OwnedIntermediateShardBodyError {
 /// efficiently or storing in memory or on disk.
 #[derive(Debug, Clone)]
 pub struct OwnedIntermediateShardBody {
-    inner: Yoke<IntermediateShardBody<'static>, SharedAlignedBuffer>,
+    inner: Arc<Yoke<IntermediateShardBody<'static>, SharedAlignedBuffer>>,
 }
 
 impl GenericOwnedBlockBody for OwnedIntermediateShardBody {
@@ -549,7 +552,9 @@ impl OwnedIntermediateShardBody {
         })
         .map_err(move |()| buffer)?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
 
     /// Inner buffer with block body contents
@@ -610,7 +615,7 @@ impl From<AddTransactionError> for OwnedLeafShardBodyError {
 /// efficiently or storing in memory or on disk.
 #[derive(Debug, Clone)]
 pub struct OwnedLeafShardBody {
-    inner: Yoke<LeafShardBody<'static>, SharedAlignedBuffer>,
+    inner: Arc<Yoke<LeafShardBody<'static>, SharedAlignedBuffer>>,
 }
 
 impl GenericOwnedBlockBody for OwnedLeafShardBody {
@@ -677,7 +682,9 @@ impl OwnedLeafShardBody {
         })
         .map_err(move |()| buffer)?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
 
     /// Inner buffer with block body contents

--- a/crates/shared/ab-core-primitives/src/block/header/owned.rs
+++ b/crates/shared/ab-core-primitives/src/block/header/owned.rs
@@ -10,6 +10,7 @@ use crate::hashes::Blake3Hash;
 use crate::shard::ShardKind;
 use ab_aligned_buffer::{OwnedAlignedBuffer, SharedAlignedBuffer};
 use ab_io_type::trivial_type::TrivialType;
+use alloc::sync::Arc;
 use core::fmt;
 use derive_more::From;
 use yoke::Yoke;
@@ -55,7 +56,7 @@ pub enum OwnedBeaconChainHeaderError {
 /// efficiently or storing in memory or on disk.
 #[derive(Debug, Clone)]
 pub struct OwnedBeaconChainHeader {
-    inner: Yoke<BeaconChainHeader<'static>, SharedAlignedBuffer>,
+    inner: Arc<Yoke<BeaconChainHeader<'static>, SharedAlignedBuffer>>,
 }
 
 impl GenericOwnedBlockHeader for OwnedBeaconChainHeader {
@@ -231,7 +232,9 @@ impl OwnedBeaconChainHeader {
         })
         .map_err(move |()| buffer)?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
 
     /// Inner buffer with block header contents
@@ -290,7 +293,7 @@ pub enum OwnedIntermediateShardHeaderError {
 /// efficiently or storing in memory or on disk.
 #[derive(Debug, Clone)]
 pub struct OwnedIntermediateShardHeader {
-    inner: Yoke<IntermediateShardHeader<'static>, SharedAlignedBuffer>,
+    inner: Arc<Yoke<IntermediateShardHeader<'static>, SharedAlignedBuffer>>,
 }
 
 impl GenericOwnedBlockHeader for OwnedIntermediateShardHeader {
@@ -403,7 +406,9 @@ impl OwnedIntermediateShardHeader {
         })
         .map_err(move |()| buffer)?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
 
     /// Inner buffer with block header contents
@@ -451,7 +456,7 @@ impl OwnedIntermediateShardHeaderUnsealed {
 /// efficiently or storing in memory or on disk.
 #[derive(Debug, Clone)]
 pub struct OwnedLeafShardHeader {
-    inner: Yoke<LeafShardHeader<'static>, SharedAlignedBuffer>,
+    inner: Arc<Yoke<LeafShardHeader<'static>, SharedAlignedBuffer>>,
 }
 
 impl GenericOwnedBlockHeader for OwnedLeafShardHeader {
@@ -530,7 +535,9 @@ impl OwnedLeafShardHeader {
         })
         .map_err(move |()| buffer)?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
 
     /// Inner buffer with block header contents

--- a/crates/shared/ab-core-primitives/src/solutions.rs
+++ b/crates/shared/ab-core-primitives/src/solutions.rs
@@ -523,9 +523,9 @@ impl Solution {
             });
         }
 
-        // TODO: This is a workaround for https://github.com/rust-lang/rust/issues/139866 that allows
-        //  the code to compile. Constant 16 is hardcoded here and in `if` branch below for compilation
-        //  to succeed
+        // TODO: This is a workaround for https://github.com/rust-lang/rust/issues/139866 that
+        //  allows the code to compile. Constant 65536 is hardcoded here and below for compilation
+        //  to succeed.
         const _: () = {
             assert!(Record::NUM_S_BUCKETS == 65536);
         };

--- a/crates/shared/ab-merkle-tree/src/mmr.rs
+++ b/crates/shared/ab-merkle-tree/src/mmr.rs
@@ -80,9 +80,9 @@ where
     /// Create a new instance from previously collected peaks.
     ///
     /// Returns `None` if input is invalid.
-    #[inline(always)]
+    #[inline]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
-    pub fn from_peaks(peaks: MmrPeaks<MAX_N>) -> Option<Self> {
+    pub fn from_peaks(peaks: &MmrPeaks<MAX_N>) -> Option<Self> {
         let mut result = Self {
             num_leaves: peaks.num_leaves,
             stack: [[0u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],

--- a/crates/shared/ab-merkle-tree/src/mmr.rs
+++ b/crates/shared/ab-merkle-tree/src/mmr.rs
@@ -13,11 +13,11 @@ pub struct MmrPeaks<const MAX_N: u64>
 where
     [(); MAX_N.ilog2() as usize + 1]:,
 {
+    /// Number of leaves in MMR
+    pub num_leaves: u64,
     /// MMR peaks, first [`Self::num_peaks()`] elements are occupied by values, the rest are ignored
     /// and do not need to be retained.
     pub peaks: [[u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
-    /// Number of leaves in MMR
-    pub num_leaves: u64,
 }
 
 impl<const MAX_N: u64> MmrPeaks<MAX_N>
@@ -46,9 +46,9 @@ pub struct MerkleMountainRange<const MAX_N: u64>
 where
     [(); MAX_N.ilog2() as usize + 1]:,
 {
+    num_leaves: u64,
     // Stack of intermediate nodes per tree level
     stack: [[u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
-    num_leaves: u64,
 }
 
 impl<const MAX_N: u64> Default for MerkleMountainRange<MAX_N>
@@ -72,8 +72,8 @@ where
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn new() -> Self {
         Self {
-            stack: [[0u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
             num_leaves: 0,
+            stack: [[0u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
         }
     }
 
@@ -84,8 +84,8 @@ where
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn from_peaks(peaks: MmrPeaks<MAX_N>) -> Option<Self> {
         let mut result = Self {
-            stack: [[0u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
             num_leaves: peaks.num_leaves,
+            stack: [[0u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
         };
 
         // Convert peaks (where all occupied entries are all at the beginning of the list instead)
@@ -160,8 +160,8 @@ where
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn peaks(&self) -> MmrPeaks<MAX_N> {
         let mut result = MmrPeaks {
-            peaks: [[0u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
             num_leaves: self.num_leaves,
+            peaks: [[0u8; OUT_LEN]; MAX_N.ilog2() as usize + 1],
         };
 
         // Convert stack (where occupied entries are at corresponding offsets) to peaks (where all

--- a/crates/shared/ab-merkle-tree/tests/balanced.rs
+++ b/crates/shared/ab-merkle-tree/tests/balanced.rs
@@ -104,7 +104,7 @@ where
     let mut mmr = MerkleMountainRange::<N_U64>::new();
     assert_eq!(
         mmr.peaks(),
-        MerkleMountainRange::from_peaks(mmr.peaks())
+        MerkleMountainRange::from_peaks(&mmr.peaks())
             .unwrap()
             .peaks()
     );
@@ -202,7 +202,7 @@ where
             .unwrap();
         assert_eq!(
             mmr.peaks(),
-            MerkleMountainRange::from_peaks(mmr.peaks())
+            MerkleMountainRange::from_peaks(&mmr.peaks())
                 .unwrap()
                 .peaks(),
             "N {N} leaf_index {leaf_index}"

--- a/crates/shared/ab-merkle-tree/tests/unbalanced.rs
+++ b/crates/shared/ab-merkle-tree/tests/unbalanced.rs
@@ -246,6 +246,7 @@ fn mt_unbalanced_large_range() {
     }
 }
 
+// TODO: Add MMR tests here
 fn test_basic(number_of_leaves: u64) {
     let mut rng = ChaCha8Rng::from_seed(Default::default());
 

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -38,6 +38,7 @@ name = "ab-client-api"
 version = "0.0.1"
 dependencies = [
  "ab-core-primitives",
+ "ab-merkle-tree",
  "thiserror 2.0.12",
 ]
 


### PR DESCRIPTION
There are a few commits with various tweaks and preparation, while last commit implements block MMR maintenance and verification.

Persistence abstraction trait was added to persist both block and its MMR. It'll need to be extended with more arguments (something related to state at least) later.