### PR TITLE
Switch to `rclite::Arc` for smaller size and better performance in low-level crates

### DIFF
--- a/crates/shared/ab-core-primitives/Cargo.toml
+++ b/crates/shared/ab-core-primitives/Cargo.toml
@@ -33,6 +33,9 @@ serde-big-array = { workspace = true }
 thiserror = { workspace = true }
 yoke = { workspace = true, features = ["derive"] }
 
+[target.'cfg(not(any(target_os = "none", target_os = "unknown")))'.dependencies]
+rclite = { workspace = true }
+
 [dev-dependencies]
 rand_core = { workspace = true }
 rand_chacha = { workspace = true }

--- a/crates/shared/ab-core-primitives/src/lib.rs
+++ b/crates/shared/ab-core-primitives/src/lib.rs
@@ -33,7 +33,7 @@ pub mod shard;
 pub mod solutions;
 pub mod transaction;
 
-#[cfg(any(feature = "alloc", not(any(target_os = "none", target_os = "unknown"))))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 const _: () = {


### PR DESCRIPTION
This should have been a part of https://github.com/nazar-pc/abundance/pull/308, but GitHub merged it for some reason despite failing status checks :confused: 