### PR TITLE
Faster balanced Merkle Tree construction

### DIFF
--- a/crates/shared/ab-blake3/src/single_block.rs
+++ b/crates/shared/ab-blake3/src/single_block.rs
@@ -66,6 +66,8 @@ fn hash_block_many_exact<const NUM_BLOCKS: usize>(
 
     // TODO: Can bigger chunk size be better here?
     for (inputs, outputs) in input_chunks.by_ref().zip(output_chunks.by_ref()) {
+        // TODO: This is a very awkward API, ideally we wouldn't have this array allocated inline
+        //  for no good reason
         platform.hash_many(
             &[
                 &inputs[0],
@@ -95,7 +97,6 @@ fn hash_block_many_exact<const NUM_BLOCKS: usize>(
         );
     }
 
-    // TODO: Add `NUM_BLOCKS % 16 != 0` check for better DCE?
     for (input, output) in input_chunks
         .remainder()
         .iter()
@@ -103,7 +104,7 @@ fn hash_block_many_exact<const NUM_BLOCKS: usize>(
     {
         let mut cv = key;
 
-        Platform::detect().compress_in_place(
+        platform.compress_in_place(
             &mut cv,
             input,
             BLOCK_LEN as u8,

--- a/crates/shared/ab-merkle-tree/src/lib.rs
+++ b/crates/shared/ab-merkle-tree/src/lib.rs
@@ -61,3 +61,14 @@ pub fn hash_pair_block(pair: &[u8; BLOCK_LEN]) -> [u8; OUT_LEN] {
     ab_blake3::single_block_keyed_hash(&INNER_NODE_DOMAIN_SEPARATOR, pair)
         .expect("Exactly one block worth of data; qed")
 }
+
+/// Similar to [`hash_pair_block()`] but supports processing multiple blocks at once
+#[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+pub fn hash_pair_blocks<const NUM_BLOCKS: usize>(
+    pairs: &[[u8; BLOCK_LEN]; NUM_BLOCKS],
+) -> [[u8; OUT_LEN]; NUM_BLOCKS] {
+    let mut hashes = [[0; OUT_LEN]; NUM_BLOCKS];
+    ab_blake3::single_block_keyed_hash_many_exact(&INNER_NODE_DOMAIN_SEPARATOR, pairs, &mut hashes);
+    hashes
+}


### PR DESCRIPTION
This is not the most widely used API, but it demonstrates the potential impact of BLAKE3 SIMD for Merkle Tree implementation.

This is based on https://github.com/nazar-pc/abundance/pull/344, which uses hidden/unofficial upstream APIs that are not the best suited for our purposes. Still, this substantially improves Merkle Tree construction already:
```
Before:
65536/balanced/new      time:   [3.9036 ms 3.9051 ms 3.9110 ms]
After the first commit:
65536/balanced/new      time:   [2.7289 ms 2.7753 ms 2.7870 ms]
After the second commit:
65536/balanced/new      time:   [550.77 µs 551.80 µs 552.05 µs]
```

So ~5x improvement already and I believe substantially more could still be gained by optimizing low-level `ab-blake3`.

Nothing else takes advantage of this improvement yet, but eventually more APIs should.