### PR TITLE
Initial version of `ab-direct-io-file`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ env:
   CARGO_TERM_COLOR: always
   # Build smaller artifacts to avoid running out of space in CI and make it a bit faster
   RUSTFLAGS: -C strip=symbols
+  # Needed for things like file system access
+  MIRIFLAGS: -Zmiri-disable-isolation
   RUST_BACKTRACE: full
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-direct-io-file"
+version = "0.0.1"
+dependencies = [
+ "chacha20",
+ "fs2",
+ "libc",
+ "parking_lot",
+ "tempfile",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "ab-erasure-coding"
 version = "0.1.0"
 dependencies = [
@@ -981,6 +993,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1233,7 +1246,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1459,6 +1472,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fiat-crypto"
@@ -2009,6 +2028,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litrs"
@@ -2645,7 +2670,20 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3027,6 +3065,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ derive_more = { version = "2.0.1", default-features = false }
 #  https://github.com/dalek-cryptography/curve25519-dalek/issues/626 is resolved
 # TODO: Switch to offical 4.0.4+ is released with https://github.com/ZcashFoundation/ed25519-zebra/pull/174
 ed25519-zebra = { version = "4.0.3", git = "https://github.com/ZcashFoundation/ed25519-zebra", rev = "dbb5610b818a6b54ebd347c27f8c8d3d6af89648", default-features = false }
+# TODO: Not using fs4 on purpose due to https://github.com/al8n/fs4-rs/issues/15
 fs2 = "0.4.3"
 futures = { version = "0.3.31", default-features = false, features = ["async-await"] }
 halfbrown = "0.3.0"
@@ -97,6 +98,7 @@ spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "4a9e76cd6d22a
 stable_deref_trait = { version = "1.2.0", default-features = false }
 syn = "2.0.101"
 take_mut = "0.2.2"
+tempfile = "3.20.0"
 thiserror = { version = "2.0.12", default-features = false }
 tokio = { version = "1.45.1", default-features = false }
 tracing = "0.1.41"

--- a/crates/shared/ab-direct-io-file/Cargo.toml
+++ b/crates/shared/ab-direct-io-file/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "ab-direct-io-file"
+description = "Cross-platform APIs for working with files using direct I/O"
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+fs2 = { workspace = true }
+parking_lot = { workspace = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows = { workspace = true }
+
+[dev-dependencies]
+chacha20 = { workspace = true, features = ["rng"] }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/shared/ab-direct-io-file/src/lib.rs
+++ b/crates/shared/ab-direct-io-file/src/lib.rs
@@ -1,0 +1,444 @@
+//! Cross-platform APIs for working with files using direct I/O.
+//!
+//! Depending on OS, this will use direct I/O, unbuffered, uncaches passthrough file reads/writes,
+//! bypassing as much of OS machinery as possible.
+//!
+//! NOTE: There are major alignment requirements described here:
+//! <https://learn.microsoft.com/en-us/windows/win32/fileio/file-buffering#alignment-and-file-access-requirements>
+//! <https://man7.org/linux/man-pages/man2/open.2.html>
+
+// TODO: Windows shims are incomplete under Miri: https://github.com/rust-lang/miri/issues/3482
+#[cfg(all(test, not(all(miri, windows))))]
+mod tests;
+
+use parking_lot::Mutex;
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+use std::{io, mem};
+
+/// 4096 is as a relatively safe size due to sector size on SSDs commonly being 512 or 4096 bytes
+pub const DISK_PAGE_SIZE: usize = 4096;
+/// Restrict how much data to read from disk in a single call to avoid very large memory usage
+const MAX_READ_SIZE: usize = 1024 * 1024;
+
+const _: () = {
+    assert!(MAX_READ_SIZE.is_multiple_of(DISK_PAGE_SIZE));
+};
+
+/// A wrapper data structure with 4096 bytes alignment, which is the most common alignment for
+/// direct I/O operations.
+#[derive(Debug, Copy, Clone)]
+#[repr(C, align(4096))]
+pub struct AlignedPageSize([u8; DISK_PAGE_SIZE]);
+
+const _: () = {
+    assert!(align_of::<AlignedPageSize>() == DISK_PAGE_SIZE);
+};
+
+impl Default for AlignedPageSize {
+    #[inline(always)]
+    fn default() -> Self {
+        Self([0; DISK_PAGE_SIZE])
+    }
+}
+
+impl AlignedPageSize {
+    /// Convenient conversion from slice to underlying representation for efficiency purposes
+    #[inline(always)]
+    pub fn slice_to_repr(value: &[Self]) -> &[[u8; DISK_PAGE_SIZE]] {
+        // SAFETY: `RecordChunk` is `#[repr(C)]` and guaranteed to have the same memory layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from slice of underlying representation for efficiency purposes.
+    ///
+    /// Returns `None` if not correctly aligned.
+    #[inline]
+    pub fn try_slice_from_repr(value: &[[u8; DISK_PAGE_SIZE]]) -> Option<&[Self]> {
+        // SAFETY: All bit patterns are valid
+        let (before, slice, after) = unsafe { value.align_to::<Self>() };
+
+        if before.is_empty() && after.is_empty() {
+            Some(slice)
+        } else {
+            None
+        }
+    }
+
+    /// Convenient conversion from mutable slice to underlying representation for efficiency
+    /// purposes
+    #[inline(always)]
+    pub fn slice_mut_to_repr(slice: &mut [Self]) -> &mut [[u8; DISK_PAGE_SIZE]] {
+        // SAFETY: `AlignedSectorSize` is `#[repr(C)]` and its alignment is larger than inner value
+        unsafe { mem::transmute(slice) }
+    }
+
+    /// Convenient conversion from slice of underlying representation for efficiency purposes.
+    ///
+    /// Returns `None` if not correctly aligned.
+    #[inline]
+    pub fn try_slice_mut_from_repr(value: &mut [[u8; DISK_PAGE_SIZE]]) -> Option<&mut [Self]> {
+        // SAFETY: All bit patterns are valid
+        let (before, slice, after) = unsafe { value.align_to_mut::<Self>() };
+
+        if before.is_empty() && after.is_empty() {
+            Some(slice)
+        } else {
+            None
+        }
+    }
+}
+
+/// Wrapper data structure for direct/unbuffered/uncached I/O.
+///
+/// Depending on OS, this will use direct I/O, unbuffered, uncaches passthrough file reads/writes,
+/// bypassing as much of OS machinery as possible.
+///
+/// NOTE: There are major alignment requirements described here:
+/// <https://learn.microsoft.com/en-us/windows/win32/fileio/file-buffering#alignment-and-file-access-requirements>
+/// <https://man7.org/linux/man-pages/man2/open.2.html>
+#[derive(Debug)]
+pub struct DirectIoFile {
+    file: File,
+    /// Scratch buffer of aligned memory for reads and writes
+    scratch_buffer: Mutex<Vec<AlignedPageSize>>,
+}
+
+impl DirectIoFile {
+    /// Open file with basic open options at specified path for direct/unbuffered I/O for reads and
+    /// writes.
+    ///
+    /// `options` allows to configure things like read/write/create/truncate, but custom options
+    /// will be overridden internally.
+    ///
+    /// This is especially important on Windows to prevent huge memory usage.
+    #[inline]
+    pub fn open<P>(
+        #[cfg(any(target_os = "linux", windows))] mut options: OpenOptions,
+        #[cfg(not(any(target_os = "linux", windows)))] options: OpenOptions,
+        path: P,
+    ) -> io::Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        // Direct I/O on Linux
+        #[cfg(target_os = "linux")]
+        // TODO: Unlock under Miri once supported: https://github.com/rust-lang/miri/issues/4462
+        if !cfg!(miri) {
+            use std::os::unix::fs::OpenOptionsExt;
+
+            options.custom_flags(libc::O_DIRECT);
+        }
+        // Unbuffered write-through on Windows
+        #[cfg(windows)]
+        // TODO: Unlock under Miri once supported: https://github.com/rust-lang/miri/issues/4462
+        if !cfg!(miri) {
+            use std::os::windows::fs::OpenOptionsExt;
+
+            options.custom_flags(
+                windows::Win32::Storage::FileSystem::FILE_FLAG_WRITE_THROUGH.0
+                    | windows::Win32::Storage::FileSystem::FILE_FLAG_NO_BUFFERING.0,
+            );
+        }
+        let file = options.open(path)?;
+
+        // Disable caching on macOS
+        #[cfg(target_os = "macos")]
+        // TODO: Unlock under Miri once supported: https://github.com/rust-lang/miri/issues/4462
+        if !cfg!(miri) {
+            use std::os::unix::io::AsRawFd;
+
+            // SAFETY: FFI call with correct file descriptor and arguments
+            if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_NOCACHE, 1) } != 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        Ok(Self {
+            file,
+            // In many cases, we'll want to read this much at once, so pre-allocate it right away
+            scratch_buffer: Mutex::new(vec![
+                AlignedPageSize::default();
+                MAX_READ_SIZE / DISK_PAGE_SIZE
+            ]),
+        })
+    }
+
+    /// Get file size
+    #[inline]
+    pub fn len(&self) -> io::Result<u64> {
+        Ok(self.file.metadata()?.len())
+    }
+
+    /// Returns `Ok(true)` if file is empty
+    #[inline]
+    pub fn is_empty(&self) -> io::Result<bool> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Make sure file has specified number of bytes allocated on the disk.
+    ///
+    /// Later writes within `len` will not fail due to lack of disk space.
+    #[inline(always)]
+    pub fn allocate(&self, len: u64) -> io::Result<()> {
+        fs2::FileExt::allocate(&self.file, len)
+    }
+
+    /// Truncates or extends the underlying file, updating the size of this file to become `len`.
+    ///
+    /// Note if `len` is larger than the previous file size, it will result in a sparse file. If
+    /// you'd like to pre-allocate space on disk, use [`Self::allocate()`], which may be followed by
+    /// this method to truncate the file if the new file size is smaller than the previous
+    /// ([`Self::allocate()`] doesn't truncate the file).
+    #[inline(always)]
+    pub fn set_len(&self, len: u64) -> io::Result<()> {
+        self.file.set_len(len)
+    }
+
+    /// Read the exact number of bytes needed to fill `buf` at `offset`.
+    ///
+    /// NOTE: This uses locking and buffering internally, prefer [`Self::write_all_at_raw()`] if you
+    /// can control data alignment.
+    pub fn read_exact_at(&self, buf: &mut [u8], mut offset: u64) -> io::Result<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+
+        let mut scratch_buffer = self.scratch_buffer.lock();
+
+        // This is guaranteed by constructor
+        debug_assert!(
+            AlignedPageSize::slice_to_repr(&scratch_buffer)
+                .as_flattened()
+                .len()
+                <= MAX_READ_SIZE
+        );
+
+        // First read up to `MAX_READ_SIZE - padding`
+        let padding = (offset % DISK_PAGE_SIZE as u64) as usize;
+        let first_unaligned_chunk_size = (MAX_READ_SIZE - padding).min(buf.len());
+        let (unaligned_start, buf) = buf.split_at_mut(first_unaligned_chunk_size);
+        {
+            let bytes_to_read = unaligned_start.len();
+            unaligned_start.copy_from_slice(self.read_exact_at_internal(
+                &mut scratch_buffer,
+                bytes_to_read,
+                offset,
+            )?);
+            offset += unaligned_start.len() as u64;
+        }
+
+        if buf.is_empty() {
+            return Ok(());
+        }
+
+        // Process the rest of the chunks, up to `MAX_READ_SIZE` at a time
+        for buf in buf.chunks_mut(MAX_READ_SIZE) {
+            let bytes_to_read = buf.len();
+            buf.copy_from_slice(self.read_exact_at_internal(
+                &mut scratch_buffer,
+                bytes_to_read,
+                offset,
+            )?);
+            offset += buf.len() as u64;
+        }
+
+        Ok(())
+    }
+
+    /// Write all bytes at `buf` at `offset`.
+    ///
+    /// NOTE: This uses locking and buffering internally, prefer [`Self::write_all_at_raw()`] if you
+    /// can control data alignment.
+    pub fn write_all_at(&self, buf: &[u8], mut offset: u64) -> io::Result<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+
+        let mut scratch_buffer = self.scratch_buffer.lock();
+
+        // This is guaranteed by constructor
+        debug_assert!(
+            AlignedPageSize::slice_to_repr(&scratch_buffer)
+                .as_flattened()
+                .len()
+                <= MAX_READ_SIZE
+        );
+
+        // First write up to `MAX_READ_SIZE - padding`
+        let padding = (offset % DISK_PAGE_SIZE as u64) as usize;
+        let first_unaligned_chunk_size = (MAX_READ_SIZE - padding).min(buf.len());
+        let (unaligned_start, buf) = buf.split_at(first_unaligned_chunk_size);
+        {
+            self.write_all_at_internal(&mut scratch_buffer, unaligned_start, offset)?;
+            offset += unaligned_start.len() as u64;
+        }
+
+        if buf.is_empty() {
+            return Ok(());
+        }
+
+        // Process the rest of the chunks, up to `MAX_READ_SIZE` at a time
+        for buf in buf.chunks(MAX_READ_SIZE) {
+            self.write_all_at_internal(&mut scratch_buffer, buf, offset)?;
+            offset += buf.len() as u64;
+        }
+
+        Ok(())
+    }
+
+    /// Low-level reading into aligned memory.
+    ///
+    /// `offset` needs to be page-aligned as well or use [`Self::read_exact_at()`] if you're willing
+    /// to pay for the corresponding overhead.
+    #[inline]
+    pub fn read_exact_at_raw(&self, buf: &mut [AlignedPageSize], offset: u64) -> io::Result<()> {
+        let buf = AlignedPageSize::slice_mut_to_repr(buf).as_flattened_mut();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::FileExt;
+
+            self.file.read_exact_at(buf, offset)
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::FileExt;
+
+            let mut buf = buf;
+            let mut offset = offset;
+            while !buf.is_empty() {
+                match self.file.seek_read(buf, offset) {
+                    Ok(0) => {
+                        break;
+                    }
+                    Ok(n) => {
+                        buf = &mut buf[n..];
+                        offset += n as u64;
+                    }
+                    Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {
+                        // Try again
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
+
+            if !buf.is_empty() {
+                Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "failed to fill the whole buffer",
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Low-level writing from aligned memory.
+    ///
+    /// `offset` needs to be page-aligned as well or use [`Self::write_all_at()`] if you're willing
+    /// to pay for the corresponding overhead.
+    #[inline]
+    pub fn write_all_at_raw(&self, buf: &[AlignedPageSize], offset: u64) -> io::Result<()> {
+        let buf = AlignedPageSize::slice_to_repr(buf).as_flattened();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::FileExt;
+
+            self.file.write_all_at(buf, offset)
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::FileExt;
+
+            let mut buf = buf;
+            let mut offset = offset;
+            while !buf.is_empty() {
+                match self.file.seek_write(buf, offset) {
+                    Ok(0) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::WriteZero,
+                            "failed to write whole buffer",
+                        ));
+                    }
+                    Ok(n) => {
+                        buf = &buf[n..];
+                        offset += n as u64;
+                    }
+                    Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {
+                        // Try again
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
+
+            Ok(())
+        }
+    }
+
+    /// Access internal [`File`] instance
+    #[inline(always)]
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    fn read_exact_at_internal<'a>(
+        &self,
+        scratch_buffer: &'a mut [AlignedPageSize],
+        bytes_to_read: usize,
+        offset: u64,
+    ) -> io::Result<&'a [u8]> {
+        let page_aligned_offset = offset / DISK_PAGE_SIZE as u64 * DISK_PAGE_SIZE as u64;
+        let padding = (offset - page_aligned_offset) as usize;
+
+        // Make scratch buffer of a size that is necessary to read aligned memory, accounting
+        // for extra bytes at the beginning and the end that will be thrown away
+        let pages_to_read = (padding + bytes_to_read).div_ceil(DISK_PAGE_SIZE);
+        let scratch_buffer = &mut scratch_buffer[..pages_to_read];
+
+        self.read_exact_at_raw(scratch_buffer, page_aligned_offset)?;
+
+        Ok(
+            &AlignedPageSize::slice_to_repr(scratch_buffer).as_flattened()[padding..]
+                [..bytes_to_read],
+        )
+    }
+
+    /// Panics on writes over `MAX_READ_SIZE` (including padding on both ends)
+    fn write_all_at_internal(
+        &self,
+        scratch_buffer: &mut [AlignedPageSize],
+        bytes_to_write: &[u8],
+        offset: u64,
+    ) -> io::Result<()> {
+        let page_aligned_offset = offset / DISK_PAGE_SIZE as u64 * DISK_PAGE_SIZE as u64;
+        let padding = (offset - page_aligned_offset) as usize;
+
+        // Calculate the size of the read including padding on both ends
+        let pages_to_read = (padding + bytes_to_write.len()).div_ceil(DISK_PAGE_SIZE);
+
+        if padding == 0 && pages_to_read == bytes_to_write.len() {
+            let scratch_buffer = &mut scratch_buffer[..pages_to_read];
+            AlignedPageSize::slice_mut_to_repr(scratch_buffer)
+                .as_flattened_mut()
+                .copy_from_slice(bytes_to_write);
+            self.write_all_at_raw(scratch_buffer, offset)?;
+        } else {
+            let scratch_buffer = &mut scratch_buffer[..pages_to_read];
+            // Read whole pages where `bytes_to_write` will be written
+            self.read_exact_at_raw(scratch_buffer, page_aligned_offset)?;
+            // Update the contents of existing pages and write into the file
+            AlignedPageSize::slice_mut_to_repr(scratch_buffer).as_flattened_mut()[padding..]
+                [..bytes_to_write.len()]
+                .copy_from_slice(bytes_to_write);
+            self.write_all_at_raw(scratch_buffer, page_aligned_offset)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/shared/ab-direct-io-file/src/tests.rs
+++ b/crates/shared/ab-direct-io-file/src/tests.rs
@@ -1,0 +1,128 @@
+use crate::{DirectIoFile, MAX_READ_SIZE};
+use chacha20::ChaCha8Rng;
+use chacha20::rand_core::{RngCore, SeedableRng};
+use std::fs;
+use std::fs::OpenOptions;
+use tempfile::tempdir;
+
+#[test]
+fn read_write_small() {
+    read_write_inner::<15000>(&[
+        (0_usize, 512_usize),
+        (0_usize, 4096_usize),
+        (0, 500),
+        (0, 4000),
+        (5, 50),
+        (12, 500),
+        (96, 4000),
+        (4000, 96),
+        (10000, 5),
+    ])
+}
+
+#[test]
+// TODO: Extremely slow under Miri: https://github.com/rust-lang/miri/issues/4463
+#[cfg_attr(miri, ignore)]
+fn read_write_large() {
+    read_write_inner::<{ MAX_READ_SIZE * 5 }>(&[
+        (0, MAX_READ_SIZE),
+        (0, MAX_READ_SIZE * 2),
+        (5, MAX_READ_SIZE - 5),
+        (5, MAX_READ_SIZE * 2 - 5),
+        (5, MAX_READ_SIZE),
+        (5, MAX_READ_SIZE * 2),
+        (MAX_READ_SIZE, MAX_READ_SIZE),
+        (MAX_READ_SIZE, MAX_READ_SIZE * 2),
+        (MAX_READ_SIZE + 5, MAX_READ_SIZE - 5),
+        (MAX_READ_SIZE + 5, MAX_READ_SIZE * 2 - 5),
+        (MAX_READ_SIZE + 5, MAX_READ_SIZE),
+        (MAX_READ_SIZE + 5, MAX_READ_SIZE * 2),
+    ])
+}
+
+fn read_write_inner<const BUFFER_SIZE: usize>(offset_size_pairs: &[(usize, usize)]) {
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+    let tempdir = tempdir().unwrap();
+    let file_path = tempdir.as_ref().join("file.bin");
+    let mut data = vec![0u8; BUFFER_SIZE];
+    if cfg!(miri) {
+        // TODO: This de-sugaring helps Miri to compute the thing faster:
+        //  https://github.com/rust-lang/miri/issues/4463
+        let data = data.as_mut_slice();
+        let mut index = 0;
+        let data_len = data.len();
+        while index < data_len {
+            data[index] = index as u8;
+            index += 1;
+        }
+    } else {
+        rng.fill_bytes(data.as_mut_slice());
+    }
+    fs::write(&file_path, &data).unwrap();
+
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    let file = DirectIoFile::open(options, &file_path).unwrap();
+
+    let mut buffer = Vec::new();
+    for &(offset, size) in offset_size_pairs {
+        let data = &mut data[offset..][..size];
+        buffer.resize(size, 0);
+        // Read contents
+        file.read_exact_at(buffer.as_mut_slice(), offset as u64)
+            .unwrap_or_else(|error| panic!("Offset {offset}, size {size}: {error}"));
+
+        // Ensure it is correct
+        assert_eq!(data, buffer.as_slice(), "Offset {offset}, size {size}");
+
+        // Update data with random contents and write
+        if cfg!(miri) {
+            // TODO: This de-sugaring helps Miri to compute the thing faster:
+            //  https://github.com/rust-lang/miri/issues/4463
+            let mut index = 0;
+            let data_len = data.len();
+            while index < data_len {
+                data[index] = index as u8;
+                index += 1;
+            }
+        } else {
+            rng.fill_bytes(data);
+        }
+        file.write_all_at(data, offset as u64)
+            .unwrap_or_else(|error| panic!("Offset {offset}, size {size}: {error}"));
+
+        // Read contents again
+        file.read_exact_at(buffer.as_mut_slice(), offset as u64)
+            .unwrap_or_else(|error| panic!("Offset {offset}, size {size}: {error}"));
+
+        // Ensure it is correct too
+        assert_eq!(data, buffer.as_slice(), "Offset {offset}, size {size}");
+    }
+}
+
+#[test]
+fn other_operations() {
+    let tempdir = tempdir().unwrap();
+    let file_path = tempdir.as_ref().join("file.bin");
+
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    let file = DirectIoFile::open(options, &file_path).unwrap();
+
+    assert_eq!(file.len().unwrap(), 0);
+    assert!(file.is_empty().unwrap());
+
+    // TODO: Not supported under Miri: https://github.com/rust-lang/miri/issues/4464
+    if !cfg!(miri) {
+        file.allocate(100).unwrap();
+        assert_eq!(file.len().unwrap(), 100);
+        assert!(!file.is_empty().unwrap());
+    }
+
+    file.set_len(50).unwrap();
+    assert_eq!(file.len().unwrap(), 50);
+    assert!(!file.is_empty().unwrap());
+
+    file.set_len(150).unwrap();
+    assert_eq!(file.len().unwrap(), 150);
+}

--- a/subspace/crates/subspace-farmer/src/disk_piece_cache.rs
+++ b/subspace/crates/subspace-farmer/src/disk_piece_cache.rs
@@ -265,8 +265,8 @@ impl DiskPieceCache {
         {
             let file = files.write();
             if file.size()? != expected_size {
-                // Allocating the whole file (`set_len` below can create a sparse file, which will cause
-                // writes to fail later)
+                // Allocating the whole file (`set_len` below can create a sparse file, which will
+                // cause writes to fail later)
                 file.preallocate(expected_size)
                     .map_err(DiskPieceCacheError::CantPreallocateCacheFile)?;
                 // Truncating file (if necessary)


### PR DESCRIPTION
Extracted logic from `ab-farmer-components` and `subspace-farmer`, this will be used in there eventually, but more immediately needed for the database implementation.

In contrast to code in `subspace-farmer`, this doesn't depend on `ab-farmer-components` and exposes lower-level APIs for reading/writing aligned bytes to avoid buffering and locking overhead.