### PR TITLE
Fix CI checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -370,6 +370,8 @@ jobs:
           done
 
   rust-all:
+    # Hack for buggy GitHub Actions behavior with skipped checks: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     needs:
       - cargo-clippy


### PR DESCRIPTION
`rust-all` might be skipped one of the checks it depends on have failed, which results in PR being merged instead of blocked. This introduces counter-intuitive workaround for such case.