### PR TITLE
Initial prototype of `ab-client-database`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-client-database"
+version = "0.0.1"
+dependencies = [
+ "ab-aligned-buffer",
+ "ab-blake3",
+ "ab-client-api",
+ "ab-core-primitives",
+ "ab-io-type",
+ "ab-merkle-tree",
+ "async-lock",
+ "blake3",
+ "enum-map",
+ "futures",
+ "rand_core 0.9.3",
+ "rclite",
+ "replace_with",
+ "smallvec",
+ "strum",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "ab-client-proof-of-time"
 version = "0.0.1"
 dependencies = [
@@ -1476,6 +1499,26 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_filter"
@@ -3213,6 +3256,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ab-client-block-builder = { version = "0.0.1", path = "crates/node/ab-client-blo
 ab-client-block-import = { version = "0.0.1", path = "crates/node/ab-client-block-import" }
 ab-client-block-verification = { version = "0.0.1", path = "crates/node/ab-client-block-verification" }
 ab-client-consensus-common = { version = "0.0.1", path = "crates/node/ab-client-consensus-common" }
+ab-direct-io-file = { version = "0.0.1", path = "crates/shared/ab-direct-io-file" }
 ab-client-proof-of-time = { version = "0.0.1", path = "crates/node/ab-client-proof-of-time" }
 ab-contracts-common = { version = "0.0.1", path = "crates/contracts/core/ab-contracts-common" }
 ab-contracts-macros = { version = "0.0.1", path = "crates/contracts/core/ab-contracts-macros" }
@@ -64,6 +65,7 @@ derive_more = { version = "2.0.1", default-features = false }
 #  https://github.com/dalek-cryptography/curve25519-dalek/issues/626 is resolved
 # TODO: Switch to offical 4.0.4+ is released with https://github.com/ZcashFoundation/ed25519-zebra/pull/174
 ed25519-zebra = { version = "4.0.3", git = "https://github.com/ZcashFoundation/ed25519-zebra", rev = "dbb5610b818a6b54ebd347c27f8c8d3d6af89648", default-features = false }
+enum-map = "2.7.3"
 # TODO: Not using fs4 on purpose due to https://github.com/al8n/fs4-rs/issues/15
 fs2 = "0.4.3"
 futures = { version = "0.3.31", default-features = false, features = ["async-await"] }
@@ -93,10 +95,11 @@ seq-macro = "0.3.6"
 serde = { version = "1.0.219", default-features = false }
 serde-big-array = "0.5.1"
 sha2 = { version = "0.11.0-rc.0", default-features = false }
-smallvec = "1.15.1"
+smallvec = { version = "1.15.1", features = ["union"] }
 spin = "0.10.0"
 spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "3df836eb9d7b01344f52737bf9a310d1fb5a0c26" }
 stable_deref_trait = { version = "1.2.0", default-features = false }
+strum = { version = "0.27.2", default-features = false, features = ["derive"] }
 syn = "2.0.104"
 tempfile = "3.20.0"
 thiserror = { version = "2.0.12", default-features = false }

--- a/crates/node/ab-client-database/Cargo.toml
+++ b/crates/node/ab-client-database/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "ab-client-database"
+description = "Client database"
+license = "0BSD"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+ab-aligned-buffer = { workspace = true }
+ab-blake3 = { workspace = true }
+ab-client-api = { workspace = true }
+ab-core-primitives = { workspace = true, features = ["alloc"] }
+ab-io-type = { workspace = true }
+ab-merkle-tree = { workspace = true }
+async-lock = { workspace = true, features = ["std"] }
+blake3 = { workspace = true }
+enum-map = { workspace = true }
+futures = { workspace = true, features = ["alloc"] }
+rand_core = { workspace = true, features = ["os_rng", "std"] }
+rclite = { workspace = true }
+replace_with = { workspace = true }
+smallvec = { workspace = true, features = ["drain_filter"] }
+strum = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/node/ab-client-database/src/lib.rs
+++ b/crates/node/ab-client-database/src/lib.rs
@@ -1,0 +1,1735 @@
+//! Client database.
+//!
+//! ## High-level architecture overview
+//!
+//! The database operates on [`ClientDatabaseStorageBackend`], which is backed by [`AlignedPage`]s
+//! that can be read or written. Pages contain `StorageItem`s, one storage item can occupy one or
+//! more pages, but pages always belong to a single storage item. Pages are the smallest unit and
+//! align nicely with the hardware architecture of modern SSDs. Each page starts with a prefix that
+//! describes the contents of the page. `StorageItem` always starts at the multiple of the
+//! `u128`/16 bytes, allowing for direct memory mapping onto target data structures.
+//!
+//! Individual pages are grouped into page groups (configurable via [`ClientDatabaseOptions`]). Page
+//! groups can be permanent and ephemeral. Permanent page groups store information that is never
+//! going to be deleted, like segment headers. Ephemeral page groups store the majority of the
+//! information about blocks, blockchain state and other things that are being created all the time.
+//! Once information in an ephemeral page group is too old and no longer needed, it can be
+//! repurposed for a new permanent or ephemeral page group. There are different kinds of page groups
+//! defined in `PageGroupKind`, and each variant has independent sequence numbers.
+//!
+//! Page groups are append-only, there is only one active permanent and one ephemeral page group.
+//! They are appended with more pages containing storage items until there is no space to add a
+//! complete storage item, after which the next page group is started.
+//!
+//! Ephemeral page groups can be freed only when they contain 100% outdated storage items.
+//! Individual pages can't be freed.
+//!
+//! Each storage item has a sequence number and checksums that help to define the global ordering
+//! and check whether a storage item was written fully. Upon restart, the page group containing the
+//! latest storage items is found, and the latest fully written storage item is identified to
+//! reconstruct the database state.
+//!
+//! Each page group starts with a `StorageItemKind::PageGroupHeader` storage item for easier
+//! identification.
+//!
+//! The database is typically contained in a single file (though in principle could be contained in
+//! multiple if necessary). Before the database can be used, it needs to be formatted with a
+//! specific size (it is possible to increase the size afterward) before it can be used. It is
+//! expected (but depends on the storage backend) that the whole file size is pre-allocated on disk
+//! and no writes will fail due to lack of disk space (which could be the case with a sparse file).
+
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+// TODO: This feature is not actually used in this crate, but is added as a workaround for
+//  https://github.com/rust-lang/rust/issues/141492
+#![feature(generic_const_exprs)]
+#![feature(
+    iter_collect_into,
+    maybe_uninit_as_bytes,
+    maybe_uninit_fill,
+    maybe_uninit_write_slice,
+    try_blocks
+)]
+
+pub mod storage_backend;
+mod storage_backend_adapter;
+mod storage_item;
+
+use crate::storage_backend::{AlignedPage, ClientDatabaseStorageBackend};
+use crate::storage_backend_adapter::{
+    PageGroup, PageGroups, StorageBackendAdapter, WriteBufferEntry, WriteLocation,
+};
+use crate::storage_item::block::StorageItemBlock;
+use crate::storage_item::page_group_header::StorageItemPageGroupHeader;
+use crate::storage_item::{StorageItem, StorageItemKind};
+use ab_client_api::{BlockMerkleMountainRange, ChainInfo, ChainInfoWrite, PersistBlockError};
+use ab_core_primitives::block::body::owned::GenericOwnedBlockBody;
+use ab_core_primitives::block::header::GenericBlockHeader;
+use ab_core_primitives::block::header::owned::GenericOwnedBlockHeader;
+use ab_core_primitives::block::owned::GenericOwnedBlock;
+use ab_core_primitives::block::{BlockNumber, BlockRoot};
+use ab_io_type::trivial_type::TrivialType;
+use async_lock::{
+    Mutex as AsyncMutex, RwLock as AsyncRwLock, RwLockUpgradableReadGuard,
+    RwLockWriteGuard as AsyncRwLockWriteGuard,
+};
+use enum_map::enum_map;
+use rand_core::{OsError, OsRng, TryRngCore};
+use rclite::Arc;
+use replace_with::replace_with_or_abort;
+use smallvec::{SmallVec, smallvec};
+use std::cmp::Reverse;
+use std::collections::{HashMap, VecDeque};
+use std::hash::{BuildHasherDefault, Hasher};
+use std::num::NonZeroUsize;
+use std::ops::Deref;
+use std::{fmt, io};
+use strum::FromRepr;
+use tracing::{Instrument, debug, error, info_span};
+
+/// Unique identifier for a database
+#[derive(Debug, Copy, Clone, Eq, PartialEq, TrivialType)]
+#[repr(C)]
+pub struct DatabaseId([u8; 32]);
+
+impl Deref for DatabaseId {
+    type Target = [u8; 32];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for DatabaseId {
+    #[inline(always)]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl DatabaseId {
+    #[inline(always)]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+#[derive(Debug, Copy, Clone, TrivialType, enum_map::Enum, FromRepr)]
+#[repr(u8)]
+enum PageGroupKind {
+    /// These pages are stored permanently and are never removed
+    Permanent = 0,
+    /// These pages are related to blocks and expire over time as blocks become buried deeper in
+    /// blockchain history
+    Block = 1,
+}
+
+#[derive(Default)]
+struct BlockRootHasher(u64);
+
+impl Hasher for BlockRootHasher {
+    #[inline(always)]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline(always)]
+    fn write(&mut self, bytes: &[u8]) {
+        let Some(state) = bytes.as_chunks().0.first().copied().map(u64::from_le_bytes) else {
+            return;
+        };
+
+        self.0 = state;
+    }
+}
+
+/// Options for [`ClientDatabase`]
+#[derive(Debug, Copy, Clone)]
+pub struct ClientDatabaseOptions {
+    /// Write buffer size.
+    ///
+    /// Larger buffer allows buffering more async writes for improved responsiveness but requires
+    /// more RAM. Zero buffer size means all writes must be completed before returning from the
+    /// operation that triggered it. Non-zero buffer means writes can happen in the background.
+    ///
+    /// The recommended value is 5.
+    pub write_buffer_size: usize,
+    /// Blocks at this depth are considered to be "confirmed" and irreversible from the consensus
+    /// perspective.
+    ///
+    /// This parameter allows establishing a final canonical order of blocks and eliminating any
+    /// potential forks at a specified depth and beyond.
+    pub confirmation_depth_k: BlockNumber,
+    /// Soft confirmation depth for blocks.
+    ///
+    /// Doesn't prevent forking on the consensus level but makes it extremely unlikely.
+    ///
+    /// This parameter determines how many blocks are retained in memory before being written to
+    /// disk. Writing discarded blocks to disk is a waste of resources, so they are retained in
+    /// memory before being soft-confirmed and written to disk for longer-term storage.
+    ///
+    /// A smaller number reduces memory usage while increasing the probability of unnecessary disk
+    /// writes. A larger number increases memory usage, while avoiding unnecessary disk writes, but
+    /// also increases the chance of recent blocks not being retained on disk in case of a crash.
+    ///
+    /// The recommended value is 3 blocks.
+    pub soft_confirmation_depth: BlockNumber,
+    /// Defines how many fork tips should be maintained in total.
+    ///
+    /// As natural forks occur, there may be more than one tip in existence, with only one of them
+    /// being considered "canonical". This parameter defines how many of these tips to maintain in a
+    /// sort of LRU style cache. Tips beyond this limit that were not extended for a long time will
+    /// be pruned automatically.
+    ///
+    /// A larger number results in higher memory usage and higher complexity of pruning algorithms.
+    ///
+    /// The recommended value is 3 blocks.
+    pub max_fork_tips: NonZeroUsize,
+    /// Max distance between fork tip and the best block.
+    ///
+    /// When forks are this deep, they will be pruned, even without reaching the `max_fork_tips`
+    /// limit. This essentially means the tip was not extended for some time, and while it is
+    /// theoretically possible for the chain to continue from this tip, the probability is so small
+    /// that it is not worth storing it.
+    ///
+    /// A larger value results in higher memory usage and higher complexity of pruning algorithms.
+    ///
+    /// The recommended value is 5 blocks.
+    pub max_fork_tip_distance: BlockNumber,
+}
+
+/// Options for [`ClientDatabase`]
+#[derive(Debug, Copy, Clone)]
+pub struct ClientDatabaseFormatOptions {
+    /// The number of [`AlignedPage`]s in a single page group.
+    ///
+    /// Each group always has a set of storage items with monotonically increasing sequence numbers.
+    /// The database only frees page groups for reuse when all storage items there are no longer in
+    /// use.
+    ///
+    /// A smaller number means storage can be reclaimed for reuse more quickly and higher
+    /// concurrency during restart, but must not be too small that no storage item fits within a
+    /// page group anymore. A larger number allows finding the range of sequence numbers that are
+    /// already used and where potential write interruption happened on restart more efficiently,
+    /// but will use more RAM in the process.
+    ///
+    /// The recommended size is 256 MiB unless a tiny database is used for testing purposes, where
+    /// a smaller value might work too.
+    pub page_group_size: u32,
+    /// By default, formatting will be aborted if the database appears to be already formatted.
+    ///
+    /// Setting this option to `true` skips the check and formats the database anyway.
+    pub force: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientDatabaseError {
+    /// Invalid soft confirmation depth, it must be smaller than confirmation depth k
+    #[error("Invalid soft confirmation depth, it must be smaller than confirmation depth k")]
+    InvalidSoftConfirmationDepth,
+    /// Invalid max fork tip distance, it must be smaller or equal to confirmation depth k
+    #[error("Invalid max fork tip distance, it must be smaller or equal to confirmation depth k")]
+    InvalidMaxForkTipDistance,
+    /// Storage backend has canceled read request
+    #[error("Storage backend has canceled read request")]
+    ReadRequestCancelled,
+    /// Storage backend read error
+    #[error("Storage backend read error: {error}")]
+    ReadError {
+        /// Low-level error
+        error: io::Error,
+    },
+    /// Unsupported database version
+    #[error("Unsupported database version: {database_version}")]
+    UnsupportedDatabaseVersion {
+        /// Database version
+        database_version: u8,
+    },
+    /// Page group size is too small, must be at least two pages
+    #[error("Page group size is too small ({page_group_size}), must be at least two pages")]
+    PageGroupSizeTooSmall {
+        /// Page group size in pages
+        page_group_size: u32,
+    },
+    /// Unexpected first storage item
+    #[error("Unexpected first storage item at offset {page_offset}: {storage_item:?}")]
+    UnexpectedFirstStorageItem {
+        /// First storage item
+        storage_item: Box<dyn fmt::Debug + Send + Sync>,
+        /// Page offset where storage item is found
+        page_offset: u32,
+    },
+    /// Unexpected sequence number
+    #[error(
+        "Unexpected sequence number {actual} at page offset {page_offset} (expected \
+        {expected})"
+    )]
+    UnexpectedSequenceNumber {
+        /// Sequence number in the database
+        actual: u64,
+        /// Expected sequence number
+        expected: u64,
+        /// Page offset where storage item is found
+        page_offset: u32,
+    },
+    /// Unexpected permanent storage item
+    #[error("Unexpected permanent storage item at offset {page_offset}: {storage_item:?}")]
+    UnexpectedPermanentStorageItem {
+        /// First storage item
+        storage_item: Box<dyn fmt::Debug + Send + Sync>,
+        /// Page offset where storage item is found
+        page_offset: u32,
+    },
+    /// Unexpected block storage item
+    #[error("Unexpected block storage item at offset {page_offset}: {storage_item:?}")]
+    UnexpectedBlockStorageItem {
+        /// First storage item
+        storage_item: Box<dyn fmt::Debug + Send + Sync>,
+        /// Page offset where storage item is found
+        page_offset: u32,
+    },
+    /// Invalid block
+    #[error("Invalid block at offset {page_offset}")]
+    InvalidBlock {
+        /// Page offset where storage item is found
+        page_offset: u32,
+    },
+    /// Failed to adjust ancestor block forks
+    #[error("Failed to adjust ancestor block forks")]
+    FailedToAdjustAncestorBlockForks,
+    /// Database is not formatted yet
+    #[error("Database is not formatted yet")]
+    Unformatted,
+    /// Non-permanent first page group
+    #[error("Non-permanent first page group")]
+    NonPermanentFirstPageGroup,
+}
+
+/// Error for [`ClientDatabase::format()`]
+#[derive(Debug, thiserror::Error)]
+pub enum ClientDatabaseFormatError {
+    /// Storage backend has canceled read request
+    #[error("Storage backend has canceled read request")]
+    ReadRequestCancelled,
+    /// Storage backend read error
+    #[error("Storage backend read error: {error}")]
+    ReadError {
+        /// Low-level error
+        error: io::Error,
+    },
+    /// Failed to generate database id
+    #[error("Failed to generate database id")]
+    FailedToGenerateDatabaseId {
+        /// Low-level error
+        #[from]
+        error: OsError,
+    },
+    /// Database is already formatted yet
+    #[error("Database is already formatted yet")]
+    AlreadyFormatted,
+    /// Storage backend has canceled a writing request
+    #[error("Storage backend has canceled a writing request")]
+    WriteRequestCancelled,
+    /// Storage item write error
+    #[error("Storage item write error")]
+    StorageItemWriteError {
+        /// Low-level error
+        #[from]
+        error: io::Error,
+    },
+}
+
+#[derive(Debug, Copy, Clone)]
+struct ForkTip {
+    number: BlockNumber,
+    root: BlockRoot,
+}
+
+/// Opaque parent header data structure that ensures the parent block is not removed too early
+#[derive(Debug)]
+struct OpaqueParentHeader<Header> {
+    /// Optional parent header, empty for parent of the genesis block or for the first block that
+    /// was read from persistent storage.
+    ///
+    /// NOTE: this field is not supposed to be accessed, it is only here to maintain the reference
+    /// count of the parent header.
+    _header: Option<Header>,
+}
+
+impl<Header> Default for OpaqueParentHeader<Header> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self { _header: None }
+    }
+}
+
+impl<Header> OpaqueParentHeader<Header> {
+    #[inline(always)]
+    fn new(header: Header) -> Self {
+        Self {
+            _header: Some(header),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ClientDatabaseBlockInMemory<Block>
+where
+    Block: GenericOwnedBlock,
+{
+    block: Block,
+    parent_header: OpaqueParentHeader<Block::Header>,
+    mmr_with_block: Arc<BlockMerkleMountainRange>,
+}
+
+/// Client database block contains details about the block state in the database.
+///
+/// Originally all blocks are stored in memory. Once a block is soft-confirmed (see
+/// [`ClientDatabaseOptions::soft_confirmation_depth`]), it is persisted (likely on disk). Later
+///  when it is "confirmed" fully (see [`ClientDatabaseOptions::soft_confirmation_depth`]), it becomes
+/// irreversible.
+#[derive(Debug)]
+enum ClientDatabaseBlock<Block>
+where
+    Block: GenericOwnedBlock,
+{
+    /// Block is stored in memory and wasn't persisted yet
+    InMemory(ClientDatabaseBlockInMemory<Block>),
+    /// Block was persisted (likely on disk)
+    Persisted {
+        header: Block::Header,
+        parent_header: OpaqueParentHeader<Block::Header>,
+        mmr_with_block: Arc<BlockMerkleMountainRange>,
+        write_location: WriteLocation,
+    },
+    /// Block was persisted (likely on disk) and is irreversibly "confirmed" from the consensus
+    /// perspective
+    PersistedConfirmed {
+        header: Block::Header,
+        _parent_header: OpaqueParentHeader<Block::Header>,
+        #[expect(dead_code, reason = "Not used yet")]
+        write_location: WriteLocation,
+    },
+}
+
+impl<Block> ClientDatabaseBlock<Block>
+where
+    Block: GenericOwnedBlock,
+{
+    #[inline(always)]
+    fn header(&self) -> &Block::Header {
+        match self {
+            Self::InMemory(in_memory) => in_memory.block.header(),
+            Self::Persisted { header, .. } => header,
+            Self::PersistedConfirmed { header, .. } => header,
+        }
+    }
+
+    #[inline(always)]
+    fn mmr_with_block(&self) -> Option<&Arc<BlockMerkleMountainRange>> {
+        match self {
+            Self::InMemory(in_memory) => Some(&in_memory.mmr_with_block),
+            Self::Persisted { mmr_with_block, .. } => Some(mmr_with_block),
+            Self::PersistedConfirmed { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct State<Block>
+where
+    Block: GenericOwnedBlock,
+{
+    /// Tips of forks that have no descendants.
+    ///
+    /// The current best block is at the front, the rest are in the order from most recently updated
+    /// towards the front to least recently at the back.
+    fork_tips: VecDeque<ForkTip>,
+    /// Map from block root to block number.
+    ///
+    /// Is meant to be used in conjunction with `headers` and `blocks` fields, which are indexed by
+    /// block numbers.
+    block_roots: HashMap<BlockRoot, BlockNumber, BuildHasherDefault<BlockRootHasher>>,
+    /// List of blocks with the newest at the front.
+    ///
+    /// The first element of the first entry corresponds to the best block.
+    ///
+    /// It is expected that in most block numbers there will be exactly one block, some two,
+    /// anything more than that will be very rare. The list of forks for a block number is organized
+    /// in such a way that the first entry at every block number corresponds to the canonical
+    /// version of the blockchain at any point in time.
+    ///
+    /// A position withing this data structure is called "block offset". This is an ephemeral value
+    /// and changes as new best blocks are added. Blocks at the same height are collectively called
+    /// "block forks" and the position of the block within the same block height is called
+    /// "fork offset". While fork offset `0` always corresponds to the canonical version of the
+    /// blockchain, other offsets are not guaranteed to follow any particular ordering rules.
+    blocks: VecDeque<SmallVec<[ClientDatabaseBlock<Block>; 2]>>,
+}
+
+impl<Block> State<Block>
+where
+    Block: GenericOwnedBlock,
+{
+    #[inline(always)]
+    fn best_tip(&self) -> &ForkTip {
+        self.fork_tips
+            .front()
+            .expect("The best block is always present; qed")
+    }
+
+    #[inline(always)]
+    fn best_header(&self) -> &Block::Header {
+        self.blocks
+            .front()
+            .expect("The best block is always present; qed")
+            .first()
+            .expect("The best block is always present; qed")
+            .header()
+    }
+}
+
+#[derive(Debug)]
+struct BlockToPersist<'a, Block>
+where
+    Block: GenericOwnedBlock,
+{
+    block_offset: usize,
+    fork_offset: usize,
+    block: &'a ClientDatabaseBlockInMemory<Block>,
+}
+
+#[derive(Debug)]
+struct PersistedBlock {
+    block_offset: usize,
+    fork_offset: usize,
+    write_location: WriteLocation,
+}
+
+#[derive(Debug)]
+struct Inner<Block, StorageBackend>
+where
+    Block: GenericOwnedBlock,
+{
+    state: AsyncRwLock<State<Block>>,
+    storage_backend_adapter: AsyncMutex<StorageBackendAdapter>,
+    storage_backend: StorageBackend,
+    options: ClientDatabaseOptions,
+}
+
+/// Client database
+#[derive(Debug)]
+pub struct ClientDatabase<Block, StorageBackend>
+where
+    Block: GenericOwnedBlock,
+{
+    inner: Arc<Inner<Block, StorageBackend>>,
+}
+
+impl<Block, StorageBackend> Clone for ClientDatabase<Block, StorageBackend>
+where
+    Block: GenericOwnedBlock,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<Block, StorageBackend> Drop for ClientDatabase<Block, StorageBackend>
+where
+    Block: GenericOwnedBlock,
+{
+    fn drop(&mut self) {
+        // TODO: Persist things that were not persisted yet to reduce the data loss on shutdown
+    }
+}
+
+impl<Block, StorageBackend> ChainInfo<Block> for ClientDatabase<Block, StorageBackend>
+where
+    Block: GenericOwnedBlock,
+    StorageBackend: ClientDatabaseStorageBackend,
+{
+    fn best_root(&self) -> BlockRoot {
+        // Blocking read lock is fine because the only place where write lock is taken is short and
+        // all other locks are read locks
+        self.inner.state.read_blocking().best_tip().root
+    }
+
+    fn best_header(&self) -> Block::Header {
+        // Blocking read lock is fine because the only place where write lock is taken is short and
+        // all other locks are read locks
+        self.inner.state.read_blocking().best_header().clone()
+    }
+
+    fn ancestor_header(
+        &self,
+        ancestor_block_number: BlockNumber,
+        descendant_block_root: &BlockRoot,
+    ) -> Option<Block::Header> {
+        // Blocking read lock is fine because the only place where write lock is taken is short and
+        // all other locks are read locks
+        let state = self.inner.state.read_blocking();
+        let best_number = state.best_tip().number;
+
+        let ancestor_block_offset =
+            best_number.checked_sub(ancestor_block_number)?.as_u64() as usize;
+        let ancestor_block_candidates = state.blocks.get(ancestor_block_offset)?;
+
+        let descendant_block_number = *state.block_roots.get(descendant_block_root)?;
+        if ancestor_block_number >= descendant_block_number {
+            return None;
+        }
+        let descendant_block_offset =
+            best_number.checked_sub(descendant_block_number)?.as_u64() as usize;
+
+        // Range of blocks where the first item is expected to contain a descendant
+        let mut blocks_range_iter = state
+            .blocks
+            .iter()
+            .enumerate()
+            .skip(descendant_block_offset);
+
+        let (_offset, descendant_block_candidates) = blocks_range_iter.next()?;
+        let descendant_header = descendant_block_candidates
+            .iter()
+            .find(|block| &*block.header().header().root() == descendant_block_root)?
+            .header()
+            .header();
+
+        // If there are no forks at this level, then this is the canonical chain and ancestor
+        // block number we're looking for is the first block at the corresponding block number.
+        // Similarly, if there is just a single ancestor candidate and descendant exists, it must be
+        // the one we care about.
+        if descendant_block_candidates.len() == 1 || ancestor_block_candidates.len() == 1 {
+            return ancestor_block_candidates
+                .iter()
+                .next()
+                .map(|block| block.header().clone());
+        }
+
+        let mut parent_block_root = &descendant_header.prefix.parent_root;
+
+        // Iterate over the blocks following descendant until ancestor is reached
+        for (block_offset, parent_candidates) in blocks_range_iter {
+            let parent_header = parent_candidates
+                .iter()
+                .find(|header| &*header.header().header().root() == parent_block_root)?
+                .header();
+
+            // When header offset matches, we found the header
+            if block_offset == ancestor_block_offset {
+                return Some(parent_header.clone());
+            }
+
+            parent_block_root = &parent_header.header().prefix.parent_root;
+        }
+
+        None
+    }
+
+    fn header(&self, block_root: &BlockRoot) -> Option<Block::Header> {
+        // Blocking read lock is fine because the only place where write lock is taken is short and
+        // all other locks are read locks
+        let state = self.inner.state.read_blocking();
+        let best_number = state.best_tip().number;
+
+        let block_number = *state.block_roots.get(block_root)?;
+        let block_offset = best_number.checked_sub(block_number)?.as_u64() as usize;
+        let block_candidates = state.blocks.get(block_offset)?;
+
+        block_candidates.iter().find_map(|block| {
+            let header = block.header();
+
+            if &*header.header().root() == block_root {
+                Some(header.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    fn mmr_with_block(&self, block_root: &BlockRoot) -> Option<Arc<BlockMerkleMountainRange>> {
+        // Blocking read lock is fine because the only place where write lock is taken is short and
+        // all other locks are read locks
+        let state = self.inner.state.read_blocking();
+        let best_number = state.best_tip().number;
+
+        let block_number = *state.block_roots.get(block_root)?;
+        let block_offset = best_number.checked_sub(block_number)?.as_u64() as usize;
+        let block_candidates = state.blocks.get(block_offset)?;
+
+        block_candidates.iter().find_map(|block| {
+            let header = block.header();
+
+            if &*header.header().root() == block_root {
+                block.mmr_with_block().cloned()
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl<Block, StorageBackend> ChainInfoWrite<Block> for ClientDatabase<Block, StorageBackend>
+where
+    Block: GenericOwnedBlock,
+    StorageBackend: ClientDatabaseStorageBackend,
+{
+    async fn persist_block(
+        &self,
+        block: Block,
+        mmr_with_block: Arc<BlockMerkleMountainRange>,
+    ) -> Result<(), PersistBlockError> {
+        let mut state = self.inner.state.write().await;
+        let best_number = state.best_tip().number;
+
+        let header = block.header().header();
+
+        let block_number = header.prefix.number;
+        let parent_block_number = block_number
+            .checked_sub(BlockNumber::ONE)
+            .ok_or(PersistBlockError::MissingParent)?;
+
+        let parent_block_offset = best_number
+            .checked_sub(parent_block_number)
+            .ok_or(PersistBlockError::MissingParent)?
+            .as_u64() as usize;
+        let parent_header = OpaqueParentHeader::new(
+            state
+                .blocks
+                .get_mut(parent_block_offset)
+                .and_then(|fork_headers| {
+                    fork_headers.iter().find_map(|fork_header| {
+                        let fork_header = fork_header.header();
+                        if *fork_header.header().root() == header.prefix.parent_root {
+                            Some(fork_header.clone())
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .ok_or(PersistBlockError::MissingParent)?,
+        );
+
+        if block_number == best_number + BlockNumber::ONE {
+            return Self::insert_new_best_block(
+                state,
+                &self.inner,
+                block,
+                parent_header,
+                mmr_with_block,
+            )
+            .await;
+        }
+
+        let block_offset = best_number
+            .checked_sub(block_number)
+            .ok_or(PersistBlockError::MissingParent)?
+            .as_u64() as usize;
+
+        if block_offset >= self.inner.options.confirmation_depth_k.as_u64() as usize {
+            return Err(PersistBlockError::OutsideAcceptableRange);
+        }
+
+        let state = &mut *state;
+
+        let block_forks = state.blocks.get_mut(block_offset).ok_or_else(|| {
+            error!(
+                %block_number,
+                %block_offset,
+                "Failed to store block fork, header offset is missing despite being within \
+                acceptable range"
+            );
+
+            PersistBlockError::OutsideAcceptableRange
+        })?;
+
+        for (index, fork_tip) in state.fork_tips.iter_mut().enumerate() {
+            // Block's parent is no longer a fork tip, remove it
+            if fork_tip.root == header.prefix.parent_root {
+                state.fork_tips.remove(index);
+                break;
+            }
+        }
+
+        let block_root = *header.root();
+        // Insert at position 1, which means the most recent tip, which doesn't correspond to
+        // the best block
+        state.fork_tips.insert(
+            1,
+            ForkTip {
+                number: block_number,
+                root: block_root,
+            },
+        );
+        state.block_roots.insert(block_root, block_number);
+        block_forks.push(ClientDatabaseBlock::InMemory(ClientDatabaseBlockInMemory {
+            block,
+            parent_header,
+            mmr_with_block,
+        }));
+
+        Self::prune_outdated_fork_tips(block_number, state, &self.inner.options);
+
+        Ok(())
+    }
+}
+
+impl<Block, StorageBackend> ClientDatabase<Block, StorageBackend>
+where
+    Block: GenericOwnedBlock,
+    StorageBackend: ClientDatabaseStorageBackend,
+{
+    /// Current database version
+    const VERSION: u8 = 0;
+
+    /// Open the existing database.
+    ///
+    /// NOTE: The database needs to be formatted with [`Self::format()`] before it can be used.
+    pub async fn open(
+        genesis_block: Block,
+        options: ClientDatabaseOptions,
+        storage_backend: StorageBackend,
+    ) -> Result<Self, ClientDatabaseError> {
+        if options.soft_confirmation_depth >= options.confirmation_depth_k {
+            return Err(ClientDatabaseError::InvalidSoftConfirmationDepth);
+        }
+
+        if options.max_fork_tip_distance > options.confirmation_depth_k {
+            return Err(ClientDatabaseError::InvalidMaxForkTipDistance);
+        }
+
+        let database_id;
+        let database_version;
+        let page_group_size;
+        let num_page_groups;
+
+        let mut page_groups = enum_map! {
+            PageGroupKind::Permanent => PageGroups {
+                next_sequence_number: 0,
+                list: VecDeque::new(),
+            },
+            PageGroupKind::Block => PageGroups {
+                next_sequence_number: 0,
+                list: VecDeque::new(),
+            },
+        };
+        let mut free_page_groups = VecDeque::new();
+
+        let mut buffer = Vec::new();
+
+        // Check the first page group. This could have been done in the loop below, but that makes
+        // the code even more ugly than this copy-paste.
+        {
+            buffer = storage_backend
+                .read(buffer, 1, 0)
+                .await
+                .map_err(|_error| ClientDatabaseError::ReadRequestCancelled)?
+                .map_err(|error| ClientDatabaseError::ReadError { error })?;
+
+            let storage_item = match StorageItem::read_from_pages(&buffer) {
+                Ok(storage_item) => storage_item,
+                Err(_error) => {
+                    // Page group header fit the first page, so any deciding error indicates it is
+                    // not a valid page group header
+                    return Err(ClientDatabaseError::Unformatted);
+                }
+            };
+
+            let page_group_header = match storage_item.storage_item_kind {
+                StorageItemKind::PageGroupHeader(page_group_header) => {
+                    if page_group_header.database_version != Self::VERSION {
+                        return Err(ClientDatabaseError::UnsupportedDatabaseVersion {
+                            database_version: page_group_header.database_version,
+                        });
+                    }
+
+                    database_id = page_group_header.database_id;
+                    database_version = page_group_header.database_version;
+                    page_group_size = page_group_header.page_group_size;
+                    if page_group_size < 2 {
+                        return Err(ClientDatabaseError::PageGroupSizeTooSmall { page_group_size });
+                    }
+                    num_page_groups = storage_backend.num_pages() / page_group_size;
+
+                    page_group_header
+                }
+                StorageItemKind::Block(_) => {
+                    return Err(ClientDatabaseError::UnexpectedFirstStorageItem {
+                        storage_item: Box::new(storage_item),
+                        page_offset: 0,
+                    });
+                }
+            };
+
+            match page_group_header.page_group_kind {
+                PageGroupKind::Permanent => {
+                    page_groups[PageGroupKind::Permanent]
+                        .list
+                        .push_front(PageGroup {
+                            first_sequence_number: storage_item.sequence_number,
+                            inner_next_page_offset: storage_item.num_pages(),
+                            first_page_offset: 0,
+                        });
+                }
+                PageGroupKind::Block => {
+                    return Err(ClientDatabaseError::NonPermanentFirstPageGroup);
+                }
+            }
+        }
+
+        // Quick scan through the rest of page groups
+        for page_group_index in 1..num_page_groups {
+            let first_page_offset = page_group_index * page_group_size;
+            buffer.clear();
+            buffer = storage_backend
+                .read(buffer, 1, first_page_offset)
+                .await
+                .map_err(|_error| ClientDatabaseError::ReadRequestCancelled)?
+                .map_err(|error| ClientDatabaseError::ReadError { error })?;
+
+            let storage_item = match StorageItem::read_from_pages(&buffer) {
+                Ok(storage_item) => storage_item,
+                Err(_error) => {
+                    free_page_groups.push_back(first_page_offset);
+                    continue;
+                }
+            };
+
+            let page_group_header = match storage_item.storage_item_kind {
+                StorageItemKind::PageGroupHeader(page_group_header) => {
+                    if !(page_group_header.database_id == database_id
+                        && page_group_header.database_version == database_version
+                        && page_group_header.page_group_size == page_group_size)
+                    {
+                        free_page_groups.push_back(first_page_offset);
+                        continue;
+                    }
+
+                    page_group_header
+                }
+                StorageItemKind::Block(_) => {
+                    return Err(ClientDatabaseError::UnexpectedFirstStorageItem {
+                        storage_item: Box::new(storage_item),
+                        page_offset: first_page_offset,
+                    });
+                }
+            };
+
+            let page_group = PageGroup {
+                first_sequence_number: storage_item.sequence_number,
+                inner_next_page_offset: storage_item.num_pages(),
+                first_page_offset,
+            };
+            page_groups[page_group_header.page_group_kind]
+                .list
+                .push_front(page_group);
+        }
+
+        // Sort page groups into the correct order of first sequence numbers
+        for entry in page_groups.values_mut() {
+            entry
+                .list
+                .make_contiguous()
+                .sort_by_key(|page_group| Reverse(page_group.first_sequence_number));
+        }
+
+        let mut state = State {
+            fork_tips: VecDeque::new(),
+            block_roots: HashMap::default(),
+            blocks: VecDeque::new(),
+        };
+
+        // Read all permanent storage groups
+        buffer = Self::read_page_groups(
+            &mut page_groups[PageGroupKind::Permanent],
+            page_group_size,
+            &storage_backend,
+            buffer,
+            |storage_item, page_offset| match storage_item.storage_item_kind {
+                StorageItemKind::PageGroupHeader(_) | StorageItemKind::Block(_) => {
+                    Err(ClientDatabaseError::UnexpectedPermanentStorageItem {
+                        storage_item: Box::new(storage_item),
+                        page_offset,
+                    })
+                }
+            },
+        )
+        .instrument(info_span!("", page_group_kind = ?PageGroupKind::Permanent))
+        .await?;
+
+        // Read all block storage groups
+        let _ = Self::read_page_groups(
+            &mut page_groups[PageGroupKind::Block],
+            page_group_size,
+            &storage_backend,
+            buffer,
+            |storage_item, page_offset| {
+                let storage_item_block = match storage_item.storage_item_kind {
+                    StorageItemKind::PageGroupHeader(_) => {
+                        return Err(ClientDatabaseError::UnexpectedBlockStorageItem {
+                            storage_item: Box::new(storage_item),
+                            page_offset,
+                        });
+                    }
+                    StorageItemKind::Block(storage_item_block) => storage_item_block,
+                };
+
+                // TODO: It would be nice to not allocate body here since we'll not use it here
+                //  anyway
+                let StorageItemBlock {
+                    header,
+                    body: _,
+                    mmr_with_block,
+                } = storage_item_block;
+
+                let header = Block::Header::from_buffer(header).map_err(|_buffer| {
+                    error!(%page_offset, "Failed to decode block header from bytes");
+
+                    ClientDatabaseError::InvalidBlock { page_offset }
+                })?;
+
+                let block_root = *header.header().root();
+                let block_number = header.header().prefix.number;
+                let parent_root = header.header().prefix.parent_root;
+
+                state.block_roots.insert(block_root, block_number);
+
+                let maybe_best_number = state
+                    .blocks
+                    .front()
+                    .and_then(|block_forks| block_forks.first())
+                    .map(|best_block| {
+                        // Type inference is not working here for some reason
+                        let header: &Block::Header = best_block.header();
+
+                        header.header().prefix.number
+                    });
+
+                let block_offset = if let Some(best_number) = maybe_best_number {
+                    if block_number <= best_number {
+                        (best_number - block_number).as_u64() as usize
+                    } else {
+                        // The new best block must follow the previous best block
+                        if block_number - best_number != BlockNumber::ONE {
+                            error!(
+                                %page_offset,
+                                %best_number,
+                                %block_number,
+                                "Invalid new best block number, it must be only one block \
+                                higher than the best block"
+                            );
+
+                            return Err(ClientDatabaseError::InvalidBlock { page_offset });
+                        }
+
+                        state.blocks.push_front(SmallVec::new());
+                        // Will insert a new block at the front
+                        0
+                    }
+                } else {
+                    state.blocks.push_front(SmallVec::new());
+                    // Will insert a new block at the front
+                    0
+                };
+
+                let parent_header = state.blocks.get(block_offset + 1).and_then(|block_forks| {
+                    block_forks
+                        .iter()
+                        .map(ClientDatabaseBlock::header)
+                        .find(|block_fork_header: &&Block::Header| {
+                            *block_fork_header.header().root() == parent_root
+                        })
+                        .cloned()
+                });
+
+                let block_forks = match state.blocks.get_mut(block_offset) {
+                    Some(block_forks) => block_forks,
+                    None => {
+                        // Ignore the older block, other blocks at its height were already pruned
+                        // anyway
+
+                        return Ok(());
+                    }
+                };
+
+                // Push a new block to the end of the list, we'll fix it up later
+                block_forks.push(ClientDatabaseBlock::Persisted {
+                    header,
+                    parent_header: parent_header
+                        .map(OpaqueParentHeader::new)
+                        .unwrap_or_default(),
+                    mmr_with_block,
+                    write_location: WriteLocation { page_offset },
+                });
+
+                // If a new block was inserted, confirm a new canonical block to prune extra
+                // in-memory information
+                if block_offset == 0 && block_forks.len() == 1 {
+                    Self::confirm_canonical_block(block_number, &mut state, &options);
+                }
+
+                Ok(())
+            },
+        )
+        .instrument(info_span!("", page_group_kind = ?PageGroupKind::Block))
+        .await?;
+
+        if let Some(best_block) = state.blocks.front().and_then(|block_forks| {
+            // The best block is last in the list here because that is how it was inserted while
+            // reading from the database
+            block_forks.last()
+        }) {
+            // Type inference is not working here for some reason
+            let header: &Block::Header = best_block.header();
+            let header = header.header();
+            let block_number = header.prefix.number;
+            let block_root = *header.root();
+
+            if !Self::adjust_ancestor_block_forks(&mut state.blocks, block_root) {
+                return Err(ClientDatabaseError::FailedToAdjustAncestorBlockForks);
+            }
+
+            // Store the best block as the first and only fork tip
+            state.fork_tips.push_front(ForkTip {
+                number: block_number,
+                root: block_root,
+            });
+        } else {
+            // If the database is empty, initialize everything with the genesis block
+            let header = genesis_block.header().header();
+            let block_number = header.prefix.number;
+            let block_root = *header.root();
+
+            state.fork_tips.push_front(ForkTip {
+                number: block_number,
+                root: block_root,
+            });
+            state.block_roots.insert(block_root, block_number);
+            state
+                .blocks
+                .push_front(smallvec![ClientDatabaseBlock::InMemory(
+                    ClientDatabaseBlockInMemory {
+                        block: genesis_block,
+                        parent_header: OpaqueParentHeader::default(),
+                        mmr_with_block: Arc::new({
+                            let mut mmr = BlockMerkleMountainRange::new();
+                            mmr.add_leaf(&block_root);
+                            mmr
+                        }),
+                    }
+                )]);
+        }
+
+        let inner = Inner {
+            state: AsyncRwLock::new(state),
+            storage_backend_adapter: AsyncMutex::new(StorageBackendAdapter::new(
+                database_id,
+                database_version,
+                page_group_size,
+                (0..options.write_buffer_size)
+                    .map(|_| WriteBufferEntry::Free(Vec::new()))
+                    .collect(),
+                page_groups,
+                free_page_groups,
+            )),
+            storage_backend,
+            options,
+        };
+
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
+    }
+
+    /// Read all page groups and call the storage item handler for every storage item except the
+    /// page group header
+    async fn read_page_groups<SIH>(
+        target_page_groups: &mut PageGroups,
+        page_group_size: u32,
+        storage_backend: &StorageBackend,
+        mut buffer: Vec<AlignedPage>,
+        mut storage_item_handler: SIH,
+    ) -> Result<Vec<AlignedPage>, ClientDatabaseError>
+    where
+        SIH: FnMut(StorageItem, u32) -> Result<(), ClientDatabaseError>,
+    {
+        let mut next_sequence_number = 0;
+
+        // Read all page groups from oldest to newest
+        for page_group in target_page_groups.list.iter_mut().rev() {
+            if next_sequence_number == 0 {
+                next_sequence_number = page_group.first_sequence_number;
+            }
+
+            buffer.clear();
+            buffer = storage_backend
+                .read(buffer, page_group_size, page_group.first_page_offset)
+                .await
+                .map_err(|_error| ClientDatabaseError::ReadRequestCancelled)?
+                .map_err(|error| ClientDatabaseError::ReadError { error })?;
+
+            let mut pages = buffer.as_slice();
+
+            while !pages.is_empty() {
+                let page_offset = page_group.first_page_offset + page_group.inner_next_page_offset;
+                let storage_item = match StorageItem::read_from_pages(pages) {
+                    Ok(storage_item) => storage_item,
+                    Err(error) => {
+                        debug!(
+                            page_offset,
+                            %error,
+                            "Failed to read storage item, considering this to be the end of the \
+                            page group"
+                        );
+                        break;
+                    }
+                };
+
+                let sequence_number = storage_item.sequence_number;
+                let num_pages = storage_item.num_pages();
+
+                if sequence_number == next_sequence_number {
+                    next_sequence_number += 1;
+                } else {
+                    error!(
+                        page_offset,
+                        actual = sequence_number,
+                        expected = next_sequence_number,
+                        "Unexpected sequence number"
+                    );
+                    return Err(ClientDatabaseError::UnexpectedSequenceNumber {
+                        actual: sequence_number,
+                        expected: next_sequence_number,
+                        page_offset,
+                    });
+                }
+
+                // The very first thing in a page group is the page group header, skip it
+                if pages.len() == page_group_size as usize {
+                    match storage_item.storage_item_kind {
+                        StorageItemKind::PageGroupHeader(_) => {
+                            // Expected storage item
+                        }
+                        StorageItemKind::Block(_) => {
+                            return Err(ClientDatabaseError::UnexpectedBlockStorageItem {
+                                storage_item: Box::new(storage_item),
+                                page_offset,
+                            });
+                        }
+                    }
+                } else {
+                    storage_item_handler(storage_item, page_offset)?;
+                }
+
+                pages = &pages[num_pages as usize..];
+                page_group.inner_next_page_offset += num_pages;
+            }
+        }
+
+        target_page_groups.next_sequence_number = next_sequence_number;
+
+        Ok(buffer)
+    }
+
+    /// Format a new database
+    pub async fn format(
+        storage_backend: &StorageBackend,
+        options: ClientDatabaseFormatOptions,
+    ) -> Result<(), ClientDatabaseFormatError> {
+        let mut buffer = vec![AlignedPage::default(); 1];
+
+        if !options.force {
+            buffer = storage_backend
+                .read(buffer, 1, 0)
+                .await
+                .map_err(|_error| ClientDatabaseFormatError::ReadRequestCancelled)?
+                .map_err(|error| ClientDatabaseFormatError::ReadError { error })?;
+
+            if StorageItem::read_from_pages(&buffer).is_ok() {
+                return Err(ClientDatabaseFormatError::AlreadyFormatted);
+            }
+        }
+
+        let storage_item = StorageItem {
+            sequence_number: 0,
+            storage_item_kind: StorageItemKind::PageGroupHeader(StorageItemPageGroupHeader {
+                database_id: DatabaseId::new({
+                    let mut id = [0; 32];
+                    OsRng.try_fill_bytes(&mut id)?;
+                    id
+                }),
+                database_version: Self::VERSION,
+                page_group_kind: PageGroupKind::Permanent,
+                padding: [0; _],
+                page_group_size: options.page_group_size,
+            }),
+        };
+        storage_item
+            .write_to_pages(&mut buffer)
+            .map_err(io::Error::other)?;
+
+        let _buffer: Vec<AlignedPage> = storage_backend
+            .write(buffer, 0)
+            .await
+            .map_err(|_cancelled| ClientDatabaseFormatError::WriteRequestCancelled)??;
+
+        Ok(())
+    }
+
+    async fn insert_new_best_block(
+        mut state: AsyncRwLockWriteGuard<'_, State<Block>>,
+        inner: &Inner<Block, StorageBackend>,
+        block: Block,
+        parent_header: OpaqueParentHeader<Block::Header>,
+        mmr_with_block: Arc<BlockMerkleMountainRange>,
+    ) -> Result<(), PersistBlockError> {
+        let header = block.header().header();
+        let block_number = header.prefix.number;
+        let block_root = *header.root();
+        let parent_root = header.prefix.parent_root;
+
+        // Adjust the relative order of forks to ensure the first index always corresponds to
+        // ancestors of the new best block
+        if !Self::adjust_ancestor_block_forks(&mut state.blocks, parent_root) {
+            return Err(PersistBlockError::MissingParent);
+        }
+
+        // Store new block in the state
+        {
+            for (index, fork_tip) in state.fork_tips.iter_mut().enumerate() {
+                // Block's parent is no longer a fork tip, remove it
+                if fork_tip.root == parent_root {
+                    state.fork_tips.remove(index);
+                    break;
+                }
+            }
+
+            state.fork_tips.push_front(ForkTip {
+                number: block_number,
+                root: block_root,
+            });
+            state.block_roots.insert(block_root, block_number);
+            state
+                .blocks
+                .push_front(smallvec![ClientDatabaseBlock::InMemory(
+                    ClientDatabaseBlockInMemory {
+                        block,
+                        parent_header,
+                        mmr_with_block
+                    }
+                )]);
+        }
+
+        let options = &inner.options;
+
+        Self::confirm_canonical_block(block_number, &mut state, options);
+        Self::prune_outdated_fork_tips(block_number, &mut state, options);
+
+        // Convert write lock into upgradable read lock to allow reads, while preventing concurrent
+        // block modifications
+        // TODO: This assumes both guarantees in https://github.com/smol-rs/async-lock/issues/100
+        //  are satisfied. If not, blocking read locks in other places will cause issues.
+        let state = AsyncRwLockWriteGuard::downgrade_to_upgradable(state);
+
+        let mut blocks_to_persist = Vec::with_capacity(
+            options
+                .confirmation_depth_k
+                .saturating_sub(options.soft_confirmation_depth)
+                .as_u64() as usize,
+        );
+        for block_offset in options.soft_confirmation_depth.as_u64() as usize.. {
+            let Some(fork_blocks) = state.blocks.get(block_offset) else {
+                break;
+            };
+
+            let len_before = blocks_to_persist.len();
+            fork_blocks
+                .iter()
+                .enumerate()
+                .filter_map(|(fork_offset, client_database_block)| {
+                    match client_database_block {
+                        ClientDatabaseBlock::InMemory(block) => Some(BlockToPersist {
+                            block_offset,
+                            fork_offset,
+                            block,
+                        }),
+                        ClientDatabaseBlock::Persisted { .. }
+                        | ClientDatabaseBlock::PersistedConfirmed { .. } => {
+                            // Already persisted
+                            None
+                        }
+                    }
+                })
+                .collect_into(&mut blocks_to_persist);
+
+            if blocks_to_persist.len() == len_before {
+                break;
+            }
+        }
+
+        let mut storage_backend_adapter = inner.storage_backend_adapter.lock().await;
+
+        // Persist blocks from older to newer
+        let mut persisted_blocks = Vec::with_capacity(blocks_to_persist.len());
+        for block_to_persist in blocks_to_persist.into_iter().rev() {
+            let BlockToPersist {
+                block_offset,
+                fork_offset,
+                block,
+            } = block_to_persist;
+
+            let write_location = storage_backend_adapter
+                .write_storage_item(
+                    PageGroupKind::Block,
+                    &inner.storage_backend,
+                    StorageItemKind::Block(StorageItemBlock {
+                        header: block.block.header().buffer().clone(),
+                        body: block.block.body().buffer().clone(),
+                        mmr_with_block: Arc::clone(&block.mmr_with_block),
+                    }),
+                )
+                .await?;
+
+            persisted_blocks.push(PersistedBlock {
+                block_offset,
+                fork_offset,
+                write_location,
+            });
+        }
+
+        // Convert blocks to persisted
+        let mut state = RwLockUpgradableReadGuard::upgrade(state).await;
+        for persisted_block in persisted_blocks {
+            let PersistedBlock {
+                block_offset,
+                fork_offset,
+                write_location,
+            } = persisted_block;
+
+            let block = state
+                .blocks
+                .get_mut(block_offset)
+                .expect("Still holding the same lock since last check; qed")
+                .get_mut(fork_offset)
+                .expect("Still holding the same lock since last check; qed");
+
+            replace_with_or_abort(block, |block| {
+                if let ClientDatabaseBlock::InMemory(in_memory) = block {
+                    let (header, _body) = in_memory.block.split();
+
+                    ClientDatabaseBlock::Persisted {
+                        header,
+                        parent_header: in_memory.parent_header,
+                        mmr_with_block: in_memory.mmr_with_block,
+                        write_location,
+                    }
+                } else {
+                    unreachable!("Still holding the same lock since last check; qed");
+                }
+            });
+        }
+
+        // TODO: Prune blocks that are no longer necessary
+        // TODO: Prune unused page groups here or elsewhere?
+
+        Ok(())
+    }
+
+    /// Adjust the relative order of forks to ensure the first index always corresponds to
+    /// `parent_block_root` and its ancestors.
+    ///
+    /// Returns `true` on success and `false` if one of the parents was not found.
+    #[must_use]
+    fn adjust_ancestor_block_forks(
+        blocks: &mut VecDeque<SmallVec<[ClientDatabaseBlock<Block>; 2]>>,
+        mut parent_block_root: BlockRoot,
+    ) -> bool {
+        let mut ancestor_blocks = blocks.iter_mut();
+
+        loop {
+            if ancestor_blocks.len() == 1 {
+                // Nothing left to adjust with a single fork
+                break;
+            }
+
+            let Some(parent_blocks) = ancestor_blocks.next() else {
+                // No more parent headers present
+                break;
+            };
+
+            let Some(fork_offset_parent_block_root) =
+                parent_blocks
+                    .iter()
+                    .enumerate()
+                    .find_map(|(fork_offset, fork_block)| {
+                        let fork_header = fork_block.header().header();
+                        if *fork_header.root() == parent_block_root {
+                            Some((fork_offset, fork_header.prefix.parent_root))
+                        } else {
+                            None
+                        }
+                    })
+            else {
+                return false;
+            };
+
+            let fork_offset;
+            (fork_offset, parent_block_root) = fork_offset_parent_block_root;
+
+            parent_blocks.swap(0, fork_offset);
+        }
+
+        true
+    }
+
+    /// Prune outdated fork tips that are too deep and have not been updated for a long time.
+    ///
+    /// Note that actual headers, blocks and MMRs could remain if they are currently used by
+    /// something or were already persisted on disk. With persisted blocks specifically, RAM usage
+    /// implications are minimal, and we wouldn't want to re-download already stored blocks in case
+    /// they end up being necessary later.
+    fn prune_outdated_fork_tips(
+        best_number: BlockNumber,
+        state: &mut State<Block>,
+        options: &ClientDatabaseOptions,
+    ) {
+        let state = &mut *state;
+
+        // These forks are just candidates because they will not be pruned if the reference count is
+        // not 1, indicating they are still in use by something
+        let mut candidate_forks_to_remove = Vec::with_capacity(options.max_fork_tips.get());
+
+        // Prune forks that are too far away from the best block
+        state.fork_tips.retain(|fork_tip| {
+            if best_number - fork_tip.number > options.max_fork_tip_distance {
+                candidate_forks_to_remove.push(*fork_tip);
+                false
+            } else {
+                true
+            }
+        });
+        // Prune forks that exceed the maximum number of forks
+        if state.fork_tips.len() > options.max_fork_tips.get() {
+            state
+                .fork_tips
+                .drain(options.max_fork_tips.get()..)
+                .collect_into(&mut candidate_forks_to_remove);
+        }
+
+        // Prune all possible candidates
+        candidate_forks_to_remove
+            .retain(|fork_tip| !Self::prune_outdated_fork(best_number, fork_tip, state));
+        // Return those that were not pruned back to the list of tips
+        state.fork_tips.extend(candidate_forks_to_remove);
+    }
+
+    /// Returns `true` if the tip was pruned successfully and `false` if it should be returned to
+    /// the list of fork tips
+    #[must_use]
+    fn prune_outdated_fork(
+        best_number: BlockNumber,
+        fork_tip: &ForkTip,
+        state: &mut State<Block>,
+    ) -> bool {
+        let block_offset = (best_number - fork_tip.number).as_u64() as usize;
+
+        // Prune fork top and all its ancestors that are not used
+        let mut block_root_to_prune = fork_tip.root;
+        let mut pruned_tip = false;
+        for block_offset in block_offset.. {
+            let Some(fork_blocks) = state.blocks.get_mut(block_offset) else {
+                if !pruned_tip {
+                    error!(
+                        %best_number,
+                        ?fork_tip,
+                        block_offset,
+                        "Block offset was not present in the database, this is an implementation \
+                        bug #1"
+                    );
+                }
+                // No forks left to prune
+                break;
+            };
+
+            if fork_blocks.len() == 1 {
+                if !pruned_tip {
+                    error!(
+                        %best_number,
+                        ?fork_tip,
+                        block_offset,
+                        "Block offset was not present in the database, this is an implementation \
+                        bug #2"
+                    );
+                }
+
+                // No forks left to prune
+                break;
+            }
+
+            let Some((fork_offset, block)) = fork_blocks
+                .iter()
+                .enumerate()
+                // Skip ancestor of the best block, it is certainly not a fork to be pruned
+                .skip(1)
+                .find(|(_fork_offset, block)| {
+                    *block.header().header().root() == block_root_to_prune
+                })
+            else {
+                if !pruned_tip {
+                    error!(
+                        %best_number,
+                        ?fork_tip,
+                        block_offset,
+                        "Block offset was not present in the database, this is an implementation \
+                        bug #3"
+                    );
+                }
+
+                // Nothing left to prune
+                break;
+            };
+
+            // More than one instance means something somewhere is using or depends on this block
+            if block.header().ref_count() > 1 {
+                break;
+            }
+
+            // Blocks that are already persisted
+            match block {
+                ClientDatabaseBlock::InMemory(_) => {
+                    // Prune
+                }
+                ClientDatabaseBlock::Persisted { .. }
+                | ClientDatabaseBlock::PersistedConfirmed { .. } => {
+                    // Already on disk, keep it in memory for later, but prune the tip
+                    pruned_tip = true;
+                    break;
+                }
+            }
+
+            state.block_roots.get_mut(&block_root_to_prune);
+            block_root_to_prune = block.header().header().prefix.parent_root;
+            fork_blocks.swap_remove(fork_offset);
+
+            pruned_tip = true;
+        }
+
+        pruned_tip
+    }
+
+    /// Confirm a block at confirmation depth k and prune any other blocks at the same depth with
+    /// their descendants
+    fn confirm_canonical_block(
+        best_number: BlockNumber,
+        state: &mut State<Block>,
+        options: &ClientDatabaseOptions,
+    ) {
+        // `+1` means it effectively confirms parent blocks instead. This is done to keep the parent
+        // of the confirmed block with its MMR in memory due to confirmed blocks not storing their
+        // MMRs, which might be needed for reorgs at the lowest possible depth.
+        let Some(block_offset) =
+            best_number.checked_sub(options.confirmation_depth_k + BlockNumber::ONE)
+        else {
+            // Nothing to prune yet
+            return;
+        };
+        let block_offset = block_offset.as_u64() as usize;
+
+        let Some(fork_blocks) = state.blocks.get_mut(block_offset) else {
+            error!(
+                %best_number,
+                block_offset,
+                "Have not found fork blocks to confirm, this is an implementation bug"
+            );
+            return;
+        };
+
+        // Mark the canonical block as confirmed
+        {
+            let Some(canonical_block) = fork_blocks.first_mut() else {
+                error!(
+                    %best_number,
+                    block_offset,
+                    "Have not found a canonical block to confirm, this is an implementation bug"
+                );
+                return;
+            };
+
+            replace_with_or_abort(canonical_block, |block| match block {
+                ClientDatabaseBlock::InMemory(_) => {
+                    error!(
+                        %best_number,
+                        block_offset,
+                        header = ?block.header(),
+                        "Block to be confirmed must not be in memory, this is an implementation bug"
+                    );
+                    block
+                }
+                ClientDatabaseBlock::Persisted {
+                    header,
+                    parent_header,
+                    mmr_with_block: _,
+                    write_location,
+                } => ClientDatabaseBlock::PersistedConfirmed {
+                    header,
+                    _parent_header: parent_header,
+                    write_location,
+                },
+                ClientDatabaseBlock::PersistedConfirmed { .. } => {
+                    error!(
+                        %best_number,
+                        block_offset,
+                        header = ?block.header(),
+                        "Block to be confirmed must not be confirmed yet, this is an \
+                        implementation bug"
+                    );
+                    block
+                }
+            });
+        }
+
+        // Prune the rest of the blocks and their descendants
+        let mut block_roots_to_prune = fork_blocks
+            .drain(1..)
+            .map(|block| *block.header().header().root())
+            .collect::<Vec<_>>();
+        let mut current_block_offset = block_offset;
+        while !block_roots_to_prune.is_empty() {
+            // Prune fork tips (if any)
+            state
+                .fork_tips
+                .retain(|fork_tip| !block_roots_to_prune.contains(&fork_tip.root));
+
+            // Prune removed block roots
+            for block_root in &block_roots_to_prune {
+                state.block_roots.remove(block_root);
+            }
+
+            // Block offset for direct descendants
+            if let Some(next_block_offset) = current_block_offset.checked_sub(1) {
+                current_block_offset = next_block_offset;
+            } else {
+                // Reached the tip
+                break;
+            }
+
+            let fork_blocks = state
+                .blocks
+                .get_mut(current_block_offset)
+                .expect("Lower block offset always exists; qed");
+
+            // Collect descendants of pruned blocks to prune them next
+            block_roots_to_prune = fork_blocks
+                .drain_filter(|block| {
+                    let header = block.header().header();
+
+                    block_roots_to_prune.contains(&header.prefix.parent_root)
+                })
+                .map(|block| *block.header().header().root())
+                .collect();
+        }
+    }
+}

--- a/crates/node/ab-client-database/src/storage_backend.rs
+++ b/crates/node/ab-client-database/src/storage_backend.rs
@@ -1,0 +1,101 @@
+use futures::channel::oneshot;
+use std::{fmt, io, mem};
+
+/// A wrapper data structure with 4096 bytes alignment, which is the most common alignment for
+/// direct I/O operations.
+#[derive(Debug, Copy, Clone)]
+#[repr(C, align(4096))]
+pub struct AlignedPage([u8; AlignedPage::SIZE]);
+
+const _: () = {
+    assert!(align_of::<AlignedPage>() == AlignedPage::SIZE);
+};
+
+impl Default for AlignedPage {
+    #[inline(always)]
+    fn default() -> Self {
+        Self([0; AlignedPage::SIZE])
+    }
+}
+
+impl AlignedPage {
+    /// 4096 is as a relatively safe size due to sector size on SSDs commonly being 512 or 4096
+    /// bytes
+    pub const SIZE: usize = 4096;
+
+    /// Convenient conversion from slice to underlying representation for efficiency purposes
+    #[inline(always)]
+    pub fn slice_to_repr(value: &[Self]) -> &[[u8; AlignedPage::SIZE]] {
+        // SAFETY: `RecordChunk` is `#[repr(C)]` and guaranteed to have the same memory layout
+        unsafe { mem::transmute(value) }
+    }
+
+    /// Convenient conversion from a slice of underlying representation for efficiency purposes.
+    ///
+    /// Returns `None` if not correctly aligned.
+    #[inline]
+    pub fn try_slice_from_repr(value: &[[u8; AlignedPage::SIZE]]) -> Option<&[Self]> {
+        // SAFETY: All bit patterns are valid
+        let (before, slice, after) = unsafe { value.align_to::<Self>() };
+
+        if before.is_empty() && after.is_empty() {
+            Some(slice)
+        } else {
+            None
+        }
+    }
+
+    /// Convenient conversion from mutable slice to underlying representation for efficiency
+    /// purposes
+    #[inline(always)]
+    pub fn slice_mut_to_repr(slice: &mut [Self]) -> &mut [[u8; AlignedPage::SIZE]] {
+        // SAFETY: `AlignedSectorSize` is `#[repr(C)]` and its alignment is larger than inner value
+        unsafe { mem::transmute(slice) }
+    }
+
+    /// Convenient conversion from a slice of underlying representation for efficiency purposes.
+    ///
+    /// Returns `None` if not correctly aligned.
+    #[inline]
+    pub fn try_slice_mut_from_repr(value: &mut [[u8; AlignedPage::SIZE]]) -> Option<&mut [Self]> {
+        // SAFETY: All bit patterns are valid
+        let (before, slice, after) = unsafe { value.align_to_mut::<Self>() };
+
+        if before.is_empty() && after.is_empty() {
+            Some(slice)
+        } else {
+            None
+        }
+    }
+}
+
+/// Storage backend to be used by [`ClientDatabase`]
+///
+/// [`ClientDatabase`]: crate::ClientDatabase
+pub trait ClientDatabaseStorageBackend: fmt::Debug + Send + Sync + 'static {
+    /// Total number of pages available for reads/writes
+    fn num_pages(&self) -> u32;
+
+    // TODO: Think whether `Vec` is the right wrapper here to avoid reallocations
+    /// Reading into aligned memory.
+    ///
+    /// `length` is the number of [`AlignedPage`] units (pages) to read into (append to)
+    /// `buffer`. `offset` is in pages too.
+    fn read(
+        &self,
+        buffer: Vec<AlignedPage>,
+        length: u32,
+        offset: u32,
+    ) -> oneshot::Receiver<io::Result<Vec<AlignedPage>>>;
+
+    // TODO: Think whether `Vec` is the right wrapper here to avoid reallocations
+    /// Writing from aligned memory.
+    ///
+    /// `offset` is in [`AlignedPage`] units (pages). After successful writing returns allocated
+    /// pages back to the caller.
+    fn write(
+        &self,
+        buffer: Vec<AlignedPage>,
+        offset: u32,
+    ) -> oneshot::Receiver<io::Result<Vec<AlignedPage>>>;
+}

--- a/crates/node/ab-client-database/src/storage_backend_adapter.rs
+++ b/crates/node/ab-client-database/src/storage_backend_adapter.rs
@@ -1,0 +1,312 @@
+use crate::storage_backend::{AlignedPage, ClientDatabaseStorageBackend};
+use crate::storage_item::page_group_header::StorageItemPageGroupHeader;
+use crate::storage_item::{StorageItem, StorageItemKind};
+use crate::{DatabaseId, PageGroupKind};
+use enum_map::EnumMap;
+use futures::FutureExt;
+use futures::channel::oneshot;
+use replace_with::replace_with_or_abort_and_return;
+use std::collections::VecDeque;
+use std::task::Poll;
+use std::{future, io};
+
+#[derive(Debug)]
+pub(crate) struct PageGroup {
+    pub(crate) first_sequence_number: u64,
+    /// Next page offset within the page group
+    pub(crate) inner_next_page_offset: u32,
+    /// Offset of the first page of this page group in the storage backend
+    pub(crate) first_page_offset: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct PageGroups {
+    /// Next sequence number to use
+    pub(crate) next_sequence_number: u64,
+    /// A list of page groups.
+    ///
+    /// The front page is the active one, meaning it is being appended to, the back page is the
+    /// oldest page.
+    ///
+    /// If pruning is needed, old pages are freed from back to front without gaps.
+    pub(crate) list: VecDeque<PageGroup>,
+}
+
+#[derive(Debug)]
+pub(crate) enum WriteBufferEntry {
+    Free(Vec<AlignedPage>),
+    Occupied(oneshot::Receiver<io::Result<Vec<AlignedPage>>>),
+}
+
+#[derive(Debug)]
+pub(crate) struct WriteLocation {
+    #[expect(dead_code, reason = "Not used yet")]
+    pub(crate) page_offset: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct StorageBackendAdapter {
+    database_id: DatabaseId,
+    database_version: u8,
+    /// Page group size in pages
+    page_group_size: u32,
+    write_buffer: Box<[WriteBufferEntry]>,
+    page_groups: EnumMap<PageGroupKind, PageGroups>,
+    /// Offsets of the first pages that correspond to free page groups.
+    ///
+    /// Newly freed pages are added to the back, the oldest freed pages are pulled from the front.
+    free_page_groups: VecDeque<u32>,
+    had_write_failure: bool,
+}
+
+impl StorageBackendAdapter {
+    pub(crate) fn new(
+        database_id: DatabaseId,
+        database_version: u8,
+        page_group_size: u32,
+        write_buffer: Box<[WriteBufferEntry]>,
+        page_groups: EnumMap<PageGroupKind, PageGroups>,
+        free_page_groups: VecDeque<u32>,
+    ) -> Self {
+        Self {
+            database_id,
+            database_version,
+            page_group_size,
+            write_buffer,
+            page_groups,
+            free_page_groups,
+            had_write_failure: false,
+        }
+    }
+
+    pub(super) async fn write_storage_item<StorageBackend>(
+        &mut self,
+        page_group_kind: PageGroupKind,
+        storage_backend: &StorageBackend,
+        storage_item_kind: StorageItemKind,
+    ) -> io::Result<WriteLocation>
+    where
+        StorageBackend: ClientDatabaseStorageBackend,
+    {
+        if self.had_write_failure {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "Previous write operation failed, writes are not allowed until restart",
+            ));
+        }
+
+        self.write_storage_item_inner(page_group_kind, storage_backend, storage_item_kind)
+            .await
+            .inspect_err(|_error| {
+                self.had_write_failure = true;
+            })
+    }
+
+    async fn write_storage_item_inner<StorageBackend>(
+        &mut self,
+        page_group_kind: PageGroupKind,
+        storage_backend: &StorageBackend,
+        storage_item_kind: StorageItemKind,
+    ) -> io::Result<WriteLocation>
+    where
+        StorageBackend: ClientDatabaseStorageBackend,
+    {
+        let target_page_groups = &mut self.page_groups[page_group_kind];
+
+        let sequence_number = target_page_groups.next_sequence_number;
+        target_page_groups.next_sequence_number += 1;
+
+        let mut storage_item = StorageItem {
+            sequence_number,
+            storage_item_kind,
+        };
+
+        let mut num_pages = storage_item.num_pages();
+        // Ensure a storage item doesn't exceed page group size. `-1` accounts for the page group
+        // header.
+        if num_pages > (self.page_group_size - 1) {
+            return Err(io::Error::new(
+                io::ErrorKind::QuotaExceeded,
+                format!(
+                    "Storage item is too large: {num_pages} pages, max supported is {} pages",
+                    self.page_group_size
+                ),
+            ));
+        }
+
+        // Check if there is an active page group and whether it has enough free pages in it
+        let (active_page_group, maybe_page_group_header) = if let Some(page_group) =
+            target_page_groups.list.front_mut()
+            && let Some(remaining_pages_in_group) = self
+                .page_group_size
+                .checked_sub(page_group.inner_next_page_offset)
+            && remaining_pages_in_group >= num_pages
+        {
+            (page_group, None)
+        } else {
+            // Allocate a new page group
+            let first_page_offset = self.free_page_groups.pop_front().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::StorageFull,
+                    "No free pages available to write a new storage item",
+                )
+            })?;
+
+            let page_group_header = StorageItem {
+                sequence_number,
+                storage_item_kind: StorageItemKind::PageGroupHeader(StorageItemPageGroupHeader {
+                    database_id: self.database_id,
+                    database_version: self.database_version,
+                    page_group_kind,
+                    padding: [0; _],
+                    page_group_size: self.page_group_size,
+                }),
+            };
+
+            // Adjust sequence numbers since the previous value was reused by a new page group
+            // header
+            target_page_groups.next_sequence_number += 1;
+            storage_item.sequence_number += 1;
+            // Add a page that corresponds to the page group header
+            num_pages += 1;
+
+            target_page_groups.list.push_front(PageGroup {
+                first_sequence_number: sequence_number,
+                inner_next_page_offset: 0,
+                first_page_offset,
+            });
+            let active_page_group = target_page_groups
+                .list
+                .front_mut()
+                .expect("Just inserted; qed");
+
+            (active_page_group, Some(page_group_header))
+        };
+
+        let page_offset =
+            active_page_group.first_page_offset + active_page_group.inner_next_page_offset;
+        active_page_group.inner_next_page_offset += num_pages;
+
+        // In case buffering is disabled, allocate a buffer on demand and wait for write to
+        // finish
+        if self.write_buffer.is_empty() {
+            let mut buffer = Vec::new();
+
+            Self::write_pages_to_buffer(
+                &storage_item,
+                maybe_page_group_header.as_ref(),
+                &mut buffer,
+            )?;
+
+            let _buffer: Vec<_> = storage_backend
+                .write(buffer, page_offset)
+                .await
+                .map_err(|_cancelled| {
+                    io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "Storage backend write was aborted",
+                    )
+                })
+                .flatten()?;
+
+            return Ok(WriteLocation { page_offset });
+        }
+
+        let write_fut = future::poll_fn(|cx| {
+            // Find a free write buffer entry among those that are either completely free or already
+            // finished and can be reused
+            let write_attempt_result = self.write_buffer.iter_mut().find_map(|entry| {
+                replace_with_or_abort_and_return(entry, |entry| {
+                    let mut buffer = match entry {
+                        // Already free buffer
+                        WriteBufferEntry::Free(buffer) => buffer,
+                        WriteBufferEntry::Occupied(mut receiver) => {
+                            // Poll pending write attempt
+                            match receiver.poll_unpin(cx) {
+                                Poll::Ready(Ok(write_result)) => match write_result {
+                                    // Write succeeded, reuse buffer
+                                    Ok(buffer) => buffer,
+                                    // Write failed
+                                    Err(error) => {
+                                        return (
+                                            Some(Err(error)),
+                                            WriteBufferEntry::Occupied(receiver),
+                                        );
+                                    }
+                                },
+                                // Write attempt was aborted
+                                Poll::Ready(Err(_cancelled)) => {
+                                    return (
+                                        Some(Err(io::Error::new(
+                                            io::ErrorKind::Interrupted,
+                                            "Storage backend write was aborted",
+                                        ))),
+                                        WriteBufferEntry::Occupied(receiver),
+                                    );
+                                }
+                                // Still in progress
+                                Poll::Pending => {
+                                    return (None, WriteBufferEntry::Occupied(receiver));
+                                }
+                            }
+                        }
+                    };
+
+                    // Resize buffer and write storage item pages
+                    if let Err(error) = Self::write_pages_to_buffer(
+                        &storage_item,
+                        maybe_page_group_header.as_ref(),
+                        &mut buffer,
+                    ) {
+                        return (
+                            Some(Err(io::Error::other(error))),
+                            WriteBufferEntry::Free(buffer),
+                        );
+                    }
+
+                    let receiver = storage_backend.write(buffer, page_offset);
+                    (
+                        Some(Ok(WriteLocation { page_offset })),
+                        WriteBufferEntry::Occupied(receiver),
+                    )
+                })
+            });
+
+            match write_attempt_result {
+                Some(result) => Poll::Ready(result),
+                None => Poll::Pending,
+            }
+        });
+
+        write_fut.await
+    }
+
+    /// Resize the buffer to the correct size and write storage item with optional prepended page
+    /// group header
+    #[inline(always)]
+    fn write_pages_to_buffer(
+        storage_item: &StorageItem,
+        maybe_page_group_header: Option<&StorageItem>,
+        buffer: &mut Vec<AlignedPage>,
+    ) -> io::Result<()> {
+        if let Some(page_group_header) = maybe_page_group_header {
+            buffer.resize_with(storage_item.num_pages() as usize + 1, AlignedPage::default);
+
+            let (header, buffer) = buffer.split_at_mut(1);
+            page_group_header
+                .write_to_pages(header)
+                .map_err(io::Error::other)?;
+            storage_item
+                .write_to_pages(buffer)
+                .map_err(io::Error::other)?;
+        } else {
+            buffer.resize_with(storage_item.num_pages() as usize, AlignedPage::default);
+
+            storage_item
+                .write_to_pages(buffer)
+                .map_err(io::Error::other)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/node/ab-client-database/src/storage_item.rs
+++ b/crates/node/ab-client-database/src/storage_item.rs
@@ -1,0 +1,247 @@
+pub(crate) mod block;
+pub(crate) mod page_group_header;
+
+use crate::storage_backend::AlignedPage;
+use crate::storage_item::block::StorageItemBlock;
+use crate::storage_item::page_group_header::StorageItemPageGroupHeader;
+use ab_blake3::single_block_hash;
+use ab_core_primitives::hashes::Blake3Hash;
+use blake3::hash;
+use strum::FromRepr;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum StorageItemError {
+    /// Buffer too small
+    #[error("Buffer too small (expected: {expected}, actual: {actual})")]
+    BufferTooSmall { expected: usize, actual: usize },
+    /// Need more bytes
+    #[error("Need {0} more bytes")]
+    NeedMoreBytes(usize),
+    /// Unknown storage item variant
+    #[error("Unknown storage item variant {0}")]
+    UnknownStorageItemVariant(u8),
+    /// Invalid MMR length
+    #[error("Invalid MMR length {0}")]
+    InvalidMmrLength(u32),
+    /// Checksum mismatch
+    #[error("Checksum mismatch (expected: {expected}, actual: {actual})")]
+    ChecksumMismatch {
+        expected: Blake3Hash,
+        actual: Blake3Hash,
+    },
+    /// Repeat checksum mismatch
+    #[error("Repeat checksum mismatch (expected: {expected}, actual: {actual})")]
+    RepeatChecksumMismatch {
+        expected: Blake3Hash,
+        actual: Blake3Hash,
+    },
+    /// Storage item checksum mismatch
+    #[error("Storage item checksum mismatch (expected: {expected}, actual: {actual})")]
+    StorageItemChecksumMismatch {
+        expected: Blake3Hash,
+        actual: Blake3Hash,
+    },
+    /// Invalid buffer contents
+    #[error("Invalid buffer contents")]
+    InvalidBufferContents,
+}
+
+#[derive(Debug)]
+pub(crate) enum StorageItemKind {
+    PageGroupHeader(StorageItemPageGroupHeader),
+    Block(StorageItemBlock),
+}
+
+impl StorageItemKind {
+    fn variant(&self) -> StorageItemVariant {
+        match self {
+            StorageItemKind::PageGroupHeader(_) => StorageItemVariant::PageGroupHeader,
+            StorageItemKind::Block(_) => StorageItemVariant::Block,
+        }
+    }
+}
+
+#[derive(Debug, FromRepr)]
+#[repr(u8)]
+enum StorageItemVariant {
+    PageGroupHeader,
+    Block,
+}
+
+#[derive(Debug)]
+pub(crate) struct StorageItem {
+    pub(crate) sequence_number: u64,
+    pub(crate) storage_item_kind: StorageItemKind,
+}
+
+impl StorageItem {
+    /// Returns the number of pages necessary to write this storage item
+    pub(crate) fn num_pages(&self) -> u32 {
+        let storage_item_size = match &self.storage_item_kind {
+            StorageItemKind::PageGroupHeader(page_group_header) => page_group_header.total_bytes(),
+            StorageItemKind::Block(block) => block.total_bytes(),
+        };
+
+        // Align buffer used by storage item to 128 bytes
+        let prefix_size = Self::prefix_size().next_multiple_of(size_of::<u128>());
+
+        (prefix_size + storage_item_size + Self::suffix_size()).div_ceil(AlignedPage::SIZE) as u32
+    }
+
+    const fn prefix_size() -> usize {
+        // Sequence number + enum variant + storage item size + checksum
+        size_of::<u64>() + size_of::<u8>() + size_of::<u32>() + size_of::<Blake3Hash>()
+    }
+
+    const fn suffix_size() -> usize {
+        // Storage item checksum + repeat of prefix checksum
+        size_of::<Blake3Hash>() * 2
+    }
+
+    /// Write a storage item to the provided buffer of aligned pages
+    pub(crate) fn write_to_pages(
+        &self,
+        buffer: &mut [AlignedPage],
+    ) -> Result<(), StorageItemError> {
+        let mut buffer = AlignedPage::slice_mut_to_repr(buffer).as_flattened_mut();
+
+        let prefix_bytes = buffer
+            .split_off_mut(..Self::prefix_size())
+            .expect("Always fits one page; qed");
+        // Align buffer used by storage item to 128 bytes
+        buffer = &mut buffer[Self::prefix_size().next_multiple_of(size_of::<u128>())..];
+
+        let storage_item_size = match &self.storage_item_kind {
+            StorageItemKind::PageGroupHeader(page_group_header) => {
+                page_group_header.write(buffer)?
+            }
+            StorageItemKind::Block(block) => block.write(buffer)?,
+        };
+        let (storage_item_bytes, mut buffer) = buffer.split_at_mut(storage_item_size);
+
+        let buffer_len = buffer.len();
+        let suffix_bytes =
+            buffer
+                .split_off_mut(..Self::suffix_size())
+                .ok_or(StorageItemError::NeedMoreBytes(
+                    buffer_len - Self::suffix_size(),
+                ))?;
+
+        let (before_checksum, checksum_bytes) =
+            prefix_bytes.split_at_mut(size_of::<u64>() + size_of::<u8>() + size_of::<u32>());
+        let (sequence_number_bytes, remainder) = before_checksum.split_at_mut(size_of::<u64>());
+        let (storage_item_variant_bytes, storage_item_size_bytes) =
+            remainder.split_at_mut(size_of::<u8>());
+
+        // Write prefix
+        sequence_number_bytes.copy_from_slice(&self.sequence_number.to_le_bytes());
+        storage_item_variant_bytes[0] = self.storage_item_kind.variant() as u8;
+        storage_item_size_bytes.copy_from_slice(&storage_item_size.to_le_bytes());
+        let checksum =
+            single_block_hash(before_checksum).expect("Less than one block worth of data; qed");
+        checksum_bytes.copy_from_slice(&checksum);
+
+        let (storage_item_checksum_bytes, prefix_checksum_repeat_bytes) =
+            suffix_bytes.split_at_mut(size_of::<Blake3Hash>());
+
+        // Write suffix
+        let storage_item_checksum = *hash(storage_item_bytes).as_bytes();
+        storage_item_checksum_bytes.copy_from_slice(&storage_item_checksum);
+        prefix_checksum_repeat_bytes.copy_from_slice(&checksum);
+
+        Ok(())
+    }
+
+    /// The inverse of [`Self::write_to_pages()`]
+    pub(crate) fn read_from_pages(pages: &[AlignedPage]) -> Result<Self, StorageItemError> {
+        let mut buffer = AlignedPage::slice_to_repr(pages).as_flattened();
+
+        let prefix_bytes = buffer
+            .split_off(..Self::prefix_size())
+            .expect("Always fits one page; qed");
+        // Align buffer used by storage item to 128 bytes
+        buffer = &buffer[Self::prefix_size().next_multiple_of(size_of::<u128>())..];
+
+        let (sequence_number_bytes, remainder) = prefix_bytes.split_at(size_of::<u64>());
+        let (storage_item_variant_bytes, remainder) = remainder.split_at(size_of::<u8>());
+        let (storage_item_size_bytes, checksum_bytes) = remainder.split_at(size_of::<u32>());
+        let checksum = Blake3Hash::new(
+            single_block_hash(&prefix_bytes[..prefix_bytes.len() - checksum_bytes.len()])
+                .expect("Less than one block worth of data; qed"),
+        );
+
+        if checksum.as_slice() != checksum_bytes {
+            return Err(StorageItemError::ChecksumMismatch {
+                expected: checksum,
+                actual: Blake3Hash::new(checksum_bytes.try_into().expect("Correct length; qed")),
+            });
+        }
+
+        let sequence_number = u64::from_le_bytes(
+            sequence_number_bytes
+                .try_into()
+                .expect("Correct length; qed"),
+        );
+        let storage_item_variant = StorageItemVariant::from_repr(storage_item_variant_bytes[0])
+            .ok_or(StorageItemError::UnknownStorageItemVariant(
+                storage_item_variant_bytes[0],
+            ))?;
+        let storage_item_size = u32::from_le_bytes(
+            storage_item_size_bytes
+                .try_into()
+                .expect("Correct length; qed"),
+        );
+
+        let buffer_len = buffer.len();
+        let storage_item_bytes = buffer.split_off(..storage_item_size as usize).ok_or(
+            StorageItemError::NeedMoreBytes(buffer_len - storage_item_size as usize),
+        )?;
+
+        let buffer_len = buffer.len();
+        let suffix_bytes =
+            buffer
+                .split_off(..Self::suffix_size())
+                .ok_or(StorageItemError::NeedMoreBytes(
+                    buffer_len - Self::suffix_size(),
+                ))?;
+        let (storage_item_checksum_bytes, prefix_checksum_repeat_bytes) =
+            suffix_bytes.split_at(size_of::<Blake3Hash>());
+
+        if checksum.as_slice() != prefix_checksum_repeat_bytes {
+            return Err(StorageItemError::RepeatChecksumMismatch {
+                expected: checksum,
+                actual: Blake3Hash::new(
+                    prefix_checksum_repeat_bytes
+                        .try_into()
+                        .expect("Correct length; qed"),
+                ),
+            });
+        }
+
+        let storage_item_checksum = Blake3Hash::from(hash(storage_item_bytes));
+        if storage_item_checksum.as_slice() != storage_item_checksum_bytes {
+            return Err(StorageItemError::StorageItemChecksumMismatch {
+                expected: storage_item_checksum,
+                actual: Blake3Hash::new(
+                    storage_item_checksum_bytes
+                        .try_into()
+                        .expect("Correct length; qed"),
+                ),
+            });
+        }
+
+        let storage_item_kind = match storage_item_variant {
+            StorageItemVariant::PageGroupHeader => StorageItemKind::PageGroupHeader(
+                StorageItemPageGroupHeader::read(storage_item_bytes)?,
+            ),
+            StorageItemVariant::Block => {
+                StorageItemKind::Block(StorageItemBlock::read(storage_item_bytes)?)
+            }
+        };
+
+        Ok(Self {
+            sequence_number,
+            storage_item_kind,
+        })
+    }
+}

--- a/crates/node/ab-client-database/src/storage_item/block.rs
+++ b/crates/node/ab-client-database/src/storage_item/block.rs
@@ -1,0 +1,135 @@
+use crate::storage_item::StorageItemError;
+use ab_aligned_buffer::SharedAlignedBuffer;
+use ab_client_api::BlockMerkleMountainRange;
+use ab_merkle_tree::mmr::MerkleMountainRangeBytes;
+use rclite::Arc;
+
+#[derive(Debug)]
+pub(crate) struct StorageItemBlock {
+    pub(crate) header: SharedAlignedBuffer,
+    pub(crate) body: SharedAlignedBuffer,
+    pub(crate) mmr_with_block: Arc<BlockMerkleMountainRange>,
+    // TODO: State, segment headers
+}
+
+impl StorageItemBlock {
+    pub(crate) fn total_bytes(&self) -> usize {
+        Self::total_bytes_inner(
+            self.header.len(),
+            self.body.len(),
+            self.mmr_with_block.as_bytes().len() as u32,
+        )
+    }
+
+    const fn total_bytes_inner(header_len: u32, body_len: u32, mmr_len: u32) -> usize {
+        Self::block_prefix_size() + Self::block_content_size(header_len, body_len, mmr_len)
+    }
+
+    const fn block_prefix_size() -> usize {
+        // 3 lengths of header/block/mmr
+        size_of::<u32>()
+    }
+
+    const fn block_content_size(header_len: u32, body_len: u32, mmr_len: u32) -> usize {
+        header_len as usize + body_len as usize + mmr_len as usize
+    }
+
+    /// Write a storage item to the provided buffer.
+    ///
+    /// Returns the number of bytes written.
+    pub(super) fn write(&self, mut buffer: &mut [u8]) -> Result<usize, StorageItemError> {
+        let total_bytes = self.total_bytes();
+
+        if buffer.len() < total_bytes {
+            return Err(StorageItemError::BufferTooSmall {
+                expected: total_bytes,
+                actual: buffer.len(),
+            });
+        }
+
+        let mmr_with_block = self.mmr_with_block.as_bytes();
+
+        // TODO: Take offsets into consideration, header and body must start at multiple of u128/16
+        //  bytes to support memory-mapped reading without extra copies
+        let contents = [
+            self.header.as_slice(),
+            self.body.as_slice(),
+            mmr_with_block.as_slice(),
+        ];
+        // Write all lengths
+        for bytes in contents {
+            let length = bytes.len() as u32;
+            buffer
+                .split_off_mut(..size_of_val(&length))
+                .expect("Enough memory, checked above; qed")
+                .copy_from_slice(&u32::to_le_bytes(length));
+        }
+        // Write content bytes
+        for bytes in contents {
+            buffer
+                .split_off_mut(..size_of_val(bytes))
+                .expect("Enough memory, checked above; qed")
+                .copy_from_slice(bytes);
+        }
+
+        Ok(total_bytes)
+    }
+
+    /// The inverse of [`Self::write_to_pages()`]
+    pub(super) fn read(mut buffer: &[u8]) -> Result<Self, StorageItemError> {
+        let buffer_len = buffer.len();
+        let prefix_bytes = buffer.split_off(..Self::block_prefix_size()).ok_or(
+            StorageItemError::NeedMoreBytes(buffer_len - Self::block_prefix_size()),
+        )?;
+
+        let (header_len, remainder) = prefix_bytes.split_at(size_of::<u32>());
+        let (body_len, mmr_len) = remainder.split_at(size_of::<u32>());
+
+        // Read lengths
+        let header_len = u32::from_le_bytes(header_len.try_into().expect("Correct length; qed"));
+        let body_len = u32::from_le_bytes(body_len.try_into().expect("Correct length; qed"));
+        let mmr_len = u32::from_le_bytes(mmr_len.try_into().expect("Correct length; qed"));
+
+        let buffer_len = buffer.len();
+        let content_size = Self::block_content_size(header_len, body_len, mmr_len);
+        let mut content_bytes = buffer
+            .split_off(..content_size)
+            .ok_or(StorageItemError::NeedMoreBytes(buffer_len - content_size))?;
+
+        // Read contents bytes
+        let header = SharedAlignedBuffer::from_bytes(
+            content_bytes
+                .split_off(..header_len as usize)
+                .expect("Just checked to have enough bytes; qed"),
+        );
+        let body = SharedAlignedBuffer::from_bytes(
+            content_bytes
+                .split_off(..body_len as usize)
+                .expect("Just checked to have enough bytes; qed"),
+        );
+        let mmr_raw_bytes = content_bytes
+            .split_off(..mmr_len as usize)
+            .expect("Just checked to have enough bytes; qed");
+        let mmr = {
+            let mut mmr_bytes = MerkleMountainRangeBytes::default();
+
+            if mmr_bytes.len() != mmr_raw_bytes.len() {
+                return Err(StorageItemError::InvalidMmrLength(
+                    mmr_raw_bytes.len() as u32
+                ));
+            }
+
+            mmr_bytes.copy_from_slice(mmr_raw_bytes);
+
+            // SAFETY: Created using `BlockMerkleMountainRange::as_bytes()` and checked data
+            // integrity
+            *unsafe { BlockMerkleMountainRange::from_bytes(&mmr_bytes) }
+        };
+
+        Ok(Self {
+            header,
+            body,
+            mmr_with_block: Arc::new(mmr),
+        })
+    }
+}

--- a/crates/node/ab-client-database/src/storage_item/page_group_header.rs
+++ b/crates/node/ab-client-database/src/storage_item/page_group_header.rs
@@ -1,0 +1,66 @@
+use crate::storage_item::StorageItemError;
+use crate::{DatabaseId, PageGroupKind};
+use ab_io_type::trivial_type::TrivialType;
+use std::mem;
+
+#[derive(Debug, Copy, Clone, TrivialType)]
+#[repr(C)]
+pub(crate) struct StorageItemPageGroupHeader {
+    /// Database ID.
+    ///
+    /// Must be the same for all pages in a database.
+    pub(crate) database_id: DatabaseId,
+    /// Database version
+    pub(crate) database_version: u8,
+    /// The kind of page group
+    pub(crate) page_group_kind: PageGroupKind,
+    // Padding for data alignment
+    pub(crate) padding: [u8; 2],
+    /// The number of pages in a page group
+    pub(crate) page_group_size: u32,
+}
+
+impl StorageItemPageGroupHeader {
+    pub(crate) const fn total_bytes(&self) -> usize {
+        size_of::<Self>()
+    }
+
+    /// Write a storage item to the provided buffer.
+    ///
+    /// Returns the number of bytes written.
+    pub(super) fn write(&self, buffer: &mut [u8]) -> Result<usize, StorageItemError> {
+        let total_bytes = size_of::<Self>();
+
+        if buffer.len() < total_bytes {
+            return Err(StorageItemError::BufferTooSmall {
+                expected: total_bytes,
+                actual: buffer.len(),
+            });
+        }
+
+        buffer[..total_bytes].copy_from_slice(self.as_bytes());
+
+        Ok(total_bytes)
+    }
+
+    /// The inverse of [`Self::write_to_pages()`]
+    pub(super) fn read(buffer: &[u8]) -> Result<Self, StorageItemError> {
+        if buffer.len() < size_of::<Self>() {
+            return Err(StorageItemError::BufferTooSmall {
+                expected: size_of::<Self>(),
+                actual: buffer.len(),
+            });
+        }
+        let kind_byte = buffer[mem::offset_of!(Self, page_group_kind)];
+        PageGroupKind::from_repr(kind_byte).ok_or(StorageItemError::InvalidBufferContents)?;
+
+        // SAFETY: `PageGroupKind` checked above, all other bit pattens are valid
+        let maybe_item = unsafe { Self::from_bytes(buffer) };
+        let item = *maybe_item.ok_or(StorageItemError::BufferTooSmall {
+            expected: size_of::<Self>(),
+            actual: buffer.len(),
+        })?;
+
+        Ok(item)
+    }
+}

--- a/crates/shared/ab-core-primitives/src/block/header/owned.rs
+++ b/crates/shared/ab-core-primitives/src/block/header/owned.rs
@@ -27,6 +27,9 @@ pub trait GenericOwnedBlockHeader:
     where
         Self: 'a;
 
+    /// Create an owned header from a buffer
+    fn from_buffer(buffer: SharedAlignedBuffer) -> Result<Self, SharedAlignedBuffer>;
+
     /// Inner buffer with block header contents
     fn buffer(&self) -> &SharedAlignedBuffer;
 
@@ -74,6 +77,11 @@ impl GenericOwnedBlockHeader for OwnedBeaconChainHeader {
     const SHARD_KIND: ShardKind = ShardKind::BeaconChain;
 
     type Header<'a> = BeaconChainHeader<'a>;
+
+    #[inline(always)]
+    fn from_buffer(buffer: SharedAlignedBuffer) -> Result<Self, SharedAlignedBuffer> {
+        Self::from_buffer(buffer)
+    }
 
     #[inline(always)]
     fn buffer(&self) -> &SharedAlignedBuffer {
@@ -331,6 +339,11 @@ impl GenericOwnedBlockHeader for OwnedIntermediateShardHeader {
     type Header<'a> = IntermediateShardHeader<'a>;
 
     #[inline(always)]
+    fn from_buffer(buffer: SharedAlignedBuffer) -> Result<Self, SharedAlignedBuffer> {
+        Self::from_buffer(buffer)
+    }
+
+    #[inline(always)]
     fn buffer(&self) -> &SharedAlignedBuffer {
         self.buffer()
     }
@@ -511,6 +524,11 @@ impl GenericOwnedBlockHeader for OwnedLeafShardHeader {
     const SHARD_KIND: ShardKind = ShardKind::LeafShard;
 
     type Header<'a> = LeafShardHeader<'a>;
+
+    #[inline(always)]
+    fn from_buffer(buffer: SharedAlignedBuffer) -> Result<Self, SharedAlignedBuffer> {
+        Self::from_buffer(buffer)
+    }
 
     #[inline(always)]
     fn buffer(&self) -> &SharedAlignedBuffer {


### PR DESCRIPTION
This is in many ways incomplete and probably broken, but I need to get it out of the door.

This implements `ab-client-api` persistence APIs and is designed with abstract storage backend that persists data in aligned 4 kiB pages.

The idea of this design is to have purpose-built database that maps nicely onto modern SSDs (in the future page size may be increased to 16 kiB if it helps with performance and write amplification). See https://abundance.build/blog/2025-07-20-sparse-merkle-tree-and-client-database-preparation/#client-database for background information.

Things currently missing (but not critical at this stage):
* block pruning from memory (bodies are pruned, but headers are stored forever)
* page pruning (storage backend will inevitably run out of space until old pages can be pruned)
* no persistence of in-memory blocks that were not written to disk yet on graceful shutdown (a few most recent blocks will be lost because of this, which is generally not critical, but still unfortunate)

Overall I think this is roughly the correct architecture. The implementation will likely churn a lot as I find a better way to structure it (lib.rs is quite large right now and will inevitably grow more as more types of information are added to the database) and add more things, but conceptually this should be close.

And there are basically no tests for now.