### PR TITLE
PoS tuning

### DIFF
--- a/crates/shared/ab-proof-of-space/src/chia.rs
+++ b/crates/shared/ab-proof-of-space/src/chia.rs
@@ -72,11 +72,10 @@ impl Table for ChiaTable {
 
     #[cfg(feature = "alloc")]
     fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
-        let mut challenge = [0; 32];
-        challenge[..size_of::<u32>()].copy_from_slice(&challenge_index.to_le_bytes());
+        let first_challenge_bytes = challenge_index.to_le_bytes();
 
         self.tables
-            .find_proof(&challenge)
+            .find_proof(first_challenge_bytes)
             .next()
             .map(PosProof::from)
     }

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -6,7 +6,7 @@ mod tables;
 mod utils;
 
 pub use crate::chiapos::table::TablesCache;
-use crate::chiapos::table::metadata_size_bytes;
+use crate::chiapos::table::{metadata_size_bytes, num_buckets};
 use crate::chiapos::tables::TablesGeneric;
 use crate::chiapos::utils::EvaluatableUsize;
 
@@ -27,7 +27,8 @@ where
     EvaluatableUsize<{ metadata_size_bytes(K, 4) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized;
+    EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
+    [(); num_buckets(K)]:;
 
 macro_rules! impl_any {
     ($($k: expr$(,)? )*) => {

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -28,6 +28,7 @@ where
     EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
+    [(); 1 << K]:,
     [(); num_buckets(K)]:;
 
 macro_rules! impl_any {

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -74,9 +74,9 @@ impl Tables<$k> {
     /// Find proof of space for given challenge.
     pub fn find_proof<'a>(
         &'a self,
-        challenge: &'a Challenge,
+        first_challenge_bytes: [u8; 4],
     ) -> impl Iterator<Item = [u8; 64 * $k / 8]> + 'a {
-        self.0.find_proof(challenge)
+        self.0.find_proof(first_challenge_bytes)
     }
 
     /// Verify proof of space for given seed and challenge.

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
@@ -152,13 +152,13 @@ fn test_matches() {
         {
             *position = Position::from(index as u32);
         }
-        let last_table_ys = left_bucket_ys
+        let parent_table_ys = left_bucket_ys
             .iter()
             .copied()
             .chain(right_bucket_ys.iter().copied())
             .collect::<Vec<_>>();
-        let last_table = Table::<K, 2>::Other {
-            ys: last_table_ys,
+        let parent_table = Table::<K, 2>::Other {
+            ys: parent_table_ys,
             // Not used below
             positions: Default::default(),
             // Not used below
@@ -174,16 +174,16 @@ fn test_matches() {
                 left_bucket_index as u32,
                 &left_bucket,
                 &right_bucket,
-                &last_table,
+                &parent_table,
                 &mut matches,
                 &left_targets,
             )
         };
         for m in matches {
             // SAFETY: All `y`s are initialized
-            let yl = usize::from(unsafe { last_table.y(m.left_position) });
+            let yl = usize::from(unsafe { parent_table.y(m.left_position) });
             // SAFETY: All `y`s are initialized
-            let yr = usize::from(unsafe { last_table.y(m.right_position) });
+            let yr = usize::from(unsafe { parent_table.y(m.right_position) });
 
             assert!(check_match(yl, yr));
             total_matches += 1;

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
@@ -152,15 +152,19 @@ fn test_matches() {
         {
             *position = Position::from(index as u32);
         }
-        let parent_table_ys = left_bucket_ys
-            .iter()
-            .copied()
-            .chain(right_bucket_ys.iter().copied())
-            .collect::<Vec<_>>();
+        // SAFETY: Contents is `MaybeUninit`
+        let mut parent_table_ys =
+            unsafe { Box::<[MaybeUninit<Y>; 1 << K]>::new_uninit().assume_init() };
+        parent_table_ys
+            .iter_mut()
+            .zip(left_bucket_ys.iter().chain(&right_bucket_ys))
+            .for_each(|(output, &input)| {
+                output.write(input);
+            });
         let parent_table = Table::<K, 2>::Other {
             ys: parent_table_ys,
-            // Not used below
-            positions: Default::default(),
+            // SAFETY: Not used below
+            positions: unsafe { Box::new_uninit().assume_init() },
             // Not used below
             metadatas: Default::default(),
             // SAFETY: Not used below

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
@@ -152,15 +152,11 @@ fn test_matches() {
         {
             *position = Position::from(index as u32);
         }
-        // SAFETY: Contents is `MaybeUninit`
-        let mut parent_table_ys =
-            unsafe { Box::<[MaybeUninit<Y>; 1 << K]>::new_uninit().assume_init() };
-        parent_table_ys
-            .iter_mut()
-            .zip(left_bucket_ys.iter().chain(&right_bucket_ys))
-            .for_each(|(output, &input)| {
-                output.write(input);
-            });
+        let parent_table_ys = left_bucket_ys
+            .iter()
+            .copied()
+            .chain(right_bucket_ys.iter().copied())
+            .collect::<Vec<_>>();
         let parent_table = Table::<K, 2>::Other {
             ys: parent_table_ys,
             // SAFETY: Not used below

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
@@ -7,10 +7,11 @@ use crate::chiapos::Seed;
 use crate::chiapos::constants::{PARAM_B, PARAM_BC, PARAM_C, PARAM_EXT};
 use crate::chiapos::table::types::{Metadata, Position, X, Y};
 use crate::chiapos::table::{
-    COMPUTE_F1_SIMD_FACTOR, calculate_left_targets, compute_f1, compute_f1_simd, compute_fn,
+    COMPUTE_F1_SIMD_FACTOR, Table, calculate_left_targets, compute_f1, compute_f1_simd, compute_fn,
     compute_fn_simd, find_matches_in_buckets, metadata_size_bytes,
 };
 use crate::chiapos::utils::EvaluatableUsize;
+use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -155,8 +156,16 @@ fn test_matches() {
             .iter()
             .copied()
             .chain(right_bucket_ys.iter().copied())
-            .map(MaybeUninit::new)
             .collect::<Vec<_>>();
+        let last_table = Table::<K, 2>::Other {
+            ys: last_table_ys,
+            // Not used below
+            positions: Default::default(),
+            // Not used below
+            metadatas: Default::default(),
+            // SAFETY: Not used below
+            buckets: unsafe { Box::new_uninit().assume_init() },
+        };
 
         let mut matches = [MaybeUninit::uninit(); _];
         // SAFETY: Positions correspond to `y`s
@@ -165,26 +174,16 @@ fn test_matches() {
                 left_bucket_index as u32,
                 &left_bucket,
                 &right_bucket,
-                &last_table_ys,
+                &last_table,
                 &mut matches,
                 &left_targets,
             )
         };
         for m in matches {
             // SAFETY: All `y`s are initialized
-            let yl = usize::from(unsafe {
-                last_table_ys
-                    .get(usize::from(m.left_position))
-                    .unwrap()
-                    .assume_init()
-            });
+            let yl = usize::from(unsafe { last_table.y(m.left_position) });
             // SAFETY: All `y`s are initialized
-            let yr = usize::from(unsafe {
-                last_table_ys
-                    .get(usize::from(m.right_position))
-                    .unwrap()
-                    .assume_init()
-            });
+            let yr = usize::from(unsafe { last_table.y(m.right_position) });
 
             assert!(check_match(yl, yr));
             total_matches += 1;

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/types.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/types.rs
@@ -3,7 +3,6 @@ use crate::chiapos::table::metadata_size_bytes;
 use crate::chiapos::utils::EvaluatableUsize;
 use core::iter::Step;
 use core::mem;
-use core::mem::MaybeUninit;
 use core::ops::RangeInclusive;
 use derive_more::{Add, AddAssign, From, Into};
 
@@ -93,15 +92,6 @@ impl Y {
         // TODO: Should have been transmute, but https://github.com/rust-lang/rust/issues/61956
         // SAFETY: `Y` is `#[repr(C)]` and guaranteed to have the same memory layout
         unsafe { mem::transmute_copy(&array) }
-    }
-
-    /// Convenient conversion to a slice of underlying representation for efficiency purposes
-    #[inline(always)]
-    pub(super) const fn maybe_uninit_repr_from_slice(
-        value: &[MaybeUninit<Self>],
-    ) -> &[MaybeUninit<u32>] {
-        // SAFETY: `Y` is `#[repr(C)]` and guaranteed to have the same memory layout
-        unsafe { mem::transmute(value) }
     }
 }
 

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
@@ -193,15 +193,12 @@ where
     /// Find proof of space for a given challenge
     pub(super) fn find_proof<'a>(
         &'a self,
-        challenge: &'a Challenge,
+        first_challenge_bytes: [u8; 4],
     ) -> impl Iterator<Item = [u8; 64 * K as usize / 8]> + 'a {
         // We take advantage of the fact that entries are sorted by `y` (as big-endian numbers) to
         // quickly seek to desired offset
-        let first_k_challenge_bits = u32::from_be_bytes(
-            challenge[..size_of::<u32>()]
-                .try_into()
-                .expect("Challenge is known to statically have enough bytes; qed"),
-        ) >> (u32::BITS as usize - usize::from(K));
+        let first_k_challenge_bits =
+            u32::from_be_bytes(first_challenge_bytes) >> (u32::BITS as usize - usize::from(K));
 
         // Iterate just over elements that are matching `first_k_challenge_bits` prefix
         self.table_7.buckets()[Y::bucket_range_from_first_k_bits(first_k_challenge_bits)]

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
@@ -42,6 +42,7 @@ where
     EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
+    [(); 1 << K]:,
     [(); num_buckets(K)]:,
 {
     table_2: Table<K, 2>,
@@ -63,6 +64,7 @@ where
     EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
     EvaluatableUsize<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>: Sized,
     EvaluatableUsize<{ 64 * K as usize / 8 }>: Sized,
+    [(); 1 << K]:,
     [(); num_buckets(K)]:,
 {
     /// Create Chia proof of space tables. There also exists [`Self::create_parallel()`] that trades

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
@@ -8,6 +8,7 @@ pub use crate::chiapos::table::TablesCache;
 use crate::chiapos::table::types::{Metadata, Position, X, Y};
 use crate::chiapos::table::{
     COMPUTE_F1_SIMD_FACTOR, Table, compute_f1, compute_fn, has_match, metadata_size_bytes,
+    num_buckets,
 };
 use crate::chiapos::utils::EvaluatableUsize;
 use crate::chiapos::{Challenge, Quality, Seed};
@@ -41,6 +42,7 @@ where
     EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
+    [(); num_buckets(K)]:,
 {
     table_2: Table<K, 2>,
     table_3: Table<K, 3>,
@@ -61,6 +63,7 @@ where
     EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
     EvaluatableUsize<{ K as usize * COMPUTE_F1_SIMD_FACTOR / u8::BITS as usize }>: Sized,
     EvaluatableUsize<{ 64 * K as usize / 8 }>: Sized,
+    [(); num_buckets(K)]:,
 {
     /// Create Chia proof of space tables. There also exists [`Self::create_parallel()`] that trades
     /// CPU efficiency and memory usage for lower latency.

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables/tests.rs
@@ -18,15 +18,18 @@ fn self_verification() {
     for challenge_index in 0..1000_u32 {
         let mut challenge = [0; 32];
         challenge[..size_of::<u32>()].copy_from_slice(&challenge_index.to_le_bytes());
+        let first_challenge_bytes = challenge[..4].try_into().unwrap();
         let qualities = tables.find_quality(&challenge).collect::<Vec<_>>();
         assert_eq!(
             qualities,
             tables_parallel.find_quality(&challenge).collect::<Vec<_>>()
         );
-        let proofs = tables.find_proof(&challenge).collect::<Vec<_>>();
+        let proofs = tables.find_proof(first_challenge_bytes).collect::<Vec<_>>();
         assert_eq!(
             proofs,
-            tables_parallel.find_proof(&challenge).collect::<Vec<_>>()
+            tables_parallel
+                .find_proof(first_challenge_bytes)
+                .collect::<Vec<_>>()
         );
 
         assert_eq!(qualities.len(), proofs.len());

--- a/crates/shared/ab-proof-of-space/src/lib.rs
+++ b/crates/shared/ab-proof-of-space/src/lib.rs
@@ -16,6 +16,7 @@
     sync_unsafe_cell,
     vec_into_raw_parts
 )]
+extern crate alloc;
 
 pub mod chia;
 pub mod chiapos;

--- a/crates/shared/ab-proof-of-space/src/lib.rs
+++ b/crates/shared/ab-proof-of-space/src/lib.rs
@@ -4,7 +4,11 @@
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
 #![feature(
     array_windows,
+    const_from,
+    const_trait_impl,
+    exact_size_is_empty,
     generic_const_exprs,
+    maybe_uninit_fill,
     maybe_uninit_slice,
     maybe_uninit_write_slice,
     portable_simd,

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -197,7 +197,6 @@ dependencies = [
  "derive_more 2.0.1",
  "rayon",
  "seq-macro",
- "spin 0.10.0",
 ]
 
 [[package]]
@@ -7414,7 +7413,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin 0.5.2",
+ "spin",
  "untrusted 0.7.1",
  "web-sys",
  "winapi",
@@ -9902,15 +9901,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spinning_top"


### PR DESCRIPTION
This is a follow-up to https://github.com/nazar-pc/abundance/pull/380, where all allocations are fixed size. The performance is mostly the same as before with some variability. While I did notice slightly higher peak performance, I'd say it is inconclusive:
```
Before:
chia/table/single/1x    time:   [750.41 ms 760.79 ms 772.80 ms]
                        thrpt:  [1.2940  elem/s 1.3144  elem/s 1.3326  elem/s]
chia/table/parallel/8x  time:   [543.21 ms 549.05 ms 553.93 ms]
                        thrpt:  [14.442  elem/s 14.571  elem/s 14.727  elem/s]
After:
chia/table/single/1x    time:   [747.82 ms 756.94 ms 768.09 ms]
                        thrpt:  [1.3019  elem/s 1.3211  elem/s 1.3372  elem/s]
chia/table/parallel/8x  time:   [529.15 ms 534.42 ms 540.15 ms]
                        thrpt:  [14.811  elem/s 14.969  elem/s 15.119  elem/s]
```

It is nice to break 15 elements/s on 8C16T CPU though.

The biggest noticeable change is probably even lower memory usage with `y`s of the parent table being freed after use like metadata clearing introduced in https://github.com/nazar-pc/abundance/pull/380.