### PR TITLE
Update `rust-gpu` to the current `main` revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "spirv-std"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=3e89e6cc7b32b51db51d75b5f558ccd7ecf5b850#3e89e6cc7b32b51db51d75b5f558ccd7ecf5b850"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=87ea628070561f576aeef84c92a0e3e3c25d63ff#87ea628070561f576aeef84c92a0e3e3c25d63ff"
 dependencies = [
  "bitflags 1.3.2",
  "glam",
@@ -3014,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-macros"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=3e89e6cc7b32b51db51d75b5f558ccd7ecf5b850#3e89e6cc7b32b51db51d75b5f558ccd7ecf5b850"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=87ea628070561f576aeef84c92a0e3e3c25d63ff#87ea628070561f576aeef84c92a0e3e3c25d63ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-types"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=3e89e6cc7b32b51db51d75b5f558ccd7ecf5b850#3e89e6cc7b32b51db51d75b5f558ccd7ecf5b850"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=87ea628070561f576aeef84c92a0e3e3c25d63ff#87ea628070561f576aeef84c92a0e3e3c25d63ff"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ serde-big-array = "0.5.1"
 sha2 = { version = "0.11.0-rc.0", default-features = false }
 smallvec = "1.15.1"
 spin = "0.10.0"
-spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "3e89e6cc7b32b51db51d75b5f558ccd7ecf5b850" }
+spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "87ea628070561f576aeef84c92a0e3e3c25d63ff" }
 stable_deref_trait = { version = "1.2.0", default-features = false }
 syn = "2.0.104"
 tempfile = "3.20.0"


### PR DESCRIPTION
This finally unblocks some of the GPU-related work I had in a local branch for a long time, mostly thanks to https://github.com/Rust-GPU/rust-gpu/pull/317