### PR TITLE
Implement `compute_fn()` in `ab-proof-of-space-gpu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,9 +438,11 @@ dependencies = [
 name = "ab-proof-of-space-gpu"
 version = "0.1.0"
 dependencies = [
+ "ab-blake3",
  "ab-chacha8",
  "ab-core-primitives",
  "cargo-gpu",
+ "chacha20",
  "futures",
  "spirv-std",
  "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,11 +107,12 @@ wgpu = { version = "26.0.1", default-features = false, features = ["metal", "spi
 windows = { version = "0.61.3", features = ["Win32_Storage_FileSystem"] }
 yoke = { version = "0.8.0", default-features = false }
 
-# Following libraries have a major impact on developement experience and need to be compiled with optimizations even in
-# debug builds
+# The following libraries have a major impact on developement experience and need to be compiled with optimizations even
+# in debug builds
 [profile.dev.package]
 ab-archiving = { opt-level = 3 }
 ab-proof-of-space = { opt-level = 3 }
+ab-proof-of-space-gpu = { opt-level = 3 }
 ab-proof-of-time = { opt-level = 3 }
 blake3 = { opt-level = 3 }
 reed-solomon-simd = { opt-level = 3 }

--- a/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
+++ b/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
@@ -21,6 +21,7 @@ crate-type = ["dylib", "lib"]
 # TODO: Benches
 
 [dependencies]
+ab-blake3 = { workspace = true }
 ab-chacha8 = { workspace = true }
 spirv-std = { workspace = true }
 
@@ -29,6 +30,7 @@ ab-core-primitives = { workspace = true }
 wgpu = { workspace = true }
 
 [target.'cfg(not(target_arch = "spirv"))'.dev-dependencies]
+chacha20 = { workspace = true, features = ["rng"] }
 futures = { workspace = true, features = ["executor"] }
 
 # TODO: This will be built in the shader as well, figure out a way to avoid that

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -1,7 +1,7 @@
 //! Proof of space plotting utilities for GPU (Vulkan/Metal).
 //!
-//! Just like in `ab-proof-of-space`, max supported `K` within range `15..=25` due to internal data
-//! structures used.
+//! Similarly to `ab-proof-of-space`, max supported `K` within range `15..=24` due to internal data
+//! structures used (`ab-proof-of-space` also supports `K=25`, but this crate doesn't for now).
 
 #![cfg_attr(target_arch = "spirv", no_std)]
 #![feature(array_chunks, bigint_helper_methods)]
@@ -17,5 +17,5 @@ use ab_core_primitives::pos::PosProof;
 // TODO: Remove gate after https://github.com/Rust-GPU/rust-gpu/pull/249
 #[cfg(not(target_arch = "spirv"))]
 const _: () = {
-    assert!(PosProof::K >= 15 && PosProof::K <= 25);
+    assert!(PosProof::K >= 15 && PosProof::K <= 24);
 };

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
@@ -1,5 +1,6 @@
 pub mod chacha8;
 pub mod compute_f1;
+pub mod compute_fn;
 // TODO: Reuse constants from `ab-proof-of-space` once https://github.com/Rust-GPU/rust-gpu/pull/249 is
 //  merged
 mod constants;

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/chacha8.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/chacha8.rs
@@ -7,7 +7,7 @@ use spirv_std::spirv;
 
 /// Produce a ChaCha8 keystream.
 ///
-/// NOTE: Length of keystream is limited by `u32`
+/// NOTE: Length of the keystream is limited by `u32`
 #[spirv(compute(threads(256), entry_point_name = "chacha8_keystream"))]
 pub fn chacha8_keystream(
     #[spirv(global_invocation_id)] invocation_id: UVec3,

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1/cpu_tests.rs
@@ -5,7 +5,7 @@ use ab_core_primitives::pos::PosProof;
 
 // TODO: Reuse code from `ab-proof-of-space`, right now this is copy-pasted from there
 /// `partial_y_offset` is in bits within `partial_y`
-pub(super) fn compute_f1<const K: u8>(x: u32, seed: &[u8; 32]) -> u32 {
+pub(super) fn correct_compute_f1<const K: u8>(x: u32, seed: &[u8; 32]) -> u32 {
     let skip_bits = u32::from(K) * x;
     let skip_u32s = skip_bits / u32::BITS;
     let partial_y_offset = skip_bits % u32::BITS;
@@ -60,7 +60,7 @@ fn compute_f1_cpu() {
 
     for x in 0..num_x {
         assert_eq!(
-            compute_f1::<{ PosProof::K }>(x, &seed),
+            correct_compute_f1::<{ PosProof::K }>(x, &seed),
             compute_f1_impl(x, chacha8_keystream.as_flattened()),
             "X={x}"
         );

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_fn.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_fn.rs
@@ -1,0 +1,375 @@
+#[cfg(all(test, not(target_arch = "spirv")))]
+mod cpu_tests;
+#[cfg(all(test, not(miri), not(target_arch = "spirv")))]
+mod gpu_tests;
+
+use crate::shader::constants::{K, PARAM_EXT};
+use crate::shader::num::{U128, U128T};
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct Match {
+    pub left_position: u32,
+    // TODO: Would it be efficient to not store it here since `left_position` already points to the
+    //  correct `y` in the parent table?
+    pub left_y: u32,
+    pub right_position: u32,
+}
+
+// TODO: Reuse code from `ab-proof-of-space` after https://github.com/Rust-GPU/rust-gpu/pull/249 and
+//  https://github.com/Rust-GPU/rust-gpu/discussions/301
+/// Compute the size of `y` in bits
+const fn y_size_bits(k: u8) -> u32 {
+    k as u32 + PARAM_EXT as u32
+}
+
+// TODO: Reuse code from `ab-proof-of-space` after https://github.com/Rust-GPU/rust-gpu/pull/249 and
+//  https://github.com/Rust-GPU/rust-gpu/discussions/301
+/// Metadata size in bits
+const fn metadata_size_bits(k: u8, table_number: u8) -> u32 {
+    k as u32
+        * match table_number {
+            1 => 1,
+            2 => 2,
+            3 | 4 => 4,
+            5 => 3,
+            6 => 2,
+            7 => 0,
+            _ => unreachable!(),
+        }
+}
+
+// TODO: Make unsafe and avoid bounds check
+// TODO: Reuse code from `ab-proof-of-space` after https://github.com/Rust-GPU/rust-gpu/pull/249 and
+//  https://github.com/Rust-GPU/rust-gpu/discussions/301
+#[inline(always)]
+pub(super) fn compute_fn_impl<const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    y: u32,
+    left_metadata: U128,
+    right_metadata: U128,
+) -> (u32, U128) {
+    // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+    //  shouldn't be necessary otherwise
+    let parent_metadata_bits = const { metadata_size_bits(K, PARENT_TABLE_NUMBER) };
+
+    // Only supports `K` from 15 to 25 (otherwise math will not be correct when concatenating y,
+    // left metadata and right metadata)
+    let mut input_words = [0; _];
+    let byte_length = {
+        // Take only bytes where bits were set
+        // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+        //  shouldn't be necessary otherwise
+        let num_bytes_with_data =
+            (const { y_size_bits(K) } + parent_metadata_bits * 2).div_ceil(u8::BITS);
+
+        // Collect `K` most significant bits of `y` at the final offset of eventual `input_a`
+        // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+        //  shouldn't be necessary otherwise
+        let y_bits = U128::from(y) << (u128::BITS - const { y_size_bits(K) });
+
+        // Move bits of `left_metadata` at the final offset of eventual `input_a`
+        // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+        //  shouldn't be necessary otherwise
+        let left_metadata_bits =
+            left_metadata << (u128::BITS - parent_metadata_bits - const { y_size_bits(K) });
+
+        // Part of the `right_bits` at the final offset of eventual `input_a`
+        // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+        //  shouldn't be necessary otherwise
+        let y_and_left_bits = const { y_size_bits(K) } + parent_metadata_bits;
+        let right_bits_start_offset = u128::BITS - parent_metadata_bits;
+
+        // If `right_metadata` bits start to the left of the desired position in `input_a` move
+        // bits right, else move left
+        if right_bits_start_offset < y_and_left_bits {
+            let right_bits_pushed_into_input_b = y_and_left_bits - right_bits_start_offset;
+            // Collect bits of `right_metadata` that will fit into `input_a` at the final offset in
+            // eventual `input_a`
+            let right_bits_a = right_metadata >> right_bits_pushed_into_input_b;
+            let input_a = y_bits | left_metadata_bits | right_bits_a;
+            // Collect bits of `right_metadata` that will spill over into `input_b`
+            let input_b = right_metadata << (u128::BITS - right_bits_pushed_into_input_b);
+
+            let input_a_words = input_a.as_be_bytes_to_le_u32_words();
+            // TODO: Manually indexing elements and constructing an array is a workaround for
+            //  rust-gpu to compile
+            // input_words[..input_a_words.len()].copy_from_slice(&input_a_words);
+            input_words[0] = input_a_words[0];
+            input_words[1] = input_a_words[1];
+            input_words[2] = input_a_words[2];
+            input_words[3] = input_a_words[3];
+            let input_b_words = input_b.as_be_bytes_to_le_u32_words();
+            // TODO: Manually indexing elements and constructing an array is a workaround for
+            //  rust-gpu to compile
+            // input_words[input_a_words.len()..].copy_from_slice(&input_b_words);
+            input_words[4] = input_b_words[0];
+            input_words[5] = input_b_words[1];
+            input_words[6] = input_b_words[2];
+            input_words[7] = input_b_words[3];
+
+            size_of::<u128>() as u32 + right_bits_pushed_into_input_b.div_ceil(u8::BITS)
+        } else {
+            let right_bits_a = right_metadata << (right_bits_start_offset - y_and_left_bits);
+            let input_a = y_bits | left_metadata_bits | right_bits_a;
+            let input_a_words = input_a.as_be_bytes_to_le_u32_words();
+            // TODO: Manually indexing elements and constructing an array is a workaround for
+            //  rust-gpu to compile
+            // input_words[..input_a_words.len()].copy_from_slice(&input_a_words);
+            input_words[0] = input_a_words[0];
+            input_words[1] = input_a_words[1];
+            input_words[2] = input_a_words[2];
+            input_words[3] = input_a_words[3];
+
+            num_bytes_with_data
+        }
+    };
+    let hash = ab_blake3::single_block_hash_portable_words(&input_words, byte_length);
+
+    // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+    //  shouldn't be necessary otherwise
+    let y_output = hash[0].to_be() >> (u32::BITS - const { y_size_bits(K) });
+
+    // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+    //  shouldn't be necessary otherwise
+    let metadata_size_bits = const { metadata_size_bits(K, TABLE_NUMBER) };
+
+    let metadata = if TABLE_NUMBER < 4 {
+        (left_metadata << parent_metadata_bits) | right_metadata
+    } else if metadata_size_bits > 0 {
+        // For K up to 24 it is guaranteed that metadata + bit offset will always fit into 4 `u32`
+        // words (equivalent to `u128` size). For K=25 it'll be necessary to have fifth word, which
+        // will become more cumbersome to handle. We collect bytes necessary, potentially with extra
+        // bits at the start and end of the bytes that will be taken care of later.
+        // TODO: Manually indexing elements and constructing an array is a workaround for rust-gpu
+        //  to compile
+        // let metadata = U128::from_le_u32_words_as_be_bytes(
+        //     hash[(y_size_bits(K) / u32::BITS) as usize..][..size_of::<u128>() / size_of::<u32>()]
+        //         .try_into()
+        //         .expect("Always enough bits for any K; qed"),
+        // );
+        // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+        //  shouldn't be necessary otherwise
+        let first_element = (const { y_size_bits(K) } / u32::BITS) as usize;
+        let metadata = U128::from_le_u32_words_as_be_bytes(&[
+            hash[first_element],
+            hash[first_element + 1],
+            hash[first_element + 2],
+            hash[first_element + 3],
+        ]);
+        // Remove extra bits at the beginning
+        // TODO: `const {}` is a workaround for https://github.com/Rust-GPU/rust-gpu/issues/322 and
+        //  shouldn't be necessary otherwise
+        let metadata = metadata << (const { y_size_bits(K) } % u32::BITS);
+        // Move bits into the correct location
+        metadata >> (u128::BITS - metadata_size_bits)
+    } else {
+        U128::ZERO
+    };
+
+    (y_output, metadata)
+}
+
+#[inline(always)]
+fn compute_fn<const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    invocation_id: UVec3,
+    num_workgroups: UVec3,
+    workgroup_size: u32,
+    matches: &[Match],
+    parent_metadatas: &[U128],
+    ys: &mut [u32],
+    metadatas: &mut [U128],
+) {
+    // TODO: Make a single input bounds check and use unsafe to avoid bounds check later
+    let invocation_id = invocation_id.x;
+    let num_workgroups = num_workgroups.x;
+
+    let global_size = workgroup_size * num_workgroups;
+
+    // TODO: More idiomatic version currently doesn't compile:
+    //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+    for index in (invocation_id..matches.len() as u32).step_by(global_size as usize) {
+        let index = index as usize;
+
+        let m = matches[index];
+        let left_metadata = parent_metadatas[m.left_position as usize];
+        let right_metadata = parent_metadatas[m.right_position as usize];
+
+        let (y, metadata) = compute_fn_impl::<TABLE_NUMBER, PARENT_TABLE_NUMBER>(
+            m.left_y,
+            left_metadata,
+            right_metadata,
+        );
+
+        ys[index] = y;
+        // The last table doesn't have any metadata
+        if TABLE_NUMBER < 7 {
+            metadatas[index] = metadata;
+        }
+    }
+}
+
+/// Compute Chia's `f2()` function from matches in the parent table and corresponding metadata
+#[spirv(compute(threads(256), entry_point_name = "compute_f2"))]
+pub fn compute_f2(
+    #[spirv(global_invocation_id)] invocation_id: UVec3,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    // TODO: Uncomment once https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    // #[spirv(workgroup_size)] workgroup_size: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] matches: &[Match],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_metadatas: &[U128],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] ys: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] metadatas: &mut [U128],
+) {
+    // TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` above, can be removed once
+    //  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    let workgroup_size = 256_u32;
+
+    compute_fn::<2, 1>(
+        invocation_id,
+        num_workgroups,
+        workgroup_size,
+        matches,
+        parent_metadatas,
+        ys,
+        metadatas,
+    )
+}
+
+/// Compute Chia's `f3()` function from matches in the parent table and corresponding metadata
+#[spirv(compute(threads(256), entry_point_name = "compute_f3"))]
+pub fn compute_f3(
+    #[spirv(global_invocation_id)] invocation_id: UVec3,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    // TODO: Uncomment once https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    // #[spirv(workgroup_size)] workgroup_size: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] matches: &[Match],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_metadatas: &[U128],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] ys: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] metadatas: &mut [U128],
+) {
+    // TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` above, can be removed once
+    //  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    let workgroup_size = 256_u32;
+
+    compute_fn::<3, 2>(
+        invocation_id,
+        num_workgroups,
+        workgroup_size,
+        matches,
+        parent_metadatas,
+        ys,
+        metadatas,
+    )
+}
+
+/// Compute Chia's `f4()` function from matches in the parent table and corresponding metadata
+#[spirv(compute(threads(256), entry_point_name = "compute_f4"))]
+pub fn compute_f4(
+    #[spirv(global_invocation_id)] invocation_id: UVec3,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    // TODO: Uncomment once https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    // #[spirv(workgroup_size)] workgroup_size: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] matches: &[Match],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_metadatas: &[U128],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] ys: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] metadatas: &mut [U128],
+) {
+    // TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` above, can be removed once
+    //  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    let workgroup_size = 256_u32;
+
+    compute_fn::<4, 3>(
+        invocation_id,
+        num_workgroups,
+        workgroup_size,
+        matches,
+        parent_metadatas,
+        ys,
+        metadatas,
+    )
+}
+
+/// Compute Chia's `f5()` function from matches in the parent table and corresponding metadata
+#[spirv(compute(threads(256), entry_point_name = "compute_f5"))]
+pub fn compute_f5(
+    #[spirv(global_invocation_id)] invocation_id: UVec3,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    // TODO: Uncomment once https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    // #[spirv(workgroup_size)] workgroup_size: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] matches: &[Match],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_metadatas: &[U128],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] ys: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] metadatas: &mut [U128],
+) {
+    // TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` above, can be removed once
+    //  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    let workgroup_size = 256_u32;
+
+    compute_fn::<5, 4>(
+        invocation_id,
+        num_workgroups,
+        workgroup_size,
+        matches,
+        parent_metadatas,
+        ys,
+        metadatas,
+    )
+}
+
+/// Compute Chia's `f6()` function from matches in the parent table and corresponding metadata
+#[spirv(compute(threads(256), entry_point_name = "compute_f6"))]
+pub fn compute_f6(
+    #[spirv(global_invocation_id)] invocation_id: UVec3,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    // TODO: Uncomment once https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    // #[spirv(workgroup_size)] workgroup_size: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] matches: &[Match],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_metadatas: &[U128],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] ys: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] metadatas: &mut [U128],
+) {
+    // TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` above, can be removed once
+    //  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    let workgroup_size = 256_u32;
+
+    compute_fn::<6, 5>(
+        invocation_id,
+        num_workgroups,
+        workgroup_size,
+        matches,
+        parent_metadatas,
+        ys,
+        metadatas,
+    )
+}
+
+/// Compute Chia's `f7()` function from matches in the parent table and corresponding metadata
+#[spirv(compute(threads(256), entry_point_name = "compute_f7"))]
+pub fn compute_f7(
+    #[spirv(global_invocation_id)] invocation_id: UVec3,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    // TODO: Uncomment once https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    // #[spirv(workgroup_size)] workgroup_size: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] matches: &[Match],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_metadatas: &[U128],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] ys: &mut [u32],
+    // TODO: This argument should not be required, but it is currently not possible to compile
+    //  `&mut []` under `rust-gpu` directly
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] metadatas: &mut [U128],
+) {
+    // TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` above, can be removed once
+    //  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+    let workgroup_size = 256_u32;
+
+    compute_fn::<7, 6>(
+        invocation_id,
+        num_workgroups,
+        workgroup_size,
+        matches,
+        parent_metadatas,
+        ys,
+        metadatas,
+    )
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_fn/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_fn/cpu_tests.rs
@@ -1,0 +1,121 @@
+use crate::shader::compute_fn::{compute_fn_impl, metadata_size_bits, y_size_bits};
+use crate::shader::constants::K;
+use chacha20::ChaCha8Rng;
+use chacha20::rand_core::{RngCore, SeedableRng};
+
+// TODO: Reuse code from `ab-proof-of-space`, right now this is copy-pasted from there
+pub(super) fn correct_compute_fn<const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    y: u32,
+    left_metadata: u128,
+    right_metadata: u128,
+) -> (u32, u128) {
+    let parent_metadata_bits = metadata_size_bits(K, PARENT_TABLE_NUMBER);
+
+    // Only supports `K` from 15 to 25 (otherwise math will not be correct when concatenating y,
+    // left metadata and right metadata)
+    let hash = {
+        // Take only bytes where bits were set
+        let num_bytes_with_data =
+            (y_size_bits(K) + parent_metadata_bits * 2).div_ceil(u8::BITS) as usize;
+
+        // Collect `K` most significant bits of `y` at the final offset of eventual `input_a`
+        let y_bits = u128::from(y) << (u128::BITS - y_size_bits(K));
+
+        // Move bits of `left_metadata` at the final offset of eventual `input_a`
+        let left_metadata_bits =
+            left_metadata << (u128::BITS - parent_metadata_bits - y_size_bits(K));
+
+        // Part of the `right_bits` at the final offset of eventual `input_a`
+        let y_and_left_bits = y_size_bits(K) + parent_metadata_bits;
+        let right_bits_start_offset = u128::BITS - parent_metadata_bits;
+
+        // If `right_metadata` bits start to the left of the desired position in `input_a` move
+        // bits right, else move left
+        if right_bits_start_offset < y_and_left_bits {
+            let right_bits_pushed_into_input_b = y_and_left_bits - right_bits_start_offset;
+            // Collect bits of `right_metadata` that will fit into `input_a` at the final offset in
+            // eventual `input_a`
+            let right_bits_a = right_metadata >> right_bits_pushed_into_input_b;
+            let input_a = y_bits | left_metadata_bits | right_bits_a;
+            // Collect bits of `right_metadata` that will spill over into `input_b`
+            let input_b = right_metadata << (u128::BITS - right_bits_pushed_into_input_b);
+
+            let input = [input_a.to_be_bytes(), input_b.to_be_bytes()];
+            let input_len =
+                size_of::<u128>() + right_bits_pushed_into_input_b.div_ceil(u8::BITS) as usize;
+            ab_blake3::single_block_hash(&input.as_flattened()[..input_len])
+                .expect("Exactly a single block worth of bytes; qed")
+        } else {
+            let right_bits_a = right_metadata << (right_bits_start_offset - y_and_left_bits);
+            let input_a = y_bits | left_metadata_bits | right_bits_a;
+
+            ab_blake3::single_block_hash(&input_a.to_be_bytes()[..num_bytes_with_data])
+                .expect("Less than a single block worth of bytes; qed")
+        }
+    };
+
+    let y_output =
+        u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]]) >> (u32::BITS - y_size_bits(K));
+
+    let metadata_size_bits = metadata_size_bits(K, TABLE_NUMBER);
+
+    let metadata = if TABLE_NUMBER < 4 {
+        (left_metadata << parent_metadata_bits) | right_metadata
+    } else if metadata_size_bits > 0 {
+        // For K up to 25 it is guaranteed that metadata + bit offset will always fit into u128.
+        // We collect the bytes necessary, potentially with extra bits at the start and end of the
+        // bytes that will be taken care of later.
+        let metadata = u128::from_be_bytes(
+            hash[(y_size_bits(K) / u8::BITS) as usize..][..size_of::<u128>()]
+                .try_into()
+                .expect("Always enough bits for any K; qed"),
+        );
+        // Remove extra bits at the beginning
+        let metadata = metadata << ((y_size_bits(K) % u8::BITS) as usize);
+        // Move bits into the correct location
+        metadata >> (u128::BITS - metadata_size_bits)
+    } else {
+        0
+    };
+
+    (y_output, metadata)
+}
+
+pub(super) fn random_y(rng: &mut ChaCha8Rng) -> u32 {
+    rng.next_u32() >> (u32::BITS - y_size_bits(K))
+}
+
+pub(super) fn random_metadata<const TABLE_NUMBER: u8>(rng: &mut ChaCha8Rng) -> u128 {
+    let mut left_metadata = 0u128.to_le_bytes();
+    rng.fill_bytes(&mut left_metadata);
+    u128::from_le_bytes(left_metadata) >> (u128::BITS - metadata_size_bits(K, TABLE_NUMBER))
+}
+
+fn test_compute_fn_cpu_impl<const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    rng: &mut ChaCha8Rng,
+) {
+    let y = random_y(rng);
+    let left_metadata = random_metadata::<PARENT_TABLE_NUMBER>(rng);
+    let right_metadata = random_metadata::<PARENT_TABLE_NUMBER>(rng);
+
+    assert_eq!(
+        correct_compute_fn::<TABLE_NUMBER, PARENT_TABLE_NUMBER>(y, left_metadata, right_metadata),
+        compute_fn_impl::<TABLE_NUMBER, PARENT_TABLE_NUMBER>(y, left_metadata, right_metadata),
+        "TABLE_NUMBER={TABLE_NUMBER}: Y={y}, left_metadata={left_metadata}, right_metadata={right_metadata}"
+    );
+}
+
+#[test]
+fn compute_fn_cpu() {
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+
+    // Just some random comparisons against reference implementation
+    for _ in 0..10 {
+        test_compute_fn_cpu_impl::<2, 1>(&mut rng);
+        test_compute_fn_cpu_impl::<3, 2>(&mut rng);
+        test_compute_fn_cpu_impl::<4, 3>(&mut rng);
+        test_compute_fn_cpu_impl::<5, 4>(&mut rng);
+        test_compute_fn_cpu_impl::<6, 5>(&mut rng);
+        test_compute_fn_cpu_impl::<7, 6>(&mut rng);
+    }
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_fn/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_fn/gpu_tests.rs
@@ -1,0 +1,343 @@
+use crate::shader::compute_fn::Match;
+use crate::shader::compute_fn::cpu_tests::{correct_compute_fn, random_metadata, random_y};
+use crate::shader::{SHADER_U32, SHADER_U64};
+use chacha20::ChaCha8Rng;
+use chacha20::rand_core::{RngCore, SeedableRng};
+use futures::executor::block_on;
+use std::slice;
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use wgpu::{
+    Adapter, BackendOptions, Backends, BindGroupDescriptor, BindGroupEntry,
+    BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BufferAddress, BufferBindingType,
+    BufferDescriptor, BufferUsages, CommandEncoderDescriptor, ComputePipelineDescriptor,
+    DeviceDescriptor, Features, Instance, InstanceDescriptor, InstanceFlags, Limits, MapMode,
+    MemoryBudgetThresholds, MemoryHints, PipelineLayoutDescriptor, PollType, ShaderStages, Trace,
+};
+
+#[test]
+fn compute_f2_gpu() {
+    test_compute_fn_gpu_impl::<2, 1>(&mut ChaCha8Rng::from_seed(Default::default()));
+}
+
+#[test]
+fn compute_f3_gpu() {
+    test_compute_fn_gpu_impl::<3, 2>(&mut ChaCha8Rng::from_seed(Default::default()));
+}
+
+#[test]
+fn compute_f4_gpu() {
+    test_compute_fn_gpu_impl::<4, 3>(&mut ChaCha8Rng::from_seed(Default::default()));
+}
+
+#[test]
+fn compute_f5_gpu() {
+    test_compute_fn_gpu_impl::<5, 4>(&mut ChaCha8Rng::from_seed(Default::default()));
+}
+
+#[test]
+fn compute_f6_gpu() {
+    test_compute_fn_gpu_impl::<6, 5>(&mut ChaCha8Rng::from_seed(Default::default()));
+}
+
+#[test]
+fn compute_f7_gpu() {
+    test_compute_fn_gpu_impl::<7, 6>(&mut ChaCha8Rng::from_seed(Default::default()));
+}
+
+fn test_compute_fn_gpu_impl<const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>(
+    rng: &mut ChaCha8Rng,
+) {
+    let parent_table_size = 100_usize;
+    let num_matches = 100_usize;
+
+    let parent_ys = (0..parent_table_size)
+        .map(|_| random_y(rng))
+        .collect::<Vec<_>>();
+    let parent_metadatas = (0..parent_table_size)
+        .map(|_| random_metadata::<PARENT_TABLE_NUMBER>(rng))
+        .collect::<Vec<_>>();
+    let matches = (0..num_matches)
+        .map(|_| {
+            let left_position = rng.next_u32() % parent_table_size as u32;
+            let right_position = rng.next_u32() % parent_table_size as u32;
+
+            Match {
+                left_position,
+                left_y: parent_ys[left_position as usize],
+                right_position,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let Some((actual_ys, actual_metadatas)) =
+        block_on(compute_fn::<TABLE_NUMBER>(&matches, &parent_metadatas))
+    else {
+        if cfg!(feature = "__force-gpu-tests") {
+            panic!("Skipping tests, no compatible device detected");
+        } else {
+            eprintln!("Skipping tests, no compatible device detected");
+            return;
+        }
+    };
+
+    let (expected_ys, expected_metadatas) = matches
+        .iter()
+        .map(|m| {
+            let left_metadata = parent_metadatas[m.left_position as usize];
+            let right_metadata = parent_metadatas[m.right_position as usize];
+            correct_compute_fn::<TABLE_NUMBER, PARENT_TABLE_NUMBER>(
+                m.left_y,
+                left_metadata,
+                right_metadata,
+            )
+        })
+        .unzip::<_, _, Vec<_>, Vec<_>>();
+
+    assert_eq!(actual_ys.len(), expected_ys.len());
+    assert_eq!(actual_metadatas.len(), expected_metadatas.len());
+    for (index, (expected, actual)) in expected_ys
+        .into_iter()
+        .zip(expected_metadatas)
+        .zip(actual_ys.into_iter().zip(actual_metadatas))
+        .enumerate()
+    {
+        assert_eq!(expected, actual, "index={index}");
+    }
+}
+
+async fn compute_fn<const TABLE_NUMBER: u8>(
+    matches: &[Match],
+    parent_metadatas: &[u128],
+) -> Option<(Vec<u32>, Vec<u128>)> {
+    let backends = Backends::from_env().unwrap_or(Backends::METAL | Backends::VULKAN);
+    let instance = Instance::new(&InstanceDescriptor {
+        backends,
+        flags: InstanceFlags::GPU_BASED_VALIDATION.with_env(),
+        memory_budget_thresholds: MemoryBudgetThresholds::default(),
+        backend_options: BackendOptions::from_env_or_default(),
+    });
+
+    let adapters = instance.enumerate_adapters(backends);
+    let mut result = None;
+
+    for adapter in adapters {
+        println!("Testing adapter {:?}", adapter.get_info());
+
+        let adapter_result =
+            compute_fn_adapter::<TABLE_NUMBER>(matches, parent_metadatas, adapter).await?;
+
+        match &result {
+            Some(result) => {
+                assert!(result == &adapter_result);
+            }
+            None => {
+                result.replace(adapter_result);
+            }
+        }
+    }
+
+    result
+}
+
+async fn compute_fn_adapter<const TABLE_NUMBER: u8>(
+    matches: &[Match],
+    parent_metadatas: &[u128],
+    adapter: Adapter,
+) -> Option<(Vec<u32>, Vec<u128>)> {
+    let num_matches = matches.len();
+
+    let (required_features, shader) = if adapter.features().contains(Features::SHADER_INT64) {
+        (Features::SHADER_INT64, SHADER_U64)
+    } else {
+        (Features::default(), SHADER_U32)
+    };
+
+    let (device, queue) = adapter
+        .request_device(&DeviceDescriptor {
+            label: None,
+            required_features,
+            required_limits: Limits::default(),
+            memory_hints: MemoryHints::Performance,
+            trace: Trace::default(),
+        })
+        .await
+        .unwrap();
+
+    let module = device.create_shader_module(shader);
+
+    let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+        label: None,
+        entries: &[
+            BindGroupLayoutEntry {
+                binding: 0,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: true },
+                },
+            },
+            BindGroupLayoutEntry {
+                binding: 1,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: true },
+                },
+            },
+            BindGroupLayoutEntry {
+                binding: 2,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: false },
+                },
+            },
+            BindGroupLayoutEntry {
+                binding: 3,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: false },
+                },
+            },
+        ],
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+        label: None,
+        bind_group_layouts: &[&bind_group_layout],
+        push_constant_ranges: &[],
+    });
+
+    let compute_pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+        compilation_options: Default::default(),
+        cache: None,
+        label: None,
+        layout: Some(&pipeline_layout),
+        module: &module,
+        entry_point: Some(&format!("compute_f{TABLE_NUMBER}")),
+    });
+
+    let matches_gpu = device.create_buffer_init(&BufferInitDescriptor {
+        label: None,
+        contents: unsafe {
+            slice::from_raw_parts(matches.as_ptr().cast::<u8>(), size_of_val(matches))
+        },
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+    });
+
+    let parent_metadatas_gpu = device.create_buffer_init(&BufferInitDescriptor {
+        label: None,
+        contents: unsafe {
+            slice::from_raw_parts(
+                parent_metadatas.as_ptr().cast::<u8>(),
+                size_of_val(parent_metadatas),
+            )
+        },
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+    });
+
+    let ys_host = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: (size_of::<u32>() * num_matches) as BufferAddress,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let ys_gpu = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: ys_host.size(),
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let metadatas_host = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: (size_of::<u128>() * num_matches) as BufferAddress,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let metadatas_gpu = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: metadatas_host.size(),
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let bind_group = device.create_bind_group(&BindGroupDescriptor {
+        label: None,
+        layout: &bind_group_layout,
+        entries: &[
+            BindGroupEntry {
+                binding: 0,
+                resource: matches_gpu.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 1,
+                resource: parent_metadatas_gpu.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 2,
+                resource: ys_gpu.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 3,
+                resource: metadatas_gpu.as_entire_binding(),
+            },
+        ],
+    });
+
+    let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+
+    {
+        let mut cpass = encoder.begin_compute_pass(&Default::default());
+        cpass.set_bind_group(0, &bind_group, &[]);
+        cpass.set_pipeline(&compute_pipeline);
+        cpass.dispatch_workgroups(device.limits().max_compute_workgroup_size_x, 1, 1);
+    }
+
+    encoder.copy_buffer_to_buffer(&ys_gpu, 0, &ys_host, 0, ys_host.size());
+    encoder.copy_buffer_to_buffer(&metadatas_gpu, 0, &metadatas_host, 0, metadatas_host.size());
+
+    queue.submit([encoder.finish()]);
+
+    ys_host.map_async(MapMode::Read, .., |r| r.unwrap());
+    metadatas_host.map_async(MapMode::Read, .., |r| r.unwrap());
+    device.poll(PollType::Wait).unwrap();
+
+    let ys = {
+        // Statically ensure it is aligned correctly
+        const _: () = {
+            assert!(align_of::<u32>() <= wgpu::MAP_ALIGNMENT as usize);
+        };
+        let ys_host_ptr = ys_host.get_mapped_range(..).as_ptr().cast::<u32>();
+        // Assert just in case
+        assert!(ys_host_ptr.is_aligned());
+
+        unsafe { slice::from_raw_parts(ys_host_ptr, num_matches) }.to_vec()
+    };
+    let metadatas = {
+        let metadatas_host_ptr = metadatas_host.get_mapped_range(..).as_ptr().cast::<u128>();
+        // Alignment seems to always be larger than `u128`, so to simplify code, just assert and
+        // move on
+        assert!(
+            metadatas_host_ptr.is_aligned(),
+            "Alignment wasn't sufficient"
+        );
+
+        unsafe { slice::from_raw_parts(metadatas_host_ptr, num_matches) }.to_vec()
+    };
+    ys_host.unmap();
+    metadatas_host.unmap();
+
+    Some((ys, metadatas))
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/num.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/num.rs
@@ -5,17 +5,14 @@ mod u64;
 #[cfg(not(target_arch = "spirv"))]
 pub(super) use crate::shader::num::native::U64;
 #[cfg(not(target_arch = "spirv"))]
-#[expect(unused_imports, reason = "Not using U128 yet")]
 pub(super) use crate::shader::num::native::U128;
 #[cfg(all(target_arch = "spirv", not(target_feature = "Int64")))]
 pub(super) use crate::shader::num::u32::U64;
 #[cfg(all(target_arch = "spirv", not(target_feature = "Int64")))]
 pub(super) use crate::shader::num::u32::U128;
 #[cfg(all(target_arch = "spirv", target_feature = "Int64"))]
-#[expect(unused_imports, reason = "Not using U128 yet")]
 pub(super) use crate::shader::num::u64::U64;
 #[cfg(all(target_arch = "spirv", target_feature = "Int64"))]
-#[expect(unused_imports, reason = "Not using U128 yet")]
 pub(super) use crate::shader::num::u64::U128;
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
@@ -84,7 +81,6 @@ pub(super) trait U128T:
     + Shr<u32>
     + ShrAssign<u32>
 {
-    #[expect(dead_code, reason = "Not used yet")]
     const ZERO: Self;
 
     #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
@@ -93,9 +89,7 @@ pub(super) trait U128T:
     #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
     fn from_be_bytes(bytes: [u8; 16]) -> Self;
 
-    #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
     fn as_be_bytes_to_le_u32_words(&self) -> [u32; 4];
 
-    #[cfg_attr(not(test), expect(dead_code, reason = "Not used yet"))]
     fn from_le_u32_words_as_be_bytes(words: &[u32; 4]) -> Self;
 }

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/num/u32.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/num/u32.rs
@@ -3,7 +3,6 @@ mod tests;
 
 use crate::shader::num::{U64T, U128T};
 use core::cmp::{Eq, PartialEq};
-use core::mem;
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Shl, ShlAssign,
     Shr, ShrAssign, Sub, SubAssign,
@@ -246,8 +245,16 @@ impl U128T for U128 {
 
     #[inline(always)]
     fn as_be_bytes_to_le_u32_words(&self) -> [u32; 4] {
-        // SAFETY: All bit patterns are valid, alignment is the same
-        let be_words = unsafe { mem::transmute::<&[U64; 2], &[u32; 4]>(&self.0) };
+        // TODO: `transmute()` doesn't work in `rust-gpu`, probably because of
+        //  https://github.com/Rust-GPU/rust-gpu/issues/241
+        // // SAFETY: All bit patterns are valid, alignment is the same
+        // let be_words = unsafe { mem::transmute::<&[U64; 2], &[u32; 4]>(&self.0) };
+        let be_words = [
+            self.0[0].0[0],
+            self.0[0].0[1],
+            self.0[1].0[0],
+            self.0[1].0[1],
+        ];
 
         [
             be_words[3].swap_bytes(),
@@ -266,8 +273,14 @@ impl U128T for U128 {
             words[0].swap_bytes(),
         ];
 
-        // SAFETY: All bit patterns are valid, alignment is the same
-        Self(unsafe { mem::transmute::<[u32; 4], [U64; 2]>(be_words) })
+        // TODO: `transmute()` doesn't work in `rust-gpu`, probably because of
+        //  https://github.com/Rust-GPU/rust-gpu/issues/241
+        // // SAFETY: All bit patterns are valid, alignment is the same
+        // Self(unsafe { mem::transmute::<[u32; 4], [U64; 2]>(be_words) })
+        Self([
+            U64([be_words[0], be_words[1]]),
+            U64([be_words[2], be_words[3]]),
+        ])
     }
 }
 

--- a/crates/shared/ab-blake3/Cargo.toml
+++ b/crates/shared/ab-blake3/Cargo.toml
@@ -20,8 +20,11 @@ all-features = true
 # TODO: Would be nice to have benchmarks here
 
 [dependencies]
-blake3 = { workspace = true }
 no-panic = { workspace = true, optional = true }
+
+# TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+blake3 = { workspace = true }
 
 [features]
 # Check that code can't panic under any conditions

--- a/crates/shared/ab-blake3/src/lib.rs
+++ b/crates/shared/ab-blake3/src/lib.rs
@@ -3,18 +3,29 @@
 #![no_std]
 #![feature(array_chunks)]
 
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 mod const_fn;
+#[cfg(not(target_arch = "spirv"))]
 mod platform;
 mod portable;
 mod single_block;
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 mod single_chunk;
 
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 pub use const_fn::{const_derive_key, const_hash, const_keyed_hash};
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 pub use platform::{le_bytes_from_words_32, words_from_le_bytes_32, words_from_le_bytes_64};
-pub use single_block::{
-    single_block_derive_key, single_block_hash, single_block_hash_portable_words,
-    single_block_keyed_hash,
-};
+pub use single_block::single_block_hash_portable_words;
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
+pub use single_block::{single_block_derive_key, single_block_hash, single_block_keyed_hash};
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 pub use single_chunk::{single_chunk_derive_key, single_chunk_hash, single_chunk_keyed_hash};
 
 /// The number of bytes in a hash
@@ -28,6 +39,7 @@ pub const BLOCK_LEN: usize = 64;
 ///
 /// You don't usually need to think about this number, but it often comes up in benchmarks, because
 /// the maximum degree of parallelism used by the implementation equals the number of chunks.
+#[cfg(not(target_arch = "spirv"))]
 const CHUNK_LEN: usize = 1024;
 
 // While iterating the compression function within a chunk, the CV is
@@ -36,8 +48,10 @@ const CHUNK_LEN: usize = 1024;
 // needs to hash both input bytes and parent nodes, so its better for its
 // output CVs to be represented as bytes.
 type CVWords = [u32; 8];
+#[cfg(not(target_arch = "spirv"))]
 type CVBytes = [u8; 32]; // little-endian
 
+#[cfg(not(target_arch = "spirv"))]
 type BlockBytes = [u8; BLOCK_LEN];
 type BlockWords = [u32; 16];
 
@@ -61,8 +75,12 @@ const MSG_SCHEDULE: [[usize; 16]; 7] = [
 // high and go down.
 const CHUNK_START: u8 = 1 << 0;
 const CHUNK_END: u8 = 1 << 1;
+#[cfg(not(target_arch = "spirv"))]
 const PARENT: u8 = 1 << 2;
 const ROOT: u8 = 1 << 3;
+#[cfg(not(target_arch = "spirv"))]
 const KEYED_HASH: u8 = 1 << 4;
+#[cfg(not(target_arch = "spirv"))]
 const DERIVE_KEY_CONTEXT: u8 = 1 << 5;
+#[cfg(not(target_arch = "spirv"))]
 const DERIVE_KEY_MATERIAL: u8 = 1 << 6;

--- a/crates/shared/ab-blake3/src/single_block.rs
+++ b/crates/shared/ab-blake3/src/single_block.rs
@@ -6,14 +6,18 @@
 #[cfg(test)]
 mod tests;
 
+#[cfg(not(target_arch = "spirv"))]
 use crate::platform::{le_bytes_from_words_32, words_from_le_bytes_32};
-use crate::{
-    BLOCK_LEN, BlockWords, CHUNK_END, CHUNK_START, CVWords, DERIVE_KEY_CONTEXT,
-    DERIVE_KEY_MATERIAL, IV, KEY_LEN, KEYED_HASH, OUT_LEN, ROOT, portable,
-};
+#[cfg(not(target_arch = "spirv"))]
+use crate::{BLOCK_LEN, DERIVE_KEY_CONTEXT, DERIVE_KEY_MATERIAL, KEY_LEN, KEYED_HASH, OUT_LEN};
+use crate::{BlockWords, CHUNK_END, CHUNK_START, CVWords, IV, ROOT, portable};
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 use blake3::platform::Platform;
 
 // Hash a single block worth of values
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 #[inline(always)]
 fn hash_block(input: &[u8], key: CVWords, flags: u8) -> Option<[u8; OUT_LEN]> {
     // If the whole subtree is one block, hash it directly with a ChunkState.
@@ -39,6 +43,8 @@ fn hash_block(input: &[u8], key: CVWords, flags: u8) -> Option<[u8; OUT_LEN]> {
 /// Hashing function for at most a single block worth of bytes.
 ///
 /// Returns `None` if input length exceeds one block.
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_block_hash(input: &[u8]) -> Option<[u8; OUT_LEN]> {
@@ -48,6 +54,8 @@ pub fn single_block_hash(input: &[u8]) -> Option<[u8; OUT_LEN]> {
 /// The keyed hash function for at most a single block worth of bytes.
 ///
 /// Returns `None` if input length exceeds one block.
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_block_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Option<[u8; OUT_LEN]> {
@@ -58,6 +66,8 @@ pub fn single_block_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Option<[u8;
 // The key derivation function for at most a single block worth of bytes.
 //
 // Returns `None` if either context or key material length exceed one block.
+// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
+#[cfg(not(target_arch = "spirv"))]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_block_derive_key(context: &str, key_material: &[u8]) -> Option<[u8; OUT_LEN]> {
@@ -85,7 +95,7 @@ pub fn single_block_derive_key(context: &str, key_material: &[u8]) -> Option<[u8
 pub fn single_block_hash_portable_words(input: &BlockWords, num_bytes: u32) -> CVWords {
     let mut cv = *IV;
 
-    portable::compress_in_place(
+    portable::compress_in_place_u32(
         &mut cv,
         input,
         num_bytes,

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
@@ -129,8 +129,8 @@ where
             .binary_search_by(|&y| y.first_k_bits::<K>().cmp(&first_k_challenge_bits))
             .unwrap_or_else(|insert| insert);
 
-        // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
-        // find the very first match in case there are multiple
+        // We only compare the first K bits above, which is why `binary_search_by` is not guaranteed
+        // to find the very first match in case there are multiple
         for index in (0..first_matching_element).rev() {
             if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
                 first_matching_element = index;
@@ -212,8 +212,8 @@ where
             .binary_search_by(|&y| y.first_k_bits::<K>().cmp(&first_k_challenge_bits))
             .unwrap_or_else(|insert| insert);
 
-        // We only compare first K bits above, which is why `binary_search_by` is not guaranteed to
-        // find the very first match in case there are multiple
+        // We only compare the first K bits above, which is why `binary_search_by` is not guaranteed
+        // to find the very first match in case there are multiple
         for index in (0..first_matching_element).rev() {
             if ys[index].first_k_bits::<K>() == first_k_challenge_bits {
                 first_matching_element = index;
@@ -276,8 +276,8 @@ where
                             [..(x_offset_in_bits % u8::BITS as usize + usize::from(K))
                                 .div_ceil(u8::BITS as usize)];
 
-                        // Bits of `x` already shifted to correct location as they will appear in
-                        // `proof`
+                        // Bits of `x` already shifted to the correct location as they will appear
+                        // in `proof`
                         let x_shifted = u32::from(x)
                             << (u32::BITS as usize
                                 - (usize::from(K) + x_offset_in_bits % u8::BITS as usize));


### PR DESCRIPTION
One more component necessary for plotting on GPU. A lot of workarounds and some upstream fixes were necessary to get to this point. There are still more bits and pieces missing, but this is a good progress.

Key things missing:
* sorting (might be possible to use a crate from crates.io)
* matching
* erasure coding
* combining it all into some usable public API

Any of those can _technically_ be done on CPU, but will be wildly inefficient due to excessive memory copies.