### PR TITLE
Initial version of `ab-sparse-merkle-tree`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-sparse-merkle-tree"
+version = "0.0.1"
+dependencies = [
+ "ab-blake3",
+ "ab-merkle-tree",
+ "no-panic",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "ab-system-contract-address-allocator"
 version = "0.0.1"
 dependencies = [

--- a/crates/shared/ab-merkle-tree/src/mmr.rs
+++ b/crates/shared/ab-merkle-tree/src/mmr.rs
@@ -248,7 +248,8 @@ where
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     pub fn add_leaf(&mut self, leaf: &[u8; OUT_LEN]) -> bool {
-        // How many leaves were processed so far
+        // How many leaves were processed so far. Should have been `num_leaves == MAX_N`, but `>=`
+        // helps compiler with panic safety checks.
         if self.num_leaves >= MAX_N {
             return false;
         }
@@ -287,7 +288,8 @@ where
     {
         // TODO: This can be optimized further
         for leaf in leaves {
-            // How many leaves were processed so far
+            // How many leaves were processed so far. Should have been `num_leaves == MAX_N`, but
+            // `>=` helps compiler with panic safety checks.
             if self.num_leaves >= MAX_N {
                 return false;
             }
@@ -372,7 +374,8 @@ where
         let mut position = self.num_leaves;
 
         {
-            // How many leaves were processed so far
+            // How many leaves were processed so far. Should have been `num_leaves == MAX_N`, but
+            // `>=` helps compiler with panic safety checks.
             if self.num_leaves >= MAX_N {
                 return None;
             }

--- a/crates/shared/ab-merkle-tree/src/unbalanced.rs
+++ b/crates/shared/ab-merkle-tree/src/unbalanced.rs
@@ -54,7 +54,8 @@ impl UnbalancedMerkleTree {
         let mut num_leaves = 0_u64;
 
         for hash in leaves {
-            // How many leaves were processed so far
+            // How many leaves were processed so far. Should have been `num_leaves == MAX_N`, but
+            // `>=` helps compiler with panic safety checks.
             if num_leaves >= MAX_N {
                 return None;
             }
@@ -200,7 +201,8 @@ impl UnbalancedMerkleTree {
         let mut position = target_index;
 
         for (current_index, hash) in leaves.into_iter().enumerate() {
-            // How many leaves were processed so far
+            // How many leaves were processed so far. Should have been `num_leaves == MAX_N`, but
+            // `>=` helps compiler with panic safety checks.
             if num_leaves >= MAX_N {
                 return None;
             }

--- a/crates/shared/ab-sparse-merkle-tree/Cargo.toml
+++ b/crates/shared/ab-sparse-merkle-tree/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ab-sparse-merkle-tree"
+description = "Sparse Merkle Tree and related data structures"
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+# TODO: Benches
+
+[dependencies]
+ab-blake3 = { workspace = true }
+no-panic = { workspace = true, optional = true }
+
+[dev-dependencies]
+ab-merkle-tree = { workspace = true }
+rand_core = { workspace = true }
+rand_chacha = { workspace = true }
+
+[features]
+no-panic = [
+    "dep:no-panic",
+]
+
+[lints]
+workspace = true

--- a/crates/shared/ab-sparse-merkle-tree/src/lib.rs
+++ b/crates/shared/ab-sparse-merkle-tree/src/lib.rs
@@ -1,0 +1,276 @@
+//! Sparse Merkle Tree and related data structures.
+//!
+//! Sparse Merkle Tree is essentially a huge Balanced Merkle Tree, where most of the leaves are
+//! empty. By "empty" here we mean `[0u8; 32]`. In order to optimize proofs and their verification,
+//! hashing function is customized and returns `[0u8; 32]` when both left and right branch are
+//! `[0u8; 32]`, otherwise BLAKE3 hash is used like in a Balanced Merkle Tree.
+
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+#![feature(generic_const_exprs)]
+#![no_std]
+
+use ab_blake3::{KEY_LEN, OUT_LEN};
+
+/// Used as a key in keyed blake3 hash for inner nodes of Merkle Trees.
+///
+/// This value is a blake3 hash of as string `merkle-tree-inner-node`.
+pub const INNER_NODE_DOMAIN_SEPARATOR: [u8; KEY_LEN] =
+    ab_blake3::const_hash(b"merkle-tree-inner-node");
+
+/// Helper function to hash two nodes together using [`ab_blake3::single_block_keyed_hash()`] and
+/// [`INNER_NODE_DOMAIN_SEPARATOR`]
+#[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub fn hash_pair(left: &[u8; OUT_LEN], right: &[u8; OUT_LEN]) -> [u8; OUT_LEN] {
+    let mut pair = [0u8; OUT_LEN * 2];
+    pair[..OUT_LEN].copy_from_slice(left);
+    pair[OUT_LEN..].copy_from_slice(right);
+
+    ab_blake3::single_block_keyed_hash(&INNER_NODE_DOMAIN_SEPARATOR, &pair)
+        .expect("Exactly one block worth of data; qed")
+}
+
+/// Ensuring only supported `NUM_BITS` can be specified for [`SparseMerkleTree`].
+///
+/// This is essentially a workaround for the current Rust type system constraints that do not allow
+/// a nicer way to do the same thing at compile time.
+pub const fn ensure_supported_bits(bits: u8) -> usize {
+    assert!(
+        bits <= 128,
+        "This Sparse Merkle Tree doesn't support more than 2^128 leaves"
+    );
+
+    assert!(
+        bits != 0,
+        "This Sparse Merkle Tree must have more than one leaf"
+    );
+
+    0
+}
+
+/// Sparse Merkle Tree Leaf
+#[derive(Debug)]
+pub enum Leaf<'a> {
+    // TODO: Batch of leaves for efficiently, especially with SIMD?
+    /// Leaf is occupied by a value
+    Occupied {
+        /// Leaf value
+        leaf: &'a [u8; OUT_LEN],
+    },
+    /// Leaf is empty
+    Empty {
+        /// Number of consecutive empty leafs
+        skip_count: u128,
+    },
+}
+
+impl<'a> From<&'a [u8; OUT_LEN]> for Leaf<'a> {
+    #[inline(always)]
+    fn from(leaf: &'a [u8; OUT_LEN]) -> Self {
+        Self::Occupied { leaf }
+    }
+}
+
+// TODO: A version that can hold intermediate nodes in memory, efficiently update leaves, etc.
+/// Sparse Merkle Tree variant that has hash-sized leaves, with most leaves being empty
+/// (have value `[0u8; 32]`).
+///
+/// In contrast to a proper Balanced Merkle Tree, constant `BITS` here specifies the max number of
+/// leaves hypothetically possible in a tree (2^BITS, often untractable), rather than the number of
+/// non-empty leaves actually present.
+#[derive(Debug)]
+pub struct SparseMerkleTree<const BITS: u8>;
+
+// TODO: Optimize by implementing SIMD-accelerated hashing of multiple values:
+//  https://github.com/BLAKE3-team/BLAKE3/issues/478
+impl<const BITS: u8> SparseMerkleTree<BITS>
+where
+    [(); ensure_supported_bits(BITS)]:,
+{
+    // TODO: Method that generates not only root, but also proof, like Unbalanced Merkle Tree
+    /// Compute Merkle Tree root.
+    ///
+    /// If provided iterator ends early, it means the rest of the leaves are empty.
+    ///
+    /// There must be no [`Leaf::Occupied`] for empty/unoccupied leaves or else they may result in
+    /// invalid root, [`Leaf::Empty`] must be used instead.
+    ///
+    /// Returns `None` if too many leaves were provided.
+    #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    pub fn compute_root_only<'a, Iter>(leaves: Iter) -> Option<[u8; OUT_LEN]>
+    where
+        [(); BITS as usize + 1]:,
+        Iter: IntoIterator<Item = Leaf<'a>> + 'a,
+    {
+        // Stack of intermediate nodes per tree level
+        let mut stack = [[0u8; OUT_LEN]; BITS as usize + 1];
+        let mut processed_some = false;
+        let mut num_leaves = 0_u128;
+
+        for leaf in leaves {
+            if u32::from(BITS) < u128::BITS {
+                // How many leaves were processed so far
+                if num_leaves == 2u128.pow(u32::from(BITS)) {
+                    return None;
+                }
+            } else {
+                // For `BITS == u128::BITS` `num_leaves` will wrap around back to zero right at the
+                // very end
+                if processed_some && num_leaves == 0 {
+                    return None;
+                }
+                processed_some = true;
+            }
+
+            match leaf {
+                Leaf::Occupied { leaf } => {
+                    let mut current = *leaf;
+
+                    // Every bit set to `1` corresponds to an active Merkle Tree level
+                    let lowest_active_levels = num_leaves.trailing_ones() as usize;
+                    for item in stack.iter().take(lowest_active_levels) {
+                        current = hash_pair(item, &current);
+                    }
+
+                    // Place the current hash at the first inactive level
+                    // SAFETY: Number of lowest active levels corresponds to the number of inserted
+                    // elements, which in turn is checked above to fit into 2^BITS, while `BITS`
+                    // generic in turn ensured sufficient stack size
+                    *unsafe { stack.get_unchecked_mut(lowest_active_levels) } = current;
+                    // Wrapping is needed for `BITS == u128::BITS`, where number of leaves narrowly
+                    // doesn't fit into `u128` itself
+                    num_leaves = num_leaves.wrapping_add(1);
+                }
+                Leaf::Empty { skip_count } => {
+                    num_leaves =
+                        Self::skip_leaves(&mut stack, &mut processed_some, num_leaves, skip_count)?;
+                }
+            }
+        }
+
+        if u32::from(BITS) < u128::BITS {
+            Self::skip_leaves(
+                &mut stack,
+                &mut processed_some,
+                num_leaves,
+                2u128.pow(u32::from(BITS)) - num_leaves,
+            )?;
+        } else if processed_some && num_leaves != 0 {
+            // For `BITS == u128::BITS` `num_leaves` will wrap around back to zero right at the
+            // very end, so we reverse the mechanism here
+            Self::skip_leaves(
+                &mut stack,
+                &mut processed_some,
+                num_leaves,
+                0u128.wrapping_sub(num_leaves),
+            )?;
+        }
+
+        Some(stack[BITS as usize])
+    }
+
+    /// Returns updated number of leaves
+    #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    fn skip_leaves(
+        stack: &mut [[u8; OUT_LEN]; BITS as usize + 1],
+        processed_some: &mut bool,
+        mut num_leaves: u128,
+        mut skip_count: u128,
+    ) -> Option<u128>
+    where
+        [(); BITS as usize + 1]:,
+    {
+        const ZERO: [u8; OUT_LEN] = [0; OUT_LEN];
+
+        if u32::from(BITS) < u128::BITS {
+            // How many leaves were processed so far
+            if num_leaves.checked_add(skip_count)? > 2u128.pow(u32::from(BITS)) {
+                return None;
+            }
+        } else {
+            // For `BITS == u128::BITS` `num_leaves` will wrap around back to zero right at the
+            // very end
+            let (overflow_amount, overflowed) = num_leaves.overflowing_add(skip_count);
+            if *processed_some && overflowed && overflow_amount > 0 {
+                return None;
+            }
+            *processed_some = true;
+        }
+
+        while skip_count > 0 {
+            // Find the largest aligned chunk to skip for the current state of the tree
+            let max_levels_to_skip = skip_count.ilog2().min(num_leaves.trailing_zeros());
+            let chunk_size = 1u128 << max_levels_to_skip;
+
+            let mut level = max_levels_to_skip;
+            let mut current = ZERO;
+            for item in stack.iter().skip(max_levels_to_skip as usize) {
+                // Check active level for merging up the stack.
+                //
+                // `BITS == u128::BITS` condition is only added for better dead code elimination
+                // since that check is only relevant for 2^128 leaves case and nothing else.
+                if (u32::from(BITS) == u128::BITS && level == u128::BITS)
+                    || num_leaves & (1 << level) == 0
+                {
+                    // Level wasn't active before, stop here
+                    break;
+                }
+
+                // Hash together unless both are zero
+                if !(item == &ZERO && current == ZERO) {
+                    current = hash_pair(item, &current);
+                }
+
+                level += 1;
+            }
+            // SAFETY: Level is limited by the number of leaves, which in turn is checked above to
+            // fit into 2^BITS, while `BITS` generic in turn ensured sufficient stack size
+            *unsafe { stack.get_unchecked_mut(level as usize) } = current;
+
+            // Wrapping is needed for `BITS == u128::BITS`, where number of leaves narrowly
+            // doesn't fit into `u128` itself
+            num_leaves = num_leaves.wrapping_add(chunk_size);
+            skip_count -= chunk_size;
+        }
+
+        Some(num_leaves)
+    }
+
+    /// Verify previously generated proof.
+    ///
+    /// Leaf can either be leaf value for a leaf that is occupied or `[0; 32]` for a leaf that is
+    /// supposed to be empty.
+    #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    pub fn verify(
+        root: &[u8; OUT_LEN],
+        proof: &[[u8; OUT_LEN]; BITS as usize],
+        leaf_index: u128,
+        leaf: [u8; OUT_LEN],
+    ) -> bool
+    where
+        [(); BITS as usize]:,
+    {
+        // For `BITS == u128::BITS` any index is valid by definition
+        if u32::from(BITS) < u128::BITS && leaf_index >= 2u128.pow(u32::from(BITS)) {
+            return false;
+        }
+
+        let mut computed_root = leaf;
+
+        let mut position = leaf_index;
+        for hash in proof {
+            computed_root = if position % 2 == 0 {
+                hash_pair(&computed_root, hash)
+            } else {
+                hash_pair(hash, &computed_root)
+            };
+
+            position /= 2;
+        }
+
+        root == &computed_root
+    }
+}

--- a/crates/shared/ab-sparse-merkle-tree/tests/smt.rs
+++ b/crates/shared/ab-sparse-merkle-tree/tests/smt.rs
@@ -1,0 +1,309 @@
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+#![feature(array_chunks, generic_const_exprs)]
+
+use ab_blake3::OUT_LEN;
+use ab_merkle_tree::balanced::BalancedMerkleTree;
+use ab_sparse_merkle_tree::{Leaf, SparseMerkleTree, hash_pair};
+use rand_chacha::ChaCha8Rng;
+use rand_core::{RngCore, SeedableRng};
+
+const ZERO: [u8; OUT_LEN] = [0; OUT_LEN];
+
+#[test]
+fn test_hash_pair() {
+    let a = [1; _];
+    let b = [2; _];
+
+    // Ensure both Merkle Tree and Sparse Merkle Tree use compatible hashes
+    assert_eq!(hash_pair(&a, &b), ab_merkle_tree::hash_pair(&a, &b));
+}
+
+#[test]
+fn smt_empty() {
+    assert_eq!(SparseMerkleTree::<1>::compute_root_only([]).unwrap(), ZERO);
+    assert_eq!(
+        SparseMerkleTree::<1>::compute_root_only([Leaf::Empty { skip_count: 1 }]).unwrap(),
+        ZERO
+    );
+    assert_eq!(
+        SparseMerkleTree::<1>::compute_root_only([
+            Leaf::Empty { skip_count: 1 },
+            Leaf::Empty { skip_count: 0 },
+            Leaf::Empty { skip_count: 1 },
+        ])
+        .unwrap(),
+        ZERO
+    );
+    assert_eq!(
+        SparseMerkleTree::<1>::compute_root_only([Leaf::Empty { skip_count: 2 }]).unwrap(),
+        ZERO
+    );
+
+    assert_eq!(SparseMerkleTree::<2>::compute_root_only([]).unwrap(), ZERO);
+    assert_eq!(
+        SparseMerkleTree::<2>::compute_root_only([Leaf::Empty { skip_count: 4 }]).unwrap(),
+        ZERO
+    );
+}
+
+#[test]
+fn smt_too_many_leaves() {
+    // 3 leaves is more than 2^1=2
+    assert!(SparseMerkleTree::<1>::compute_root_only([ZERO; 3].iter().map(Leaf::from)).is_none());
+    assert!(SparseMerkleTree::<1>::compute_root_only([Leaf::Empty { skip_count: 3 }]).is_none());
+    assert!(
+        SparseMerkleTree::<1>::compute_root_only(
+            [ZERO; 2]
+                .iter()
+                .map(Leaf::from)
+                .chain([Leaf::Empty { skip_count: 1 }])
+        )
+        .is_none()
+    );
+    // Even an empty skip at the end is not supported
+    assert!(
+        SparseMerkleTree::<1>::compute_root_only(
+            [ZERO; 2]
+                .iter()
+                .map(Leaf::from)
+                .chain([Leaf::Empty { skip_count: 0 }])
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn smt_32_full() {
+    const N: usize = 32;
+    const BITS: u8 = N.ilog2() as u8;
+
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+
+    let leaves = {
+        let mut leaves = [[0u8; OUT_LEN]; N];
+        for hash in &mut leaves {
+            rng.fill_bytes(hash);
+        }
+        leaves
+    };
+
+    // Full tree (unlikely to exist in practice) is identical to the regular Balanced Merkle Tree
+    assert_eq!(
+        SparseMerkleTree::<BITS>::compute_root_only(
+            leaves.iter().map(|leaf| Leaf::Occupied { leaf })
+        )
+        .unwrap(),
+        BalancedMerkleTree::compute_root_only(&leaves)
+    );
+}
+
+#[test]
+fn smt_32_1_missing() {
+    test_32(1);
+}
+
+#[test]
+fn smt_32_2_missing() {
+    test_32(2);
+}
+
+#[test]
+fn smt_32_3_missing() {
+    test_32(3);
+}
+
+#[test]
+fn smt_32_4_missing() {
+    test_32(4);
+}
+
+#[test]
+fn smt_32_5_missing() {
+    test_32(5);
+}
+
+#[test]
+fn smt_128_bit() {
+    const BITS: u8 = u128::BITS as u8;
+
+    assert_eq!(
+        SparseMerkleTree::<BITS>::compute_root_only([]).unwrap(),
+        ZERO
+    );
+    assert_eq!(
+        SparseMerkleTree::<BITS>::compute_root_only([
+            Leaf::Empty {
+                skip_count: u128::MAX
+            },
+            Leaf::Empty { skip_count: 1 }
+        ])
+        .unwrap(),
+        ZERO
+    );
+
+    {
+        let first_leaf = [1; OUT_LEN];
+        let correct_root = {
+            let mut root = first_leaf;
+
+            for _ in 0..BITS {
+                root = hash_pair(&root, &ZERO);
+            }
+
+            root
+        };
+
+        assert_eq!(
+            SparseMerkleTree::<BITS>::compute_root_only([Leaf::Occupied { leaf: &first_leaf }])
+                .unwrap(),
+            correct_root
+        );
+        assert_eq!(
+            SparseMerkleTree::<BITS>::compute_root_only([
+                Leaf::Occupied { leaf: &first_leaf },
+                Leaf::Empty {
+                    skip_count: u128::MAX
+                }
+            ])
+            .unwrap(),
+            correct_root
+        );
+
+        // Even an empty skip at the end is not supported
+        assert!(
+            SparseMerkleTree::<BITS>::compute_root_only([
+                Leaf::Occupied { leaf: &first_leaf },
+                Leaf::Empty {
+                    skip_count: u128::MAX
+                },
+                Leaf::Empty { skip_count: 0 }
+            ])
+            .is_none()
+        );
+    }
+    {
+        let last_leaf = [2; OUT_LEN];
+        let correct_root = {
+            let mut root = last_leaf;
+
+            for _ in 0..BITS {
+                root = hash_pair(&ZERO, &root);
+            }
+
+            root
+        };
+
+        assert_eq!(
+            SparseMerkleTree::<BITS>::compute_root_only([
+                Leaf::Empty {
+                    skip_count: u128::MAX
+                },
+                Leaf::Occupied { leaf: &last_leaf }
+            ])
+            .unwrap(),
+            correct_root
+        );
+
+        assert!(
+            SparseMerkleTree::<BITS>::compute_root_only([
+                Leaf::Empty {
+                    skip_count: u128::MAX
+                },
+                Leaf::Empty { skip_count: 1 },
+                Leaf::Occupied { leaf: &last_leaf }
+            ])
+            .is_none()
+        );
+    }
+}
+
+/// Inefficient, full of allocations, but very simple to understand implementation
+fn naive_sparse_merkle_tree_root(leaves: &[[u8; OUT_LEN]]) -> [u8; OUT_LEN] {
+    let mut level = leaves.to_vec();
+
+    while level.len() > 1 {
+        level = level
+            .array_chunks()
+            .map(|[left, right]| {
+                if left == &ZERO && right == &ZERO {
+                    ZERO
+                } else {
+                    hash_pair(left, right)
+                }
+            })
+            .collect();
+    }
+
+    level.into_iter().next().unwrap()
+}
+
+fn test_32(total_skip_size: usize) {
+    const N: usize = 32;
+    const BITS: u8 = N.ilog2() as u8;
+
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+
+    let leaves = {
+        let mut leaves = [[0u8; OUT_LEN]; N];
+        for hash in &mut leaves {
+            rng.fill_bytes(hash);
+        }
+        leaves
+    };
+
+    // Try all permutations of the location of the full total skip size within a set of leaves
+    for offset in 0..N - total_skip_size {
+        let mut modified_leaves = leaves;
+        modified_leaves[offset..][..total_skip_size].fill(ZERO);
+
+        let correct_root = naive_sparse_merkle_tree_root(&modified_leaves);
+
+        // Skip one leaf at a time
+        assert_eq!(
+            SparseMerkleTree::<BITS>::compute_root_only(modified_leaves.iter().map(|leaf| {
+                if leaf == &ZERO {
+                    Leaf::Empty { skip_count: 1 }
+                } else {
+                    Leaf::Occupied { leaf }
+                }
+            }))
+            .unwrap(),
+            correct_root,
+            "offset={offset} total_skip_size={total_skip_size}"
+        );
+
+        // Skip all leaves at once
+        assert_eq!(
+            SparseMerkleTree::<BITS>::compute_root_only(
+                modified_leaves[..offset]
+                    .iter()
+                    .map(Leaf::from)
+                    .chain([Leaf::Empty {
+                        skip_count: total_skip_size as u128
+                    }])
+                    // Throw an empty skip in the middle, shouldn't impact anything
+                    .chain([Leaf::Empty { skip_count: 0 }])
+                    .chain(
+                        modified_leaves[offset + total_skip_size..]
+                            .iter()
+                            .map(Leaf::from)
+                    )
+            )
+            .unwrap(),
+            correct_root,
+            "offset={offset} total_skip_size={total_skip_size}"
+        );
+
+        if let Some(stripped) =
+            modified_leaves.strip_suffix(&modified_leaves[offset..][..total_skip_size])
+        {
+            // Do not specify empty leaves at the end
+            assert_eq!(
+                SparseMerkleTree::<BITS>::compute_root_only(stripped.iter().map(Leaf::from))
+                    .unwrap(),
+                correct_root,
+                "offset={offset} total_skip_size={total_skip_size}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This initial version of Sparse Merkle Tree is quite basic, but still important.

It doesn't deal with persistence in any way. Since Sparse Merkle Tree is recursive, it'll be possible to create sub-trees with caching on top of this primitive later.

Another observation is that on modern CPUs it is possible to hash 7-9 GiB/s of data using BLAKE3 on a single core if manage to feed it will data. That is up to 300M leaves (assuming a Balanced Merkle Tree), which is a lot, it is the same ballpark as the number of contracts and EOAs on Ethereum (if the numbers I saw are to be believed).

For testing purposes even hashing the whole state every block will be fine for some time, but huge number of optimizations exists with splitting the tree, hashing with SIMD and using multiple cores.

One tricky part of this implementation is support for $2^{128}$ leaves (which also happens to be the max number of leaves supported by this implementation). Since `u128` is used as a container for things like number of leaves, it narrowly overflows and this overflow needed to be handled as a special case in a few places.