### PR TITLE
Cleanups

### DIFF
--- a/crates/contracts/core/ab-contracts-common/src/env.rs
+++ b/crates/contracts/core/ab-contracts-common/src/env.rs
@@ -52,7 +52,7 @@ pub struct PreparedMethod<'a> {
 pub struct EnvState {
     /// Shard index where execution is happening
     pub shard_index: ShardIndex,
-    /// Explicit padding, contents does not matter
+    /// Explicit padding, contents must be all zeroes
     pub padding_0: [u8; 4],
     /// Own address of the contract
     pub own_address: Address,

--- a/crates/execution/ab-executor-native/src/context.rs
+++ b/crates/execution/ab-executor-native/src/context.rs
@@ -56,7 +56,7 @@ impl<'a> ExecutorContext for NativeExecutorContext<'a> {
 
         let env_state = EnvState {
             shard_index: self.shard_index,
-            padding_0: Default::default(),
+            padding_0: [0; _],
             own_address: *contract,
             context: match method_context {
                 MethodContext::Keep => previous_env_state.context,

--- a/crates/execution/ab-executor-native/src/lib.rs
+++ b/crates/execution/ab-executor-native/src/lib.rs
@@ -286,7 +286,7 @@ impl NativeExecutor {
 
         let env_state = EnvState {
             shard_index: self.shard_index,
-            padding_0: Default::default(),
+            padding_0: [0; _],
             own_address: Address::NULL,
             context: Address::NULL,
             caller: Address::NULL,
@@ -344,7 +344,7 @@ impl NativeExecutor {
         // TODO: This is a pretty large data structure to copy around, try to make it a reference
         let env_state = EnvState {
             shard_index: self.shard_index,
-            padding_0: Default::default(),
+            padding_0: [0; _],
             own_address: Address::NULL,
             context: Address::NULL,
             caller: Address::NULL,
@@ -402,7 +402,7 @@ impl NativeExecutor {
         // TODO: This is a pretty large data structure to copy around, try to make it a reference
         let env_state = EnvState {
             shard_index: self.shard_index,
-            padding_0: Default::default(),
+            padding_0: [0; _],
             own_address: Address::NULL,
             context: Address::NULL,
             caller: Address::NULL,
@@ -485,7 +485,7 @@ impl NativeExecutor {
     {
         let env_state = EnvState {
             shard_index: self.shard_index,
-            padding_0: Default::default(),
+            padding_0: [0; _],
             own_address: contract,
             context: contract,
             caller: Address::NULL,
@@ -512,7 +512,7 @@ impl NativeExecutor {
     {
         let env_state = EnvState {
             shard_index: self.shard_index,
-            padding_0: Default::default(),
+            padding_0: [0; _],
             own_address: Address::NULL,
             context: Address::NULL,
             caller: Address::NULL,

--- a/crates/node/ab-client-block-builder/src/beacon_chain.rs
+++ b/crates/node/ab-client-block-builder/src/beacon_chain.rs
@@ -161,7 +161,6 @@ where
         }
 
         BlockHeaderPrefix {
-            version: BlockHeaderPrefix::BLOCK_VERSION,
             number: block_number,
             shard_index: ShardIndex::BEACON_CHAIN,
             padding: [0; _],

--- a/crates/node/ab-client-block-builder/src/beacon_chain.rs
+++ b/crates/node/ab-client-block-builder/src/beacon_chain.rs
@@ -163,7 +163,7 @@ where
         BlockHeaderPrefix {
             number: block_number,
             shard_index: ShardIndex::BEACON_CHAIN,
-            padding: [0; _],
+            padding_0: [0; _],
             timestamp,
             parent_root: *parent_block_root,
             // TODO: Real MMR root

--- a/crates/node/ab-client-block-verification/src/beacon_chain.rs
+++ b/crates/node/ab-client-block-verification/src/beacon_chain.rs
@@ -148,8 +148,7 @@ where
         parent_block_mmr_root: &Blake3Hash,
         header_prefix: &BlockHeaderPrefix,
     ) -> Result<(), BlockVerificationError> {
-        let basic_valid = header_prefix.version == BlockHeaderPrefix::BLOCK_VERSION
-            && header_prefix.number == parent_header_prefix.number + BlockNumber::ONE
+        let basic_valid = header_prefix.number == parent_header_prefix.number + BlockNumber::ONE
             && header_prefix.shard_index == parent_header_prefix.shard_index
             && &header_prefix.mmr_root == parent_block_mmr_root
             && header_prefix.timestamp > parent_header_prefix.timestamp;

--- a/crates/shared/ab-core-primitives/src/block/header.rs
+++ b/crates/shared/ab-core-primitives/src/block/header.rs
@@ -65,13 +65,11 @@ where
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[repr(C)]
 pub struct BlockHeaderPrefix {
-    /// Block version
-    pub version: u64,
     /// Block number
     pub number: BlockNumber,
     /// Shard index
     pub shard_index: ShardIndex,
-    /// Padding for data structure alignment
+    /// Padding for data structure alignment, contents must be all zeroes
     pub padding: [u8; 4],
     /// Block timestamp
     pub timestamp: BlockTimestamp,
@@ -83,9 +81,6 @@ pub struct BlockHeaderPrefix {
 }
 
 impl BlockHeaderPrefix {
-    /// The only supported block version right now
-    pub const BLOCK_VERSION: u64 = 0;
-
     /// Hash of the block header prefix, part of the eventual block root
     pub fn hash(&self) -> Blake3Hash {
         // TODO: Keyed hash
@@ -1630,9 +1625,7 @@ impl<'a> BlockHeader<'a> {
         // SAFETY: All bit patterns are valid
         let prefix = unsafe { BlockHeaderPrefix::from_bytes(prefix) }?;
 
-        if !(prefix.version == BlockHeaderPrefix::BLOCK_VERSION
-            && prefix.padding == [0; _]
-            && prefix.shard_index.as_u32() <= ShardIndex::MAX_SHARD_INDEX)
+        if !(prefix.padding == [0; _] && prefix.shard_index.as_u32() <= ShardIndex::MAX_SHARD_INDEX)
         {
             return None;
         }

--- a/crates/shared/ab-core-primitives/src/block/header.rs
+++ b/crates/shared/ab-core-primitives/src/block/header.rs
@@ -70,7 +70,7 @@ pub struct BlockHeaderPrefix {
     /// Shard index
     pub shard_index: ShardIndex,
     /// Padding for data structure alignment, contents must be all zeroes
-    pub padding: [u8; 4],
+    pub padding_0: [u8; 4],
     /// Block timestamp
     pub timestamp: BlockTimestamp,
     /// Root of the parent block
@@ -1625,7 +1625,8 @@ impl<'a> BlockHeader<'a> {
         // SAFETY: All bit patterns are valid
         let prefix = unsafe { BlockHeaderPrefix::from_bytes(prefix) }?;
 
-        if !(prefix.padding == [0; _] && prefix.shard_index.as_u32() <= ShardIndex::MAX_SHARD_INDEX)
+        if !(prefix.padding_0 == [0; _]
+            && prefix.shard_index.as_u32() <= ShardIndex::MAX_SHARD_INDEX)
         {
             return None;
         }

--- a/crates/shared/ab-core-primitives/src/transaction.rs
+++ b/crates/shared/ab-core-primitives/src/transaction.rs
@@ -57,6 +57,7 @@ impl AsMut<[u8]> for TransactionHash {
 #[derive(Debug, Copy, Clone, TrivialType)]
 #[repr(C)]
 pub struct TransactionHeader {
+    // TODO: Right now this is primarily used for data alignment, but is it useful in general?
     // TODO: Some more complex field?
     /// Transaction version
     pub version: u64,


### PR DESCRIPTION
This primarily removes `version` field from the block header, I don't think it'll be needed