### PR TITLE
PoS buckets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,11 +497,9 @@ dependencies = [
  "chacha20",
  "criterion",
  "derive_more 2.0.1",
- "parking_lot",
  "rayon",
  "seq-macro",
  "sha2 0.11.0-rc.0",
- "spin",
 ]
 
 [[package]]
@@ -3239,15 +3237,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "spin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spirv"

--- a/crates/shared/ab-proof-of-space/Cargo.toml
+++ b/crates/shared/ab-proof-of-space/Cargo.toml
@@ -23,11 +23,9 @@ ab-chacha8 = { workspace = true }
 ab-core-primitives = { workspace = true }
 chacha20 = { workspace = true, features = ["cipher"] }
 derive_more = { workspace = true, features = ["full"] }
-parking_lot = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 seq-macro = { workspace = true }
 sha2 = { workspace = true, optional = true }
-spin = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -44,8 +42,6 @@ alloc = []
 std = [
     "alloc",
     "derive_more/std",
-    # In no-std environment we use `spin`
-    "parking_lot",
 ]
 # Enabling this feature exposes quality search on `chiapos` module as well as enables support for K=15..=25 (by default
 # only K=20 is exposed)

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -690,7 +690,8 @@ pub(super) enum Table<const K: u8, const TABLE_NUMBER: u8>
 where
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
 {
-    /// First table with contents of entries split into separate vectors for more efficient access
+    /// First table with the contents of entries split into separate vectors for more efficient
+    /// access
     First {
         /// Derived values computed from `x`
         ys: Vec<Y>,
@@ -699,7 +700,7 @@ where
     },
     /// Other tables
     Other {
-        /// Derived values computed from previous table
+        /// Derived values computed from the previous table
         ys: Vec<Y>,
         /// Left and right entry positions in a previous table encoded into bits
         positions: Vec<[Position; 2]>,
@@ -821,7 +822,7 @@ where
     Self: private::SupportedOtherTables,
     EvaluatableUsize<{ metadata_size_bytes(K, TABLE_NUMBER) }>: Sized,
 {
-    /// Creates new [`TABLE_NUMBER`] table. There also exists [`Self::create_parallel()`] that
+    /// Creates a new [`TABLE_NUMBER`] table. There also exists [`Self::create_parallel()`] that
     /// trades CPU efficiency and memory usage for lower latency and with multiple parallel calls,
     /// better overall performance.
     pub(super) fn create<const PARENT_TABLE_NUMBER: u8>(
@@ -1058,8 +1059,8 @@ where
         ys
     }
 
-    /// Returns `None` on invalid position or first table, `Some(left_position, right_position)` in
-    /// previous table on success
+    /// Returns `None` for an invalid position or first table, `Some(left_position, right_position)`
+    /// in the previous table on success
     pub(super) fn position(&self, position: Position) -> Option<[Position; 2]> {
         match self {
             Table::First { .. } => None,
@@ -1067,7 +1068,7 @@ where
         }
     }
 
-    /// Returns `None` on invalid position or for table number 7
+    /// Returns `None` for an invalid position or for table number 7
     pub(super) fn metadata(&self, position: Position) -> Option<Metadata<K, TABLE_NUMBER>> {
         match self {
             Table::First { xs, .. } => xs.get(usize::from(position)).map(|&x| Metadata::from(x)),

--- a/crates/shared/ab-proof-of-space/src/lib.rs
+++ b/crates/shared/ab-proof-of-space/src/lib.rs
@@ -5,9 +5,12 @@
 #![feature(
     array_windows,
     generic_const_exprs,
-    iter_collect_into,
+    maybe_uninit_slice,
+    maybe_uninit_write_slice,
     portable_simd,
-    step_trait
+    step_trait,
+    sync_unsafe_cell,
+    vec_into_raw_parts
 )]
 
 pub mod chia;

--- a/specs/00-subspace-diff.md
+++ b/specs/00-subspace-diff.md
@@ -93,3 +93,18 @@ submitted to enact such change.
 
 After switching from KZG to Merkle Trees, commitments are renamed to roots, witnesses to proofs. Scalars are also called
 record chunks now.
+
+## Proof-of-space
+
+While there are many valid proof-of-space constructions that will successfully validate by Subspace consensus, reference
+implementation used one that corresponded to Chia reference implementation and contained all possible proofs. Turns out,
+this is unnecessary for Subspace purposes. Because of this, implementation was optimized for performance on both CPU and
+GPU at the cost of throwing away some proofs, while ensuring there is still enough of them left to fully encode sectors
+during plotting.
+
+In particular, new optimized implementation doesn't sort tables by `y` values, instead it only groups them by buckets,
+while limiting the bucket size for performance reasons. Similarly, matches that were found are also truncated for
+performance reasons. So as a result, some of the proofs that must exist will not be found.
+
+Since the tables are no longer sorted, proof searching now does full scan of the buckets where matching `y` values are
+potentially located, which while is a bit slower, is more than compensated by table creation performance improvements.


### PR DESCRIPTION
This is a major re-architecture of how Proof-of-Space is implemented.

It sacrifices the completeness of the tables for high-performance parallel processing, which is already faster on the CPU and will be very beneficial for GPU implementation as well. See subspace diff document for brief details, I'll also write a blog post describing the changed in more detail.

As the result, table creation is substantially faster, there are less allocations, memory usage has also decreased substantially, probably up to 80%.

The previous best observed result for parallel table construction was:
```
chia/table/parallel/8x  time:   [677.60 ms 684.25 ms 692.06 ms]
                        thrpt:  [11.560  elem/s 11.692  elem/s 11.806  elem/s]
```
With this PR performance is much higher:
```
chia/table/parallel/8x  time:   [543.21 ms 549.05 ms 553.93 ms]
                        thrpt:  [14.442  elem/s 14.571  elem/s 14.727  elem/s]
```

I saw 10ms lower times with slightly different implementation that instead of collecting results into final vectors right away was instead collecting results into intermediate combined vector. While it was a tiny bit faster and simplified the code in a bunch of places, it required more memory in the process. I think now that most places don't use `ys` as a list and values are scattered in RAM anyway, we can combine everything together for both sequential and parallel variant (probably except metadata, which is now freed to reduce peak memory usage and allow allocator to reuse memory), but that will be an exercise for another day.

Single-threaded table creation also improved massively:
```
Before:
chia/table/single/1x    time:   [920.37 ms 924.24 ms 929.24 ms]
                        thrpt:  [1.0762  elem/s 1.0820  elem/s 1.0865  elem/s]
After:
chia/table/single/1x    time:   [750.41 ms 760.79 ms 772.80 ms]
                        thrpt:  [1.2940  elem/s 1.3144  elem/s 1.3326  elem/s]
```

Proof generation is slightly slower, but considering up to $$2^{16}$$ will be queried, the tiny increase in time (~4ms for each encoded piece that will likely be amortized anyway) is certainly worth the performance increase. Also majority of the slowdown is for missing proofs, which are the minority.
```
Before:
chia/proof/missing      time:   [20.764 ns 21.179 ns 21.459 ns]
                        thrpt:  [46.600 Melem/s 47.217 Melem/s 48.160 Melem/s]
chia/proof/present      time:   [360.24 ns 360.65 ns 361.08 ns]
                        thrpt:  [2.7695 Melem/s 2.7727 Melem/s 2.7760 Melem/s]
After:
chia/proof/missing      time:   [101.94 ns 102.22 ns 102.58 ns]
                        thrpt:  [9.7486 Melem/s 9.7824 Melem/s 9.8099 Melem/s]
chia/proof/present      time:   [376.64 ns 377.52 ns 379.55 ns]
                        thrpt:  [2.6347 Melem/s 2.6489 Melem/s 2.6551 Melem/s]
```

There are still a few optimizations to explore with new architecture and, as before, BLAKE3 SIMD will also provide a substantial boost here.

Very happy with the result after countless fruitless attempts and unsuccessful (performance-wise) rewrites, including alternative search implementations and other tweaks. GPU implementation will follow the same general pattern and should be implementable a lot more efficiently than the previous algorithm (while remaining compatible with this updated CPU implementation).

I considered having two incompatible implementations: one CPU-optimized (that can't be used with GPU) and another GPU-optimized (that will have a CPU version as a fallback), but for now I think we can get away with this version.

There are also some optimizations that would introduce non-determinism, which could still be exploited if a trace is recorded about the exact path the code followed during table creation, essentially trading faster initial table creation for slower reconstruction afterward. Don't think it is worth the complexity either, but it is a hypothetical possibility.

So many options to consider after thinking about it during last few weeks!