### PR TITLE
Modern/fallback GPU shaders

### DIFF
--- a/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
@@ -9,28 +9,53 @@ mod shader_bytes;
 // TODO: Reuse constants from `ab-proof-of-space` once it compiles with `rust-gpu`
 pub mod types;
 
-/// Compiled SPIR-V shader for GPU that only supports `u32` (no `Int64` capability).
-///
-/// For a shader with `Int64` capability, see [`SHADER_U64`].
 #[cfg(not(target_arch = "spirv"))]
-pub const SHADER_U32: wgpu::ShaderModuleDescriptor<'static> = {
+use wgpu::{Features, Limits};
+
+/// Compiled SPIR-V shader for GPU that only supports baseline Vulkan features.
+///
+/// For a shader with modern features, see [`SHADER_MODERN`].
+#[cfg(not(target_arch = "spirv"))]
+const SHADER_FALLBACK: wgpu::ShaderModuleDescriptor<'static> = {
     use crate::shader::shader_bytes::ShaderBytes;
 
     const SHADER_BYTES_INTERNAL: &ShaderBytes<[u8]> =
-        &ShaderBytes(*include_bytes!(env!("SHADER_PATH_U32")));
+        &ShaderBytes(*include_bytes!(env!("SHADER_PATH_FALLBACK")));
 
     SHADER_BYTES_INTERNAL.to_module()
 };
 
-/// Compiled SPIR-V shader for GPUs that supports `u64` (`Int64` capability).
+/// Compiled SPIR-V shader for GPUs that supports modern Vulkan features.
 ///
-/// For a shader without `Int64` capability, see [`SHADER_U32`].
+/// For a shader without modern features, see [`SHADER_FALLBACK`].
 #[cfg(not(target_arch = "spirv"))]
-pub const SHADER_U64: wgpu::ShaderModuleDescriptor<'static> = {
+const SHADER_MODERN: wgpu::ShaderModuleDescriptor<'static> = {
     use crate::shader::shader_bytes::ShaderBytes;
 
     const SHADER_BYTES_INTERNAL: &ShaderBytes<[u8]> =
-        &ShaderBytes(*include_bytes!(env!("SHADER_PATH_U64")));
+        &ShaderBytes(*include_bytes!(env!("SHADER_PATH_MODERN")));
 
     SHADER_BYTES_INTERNAL.to_module()
 };
+
+#[cfg(not(target_arch = "spirv"))]
+pub fn select_shader_features_limits(
+    adapter_features: Features,
+) -> (wgpu::ShaderModuleDescriptor<'static>, Features, Limits) {
+    const SHADER_MODERN_FEATURES: Features = Features::SHADER_INT64;
+
+    if adapter_features.contains(SHADER_MODERN_FEATURES) {
+        (
+            SHADER_MODERN,
+            SHADER_MODERN_FEATURES,
+            Limits {
+                // Modern GPUs have at least 32 kiB of shared memory
+                max_compute_workgroup_storage_size: 32 * 1024,
+                ..Limits::defaults()
+            },
+        )
+    } else {
+        // Fallback GPU supports only baseline features and no extras
+        (SHADER_FALLBACK, Features::default(), Limits::defaults())
+    }
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/chacha8.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/chacha8.rs
@@ -5,30 +5,29 @@ use ab_chacha8::{ChaCha8Block, ChaCha8State};
 use spirv_std::glam::UVec3;
 use spirv_std::spirv;
 
+// TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` below, can be removed once
+//  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+const WORKGROUP_SIZE: u32 = 256;
+
 /// Produce a ChaCha8 keystream.
 ///
-/// NOTE: Length of the keystream is limited by `u32`
+/// NOTE: Length of the keystream is limited by `u32`.
 #[spirv(compute(threads(256), entry_point_name = "chacha8_keystream"))]
 pub fn chacha8_keystream(
-    #[spirv(global_invocation_id)] invocation_id: UVec3,
+    #[spirv(global_invocation_id)] global_invocation_id: UVec3,
     #[spirv(num_workgroups)] num_workgroups: UVec3,
-    // TODO: Uncomment once https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
-    // #[spirv(workgroup_size)] workgroup_size: UVec3,
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] initial_state: &ChaCha8Block,
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] keystream: &mut [ChaCha8Block],
 ) {
-    let invocation_id = invocation_id.x;
+    let global_invocation_id = global_invocation_id.x;
     let num_workgroups = num_workgroups.x;
 
-    // TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` above, can be removed once
-    //  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
-    let workgroup_size = 256_u32;
-    let global_size = workgroup_size * num_workgroups;
+    let global_size = WORKGROUP_SIZE * num_workgroups;
     let initial_state = ChaCha8State::from_repr(*initial_state);
 
     // TODO: More idiomatic version currently doesn't compile:
     //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
-    for position in (invocation_id..keystream.len() as u32).step_by(global_size as usize) {
+    for position in (global_invocation_id..keystream.len() as u32).step_by(global_size as usize) {
         // TODO: Make sure bounds check here is elided
         keystream[position as usize] = initial_state.compute_block(position);
     }

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -397,11 +397,6 @@ where
     [(); 1 << K]:,
     [(); num_buckets(K)]:,
 {
-    if right_bucket[0] == Position::SENTINEL {
-        // Completely empty bucket
-        return &[];
-    }
-
     let left_base = left_bucket_index * u32::from(PARAM_BC);
     let right_base = left_base + u32::from(PARAM_BC);
 


### PR DESCRIPTION
This prepares for more separation between two shader builds. It is no longer about supporting or not supporting `u64`, but also shared memory size and potentially some other features.

Modern version will assume relatively modern GPUs with 32 kiB+ of shared memory, the fallback version will work fine on baseline 16 kiB too, although with reduced performance.

There are also some cleanups included here.

Not in this PR, but Vulkan version requirements will also increase to 1.3 (for both variants) in order to support compact and efficient implementation using subgroup intrinsics of rust-gpu.