### PR TITLE
PoS smaller left targets

### DIFF
--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -32,8 +32,8 @@ use seq_macro::seq;
 use spin::Mutex;
 
 pub(super) const COMPUTE_F1_SIMD_FACTOR: usize = 8;
+const FIND_MATCHES_UNROLL_FACTOR: usize = 8;
 const COMPUTE_FN_SIMD_FACTOR: usize = 16;
-const FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR: usize = 8;
 
 /// Compute the size of `y` in bits
 pub(super) const fn y_size_bits(k: u8) -> usize {
@@ -323,15 +323,15 @@ fn find_matches(
             .as_array();
 
         const _: () = {
-            assert!((PARAM_M as usize).is_multiple_of(FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR));
+            assert!((PARAM_M as usize).is_multiple_of(FIND_MATCHES_UNROLL_FACTOR));
         };
 
         for r_targets in left_targets_r
-            .as_chunks::<FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR>()
+            .as_chunks::<FIND_MATCHES_UNROLL_FACTOR>()
             .0
             .iter()
         {
-            let rmap_items: [_; FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR] = seq!(N in 0..8 {
+            let rmap_items: [_; FIND_MATCHES_UNROLL_FACTOR] = seq!(N in 0..8 {
                 [
                 #(
                     rmap[usize::from(r_targets[N])],
@@ -344,7 +344,7 @@ fn find_matches(
                 continue;
             }
 
-            let _: [(); FIND_MATCHES_AND_COMPUTE_UNROLL_FACTOR] = seq!(N in 0..8 {
+            let _: [(); FIND_MATCHES_UNROLL_FACTOR] = seq!(N in 0..8 {
                 [
                 #(
                 {


### PR DESCRIPTION
I noticed that `LeftTargets` was using `u32` as a value, even though it was indexing a bucket, whose size is `PARAM_BC = 15113`, which fits comfortably into `u16`.

Also the order of elements doesn't impact correctness, but if sorted, it'll help with locality in case smaller chunks of targets are processed at a time, like with current unrolling code.

As the result, the whole thing is just a bit faster. The lowest time I observed decreased too, but remains quite variable:
```
Before:
chia/table/parallel/8x  time:   [684.74 ms 694.02 ms 704.01 ms]
                        thrpt:  [11.363  elem/s 11.527  elem/s 11.683  elem/s]
After:
chia/table/parallel/8x  time:   [677.60 ms 684.25 ms 692.06 ms]
                        thrpt:  [11.560  elem/s 11.692  elem/s 11.806  elem/s]
```