### PR TITLE
Initial version of `ab-blake3` crate with `const fn` functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-blake3"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+]
+
+[[package]]
 name = "ab-chacha8"
 version = "0.1.0"
 dependencies = [

--- a/crates/shared/ab-blake3/Cargo.toml
+++ b/crates/shared/ab-blake3/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ab-blake3"
+description = "Optimized and more exotic APIs around BLAKE3"
+license = "0BSD"
+version = "0.1.0"
+authors = [
+    "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
+    "Jack O'Connor <oconnor663@gmail.com>",
+    "Samuel Neves",
+]
+# TODO: Switch to 2024 edition after https://github.com/Rust-GPU/rust-gpu/pull/249
+edition = "2021"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+# TODO: Would be nice to have benchmarks here
+
+[dev-dependencies]
+blake3 = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/shared/ab-blake3/src/const_fn.rs
+++ b/crates/shared/ab-blake3/src/const_fn.rs
@@ -1,0 +1,491 @@
+//! `const fn` BLAKE3 functions.
+//!
+//! This module and submodules are copied with modifications from the official [`blake3`] crate and
+//! is expected to be removed once https://github.com/BLAKE3-team/BLAKE3/pull/439 or similar lands
+//! upstream.
+//!
+//! [`blake3`]: https://github.com/BLAKE3-team/BLAKE3
+
+mod hazmat;
+mod platform;
+mod portable;
+#[cfg(test)]
+mod tests;
+
+use crate::{BLOCK_LEN, KEY_LEN, OUT_LEN};
+use core::mem::MaybeUninit;
+use core::{fmt, slice};
+use platform::{MAX_SIMD_DEGREE, MAX_SIMD_DEGREE_OR_2};
+
+/// The number of bytes in a chunk, 1024.
+///
+/// You don't usually need to think about this number, but it often comes up in benchmarks, because
+/// the maximum degree of parallelism used by the implementation equals the number of chunks.
+const CHUNK_LEN: usize = 1024;
+
+// While iterating the compression function within a chunk, the CV is
+// represented as words, to avoid doing two extra endianness conversions for
+// each compression in the portable implementation. But the hash_many interface
+// needs to hash both input bytes and parent nodes, so its better for its
+// output CVs to be represented as bytes.
+type CVWords = [u32; 8];
+type CVBytes = [u8; 32]; // little-endian
+
+const IV: &CVWords = &[
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+const MSG_SCHEDULE: [[usize; 16]; 7] = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8],
+    [3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1],
+    [10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6],
+    [12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4],
+    [9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7],
+    [11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13],
+];
+
+// These are the internal flags that we use to domain separate root/non-root,
+// chunk/parent, and chunk beginning/middle/end. These get set at the high end
+// of the block flags word in the compression function, so their values start
+// high and go down.
+const CHUNK_START: u8 = 1 << 0;
+const CHUNK_END: u8 = 1 << 1;
+const PARENT: u8 = 1 << 2;
+const ROOT: u8 = 1 << 3;
+const KEYED_HASH: u8 = 1 << 4;
+const DERIVE_KEY_CONTEXT: u8 = 1 << 5;
+const DERIVE_KEY_MATERIAL: u8 = 1 << 6;
+
+/// `Output` with `const fn` methods
+struct ConstOutput {
+    input_chaining_value: CVWords,
+    block: [u8; 64],
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+}
+
+impl ConstOutput {
+    const fn chaining_value(&self) -> CVBytes {
+        let mut cv = self.input_chaining_value;
+        portable::compress_in_place(
+            &mut cv,
+            &self.block,
+            self.block_len,
+            self.counter,
+            self.flags,
+        );
+        platform::le_bytes_from_words_32(&cv)
+    }
+
+    const fn root_hash(&self) -> [u8; OUT_LEN] {
+        debug_assert!(self.counter == 0);
+        let mut cv = self.input_chaining_value;
+        portable::compress_in_place(&mut cv, &self.block, self.block_len, 0, self.flags | ROOT);
+        platform::le_bytes_from_words_32(&cv)
+    }
+}
+
+/// [`ChunkState`] with `const fn` methods
+struct ConstChunkState {
+    cv: CVWords,
+    chunk_counter: u64,
+    buf: [u8; BLOCK_LEN],
+    buf_len: u8,
+    blocks_compressed: u8,
+    flags: u8,
+}
+
+impl ConstChunkState {
+    const fn new(key: &CVWords, chunk_counter: u64, flags: u8) -> Self {
+        Self {
+            cv: *key,
+            chunk_counter,
+            buf: [0; BLOCK_LEN],
+            buf_len: 0,
+            blocks_compressed: 0,
+            flags,
+        }
+    }
+
+    const fn count(&self) -> usize {
+        BLOCK_LEN * self.blocks_compressed as usize + self.buf_len as usize
+    }
+
+    const fn fill_buf(&mut self, input: &mut &[u8]) {
+        let want = BLOCK_LEN - self.buf_len as usize;
+        let take = if want < input.len() {
+            want
+        } else {
+            input.len()
+        };
+        let output = self
+            .buf
+            .split_at_mut(self.buf_len as usize)
+            .1
+            .split_at_mut(take)
+            .0;
+        output.copy_from_slice(input.split_at(take).0);
+        self.buf_len += take as u8;
+        *input = input.split_at(take).1;
+    }
+
+    const fn start_flag(&self) -> u8 {
+        if self.blocks_compressed == 0 {
+            CHUNK_START
+        } else {
+            0
+        }
+    }
+
+    // Try to avoid buffering as much as possible, by compressing directly from
+    // the input slice when full blocks are available.
+    const fn update(&mut self, mut input: &[u8]) -> &mut Self {
+        if self.buf_len > 0 {
+            self.fill_buf(&mut input);
+            if !input.is_empty() {
+                debug_assert!(self.buf_len as usize == BLOCK_LEN);
+                let block_flags = self.flags | self.start_flag(); // borrowck
+                portable::compress_in_place(
+                    &mut self.cv,
+                    &self.buf,
+                    BLOCK_LEN as u8,
+                    self.chunk_counter,
+                    block_flags,
+                );
+                self.buf_len = 0;
+                self.buf = [0; BLOCK_LEN];
+                self.blocks_compressed += 1;
+            }
+        }
+
+        while input.len() > BLOCK_LEN {
+            debug_assert!(self.buf_len == 0);
+            let block_flags = self.flags | self.start_flag(); // borrowck
+            portable::compress_in_place(
+                &mut self.cv,
+                input
+                    .first_chunk::<BLOCK_LEN>()
+                    .expect("Interation only starts when there is at least `BLOCK_LEN` bytes; qed"),
+                BLOCK_LEN as u8,
+                self.chunk_counter,
+                block_flags,
+            );
+            self.blocks_compressed += 1;
+            input = input.split_at(BLOCK_LEN).1;
+        }
+
+        self.fill_buf(&mut input);
+        debug_assert!(input.is_empty());
+        debug_assert!(self.count() <= CHUNK_LEN);
+        self
+    }
+
+    const fn output(&self) -> ConstOutput {
+        let block_flags = self.flags | self.start_flag() | CHUNK_END;
+        ConstOutput {
+            input_chaining_value: self.cv,
+            block: self.buf,
+            block_len: self.buf_len,
+            counter: self.chunk_counter,
+            flags: block_flags,
+        }
+    }
+}
+
+// Don't derive(Debug), because the state may be secret.
+impl fmt::Debug for ConstChunkState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConstChunkState")
+            .field("count", &self.count())
+            .field("chunk_counter", &self.chunk_counter)
+            .field("flags", &self.flags)
+            .finish()
+    }
+}
+
+// IMPLEMENTATION NOTE
+// ===================
+// The recursive function compress_subtree_wide(), implemented below, is the
+// basis of high-performance BLAKE3. We use it both for all-at-once hashing,
+// and for the incremental input with Hasher (though we have to be careful with
+// subtree boundaries in the incremental case). compress_subtree_wide() applies
+// several optimizations at the same time:
+// - Multithreading with Rayon.
+// - Parallel chunk hashing with SIMD.
+// - Parallel parent hashing with SIMD. Note that while SIMD chunk hashing
+//   maxes out at MAX_SIMD_DEGREE*CHUNK_LEN, parallel parent hashing continues
+//   to benefit from larger inputs, because more levels of the tree benefit can
+//   use full-width SIMD vectors for parent hashing. Without parallel parent
+//   hashing, we lose about 10% of overall throughput on AVX2 and AVX-512.
+
+/// Undocumented and unstable, for benchmarks only.
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+enum IncrementCounter {
+    Yes,
+    No,
+}
+
+impl IncrementCounter {
+    #[inline]
+    const fn yes(&self) -> bool {
+        match self {
+            IncrementCounter::Yes => true,
+            IncrementCounter::No => false,
+        }
+    }
+}
+
+// Use SIMD parallelism to hash up to MAX_SIMD_DEGREE chunks at the same time
+// on a single thread. Write out the chunk chaining values and return the
+// number of chunks hashed. These chunks are never the root and never empty;
+// those cases use a different codepath.
+const fn const_compress_chunks_parallel(
+    input: &[u8],
+    key: &CVWords,
+    chunk_counter: u64,
+    flags: u8,
+    out: &mut [u8],
+) -> usize {
+    debug_assert!(!input.is_empty(), "empty chunks below the root");
+    debug_assert!(input.len() <= MAX_SIMD_DEGREE * CHUNK_LEN);
+
+    let mut chunks = input;
+    let mut chunks_so_far = 0;
+    let mut chunks_array = [MaybeUninit::<&[u8; CHUNK_LEN]>::uninit(); MAX_SIMD_DEGREE];
+    while let Some(chunk) = chunks.first_chunk::<CHUNK_LEN>() {
+        chunks = chunks.split_at(CHUNK_LEN).1;
+        chunks_array[chunks_so_far].write(chunk);
+        chunks_so_far += 1;
+    }
+    portable::hash_many(
+        // SAFETY: Exactly `chunks_so_far` elements of `chunks_array` were initialized above
+        unsafe {
+            slice::from_raw_parts(
+                chunks_array.as_ptr().cast::<&[u8; CHUNK_LEN]>(),
+                chunks_so_far,
+            )
+        },
+        key,
+        chunk_counter,
+        IncrementCounter::Yes,
+        flags,
+        CHUNK_START,
+        CHUNK_END,
+        out,
+    );
+
+    // Hash the remaining partial chunk, if there is one. Note that the empty
+    // chunk (meaning the empty message) is a different codepath.
+    if !chunks.is_empty() {
+        let counter = chunk_counter + chunks_so_far as u64;
+        let mut chunk_state = ConstChunkState::new(key, counter, flags);
+        chunk_state.update(chunks);
+        let out = out
+            .split_at_mut(chunks_so_far * OUT_LEN)
+            .1
+            .split_at_mut(OUT_LEN)
+            .0;
+        let chaining_value = chunk_state.output().chaining_value();
+        out.copy_from_slice(&chaining_value);
+        chunks_so_far + 1
+    } else {
+        chunks_so_far
+    }
+}
+
+// Use SIMD parallelism to hash up to MAX_SIMD_DEGREE parents at the same time
+// on a single thread. Write out the parent chaining values and return the
+// number of parents hashed. (If there's an odd input chaining value left over,
+// return it as an additional output.) These parents are never the root and
+// never empty; those cases use a different codepath.
+const fn const_compress_parents_parallel(
+    child_chaining_values: &[u8],
+    key: &CVWords,
+    flags: u8,
+    out: &mut [u8],
+) -> usize {
+    debug_assert!(
+        child_chaining_values.len() % OUT_LEN == 0,
+        "wacky hash bytes"
+    );
+    let num_children = child_chaining_values.len() / OUT_LEN;
+    debug_assert!(num_children >= 2, "not enough children");
+    debug_assert!(num_children <= 2 * MAX_SIMD_DEGREE_OR_2, "too many");
+
+    let mut parents = child_chaining_values;
+    // Use MAX_SIMD_DEGREE_OR_2 rather than MAX_SIMD_DEGREE here, because of
+    // the requirements of compress_subtree_wide().
+    let mut parents_so_far = 0;
+    let mut parents_array = [MaybeUninit::<&[u8; BLOCK_LEN]>::uninit(); MAX_SIMD_DEGREE_OR_2];
+    while let Some(parent) = parents.first_chunk::<BLOCK_LEN>() {
+        parents = parents.split_at(BLOCK_LEN).1;
+        parents_array[parents_so_far].write(parent);
+        parents_so_far += 1;
+    }
+    portable::hash_many(
+        // SAFETY: Exactly `parents_so_far` elements of `parents_array` were initialized above
+        unsafe {
+            slice::from_raw_parts(
+                parents_array.as_ptr().cast::<&[u8; BLOCK_LEN]>(),
+                parents_so_far,
+            )
+        },
+        key,
+        0, // Parents always use counter 0.
+        IncrementCounter::No,
+        flags | PARENT,
+        0, // Parents have no start flags.
+        0, // Parents have no end flags.
+        out,
+    );
+
+    // If there's an odd child left over, it becomes an output.
+    if !parents.is_empty() {
+        let out = out
+            .split_at_mut(parents_so_far * OUT_LEN)
+            .1
+            .split_at_mut(OUT_LEN)
+            .0;
+        out.copy_from_slice(parents);
+        parents_so_far + 1
+    } else {
+        parents_so_far
+    }
+}
+
+// The wide helper function returns (writes out) an array of chaining values
+// and returns the length of that array. The number of chaining values returned
+// is the dynamically detected SIMD degree, at most MAX_SIMD_DEGREE. Or fewer,
+// if the input is shorter than that many chunks. The reason for maintaining a
+// wide array of chaining values going back up the tree, is to allow the
+// implementation to hash as many parents in parallel as possible.
+//
+// As a special case when the SIMD degree is 1, this function will still return
+// at least 2 outputs. This guarantees that this function doesn't perform the
+// root compression. (If it did, it would use the wrong flags, and also we
+// wouldn't be able to implement extendable output.) Note that this function is
+// not used when the whole input is only 1 chunk long; that's a different
+// codepath.
+//
+// Why not just have the caller split the input on the first update(), instead
+// of implementing this special rule? Because we don't want to limit SIMD or
+// multithreading parallelism for that update().
+const fn const_compress_subtree_wide(
+    input: &[u8],
+    key: &CVWords,
+    chunk_counter: u64,
+    flags: u8,
+    out: &mut [u8],
+) -> usize {
+    if input.len() <= CHUNK_LEN {
+        return const_compress_chunks_parallel(input, key, chunk_counter, flags, out);
+    }
+
+    let (left, right) = input.split_at(hazmat::left_subtree_len(input.len() as u64) as usize);
+    let right_chunk_counter = chunk_counter + (left.len() / CHUNK_LEN) as u64;
+
+    // Make space for the child outputs. Here we use MAX_SIMD_DEGREE_OR_2 to
+    // account for the special case of returning 2 outputs when the SIMD degree
+    // is 1.
+    let mut cv_array = [0; 2 * MAX_SIMD_DEGREE_OR_2 * OUT_LEN];
+    let degree = if left.len() == CHUNK_LEN { 1 } else { 2 };
+    let (left_out, right_out) = cv_array.split_at_mut(degree * OUT_LEN);
+
+    // Recurse!
+    let left_n = const_compress_subtree_wide(left, key, chunk_counter, flags, left_out);
+    let right_n = const_compress_subtree_wide(right, key, right_chunk_counter, flags, right_out);
+
+    // The special case again. If simd_degree=1, then we'll have left_n=1 and
+    // right_n=1. Rather than compressing them into a single output, return
+    // them directly, to make sure we always have at least two outputs.
+    debug_assert!(left_n == degree);
+    debug_assert!(right_n >= 1 && right_n <= left_n);
+    if left_n == 1 {
+        out.split_at_mut(2 * OUT_LEN)
+            .0
+            .copy_from_slice(cv_array.split_at(2 * OUT_LEN).0);
+        return 2;
+    }
+
+    // Otherwise, do one layer of parent node compression.
+    let num_children = left_n + right_n;
+    const_compress_parents_parallel(cv_array.split_at(num_children * OUT_LEN).0, key, flags, out)
+}
+
+// Hash a subtree with compress_subtree_wide(), and then condense the resulting
+// list of chaining values down to a single parent node. Don't compress that
+// last parent node, however. Instead, return its message bytes (the
+// concatenated chaining values of its children). This is necessary when the
+// first call to update() supplies a complete subtree, because the topmost
+// parent node of that subtree could end up being the root. It's also necessary
+// for extended output in the general case.
+//
+// As with compress_subtree_wide(), this function is not used on inputs of 1
+// chunk or less. That's a different codepath.
+const fn const_compress_subtree_to_parent_node(
+    input: &[u8],
+    key: &CVWords,
+    chunk_counter: u64,
+    flags: u8,
+) -> [u8; BLOCK_LEN] {
+    debug_assert!(input.len() > CHUNK_LEN);
+    let mut cv_array = [0; MAX_SIMD_DEGREE_OR_2 * OUT_LEN];
+    let mut num_cvs = const_compress_subtree_wide(input, key, chunk_counter, flags, &mut cv_array);
+    debug_assert!(num_cvs >= 2);
+
+    // If MAX_SIMD_DEGREE is greater than 2 and there's enough input,
+    // compress_subtree_wide() returns more than 2 chaining values. Condense
+    // them into 2 by forming parent nodes repeatedly.
+    let mut out_array = [0; MAX_SIMD_DEGREE_OR_2 * OUT_LEN / 2];
+    while num_cvs > 2 {
+        let cv_slice = cv_array.split_at(num_cvs * OUT_LEN).0;
+        num_cvs = const_compress_parents_parallel(cv_slice, key, flags, &mut out_array);
+        cv_array
+            .split_at_mut(num_cvs * OUT_LEN)
+            .0
+            .copy_from_slice(out_array.split_at(num_cvs * OUT_LEN).0);
+    }
+    *cv_array
+        .first_chunk::<BLOCK_LEN>()
+        .expect("`cv_array` is larger than `BLOCK_LEN`; qed")
+}
+
+// Hash a complete input all at once. Unlike compress_subtree_wide() and
+// compress_subtree_to_parent_node(), this function handles the 1 chunk case.
+const fn const_hash_all_at_once(input: &[u8], key: &CVWords, flags: u8) -> ConstOutput {
+    // If the whole subtree is one chunk, hash it directly with a ChunkState.
+    if input.len() <= CHUNK_LEN {
+        return ConstChunkState::new(key, 0, flags).update(input).output();
+    }
+
+    // Otherwise construct an Output object from the parent node returned by
+    // compress_subtree_to_parent_node().
+    ConstOutput {
+        input_chaining_value: *key,
+        block: const_compress_subtree_to_parent_node(input, key, 0, flags),
+        block_len: BLOCK_LEN as u8,
+        counter: 0,
+        flags: flags | PARENT,
+    }
+}
+
+/// Hashing function like `blake3::hash()`, but `const fn`
+pub const fn const_hash(input: &[u8]) -> [u8; OUT_LEN] {
+    const_hash_all_at_once(input, IV, 0).root_hash()
+}
+
+/// The keyed hash function like `blake3::keyed_hash()`, but `const fn`
+pub const fn const_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> [u8; OUT_LEN] {
+    let key_words = platform::words_from_le_bytes_32(key);
+    const_hash_all_at_once(input, &key_words, KEYED_HASH).root_hash()
+}
+
+// The key derivation function like `blake3::derive_key()`, but `const fn`
+pub const fn const_derive_key(context: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
+    let context_key = hazmat::const_hash_derive_key_context(context);
+    let context_key_words = platform::words_from_le_bytes_32(&context_key);
+    const_hash_all_at_once(key_material, &context_key_words, DERIVE_KEY_MATERIAL).root_hash()
+}

--- a/crates/shared/ab-blake3/src/const_fn/hazmat.rs
+++ b/crates/shared/ab-blake3/src/const_fn/hazmat.rs
@@ -1,0 +1,38 @@
+#[cfg(test)]
+mod tests;
+
+use crate::const_fn::{CHUNK_LEN, IV, KEY_LEN};
+
+/// An alias to distinguish [`const_hash_derive_key_context`] outputs from other keys.
+pub(super) type ContextKey = [u8; KEY_LEN];
+
+/// Given the length in bytes of either a complete input or a subtree input, return the number of
+/// bytes that belong to its left child subtree. The rest belong to its right child subtree.
+///
+/// Concretely, this function returns the largest power-of-two number of bytes that's strictly less
+/// than `input_len`. This leads to a tree where all left subtrees are "complete" and at least as
+/// large as their sibling right subtrees, as specified in section 2.1 of [the BLAKE3
+/// paper](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf). For example, if an
+/// input is exactly two chunks, its left and right subtrees both get one chunk. But if an input is
+/// two chunks plus one more byte, then its left subtree gets two chunks, and its right subtree
+/// only gets one byte.
+///
+/// This function isn't meaningful for one chunk of input, because chunks don't have children. It
+/// currently panics in debug mode if `input_len <= CHUNK_LEN`.
+#[inline(always)]
+pub(super) const fn left_subtree_len(input_len: u64) -> u64 {
+    debug_assert!(input_len > CHUNK_LEN as u64);
+    // Note that .next_power_of_two() is greater than *or equal*.
+    input_len.div_ceil(2).next_power_of_two()
+}
+
+/// Hash a [`const_derive_key`](crate::const_fn::const_derive_key) context string and return a
+/// [`ContextKey`]
+pub(super) const fn const_hash_derive_key_context(context: &str) -> ContextKey {
+    crate::const_fn::const_hash_all_at_once(
+        context.as_bytes(),
+        IV,
+        crate::const_fn::DERIVE_KEY_CONTEXT,
+    )
+    .root_hash()
+}

--- a/crates/shared/ab-blake3/src/const_fn/hazmat/tests.rs
+++ b/crates/shared/ab-blake3/src/const_fn/hazmat/tests.rs
@@ -1,0 +1,13 @@
+use crate::const_fn::hazmat::left_subtree_len;
+use crate::const_fn::CHUNK_LEN;
+
+#[test]
+fn test_left_subtree_len() {
+    assert_eq!(left_subtree_len(1025), 1024);
+    for boundary_case in [2, 4, 8, 16, 32, 64] {
+        let input_len = boundary_case * CHUNK_LEN as u64;
+        assert_eq!(left_subtree_len(input_len - 1), input_len / 2);
+        assert_eq!(left_subtree_len(input_len), input_len / 2);
+        assert_eq!(left_subtree_len(input_len + 1), input_len);
+    }
+}

--- a/crates/shared/ab-blake3/src/const_fn/platform.rs
+++ b/crates/shared/ab-blake3/src/const_fn/platform.rs
@@ -1,0 +1,79 @@
+pub(super) const MAX_SIMD_DEGREE: usize = 1;
+
+// There are some places where we want a static size that's equal to the
+// MAX_SIMD_DEGREE, but also at least 2. Constant contexts aren't currently
+// allowed to use cmp::max, so we have to hardcode this additional constant
+// value. Get rid of this once cmp::max is a const fn.
+pub(super) const MAX_SIMD_DEGREE_OR_2: usize = 2;
+
+macro_rules! extract_u32_from_byte_chunks {
+    ($src:ident, $chunk_index:literal) => {
+        u32::from_le_bytes([
+            $src[$chunk_index * 4 + 0],
+            $src[$chunk_index * 4 + 1],
+            $src[$chunk_index * 4 + 2],
+            $src[$chunk_index * 4 + 3],
+        ])
+    };
+}
+
+macro_rules! store_u32_to_by_chunks {
+    ($src:ident, $dst:ident, $chunk_index:literal) => {
+        [
+            $dst[$chunk_index * 4 + 0],
+            $dst[$chunk_index * 4 + 1],
+            $dst[$chunk_index * 4 + 2],
+            $dst[$chunk_index * 4 + 3],
+        ] = $src[$chunk_index].to_le_bytes();
+    };
+}
+
+#[inline(always)]
+pub(super) const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
+    let mut out = [0; 8];
+    out[0] = extract_u32_from_byte_chunks!(bytes, 0);
+    out[1] = extract_u32_from_byte_chunks!(bytes, 1);
+    out[2] = extract_u32_from_byte_chunks!(bytes, 2);
+    out[3] = extract_u32_from_byte_chunks!(bytes, 3);
+    out[4] = extract_u32_from_byte_chunks!(bytes, 4);
+    out[5] = extract_u32_from_byte_chunks!(bytes, 5);
+    out[6] = extract_u32_from_byte_chunks!(bytes, 6);
+    out[7] = extract_u32_from_byte_chunks!(bytes, 7);
+    out
+}
+
+#[inline(always)]
+pub(super) const fn words_from_le_bytes_64(bytes: &[u8; 64]) -> [u32; 16] {
+    let mut out = [0; 16];
+    out[0] = extract_u32_from_byte_chunks!(bytes, 0);
+    out[1] = extract_u32_from_byte_chunks!(bytes, 1);
+    out[2] = extract_u32_from_byte_chunks!(bytes, 2);
+    out[3] = extract_u32_from_byte_chunks!(bytes, 3);
+    out[4] = extract_u32_from_byte_chunks!(bytes, 4);
+    out[5] = extract_u32_from_byte_chunks!(bytes, 5);
+    out[6] = extract_u32_from_byte_chunks!(bytes, 6);
+    out[7] = extract_u32_from_byte_chunks!(bytes, 7);
+    out[8] = extract_u32_from_byte_chunks!(bytes, 8);
+    out[9] = extract_u32_from_byte_chunks!(bytes, 9);
+    out[10] = extract_u32_from_byte_chunks!(bytes, 10);
+    out[11] = extract_u32_from_byte_chunks!(bytes, 11);
+    out[12] = extract_u32_from_byte_chunks!(bytes, 12);
+    out[13] = extract_u32_from_byte_chunks!(bytes, 13);
+    out[14] = extract_u32_from_byte_chunks!(bytes, 14);
+    out[15] = extract_u32_from_byte_chunks!(bytes, 15);
+    out
+}
+
+#[inline(always)]
+pub(super) const fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
+    let mut out = [0; 32];
+    store_u32_to_by_chunks!(words, out, 0);
+    store_u32_to_by_chunks!(words, out, 1);
+    store_u32_to_by_chunks!(words, out, 2);
+    store_u32_to_by_chunks!(words, out, 3);
+    store_u32_to_by_chunks!(words, out, 4);
+    store_u32_to_by_chunks!(words, out, 5);
+    store_u32_to_by_chunks!(words, out, 6);
+    store_u32_to_by_chunks!(words, out, 7);
+    out
+}

--- a/crates/shared/ab-blake3/src/const_fn/portable.rs
+++ b/crates/shared/ab-blake3/src/const_fn/portable.rs
@@ -1,0 +1,162 @@
+use crate::const_fn::{CVBytes, CVWords, IncrementCounter, IV, MSG_SCHEDULE};
+use crate::{BLOCK_LEN, OUT_LEN};
+
+#[inline(always)]
+const fn g(state: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, x: u32, y: u32) {
+    state[a] = state[a].wrapping_add(state[b]).wrapping_add(x);
+    state[d] = (state[d] ^ state[a]).rotate_right(16);
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] = (state[b] ^ state[c]).rotate_right(12);
+    state[a] = state[a].wrapping_add(state[b]).wrapping_add(y);
+    state[d] = (state[d] ^ state[a]).rotate_right(8);
+    state[c] = state[c].wrapping_add(state[d]);
+    state[b] = (state[b] ^ state[c]).rotate_right(7);
+}
+
+#[inline(always)]
+const fn round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
+    // Select the message schedule based on the round.
+    let schedule = MSG_SCHEDULE[round];
+
+    // Mix the columns.
+    g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
+    g(state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
+    g(state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
+    g(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+
+    // Mix the diagonals.
+    g(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+    g(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+    g(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+    g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+}
+
+#[inline]
+const fn counter_low(counter: u64) -> u32 {
+    counter as u32
+}
+
+#[inline]
+const fn counter_high(counter: u64) -> u32 {
+    (counter >> 32) as u32
+}
+
+#[inline(always)]
+const fn compress_pre(
+    cv: &CVWords,
+    block: &[u8; BLOCK_LEN],
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+) -> [u32; 16] {
+    let block_words = crate::const_fn::platform::words_from_le_bytes_64(block);
+
+    let mut state = [
+        cv[0],
+        cv[1],
+        cv[2],
+        cv[3],
+        cv[4],
+        cv[5],
+        cv[6],
+        cv[7],
+        IV[0],
+        IV[1],
+        IV[2],
+        IV[3],
+        counter_low(counter),
+        counter_high(counter),
+        block_len as u32,
+        flags as u32,
+    ];
+
+    round(&mut state, &block_words, 0);
+    round(&mut state, &block_words, 1);
+    round(&mut state, &block_words, 2);
+    round(&mut state, &block_words, 3);
+    round(&mut state, &block_words, 4);
+    round(&mut state, &block_words, 5);
+    round(&mut state, &block_words, 6);
+
+    state
+}
+
+pub(super) const fn compress_in_place(
+    cv: &mut CVWords,
+    block: &[u8; BLOCK_LEN],
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+) {
+    let state = compress_pre(cv, block, block_len, counter, flags);
+
+    cv[0] = state[0] ^ state[8];
+    cv[1] = state[1] ^ state[9];
+    cv[2] = state[2] ^ state[10];
+    cv[3] = state[3] ^ state[11];
+    cv[4] = state[4] ^ state[12];
+    cv[5] = state[5] ^ state[13];
+    cv[6] = state[6] ^ state[14];
+    cv[7] = state[7] ^ state[15];
+}
+
+const fn hash1<const N: usize>(
+    input: &[u8; N],
+    key: &CVWords,
+    counter: u64,
+    flags: u8,
+    flags_start: u8,
+    flags_end: u8,
+    out: &mut CVBytes,
+) {
+    debug_assert!(N % BLOCK_LEN == 0, "uneven blocks");
+    let mut cv = *key;
+    let mut block_flags = flags | flags_start;
+    let mut slice = input.as_slice();
+    while slice.len() >= BLOCK_LEN {
+        let block;
+        (block, slice) = slice.split_at(BLOCK_LEN);
+        if slice.is_empty() {
+            block_flags |= flags_end;
+        }
+        let block = {
+            let ptr = block.as_ptr() as *const [u8; BLOCK_LEN];
+            // SAFETY: Sliced off correct length above
+            unsafe { &*ptr }
+        };
+
+        compress_in_place(&mut cv, block, BLOCK_LEN as u8, counter, block_flags);
+        block_flags = flags;
+    }
+    *out = crate::const_fn::platform::le_bytes_from_words_32(&cv);
+}
+
+#[expect(clippy::too_many_arguments, reason = "Internal")]
+pub(super) const fn hash_many<const N: usize>(
+    mut inputs: &[&[u8; N]],
+    key: &CVWords,
+    mut counter: u64,
+    increment_counter: IncrementCounter,
+    flags: u8,
+    flags_start: u8,
+    flags_end: u8,
+    mut out: &mut [u8],
+) {
+    debug_assert!(out.len() >= inputs.len() * OUT_LEN, "out too short");
+    while !inputs.is_empty() {
+        let input;
+        (input, inputs) = inputs.split_first().expect("Not empty; qed");
+        let o;
+        (o, out) = out.split_at_mut(OUT_LEN);
+        let o = {
+            let ptr = o.as_mut_ptr() as *mut [u8; OUT_LEN];
+            // SAFETY: Sliced off correct length above
+            unsafe { &mut *ptr }
+        };
+
+        hash1(input, key, counter, flags, flags_start, flags_end, o);
+        if increment_counter.yes() {
+            counter += 1;
+        }
+    }
+}

--- a/crates/shared/ab-blake3/src/const_fn/tests.rs
+++ b/crates/shared/ab-blake3/src/const_fn/tests.rs
@@ -1,0 +1,81 @@
+use crate::const_fn::{CVBytes, BLOCK_LEN, CHUNK_LEN};
+use crate::{const_derive_key, const_hash, const_keyed_hash};
+use blake3::{derive_key, hash, keyed_hash};
+
+// Interesting input lengths to run tests on.
+const TEST_CASES: &[usize] = &[
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    BLOCK_LEN - 1,
+    BLOCK_LEN,
+    BLOCK_LEN + 1,
+    2 * BLOCK_LEN - 1,
+    2 * BLOCK_LEN,
+    2 * BLOCK_LEN + 1,
+    CHUNK_LEN - 1,
+    CHUNK_LEN,
+    CHUNK_LEN + 1,
+    2 * CHUNK_LEN,
+    2 * CHUNK_LEN + 1,
+    3 * CHUNK_LEN,
+    3 * CHUNK_LEN + 1,
+    4 * CHUNK_LEN,
+    4 * CHUNK_LEN + 1,
+    5 * CHUNK_LEN,
+    5 * CHUNK_LEN + 1,
+    6 * CHUNK_LEN,
+    6 * CHUNK_LEN + 1,
+    7 * CHUNK_LEN,
+    7 * CHUNK_LEN + 1,
+    8 * CHUNK_LEN,
+    8 * CHUNK_LEN + 1,
+    16 * CHUNK_LEN - 1,
+    16 * CHUNK_LEN, // AVX512's bandwidth
+    16 * CHUNK_LEN + 1,
+    31 * CHUNK_LEN - 1,
+    31 * CHUNK_LEN, // 16 + 8 + 4 + 2 + 1
+    31 * CHUNK_LEN + 1,
+    100 * CHUNK_LEN, // subtrees larger than MAX_SIMD_DEGREE chunks
+];
+
+const TEST_CASES_MAX: usize = 100 * CHUNK_LEN;
+
+// There's a test to make sure these two are equal below.
+const TEST_KEY: CVBytes = *b"whats the Elvish word for friend";
+
+#[test]
+fn test_compare_with_upstream() {
+    let mut input_buf = [0; TEST_CASES_MAX];
+
+    // Paint the input with a repeating byte pattern. We use a cycle length of 251,
+    // because that's the largest prime number less than 256. This makes it
+    // unlikely to swapping any two adjacent input blocks or chunks will give the
+    // same answer.
+    for (i, b) in input_buf.iter_mut().enumerate() {
+        *b = (i % 251) as u8;
+    }
+
+    for &case in TEST_CASES {
+        let input = &input_buf[..case];
+
+        // regular
+        assert_eq!(hash(input), const_hash(input));
+
+        // keyed
+        assert_eq!(
+            keyed_hash(&TEST_KEY, input),
+            const_keyed_hash(&TEST_KEY, input)
+        );
+
+        // derive_key
+        let context = "BLAKE3 2019-12-27 16:13:59 example context (not the test vector one)";
+        assert_eq!(derive_key(context, input), const_derive_key(context, input));
+    }
+}

--- a/crates/shared/ab-blake3/src/lib.rs
+++ b/crates/shared/ab-blake3/src/lib.rs
@@ -1,0 +1,14 @@
+//! Optimized and more exotic APIs around BLAKE3
+
+#![no_std]
+
+mod const_fn;
+
+/// The number of bytes in a hash
+pub const OUT_LEN: usize = 32;
+/// The number of bytes in a key
+pub const KEY_LEN: usize = 32;
+/// The number of bytes in a block
+pub const BLOCK_LEN: usize = 64;
+
+pub use const_fn::{const_derive_key, const_hash, const_keyed_hash};


### PR DESCRIPTION
This essentially extracts https://github.com/BLAKE3-team/BLAKE3

This is just a beginning though. Either this version will be refactored or another created that works with `u32` words instead of bytes, so it works on GPU too.

Probably separately another version will be created that only offers API that can has up to a single block worth of data (64 bytes), which is actually a pretty common scenario, used in Merkle Trees, Chia PoSpace and other parts of consensus. Eventually there should be APIs that offer https://github.com/BLAKE3-team/BLAKE3/issues/478, which will accelerate Merkle Trees to new heights.

Either way this is a start, and while not used in this PR, should be very soon.

P.S. I tried to make it `no-panic`, but the rabbit hole went a bit too deep for the initial attempt, so maybe next time.