### PR TITLE
Extend `ab-blake3` with additional functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ name = "ab-blake3"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "no-panic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ dependencies = [
 name = "ab-contracts-common"
 version = "0.0.1"
 dependencies = [
+ "ab-blake3",
  "ab-core-primitives",
  "ab-io-type",
- "const-sha1",
  "derive_more 2.0.1",
  "no-panic",
  "thiserror 2.0.12",
@@ -1073,12 +1073,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const-sha1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "const_format"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 name = "ab-merkle-tree"
 version = "0.0.1"
 dependencies = [
- "blake3",
+ "ab-blake3",
  "criterion",
  "no-panic",
  "rand_chacha 0.9.0",
@@ -409,9 +409,9 @@ dependencies = [
 name = "ab-proof-of-space"
 version = "0.1.0"
 dependencies = [
+ "ab-blake3",
  "ab-chacha8",
  "ab-core-primitives",
- "blake3",
  "chacha20",
  "criterion",
  "derive_more 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 [workspace.dependencies]
 ab-aligned-buffer = { version = "0.0.1", path = "crates/shared/ab-aligned-buffer" }
 ab-archiving = { version = "0.1.0", path = "crates/shared/ab-archiving" }
+ab-blake3 = { version = "0.1.0", path = "crates/shared/ab-blake3" }
 ab-chacha8 = { version = "0.1.0", path = "crates/shared/ab-chacha8" }
 ab-client-api = { version = "0.0.1", path = "crates/node/ab-client-api" }
 ab-client-archiving = { version = "0.0.1", path = "crates/node/ab-client-archiving" }
@@ -54,7 +55,6 @@ blake3 = { version = "1.8.2", default-features = false }
 bytes = { version = "1.10.1", default-features = false }
 cargo-gpu = { git = "https://github.com/Rust-GPU/cargo-gpu", rev = "e5744605020d9a94931519a17815e027db5fba01", default-features = false }
 chacha20 = { version = "0.10.0-rc.0", default-features = false }
-const-sha1 = { version = "0.3.0", default-features = false }
 const_format = "0.2.34"
 core_affinity = "0.8.3"
 cpufeatures = "0.2.17"

--- a/crates/contracts/core/ab-contracts-common/Cargo.toml
+++ b/crates/contracts/core/ab-contracts-common/Cargo.toml
@@ -15,10 +15,8 @@ all-features = true
 
 [dependencies]
 ab-core-primitives = { workspace = true }
+ab-blake3 = { workspace = true }
 ab-io-type = { workspace = true }
-# TODO: Switch to blake3 once https://github.com/BLAKE3-team/BLAKE3/pull/439 is upstreamed and const hashing version is
-#  exposed
-const-sha1 = { workspace = true }
 derive_more = { workspace = true, features = ["display"] }
 no-panic = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/contracts/core/ab-contracts-common/src/method.rs
+++ b/crates/contracts/core/ab-contracts-common/src/method.rs
@@ -1,7 +1,7 @@
 use crate::metadata::ContractMetadataKind;
+use ab_blake3::const_hash;
 use ab_core_primitives::hashes::Blake3Hash;
 use ab_io_type::trivial_type::TrivialType;
-use const_sha1::sha1;
 use derive_more::Display;
 
 /// Hash of method's compact metadata, which uniquely represents method signature.
@@ -29,13 +29,7 @@ impl MethodFingerprint {
         // in const environment yet
         let compact_metadata = compact_metadata_scratch.split_at(compact_metadata_size).0;
 
-        let hash = sha1(compact_metadata).as_bytes();
-
-        Some(Self(Blake3Hash::new([
-            hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7], hash[8],
-            hash[9], hash[10], hash[11], hash[12], hash[13], hash[14], hash[15], hash[16],
-            hash[17], hash[18], hash[19], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ])))
+        Some(Self(Blake3Hash::new(const_hash(compact_metadata))))
     }
 
     #[inline(always)]

--- a/crates/shared/ab-blake3/Cargo.toml
+++ b/crates/shared/ab-blake3/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 
 # TODO: Would be nice to have benchmarks here
 
-[dev-dependencies]
+[dependencies]
 blake3 = { workspace = true }
 
 [lints]

--- a/crates/shared/ab-blake3/Cargo.toml
+++ b/crates/shared/ab-blake3/Cargo.toml
@@ -22,6 +22,13 @@ all-features = true
 
 [dependencies]
 blake3 = { workspace = true }
+no-panic = { workspace = true, optional = true }
+
+[features]
+# Check that code can't panic under any conditions
+no-panic = [
+    "dep:no-panic",
+]
 
 [lints]
 workspace = true

--- a/crates/shared/ab-blake3/src/const_fn.rs
+++ b/crates/shared/ab-blake3/src/const_fn.rs
@@ -1,10 +1,8 @@
 //! `const fn` BLAKE3 functions.
 //!
 //! This module and submodules are copied with modifications from the official [`blake3`] crate and
-//! is expected to be removed once https://github.com/BLAKE3-team/BLAKE3/pull/439 or similar lands
+//! is expected to be removed once <https://github.com/BLAKE3-team/BLAKE3/pull/439> or similar lands
 //! upstream.
-//!
-//! [`blake3`]: https://github.com/BLAKE3-team/BLAKE3
 
 mod hazmat;
 #[cfg(test)]
@@ -409,18 +407,18 @@ const fn const_hash_all_at_once(input: &[u8], key: &CVWords, flags: u8) -> Const
     }
 }
 
-/// Hashing function like `blake3::hash()`, but `const fn`
+/// Hashing function like [`blake3::hash()`], but `const fn`
 pub const fn const_hash(input: &[u8]) -> [u8; OUT_LEN] {
     const_hash_all_at_once(input, IV, 0).root_hash()
 }
 
-/// The keyed hash function like `blake3::keyed_hash()`, but `const fn`
+/// The keyed hash function like [`blake3::keyed_hash()`], but `const fn`
 pub const fn const_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> [u8; OUT_LEN] {
     let key_words = words_from_le_bytes_32(key);
     const_hash_all_at_once(input, &key_words, KEYED_HASH).root_hash()
 }
 
-// The key derivation function like `blake3::derive_key()`, but `const fn`
+// The key derivation function like [`blake3::derive_key()`], but `const fn`
 pub const fn const_derive_key(context: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
     let context_key =
         const_hash_all_at_once(context.as_bytes(), IV, DERIVE_KEY_CONTEXT).root_hash();

--- a/crates/shared/ab-blake3/src/const_fn.rs
+++ b/crates/shared/ab-blake3/src/const_fn.rs
@@ -36,19 +36,25 @@ impl ConstOutput {
         portable::compress_in_place(
             &mut cv,
             &block_words,
-            self.block_len,
+            self.block_len as u32,
             self.counter,
-            self.flags,
+            self.flags as u32,
         );
-        le_bytes_from_words_32(&cv)
+        *le_bytes_from_words_32(&cv)
     }
 
     const fn root_hash(&self) -> [u8; OUT_LEN] {
         debug_assert!(self.counter == 0);
         let mut cv = self.input_chaining_value;
         let block_words = words_from_le_bytes_64(&self.block);
-        portable::compress_in_place(&mut cv, &block_words, self.block_len, 0, self.flags | ROOT);
-        le_bytes_from_words_32(&cv)
+        portable::compress_in_place(
+            &mut cv,
+            &block_words,
+            self.block_len as u32,
+            0,
+            (self.flags | ROOT) as u32,
+        );
+        *le_bytes_from_words_32(&cv)
     }
 }
 
@@ -115,9 +121,9 @@ impl ConstChunkState {
                 portable::compress_in_place(
                     &mut self.cv,
                     &block_words,
-                    BLOCK_LEN as u8,
+                    BLOCK_LEN as u32,
                     self.chunk_counter,
-                    block_flags,
+                    block_flags as u32,
                 );
                 self.buf_len = 0;
                 self.buf = [0; BLOCK_LEN];
@@ -135,9 +141,9 @@ impl ConstChunkState {
             portable::compress_in_place(
                 &mut self.cv,
                 &block_words,
-                BLOCK_LEN as u8,
+                BLOCK_LEN as u32,
                 self.chunk_counter,
-                block_flags,
+                block_flags as u32,
             );
             self.blocks_compressed += 1;
             input = input.split_at(BLOCK_LEN).1;

--- a/crates/shared/ab-blake3/src/const_fn/hazmat.rs
+++ b/crates/shared/ab-blake3/src/const_fn/hazmat.rs
@@ -1,10 +1,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::const_fn::{CHUNK_LEN, IV, KEY_LEN};
-
-/// An alias to distinguish [`const_hash_derive_key_context`] outputs from other keys.
-pub(super) type ContextKey = [u8; KEY_LEN];
+use crate::CHUNK_LEN;
 
 /// Given the length in bytes of either a complete input or a subtree input, return the number of
 /// bytes that belong to its left child subtree. The rest belong to its right child subtree.
@@ -24,15 +21,4 @@ pub(super) const fn left_subtree_len(input_len: u64) -> u64 {
     debug_assert!(input_len > CHUNK_LEN as u64);
     // Note that .next_power_of_two() is greater than *or equal*.
     input_len.div_ceil(2).next_power_of_two()
-}
-
-/// Hash a [`const_derive_key`](crate::const_fn::const_derive_key) context string and return a
-/// [`ContextKey`]
-pub(super) const fn const_hash_derive_key_context(context: &str) -> ContextKey {
-    crate::const_fn::const_hash_all_at_once(
-        context.as_bytes(),
-        IV,
-        crate::const_fn::DERIVE_KEY_CONTEXT,
-    )
-    .root_hash()
 }

--- a/crates/shared/ab-blake3/src/const_fn/platform.rs
+++ b/crates/shared/ab-blake3/src/const_fn/platform.rs
@@ -1,3 +1,5 @@
+use crate::{BlockBytes, BlockWords};
+
 pub(super) const MAX_SIMD_DEGREE: usize = 1;
 
 // There are some places where we want a static size that's equal to the
@@ -43,7 +45,7 @@ pub(super) const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
 }
 
 #[inline(always)]
-pub(super) const fn words_from_le_bytes_64(bytes: &[u8; 64]) -> [u32; 16] {
+pub(super) const fn words_from_le_bytes_64(bytes: &BlockBytes) -> BlockWords {
     let mut out = [0; 16];
     out[0] = extract_u32_from_byte_chunks!(bytes, 0);
     out[1] = extract_u32_from_byte_chunks!(bytes, 1);

--- a/crates/shared/ab-blake3/src/const_fn/tests.rs
+++ b/crates/shared/ab-blake3/src/const_fn/tests.rs
@@ -50,6 +50,7 @@ const TEST_CASES_MAX: usize = 100 * CHUNK_LEN;
 const TEST_KEY: CVBytes = *b"whats the Elvish word for friend";
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_compare_with_upstream() {
     let mut input_buf = [0; TEST_CASES_MAX];
 

--- a/crates/shared/ab-blake3/src/lib.rs
+++ b/crates/shared/ab-blake3/src/lib.rs
@@ -6,9 +6,15 @@
 mod const_fn;
 mod platform;
 mod portable;
+mod single_block;
 mod single_chunk;
 
 pub use const_fn::{const_derive_key, const_hash, const_keyed_hash};
+pub use platform::{le_bytes_from_words_32, words_from_le_bytes_32, words_from_le_bytes_64};
+pub use single_block::{
+    single_block_derive_key, single_block_hash, single_block_hash_portable_words,
+    single_block_keyed_hash,
+};
 pub use single_chunk::{single_chunk_derive_key, single_chunk_hash, single_chunk_keyed_hash};
 
 /// The number of bytes in a hash

--- a/crates/shared/ab-blake3/src/lib.rs
+++ b/crates/shared/ab-blake3/src/lib.rs
@@ -11,4 +11,7 @@ pub const KEY_LEN: usize = 32;
 /// The number of bytes in a block
 pub const BLOCK_LEN: usize = 64;
 
+type BlockBytes = [u8; BLOCK_LEN];
+type BlockWords = [u32; 16];
+
 pub use const_fn::{const_derive_key, const_hash, const_keyed_hash};

--- a/crates/shared/ab-blake3/src/lib.rs
+++ b/crates/shared/ab-blake3/src/lib.rs
@@ -1,8 +1,15 @@
 //! Optimized and more exotic APIs around BLAKE3
 
 #![no_std]
+#![feature(array_chunks)]
 
 mod const_fn;
+mod platform;
+mod portable;
+mod single_chunk;
+
+pub use const_fn::{const_derive_key, const_hash, const_keyed_hash};
+pub use single_chunk::{single_chunk_derive_key, single_chunk_hash, single_chunk_keyed_hash};
 
 /// The number of bytes in a hash
 pub const OUT_LEN: usize = 32;
@@ -11,7 +18,45 @@ pub const KEY_LEN: usize = 32;
 /// The number of bytes in a block
 pub const BLOCK_LEN: usize = 64;
 
+/// The number of bytes in a chunk, 1024.
+///
+/// You don't usually need to think about this number, but it often comes up in benchmarks, because
+/// the maximum degree of parallelism used by the implementation equals the number of chunks.
+const CHUNK_LEN: usize = 1024;
+
+// While iterating the compression function within a chunk, the CV is
+// represented as words, to avoid doing two extra endianness conversions for
+// each compression in the portable implementation. But the hash_many interface
+// needs to hash both input bytes and parent nodes, so its better for its
+// output CVs to be represented as bytes.
+type CVWords = [u32; 8];
+type CVBytes = [u8; 32]; // little-endian
+
 type BlockBytes = [u8; BLOCK_LEN];
 type BlockWords = [u32; 16];
 
-pub use const_fn::{const_derive_key, const_hash, const_keyed_hash};
+const IV: &CVWords = &[
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+const MSG_SCHEDULE: [[usize; 16]; 7] = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8],
+    [3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1],
+    [10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6],
+    [12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4],
+    [9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7],
+    [11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13],
+];
+
+// These are the internal flags that we use to domain separate root/non-root,
+// chunk/parent, and chunk beginning/middle/end. These get set at the high end
+// of the block flags word in the compression function, so their values start
+// high and go down.
+const CHUNK_START: u8 = 1 << 0;
+const CHUNK_END: u8 = 1 << 1;
+const PARENT: u8 = 1 << 2;
+const ROOT: u8 = 1 << 3;
+const KEYED_HASH: u8 = 1 << 4;
+const DERIVE_KEY_CONTEXT: u8 = 1 << 5;
+const DERIVE_KEY_MATERIAL: u8 = 1 << 6;

--- a/crates/shared/ab-blake3/src/platform.rs
+++ b/crates/shared/ab-blake3/src/platform.rs
@@ -1,12 +1,12 @@
 use crate::{BlockBytes, BlockWords};
 
-pub(super) const MAX_SIMD_DEGREE: usize = 1;
+pub(crate) const MAX_SIMD_DEGREE: usize = 1;
 
 // There are some places where we want a static size that's equal to the
 // MAX_SIMD_DEGREE, but also at least 2. Constant contexts aren't currently
 // allowed to use cmp::max, so we have to hardcode this additional constant
 // value. Get rid of this once cmp::max is a const fn.
-pub(super) const MAX_SIMD_DEGREE_OR_2: usize = 2;
+pub(crate) const MAX_SIMD_DEGREE_OR_2: usize = 2;
 
 macro_rules! extract_u32_from_byte_chunks {
     ($src:ident, $chunk_index:literal) => {
@@ -31,7 +31,7 @@ macro_rules! store_u32_to_by_chunks {
 }
 
 #[inline(always)]
-pub(super) const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
+pub(crate) const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
     let mut out = [0; 8];
     out[0] = extract_u32_from_byte_chunks!(bytes, 0);
     out[1] = extract_u32_from_byte_chunks!(bytes, 1);
@@ -45,7 +45,7 @@ pub(super) const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
 }
 
 #[inline(always)]
-pub(super) const fn words_from_le_bytes_64(bytes: &BlockBytes) -> BlockWords {
+pub(crate) const fn words_from_le_bytes_64(bytes: &BlockBytes) -> BlockWords {
     let mut out = [0; 16];
     out[0] = extract_u32_from_byte_chunks!(bytes, 0);
     out[1] = extract_u32_from_byte_chunks!(bytes, 1);
@@ -67,7 +67,7 @@ pub(super) const fn words_from_le_bytes_64(bytes: &BlockBytes) -> BlockWords {
 }
 
 #[inline(always)]
-pub(super) const fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
+pub(crate) const fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
     let mut out = [0; 32];
     store_u32_to_by_chunks!(words, out, 0);
     store_u32_to_by_chunks!(words, out, 1);

--- a/crates/shared/ab-blake3/src/platform.rs
+++ b/crates/shared/ab-blake3/src/platform.rs
@@ -1,4 +1,5 @@
 use crate::{BlockBytes, BlockWords};
+use core::mem;
 
 pub(crate) const MAX_SIMD_DEGREE: usize = 1;
 
@@ -19,19 +20,9 @@ macro_rules! extract_u32_from_byte_chunks {
     };
 }
 
-macro_rules! store_u32_to_by_chunks {
-    ($src:ident, $dst:ident, $chunk_index:literal) => {
-        [
-            $dst[$chunk_index * 4 + 0],
-            $dst[$chunk_index * 4 + 1],
-            $dst[$chunk_index * 4 + 2],
-            $dst[$chunk_index * 4 + 3],
-        ] = $src[$chunk_index].to_le_bytes();
-    };
-}
-
+/// Converts bytes into `u32` words, the size matches BLAKE3 hash
 #[inline(always)]
-pub(crate) const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
+pub const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
     let mut out = [0; 8];
     out[0] = extract_u32_from_byte_chunks!(bytes, 0);
     out[1] = extract_u32_from_byte_chunks!(bytes, 1);
@@ -44,8 +35,9 @@ pub(crate) const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
     out
 }
 
+/// Converts bytes into `u32` words, the size matches BLAKE3 block
 #[inline(always)]
-pub(crate) const fn words_from_le_bytes_64(bytes: &BlockBytes) -> BlockWords {
+pub const fn words_from_le_bytes_64(bytes: &BlockBytes) -> BlockWords {
     let mut out = [0; 16];
     out[0] = extract_u32_from_byte_chunks!(bytes, 0);
     out[1] = extract_u32_from_byte_chunks!(bytes, 1);
@@ -66,16 +58,9 @@ pub(crate) const fn words_from_le_bytes_64(bytes: &BlockBytes) -> BlockWords {
     out
 }
 
+/// Converts `u32` words into bytes, the size matches BLAKE3 hash
 #[inline(always)]
-pub(crate) const fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
-    let mut out = [0; 32];
-    store_u32_to_by_chunks!(words, out, 0);
-    store_u32_to_by_chunks!(words, out, 1);
-    store_u32_to_by_chunks!(words, out, 2);
-    store_u32_to_by_chunks!(words, out, 3);
-    store_u32_to_by_chunks!(words, out, 4);
-    store_u32_to_by_chunks!(words, out, 5);
-    store_u32_to_by_chunks!(words, out, 6);
-    store_u32_to_by_chunks!(words, out, 7);
-    out
+pub const fn le_bytes_from_words_32(words: &[u32; 8]) -> &[u8; 32] {
+    // SAFETY: All bit patterns are valid, output alignment is smaller (1 byte) than input
+    unsafe { mem::transmute::<&[u32; 8], &[u8; 32]>(words) }
 }

--- a/crates/shared/ab-blake3/src/portable.rs
+++ b/crates/shared/ab-blake3/src/portable.rs
@@ -62,9 +62,9 @@ const fn counter_high(counter: u64) -> u32 {
 const fn compress_pre(
     cv: &CVWords,
     block_words: &BlockWords,
-    block_len: u8,
+    block_len: u32,
     counter: u64,
-    flags: u8,
+    flags: u32,
 ) -> BlockWords {
     let mut state = [
         cv[0],
@@ -81,8 +81,8 @@ const fn compress_pre(
         IV[3],
         counter_low(counter),
         counter_high(counter),
-        block_len as u32,
-        flags as u32,
+        block_len,
+        flags,
     ];
 
     round(&mut state, block_words, 0);
@@ -99,9 +99,9 @@ const fn compress_pre(
 pub(crate) const fn compress_in_place(
     cv: &mut CVWords,
     block_words: &BlockWords,
-    block_len: u8,
+    block_len: u32,
     counter: u64,
-    flags: u8,
+    flags: u32,
 ) {
     let state = compress_pre(cv, block_words, block_len, counter, flags);
 
@@ -141,10 +141,16 @@ const fn hash1<const N: usize>(
         };
         let block_words = words_from_le_bytes_64(block);
 
-        compress_in_place(&mut cv, &block_words, BLOCK_LEN as u8, counter, block_flags);
+        compress_in_place(
+            &mut cv,
+            &block_words,
+            BLOCK_LEN as u32,
+            counter,
+            block_flags as u32,
+        );
         block_flags = flags;
     }
-    *out = le_bytes_from_words_32(&cv);
+    *out = *le_bytes_from_words_32(&cv);
 }
 
 #[expect(clippy::too_many_arguments, reason = "Internal")]

--- a/crates/shared/ab-blake3/src/single_block.rs
+++ b/crates/shared/ab-blake3/src/single_block.rs
@@ -1,0 +1,97 @@
+//! BLAKE3 functions that process at most a single block.
+//!
+//! This module and submodules are copied with modifications from the official [`blake3`] crate, but
+//! is unlikely to be upstreamed.
+
+#[cfg(test)]
+mod tests;
+
+use crate::platform::{le_bytes_from_words_32, words_from_le_bytes_32};
+use crate::{
+    portable, BlockWords, CVWords, BLOCK_LEN, CHUNK_END, CHUNK_START, DERIVE_KEY_CONTEXT,
+    DERIVE_KEY_MATERIAL, IV, KEYED_HASH, KEY_LEN, OUT_LEN, ROOT,
+};
+use blake3::platform::Platform;
+
+// Hash a single block worth of values
+#[inline(always)]
+fn hash_block(input: &[u8], key: CVWords, flags: u8) -> Option<[u8; OUT_LEN]> {
+    // If the whole subtree is one block, hash it directly with a ChunkState.
+    if input.len() > BLOCK_LEN {
+        return None;
+    }
+
+    let mut cv = key;
+
+    let mut block = [0; BLOCK_LEN];
+    block[..input.len()].copy_from_slice(input);
+    Platform::detect().compress_in_place(
+        &mut cv,
+        &block,
+        input.len() as u8,
+        0,
+        flags | CHUNK_START | CHUNK_END | ROOT,
+    );
+
+    Some(*le_bytes_from_words_32(&cv))
+}
+
+/// Hashing function for at most a single block worth of bytes.
+///
+/// Returns `None` if input length exceeds one block.
+#[inline]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub fn single_block_hash(input: &[u8]) -> Option<[u8; OUT_LEN]> {
+    hash_block(input, *IV, 0)
+}
+
+/// The keyed hash function for at most a single block worth of bytes.
+///
+/// Returns `None` if input length exceeds one block.
+#[inline]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub fn single_block_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Option<[u8; OUT_LEN]> {
+    let key_words = words_from_le_bytes_32(key);
+    hash_block(input, key_words, KEYED_HASH)
+}
+
+// The key derivation function for at most a single block worth of bytes.
+//
+// Returns `None` if either context or key material length exceed one block.
+#[inline]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub fn single_block_derive_key(context: &str, key_material: &[u8]) -> Option<[u8; OUT_LEN]> {
+    let context_key = hash_block(context.as_bytes(), *IV, DERIVE_KEY_CONTEXT)?;
+    let context_key_words = words_from_le_bytes_32(&context_key);
+    hash_block(key_material, context_key_words, DERIVE_KEY_MATERIAL)
+}
+
+/// Hashing function for at most a single block worth of words using portable implementation.
+///
+/// This API operates on words and is GPU-friendly.
+///
+/// `num_bytes` specifies how many actual bytes are occupied by useful value in `input`. Bytes
+/// outside that must be set to `0`.
+///
+/// NOTE: If unused bytes are not set to `0` or invalid number of bytes is specified, it'll simply
+/// result in invalid hash.
+///
+/// [`words_from_le_bytes_32()`], [`words_from_le_bytes_64()`] and [`le_bytes_from_words_32()`] can
+/// be used to convert bytes to words and back if necessary.
+///
+/// [`words_from_le_bytes_64()`]: crate::words_from_le_bytes_64
+#[inline]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub fn single_block_hash_portable_words(input: &BlockWords, num_bytes: u32) -> CVWords {
+    let mut cv = *IV;
+
+    portable::compress_in_place(
+        &mut cv,
+        input,
+        num_bytes,
+        0,
+        (CHUNK_START | CHUNK_END | ROOT) as u32,
+    );
+
+    cv
+}

--- a/crates/shared/ab-blake3/src/single_block/tests.rs
+++ b/crates/shared/ab-blake3/src/single_block/tests.rs
@@ -1,0 +1,64 @@
+use crate::platform::{le_bytes_from_words_32, words_from_le_bytes_64};
+use crate::{
+    single_block_derive_key, single_block_hash, single_block_hash_portable_words,
+    single_block_keyed_hash, CVBytes, BLOCK_LEN, CHUNK_LEN,
+};
+use blake3::{derive_key, hash, keyed_hash};
+
+// Interesting input lengths to run tests on.
+const TEST_CASES: &[usize] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, BLOCK_LEN - 1, BLOCK_LEN];
+
+// There's a test to make sure these two are equal below.
+const TEST_KEY: CVBytes = *b"whats the Elvish word for friend";
+
+#[test]
+fn test_compare_with_upstream() {
+    let mut input_buf = [0; CHUNK_LEN];
+
+    // Paint the input with a repeating byte pattern. We use a cycle length of 251,
+    // because that's the largest prime number less than 256. This makes it
+    // unlikely to swapping any two adjacent input blocks or blocks will give the
+    // same answer.
+    for (i, b) in input_buf.iter_mut().enumerate() {
+        *b = (i % 251) as u8;
+    }
+
+    for &case in TEST_CASES {
+        let input = &input_buf[..case];
+
+        // regular
+        assert_eq!(
+            hash(input).as_bytes(),
+            &single_block_hash(input).unwrap(),
+            "{case}"
+        );
+        // regular words
+        assert_eq!(
+            hash(input).as_bytes(),
+            le_bytes_from_words_32(&single_block_hash_portable_words(
+                &{
+                    let mut block = [0; BLOCK_LEN];
+                    block[..input.len()].copy_from_slice(input);
+                    words_from_le_bytes_64(&block)
+                },
+                input.len() as u32
+            )),
+            "{case}"
+        );
+
+        // keyed
+        assert_eq!(
+            keyed_hash(&TEST_KEY, input).as_bytes(),
+            &single_block_keyed_hash(&TEST_KEY, input).unwrap(),
+            "{case}"
+        );
+
+        // derive_key
+        let context = "BLAKE3 2019-12-27 16:13:59 example context";
+        assert_eq!(
+            derive_key(context, input),
+            single_block_derive_key(context, input).unwrap(),
+            "{case}"
+        );
+    }
+}

--- a/crates/shared/ab-blake3/src/single_chunk.rs
+++ b/crates/shared/ab-blake3/src/single_chunk.rs
@@ -51,7 +51,7 @@ fn hash_chunk(input: &[u8], key: CVWords, flags: u8) -> Option<[u8; OUT_LEN]> {
         platform.compress_in_place(&mut cv, &buf, remainder.len() as u8, 0, block_flags);
     }
 
-    Some(le_bytes_from_words_32(&cv))
+    Some(*le_bytes_from_words_32(&cv))
 }
 
 /// Hashing function for at most a single chunk worth of bytes.

--- a/crates/shared/ab-blake3/src/single_chunk.rs
+++ b/crates/shared/ab-blake3/src/single_chunk.rs
@@ -1,0 +1,84 @@
+//! BLAKE3 functions that process at most a single chunk.
+//!
+//! This module and submodules are copied with modifications from the official [`blake3`] crate, but
+//! is unlikely to be upstreamed.
+//!
+//! [`blake3`]: https://github.com/BLAKE3-team/BLAKE3
+
+#[cfg(test)]
+mod tests;
+
+use crate::platform::{le_bytes_from_words_32, words_from_le_bytes_32};
+use crate::{
+    CVWords, BLOCK_LEN, CHUNK_END, CHUNK_LEN, CHUNK_START, DERIVE_KEY_CONTEXT, DERIVE_KEY_MATERIAL,
+    IV, KEYED_HASH, KEY_LEN, OUT_LEN, ROOT,
+};
+use blake3::platform::Platform;
+
+// Hash a single chunk worth of values
+#[inline(always)]
+fn hash_chunk(input: &[u8], key: CVWords, flags: u8) -> Option<[u8; OUT_LEN]> {
+    // If the whole subtree is one chunk, hash it directly with a ChunkState.
+    if input.len() > CHUNK_LEN {
+        return None;
+    }
+
+    let mut cv = key;
+    let platform = Platform::detect();
+    let blocks = input.array_chunks();
+    let remainder = blocks.remainder();
+    let num_blocks = blocks.len() + (!remainder.is_empty()) as usize;
+
+    for (block_index, block) in blocks.enumerate() {
+        let mut block_flags = flags;
+        if block_index == 0 {
+            block_flags |= CHUNK_START;
+        }
+        if block_index + 1 == num_blocks {
+            block_flags |= CHUNK_END | ROOT;
+        }
+
+        platform.compress_in_place(&mut cv, block, BLOCK_LEN as u8, 0, block_flags);
+    }
+
+    // `num_blocks == 0` means zero bytes input length
+    if !remainder.is_empty() || num_blocks == 0 {
+        let mut block_flags = flags | CHUNK_END | ROOT;
+        if num_blocks <= 1 {
+            block_flags |= CHUNK_START;
+        }
+
+        let mut buf = [0; BLOCK_LEN];
+        buf[..remainder.len()].copy_from_slice(remainder);
+        platform.compress_in_place(&mut cv, &buf, remainder.len() as u8, 0, block_flags);
+    }
+
+    Some(le_bytes_from_words_32(&cv))
+}
+
+/// Hashing function for at most a single chunk worth of bytes.
+///
+/// Returns `None` if input length exceeds one chunk.
+#[inline]
+pub fn single_chunk_hash(input: &[u8]) -> Option<[u8; OUT_LEN]> {
+    hash_chunk(input, *IV, 0)
+}
+
+/// The keyed hash function for at most a single chunk worth of bytes.
+///
+/// Returns `None` if input length exceeds one chunk.
+#[inline]
+pub fn single_chunk_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Option<[u8; OUT_LEN]> {
+    let key_words = words_from_le_bytes_32(key);
+    hash_chunk(input, key_words, KEYED_HASH)
+}
+
+// The key derivation function for at most a single chunk worth of bytes.
+//
+// Returns `None` if either context or key material length exceed one chunk.
+#[inline]
+pub fn single_chunk_derive_key(context: &str, key_material: &[u8]) -> Option<[u8; OUT_LEN]> {
+    let context_key = hash_chunk(context.as_bytes(), *IV, DERIVE_KEY_CONTEXT)?;
+    let context_key_words = words_from_le_bytes_32(&context_key);
+    hash_chunk(key_material, context_key_words, DERIVE_KEY_MATERIAL)
+}

--- a/crates/shared/ab-blake3/src/single_chunk.rs
+++ b/crates/shared/ab-blake3/src/single_chunk.rs
@@ -60,6 +60,7 @@ fn hash_chunk(input: &[u8], key: CVWords, flags: u8) -> Option<[u8; OUT_LEN]> {
 ///
 /// Returns `None` if input length exceeds one chunk.
 #[inline]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_chunk_hash(input: &[u8]) -> Option<[u8; OUT_LEN]> {
     hash_chunk(input, *IV, 0)
 }
@@ -68,6 +69,7 @@ pub fn single_chunk_hash(input: &[u8]) -> Option<[u8; OUT_LEN]> {
 ///
 /// Returns `None` if input length exceeds one chunk.
 #[inline]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_chunk_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Option<[u8; OUT_LEN]> {
     let key_words = words_from_le_bytes_32(key);
     hash_chunk(input, key_words, KEYED_HASH)
@@ -77,6 +79,7 @@ pub fn single_chunk_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Option<[u8;
 //
 // Returns `None` if either context or key material length exceed one chunk.
 #[inline]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_chunk_derive_key(context: &str, key_material: &[u8]) -> Option<[u8; OUT_LEN]> {
     let context_key = hash_chunk(context.as_bytes(), *IV, DERIVE_KEY_CONTEXT)?;
     let context_key_words = words_from_le_bytes_32(&context_key);

--- a/crates/shared/ab-blake3/src/single_chunk.rs
+++ b/crates/shared/ab-blake3/src/single_chunk.rs
@@ -2,8 +2,6 @@
 //!
 //! This module and submodules are copied with modifications from the official [`blake3`] crate, but
 //! is unlikely to be upstreamed.
-//!
-//! [`blake3`]: https://github.com/BLAKE3-team/BLAKE3
 
 #[cfg(test)]
 mod tests;

--- a/crates/shared/ab-blake3/src/single_chunk/tests.rs
+++ b/crates/shared/ab-blake3/src/single_chunk/tests.rs
@@ -1,4 +1,7 @@
-use crate::{const_derive_key, const_hash, const_keyed_hash, CVBytes, BLOCK_LEN, CHUNK_LEN};
+use crate::{
+    single_chunk_derive_key, single_chunk_hash, single_chunk_keyed_hash, CVBytes, BLOCK_LEN,
+    CHUNK_LEN,
+};
 use blake3::{derive_key, hash, keyed_hash};
 
 // Interesting input lengths to run tests on.
@@ -20,38 +23,14 @@ const TEST_CASES: &[usize] = &[
     2 * BLOCK_LEN + 1,
     CHUNK_LEN - 1,
     CHUNK_LEN,
-    CHUNK_LEN + 1,
-    2 * CHUNK_LEN,
-    2 * CHUNK_LEN + 1,
-    3 * CHUNK_LEN,
-    3 * CHUNK_LEN + 1,
-    4 * CHUNK_LEN,
-    4 * CHUNK_LEN + 1,
-    5 * CHUNK_LEN,
-    5 * CHUNK_LEN + 1,
-    6 * CHUNK_LEN,
-    6 * CHUNK_LEN + 1,
-    7 * CHUNK_LEN,
-    7 * CHUNK_LEN + 1,
-    8 * CHUNK_LEN,
-    8 * CHUNK_LEN + 1,
-    16 * CHUNK_LEN - 1,
-    16 * CHUNK_LEN, // AVX512's bandwidth
-    16 * CHUNK_LEN + 1,
-    31 * CHUNK_LEN - 1,
-    31 * CHUNK_LEN, // 16 + 8 + 4 + 2 + 1
-    31 * CHUNK_LEN + 1,
-    100 * CHUNK_LEN, // subtrees larger than MAX_SIMD_DEGREE chunks
 ];
-
-const TEST_CASES_MAX: usize = 100 * CHUNK_LEN;
 
 // There's a test to make sure these two are equal below.
 const TEST_KEY: CVBytes = *b"whats the Elvish word for friend";
 
 #[test]
 fn test_compare_with_upstream() {
-    let mut input_buf = [0; TEST_CASES_MAX];
+    let mut input_buf = [0; CHUNK_LEN];
 
     // Paint the input with a repeating byte pattern. We use a cycle length of 251,
     // because that's the largest prime number less than 256. This makes it
@@ -65,12 +44,16 @@ fn test_compare_with_upstream() {
         let input = &input_buf[..case];
 
         // regular
-        assert_eq!(hash(input), const_hash(input), "{case}");
+        assert_eq!(
+            hash(input).as_bytes(),
+            &single_chunk_hash(input).unwrap(),
+            "{case}"
+        );
 
         // keyed
         assert_eq!(
-            keyed_hash(&TEST_KEY, input),
-            const_keyed_hash(&TEST_KEY, input),
+            keyed_hash(&TEST_KEY, input).as_bytes(),
+            &single_chunk_keyed_hash(&TEST_KEY, input).unwrap(),
             "{case}"
         );
 
@@ -78,7 +61,7 @@ fn test_compare_with_upstream() {
         let context = "BLAKE3 2019-12-27 16:13:59 example context (not the test vector one)";
         assert_eq!(
             derive_key(context, input),
-            const_derive_key(context, input),
+            single_chunk_derive_key(context, input).unwrap(),
             "{case}"
         );
     }

--- a/crates/shared/ab-merkle-tree/Cargo.toml
+++ b/crates/shared/ab-merkle-tree/Cargo.toml
@@ -22,7 +22,7 @@ name = "merkle_tree"
 harness = false
 
 [dependencies]
-blake3 = { workspace = true }
+ab-blake3 = { workspace = true }
 no-panic = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/shared/ab-merkle-tree/src/balanced.rs
+++ b/crates/shared/ab-merkle-tree/src/balanced.rs
@@ -1,7 +1,7 @@
 use crate::hash_pair;
+use ab_blake3::OUT_LEN;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-use blake3::OUT_LEN;
 use core::iter;
 use core::iter::TrustedLen;
 use core::mem::MaybeUninit;

--- a/crates/shared/ab-merkle-tree/src/lib.rs
+++ b/crates/shared/ab-merkle-tree/src/lib.rs
@@ -32,7 +32,7 @@ pub mod unbalanced;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-use blake3::{KEY_LEN, OUT_LEN};
+use ab_blake3::{KEY_LEN, OUT_LEN};
 
 /// Used as a key in keyed blake3 hash for inner nodes of Merkle Trees.
 ///
@@ -43,7 +43,7 @@ pub const INNER_NODE_DOMAIN_SEPARATOR: [u8; KEY_LEN] = [
     0x1e, 0xb0, 0xa2, 0x0f, 0x5e, 0x5e, 0x26, 0x94, 0x47, 0x4b, 0x4f, 0xbd, 0x86, 0xc3, 0xc0, 0x7e,
 ];
 
-/// Helper function to hash two nodes together using [`blake3::keyed_hash()`] and
+/// Helper function to hash two nodes together using [`ab_blake3::single_block_keyed_hash()`] and
 /// [`INNER_NODE_DOMAIN_SEPARATOR`]
 #[inline(always)]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
@@ -52,5 +52,6 @@ pub fn hash_pair(left: &[u8; OUT_LEN], right: &[u8; OUT_LEN]) -> [u8; OUT_LEN] {
     pair[..OUT_LEN].copy_from_slice(left);
     pair[OUT_LEN..].copy_from_slice(right);
 
-    blake3::keyed_hash(&INNER_NODE_DOMAIN_SEPARATOR, &pair).into()
+    ab_blake3::single_block_keyed_hash(&INNER_NODE_DOMAIN_SEPARATOR, &pair)
+        .expect("Exactly one block worth of data; qed")
 }

--- a/crates/shared/ab-merkle-tree/src/mmr.rs
+++ b/crates/shared/ab-merkle-tree/src/mmr.rs
@@ -1,10 +1,10 @@
 use crate::hash_pair;
 use crate::unbalanced::UnbalancedMerkleTree;
+use ab_blake3::OUT_LEN;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use blake3::OUT_LEN;
 use core::mem;
 use core::mem::MaybeUninit;
 

--- a/crates/shared/ab-merkle-tree/src/unbalanced.rs
+++ b/crates/shared/ab-merkle-tree/src/unbalanced.rs
@@ -1,9 +1,9 @@
 use crate::hash_pair;
+use ab_blake3::OUT_LEN;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use blake3::OUT_LEN;
 use core::mem::MaybeUninit;
 
 /// Merkle Tree variant that has pre-hashed leaves with arbitrary number of elements.

--- a/crates/shared/ab-merkle-tree/tests/balanced.rs
+++ b/crates/shared/ab-merkle-tree/tests/balanced.rs
@@ -1,10 +1,10 @@
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![feature(generic_const_exprs)]
 
+use ab_blake3::OUT_LEN;
 use ab_merkle_tree::balanced::BalancedMerkleTree;
 use ab_merkle_tree::mmr::MerkleMountainRange;
 use ab_merkle_tree::unbalanced::UnbalancedMerkleTree;
-use blake3::OUT_LEN;
 use rand_chacha::ChaCha8Rng;
 use rand_core::{RngCore, SeedableRng};
 use std::mem::MaybeUninit;

--- a/crates/shared/ab-merkle-tree/tests/unbalanced.rs
+++ b/crates/shared/ab-merkle-tree/tests/unbalanced.rs
@@ -1,9 +1,9 @@
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![feature(generic_const_exprs)]
 
+use ab_blake3::OUT_LEN;
 use ab_merkle_tree::hash_pair;
 use ab_merkle_tree::unbalanced::UnbalancedMerkleTree;
-use blake3::OUT_LEN;
 use rand_chacha::ChaCha8Rng;
 use rand_core::{RngCore, SeedableRng};
 use std::mem;

--- a/crates/shared/ab-proof-of-space/Cargo.toml
+++ b/crates/shared/ab-proof-of-space/Cargo.toml
@@ -18,9 +18,9 @@ all-features = true
 bench = false
 
 [dependencies]
+ab-blake3 = { workspace = true }
 ab-chacha8 = { workspace = true }
 ab-core-primitives = { workspace = true }
-blake3 = { workspace = true }
 chacha20 = { workspace = true, features = ["cipher"] }
 derive_more = { workspace = true, features = ["full"] }
 parking_lot = { workspace = true, optional = true }

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -383,15 +383,16 @@ where
             let input = [input_a.to_be_bytes(), input_b.to_be_bytes()];
             let input_len =
                 size_of::<u128>() + right_bits_pushed_into_input_b.div_ceil(u8::BITS as usize);
-            blake3::hash(&input.as_flattened()[..input_len])
+            ab_blake3::single_block_hash(&input.as_flattened()[..input_len])
+                .expect("Exactly a single block worth of bytes; qed")
         } else {
             let right_bits_a = right_metadata << (right_bits_start_offset - y_and_left_bits);
             let input_a = y_bits | left_metadata_bits | right_bits_a;
 
-            blake3::hash(&input_a.to_be_bytes()[..num_bytes_with_data])
+            ab_blake3::single_block_hash(&input_a.to_be_bytes()[..num_bytes_with_data])
+                .expect("Less than a single block worth of bytes; qed")
         }
     };
-    let hash = <[u8; 32]>::from(hash);
 
     let y_output = Y::from(
         u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]])

--- a/crates/shared/ab-proof-of-space/src/shim.rs
+++ b/crates/shared/ab-proof-of-space/src/shim.rs
@@ -65,7 +65,8 @@ impl Table for ShimTable {
 }
 
 fn find_proof(seed: &PosSeed, challenge_index: u32) -> Option<PosProof> {
-    let quality = *blake3::hash(&challenge_index.to_le_bytes()).as_bytes();
+    let quality = ab_blake3::single_block_hash(&challenge_index.to_le_bytes())
+        .expect("Less than a single block worth of bytes; qed");
     if quality[0] % 3 > 0 {
         let mut proof = PosProof::default();
         proof

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -34,6 +34,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-blake3"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+]
+
+[[package]]
 name = "ab-chacha8"
 version = "0.1.0"
 
@@ -156,13 +163,14 @@ dependencies = [
 name = "ab-merkle-tree"
 version = "0.0.1"
 dependencies = [
- "blake3",
+ "ab-blake3",
 ]
 
 [[package]]
 name = "ab-proof-of-space"
 version = "0.1.0"
 dependencies = [
+ "ab-blake3",
  "ab-chacha8",
  "ab-core-primitives",
  "blake3",


### PR DESCRIPTION
This extends `ab-blake3` with a substantial number of additional public functions:
* single-chunk hashing
* single-block hashing
* single-block hashing of words (useful for GPU)

I also switched to `ab-blake3` in performance-sensitive crates and got some measurable speed-ups.

Merkle Tree before:
```
65536/balanced/new      time:   [4.1899 ms 4.1903 ms 4.1919 ms]
65536/balanced/compute-root-only
                        time:   [4.2740 ms 4.2743 ms 4.2754 ms]
65536/balanced/all-proofs
                        time:   [1.4789 ns 1.4796 ns 1.4824 ns]
65536/balanced/verify   time:   [70.688 ms 70.696 ms 70.728 ms]
```

Merkle Tree after:
```
65536/balanced/new      time:   [3.8788 ms 3.8789 ms 3.8790 ms]
65536/balanced/compute-root-only
                        time:   [3.6719 ms 3.6851 ms 3.6884 ms]
65536/balanced/all-proofs
                        time:   [1.4212 ns 1.4222 ns 1.4225 ns]
65536/balanced/verify   time:   [65.727 ms 65.792 ms 66.050 ms]
```

Merkle Tree will still benefit greatly from further optimization described in https://github.com/BLAKE3-team/BLAKE3/issues/478, but this is already better than before.

PoSpace before:
```
chia/table/single       time:   [1.0683 s 1.0908 s 1.1156 s]
chia/table/parallel/1x  time:   [158.26 ms 160.78 ms 163.98 ms]
chia/table/parallel/8x  time:   [860.76 ms 873.21 ms 885.64 ms]
chia/verification       time:   [7.4406 µs 7.4539 µs 7.4651 µs]
```

PoSpace after:
```
chia/table/single       time:   [977.21 ms 985.74 ms 996.67 ms]
chia/table/parallel/1x  time:   [160.87 ms 162.47 ms 163.84 ms]
chia/table/parallel/8x  time:   [821.04 ms 833.45 ms 850.07 ms]
chia/verification       time:   [6.8722 µs 6.9056 µs 6.9300 µs]
```

I also finally got rid of `const-sha1` :tada: 