### PR TITLE
PoS smaller rmap

### DIFF
--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -420,8 +420,8 @@ where
         // SAFETY: `r` is within a bucket and exists by definition
         let rmap_item = unsafe { rmap.get_unchecked_mut(r) };
 
-        // The same `y` and as a result `r` can appear in the table multiple times. We support up to
-        // two duplicates here.
+        // The same `y` and as a result `r` can appear in the table multiple times, one duplicate is
+        // supported here.
         if rmap_item[0] == Position::ZERO {
             rmap_item[0] = right_position;
         } else if rmap_item[1] == Position::ZERO {
@@ -456,7 +456,7 @@ where
             let rmap_items: [_; FIND_MATCHES_UNROLL_FACTOR] = seq!(N in 0..8 {
                 [
                 #(
-                    // SAFETY: Targets are always limited to `PARAM_BC` and this guaranteed to exist
+                    // SAFETY: Targets are always limited to `PARAM_BC` and is guaranteed to exist
                     // in `rmap`
                     *unsafe { rmap.get_unchecked(usize::from(r_targets[N])) },
                 )*

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/rmap.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/rmap.rs
@@ -1,0 +1,78 @@
+use crate::chiapos::constants::PARAM_BC;
+use crate::chiapos::table::REDUCED_BUCKETS_SIZE;
+use crate::chiapos::table::types::Position;
+
+pub(super) struct Rmap {
+    /// `0` is a sentinel value indicating no virtual pointer is stored yet.
+    ///
+    /// Physical pointer must be increased by `1` to get a virtual pointer before storing. Virtual
+    /// pointer must be decreased by `1` before reading to get a physical pointer.
+    virtual_pointers: [u16; PARAM_BC as usize],
+    positions: [[Position; 2]; REDUCED_BUCKETS_SIZE],
+    next_physical_pointer: u16,
+}
+
+impl Rmap {
+    #[inline(always)]
+    pub(super) fn new() -> Self {
+        Self {
+            virtual_pointers: [0; _],
+            positions: [[Position::ZERO; 2]; _],
+            next_physical_pointer: 0,
+        }
+    }
+
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
+    /// inserted
+    #[inline(always)]
+    unsafe fn insertion_item(&mut self, r: u32) -> &mut [Position; 2] {
+        // SAFETY: Guaranteed by function contract
+        let virtual_pointer = unsafe { self.virtual_pointers.get_unchecked_mut(r as usize) };
+
+        if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+            // SAFETY: Internal pointers are always valid
+            return unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) };
+        }
+
+        let physical_pointer = self.next_physical_pointer;
+        self.next_physical_pointer += 1;
+        *virtual_pointer = physical_pointer + 1;
+
+        // SAFETY: It is guaranteed by the function contract that the number of added elements will
+        // never exceed `REDUCED_BUCKETS_SIZE`, hence allocated pointers will always be within
+        // bounds
+        unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) }
+    }
+
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
+    /// inserted
+    #[inline(always)]
+    pub(super) unsafe fn add(&mut self, r: u32, position: Position) {
+        // SAFETY: Guaranteed by function contract
+        let rmap_item = unsafe { self.insertion_item(r) };
+
+        // The same `r` can appear in the table multiple times, one duplicate is supported here
+        if rmap_item[0] == Position::ZERO {
+            rmap_item[0] = position;
+        } else if rmap_item[1] == Position::ZERO {
+            rmap_item[1] = position;
+        }
+    }
+
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`
+    #[inline(always)]
+    pub(super) unsafe fn get(&self, r: u32) -> [Position; 2] {
+        // SAFETY: Guaranteed by function contract
+        let virtual_pointer = *unsafe { self.virtual_pointers.get_unchecked(r as usize) };
+
+        if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+            // SAFETY: Internal pointers are always valid
+            *unsafe { self.positions.get_unchecked(physical_pointer as usize) }
+        } else {
+            [Position::ZERO; 2]
+        }
+    }
+}

--- a/subspace/Cargo.lock
+++ b/subspace/Cargo.lock
@@ -12351,8 +12351,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "cipher"
-version = "0.5.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits?rev=57aea511ffc6e8122ef4abced5135ea29473ef8d#57aea511ffc6e8122ef4abced5135ea29473ef8d"


### PR DESCRIPTION
`rmap` is a key data structure for finding matches. Unfortunately, it was quite large:
> PARAM_BC * size_of::<[Position; 2]>() = 15113 * 8 = 120904 bytes

While not a huge issue for CPU, it is still large enough to not fit into L1 CPU cache. The situation is even worse on GPUs, where it is extremely desirable to keep hot data in shared memory, which is also very small (~32 kiB on older GPUs, could be 64 kiB or larger on latest GPUs).

This PR exploits the fact that while the number of slots in `rmap` is 15113, the actual number of elements is upper-bound by a constant 272. So we can create two maps: one small map with 15113 small 16-bit pointers (I tried making it even smaller with 9-bit pointers, but on CPU it becomes slightly slower than larger `rmap` rather than faster, might be different on GPU though) into the second map with just 272 larger `[Position; 2]` elements.

Two maps require strictly more instructions, but benefit from smaller footprint:
> PARAM_BC * size_of::<u16>() + REDUCED_BUCKETS_SIZE * size_of::<[Position; 2]>() = 15113 * 2 + 272 * 8 = 30226 + 2176 = 32402 bytes

This fits nicely into 32 kiB limit of shared memory on all Vulkan-capable GPUs and ends up being a bit faster for multi-threaded CPU implementation too:
```
Before:
chia/table/parallel/8x  time:   [529.15 ms 534.42 ms 540.15 ms]
                        thrpt:  [14.811  elem/s 14.969  elem/s 15.119  elem/s]
After:
chia/table/parallel/8x  time:   [518.48 ms 521.57 ms 525.13 ms]
                        thrpt:  [15.234  elem/s 15.338  elem/s 15.430  elem/s]
```

If using 9-bit pointers will have adequate performance, it should be possible to fit both `rmap` and matches found in shared memory of 32 kiB, which would be very nice!