### PR TITLE
Optimize `BalancedMerkleTree::compute_root_only()` using SIMD

### DIFF
--- a/crates/shared/ab-merkle-tree/benches/merkle_tree.rs
+++ b/crates/shared/ab-merkle-tree/benches/merkle_tree.rs
@@ -1,7 +1,9 @@
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![feature(generic_const_exprs, maybe_uninit_slice, new_zeroed_alloc)]
 
-use ab_merkle_tree::balanced::{BalancedMerkleTree, ensure_supported_n};
+use ab_merkle_tree::balanced::{
+    BalancedMerkleTree, compute_root_only_large_stack_size, ensure_supported_n,
+};
 use ab_merkle_tree::unbalanced::UnbalancedMerkleTree;
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
@@ -34,6 +36,7 @@ where
     [(); N - 1]:,
     [(); ensure_supported_n(N)]:,
     [(); N.ilog2() as usize + 1]:,
+    [(); compute_root_only_large_stack_size(N)]:,
 {
     let mut input = unsafe { Box::<[[u8; 32]; N]>::new_zeroed().assume_init() };
     for (index, input) in input.iter_mut().enumerate() {

--- a/crates/shared/ab-merkle-tree/tests/balanced.rs
+++ b/crates/shared/ab-merkle-tree/tests/balanced.rs
@@ -2,7 +2,9 @@
 #![feature(generic_const_exprs)]
 
 use ab_blake3::OUT_LEN;
-use ab_merkle_tree::balanced::{BalancedMerkleTree, ensure_supported_n};
+use ab_merkle_tree::balanced::{
+    BalancedMerkleTree, compute_root_only_large_stack_size, ensure_supported_n,
+};
 use ab_merkle_tree::mmr::MerkleMountainRange;
 use ab_merkle_tree::unbalanced::UnbalancedMerkleTree;
 use rand_chacha::ChaCha8Rng;
@@ -46,6 +48,7 @@ where
     [(); N - 1]:,
     [(); ensure_supported_n(N)]:,
     [(); N.ilog2() as usize + 1]:,
+    [(); compute_root_only_large_stack_size(N)]:,
     [(); N_U64.ilog2() as usize + 1]:,
 {
     assert!(N as u64 == N_U64);


### PR DESCRIPTION
Similarly to https://github.com/nazar-pc/abundance/pull/345, massive wins here again both for Merkle Tree root computation and archiving (which uses it) benchmarks:
```
Before:
65536/balanced/compute-root-only
                        time:   [4.0835 ms 4.0836 ms 4.0841 ms]
After:
65536/balanced/compute-root-only
                        time:   [555.84 µs 556.90 µs 557.80 µs]

Before:
segment-archiving-whole-segment
                        time:   [1.8868 s 1.8892 s 1.8914 s]
After:
segment-archiving-whole-segment
                        time:   [950.64 ms 957.24 ms 962.52 ms]
```

This is all on a single core. And archiving can be optimized further by making erasure coding more efficient and when BLAKE3 APIs are improved. Not to mention potential GPU acceleration.

Above benchmark is single-threaded, for context, single-threaded Subspace:
```
segment-archiving-whole-segment
                        time:   [39.370 s 39.370 s 39.370 s]
```

:exploding_head: 