### PR TITLE
Implement `find_matches_in_buckets` shader for GPU

### DIFF
--- a/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
+++ b/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
@@ -39,7 +39,11 @@ futures = { workspace = true, features = ["executor"] }
 cargo-gpu = { workspace = true }
 
 [features]
+# GPU tests search for compatible GPU. If no compatible GPU is found, tests are skipped unless this feature is
+# specified.
 __force-gpu-tests = []
+# Internal feature used by the build script for shader compilation. Should not be used externally.
+__modern-gpu = []
 
 [lints]
 workspace = true

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -4,7 +4,11 @@
 //! structures used (`ab-proof-of-space` also supports `K=25`, but this crate doesn't for now).
 
 #![cfg_attr(target_arch = "spirv", no_std)]
-#![feature(bigint_helper_methods, step_trait)]
+#![feature(array_windows, bigint_helper_methods, ptr_as_ref_unchecked, step_trait)]
+#![cfg_attr(
+    all(test, not(miri), not(target_arch = "spirv")),
+    feature(const_convert, const_trait_impl, maybe_uninit_fill, maybe_uninit_slice)
+)]
 
 // This is used for benchmarks of isolated shaders externally, not for general use
 #[doc(hidden)]

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
@@ -3,6 +3,7 @@ pub mod compute_f1;
 pub mod compute_fn;
 // TODO: Reuse constants from `ab-proof-of-space` once it compiles with `rust-gpu`
 mod constants;
+pub mod find_matches_in_buckets;
 mod num;
 #[cfg(not(target_arch = "spirv"))]
 mod shader_bytes;
@@ -11,6 +12,9 @@ pub mod types;
 
 #[cfg(not(target_arch = "spirv"))]
 use wgpu::{Features, Limits};
+
+/// `4` is used by LLVMpipe, hence such a low number here
+const MIN_SUBGROUP_SIZE: u32 = 4;
 
 /// Compiled SPIR-V shader for GPU that only supports baseline Vulkan features.
 ///
@@ -38,24 +42,42 @@ const SHADER_MODERN: wgpu::ShaderModuleDescriptor<'static> = {
     SHADER_BYTES_INTERNAL.to_module()
 };
 
+/// For a given set of adapter features function returns the appropriate shader version, required
+/// features, required limits and a boolean flag indicating whether the adapter is modern or not
 #[cfg(not(target_arch = "spirv"))]
 pub fn select_shader_features_limits(
     adapter_features: Features,
-) -> (wgpu::ShaderModuleDescriptor<'static>, Features, Limits) {
-    const SHADER_MODERN_FEATURES: Features = Features::SHADER_INT64;
+) -> (
+    wgpu::ShaderModuleDescriptor<'static>,
+    Features,
+    Limits,
+    bool,
+) {
+    const SHADER_BASELINE_FEATURES: Features = Features::SUBGROUP;
+    const SHADER_MODERN_FEATURES: Features = SHADER_BASELINE_FEATURES.union(Features::SHADER_INT64);
 
     if adapter_features.contains(SHADER_MODERN_FEATURES) {
         (
             SHADER_MODERN,
             SHADER_MODERN_FEATURES,
             Limits {
+                min_subgroup_size: MIN_SUBGROUP_SIZE,
                 // Modern GPUs have at least 32 kiB of shared memory
                 max_compute_workgroup_storage_size: 32 * 1024,
                 ..Limits::defaults()
             },
+            true,
         )
     } else {
         // Fallback GPU supports only baseline features and no extras
-        (SHADER_FALLBACK, Features::default(), Limits::defaults())
+        (
+            SHADER_FALLBACK,
+            SHADER_BASELINE_FEATURES,
+            Limits {
+                min_subgroup_size: MIN_SUBGROUP_SIZE,
+                ..Limits::defaults()
+            },
+            false,
+        )
     }
 }

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/chacha8/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/chacha8/gpu_tests.rs
@@ -74,7 +74,7 @@ async fn chacha8_keystream_10_blocks_adapter(
     num_blocks: usize,
     adapter: Adapter,
 ) -> Option<Vec<ChaCha8Block>> {
-    let (shader, required_features, required_limits) =
+    let (shader, required_features, required_limits, _modern) =
         select_shader_features_limits(adapter.features());
 
     let (device, queue) = adapter
@@ -173,7 +173,7 @@ async fn chacha8_keystream_10_blocks_adapter(
         let mut cpass = encoder.begin_compute_pass(&Default::default());
         cpass.set_bind_group(0, &bind_group, &[]);
         cpass.set_pipeline(&compute_pipeline);
-        cpass.dispatch_workgroups(device.limits().max_compute_workgroup_size_x, 1, 1);
+        cpass.dispatch_workgroups(device.limits().max_compute_workgroups_per_dimension, 1, 1);
     }
 
     encoder.copy_buffer_to_buffer(&keystream_gpu, 0, &keystream_host, 0, keystream_host.size());

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1/gpu_tests.rs
@@ -82,7 +82,7 @@ async fn compute_f1_adapter(
     num_x: u32,
     adapter: Adapter,
 ) -> Option<Vec<Y>> {
-    let (shader, required_features, required_limits) =
+    let (shader, required_features, required_limits, _modern) =
         select_shader_features_limits(adapter.features());
 
     let (device, queue) = adapter
@@ -185,7 +185,7 @@ async fn compute_f1_adapter(
         let mut cpass = encoder.begin_compute_pass(&Default::default());
         cpass.set_bind_group(0, &bind_group, &[]);
         cpass.set_pipeline(&compute_pipeline);
-        cpass.dispatch_workgroups(device.limits().max_compute_workgroup_size_x, 1, 1);
+        cpass.dispatch_workgroups(device.limits().max_compute_workgroups_per_dimension, 1, 1);
     }
 
     encoder.copy_buffer_to_buffer(&ys_gpu, 0, &ys_host, 0, ys_host.size());

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/constants.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/constants.rs
@@ -5,9 +5,21 @@ pub(super) const K: u8 = 20;
 const _: () = {
     assert!(K == ab_core_primitives::pos::PosProof::K);
 };
+/// Reducing bucket size for better performance.
+///
+/// The number should be sufficient to produce enough proofs for sector encoding with high
+/// probability.
+// TODO: Statistical analysis if possible.
+pub(super) const REDUCED_BUCKETS_SIZE: usize = 272;
+/// Reducing matches count for better performance.
+///
+/// The number should be sufficient to produce enough proofs for sector encoding with high
+/// probability.
+// TODO: Statistical analysis if possible.
+pub(super) const REDUCED_MATCHES_COUNT: usize = 288;
 /// PRNG extension parameter to avoid collisions
 pub(super) const PARAM_EXT: u8 = 6;
-// pub(super) const PARAM_M: u16 = 1 << PARAM_EXT;
-// pub(super) const PARAM_B: u16 = 119;
-// pub(super) const PARAM_C: u16 = 127;
-// pub(super) const PARAM_BC: u16 = PARAM_B * PARAM_C;
+pub(super) const PARAM_M: u16 = 1 << PARAM_EXT;
+pub(super) const PARAM_B: u16 = 119;
+pub(super) const PARAM_C: u16 = 127;
+pub(super) const PARAM_BC: u16 = PARAM_B * PARAM_C;

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets.rs
@@ -1,0 +1,535 @@
+#[cfg(all(test, not(miri), not(target_arch = "spirv")))]
+mod cpu_tests;
+#[cfg(all(test, not(miri), not(target_arch = "spirv")))]
+mod gpu_tests;
+pub mod rmap;
+
+use crate::shader::MIN_SUBGROUP_SIZE;
+use crate::shader::constants::{PARAM_BC, PARAM_M, REDUCED_BUCKETS_SIZE, REDUCED_MATCHES_COUNT};
+use crate::shader::find_matches_in_buckets::rmap::{
+    NextPhysicalPointer, Rmap, RmapBitPosition, RmapBitPositionExt,
+};
+use crate::shader::types::{Position, PositionExt, Y};
+use core::mem::MaybeUninit;
+use spirv_std::arch::{
+    control_barrier, subgroup_exclusive_i_add, subgroup_i_add,
+    workgroup_memory_barrier_with_group_sync,
+};
+use spirv_std::glam::UVec3;
+use spirv_std::memory::{Scope, Semantics};
+use spirv_std::spirv;
+
+// TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` below, can be removed once
+//  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+pub const WORKGROUP_SIZE: u32 = 256;
+/// Worst-case for the number of subgroups
+pub const MAX_SUBGROUPS: usize = (WORKGROUP_SIZE / MIN_SUBGROUP_SIZE) as usize;
+
+// TODO: This is a polyfill to work around for this issue:
+//  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+#[cfg(target_arch = "spirv")]
+trait ArrayIndexingPolyfill<T> {
+    /// The same as [`<[T]>::get_unchecked()`]
+    unsafe fn get_unchecked(&self, index: usize) -> &T;
+    /// The same as [`<[T]>::get_unchecked_mut()`]
+    unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T;
+}
+
+#[cfg(target_arch = "spirv")]
+impl<const N: usize, T> ArrayIndexingPolyfill<T> for [T; N] {
+    #[inline(always)]
+    unsafe fn get_unchecked(&self, index: usize) -> &T {
+        &self[index]
+    }
+
+    #[inline(always)]
+    unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
+        &mut self[index]
+    }
+}
+
+/// Container that presents itself slightly differently on CPU and GPU
+#[derive(Debug)]
+#[repr(C)]
+pub struct LeftTargetsR {
+    #[cfg(not(target_arch = "spirv"))]
+    inner: [u16; PARAM_M as usize],
+    /// Using `u32` as a container on GPU due to lack of consistent `u16` support even among modern
+    /// GPUs (notably, Naga can't recompile it to Metal today)
+    #[cfg(target_arch = "spirv")]
+    inner: [u32; PARAM_M as usize / 2],
+}
+
+impl LeftTargetsR {
+    /// # Safety
+    /// `index` must be within `0..PARAM_M` range
+    #[cfg(not(target_arch = "spirv"))]
+    #[inline(always)]
+    unsafe fn get_r(&self, index: u32) -> u32 {
+        // SAFETY: Guaranteed by function contract
+        u32::from(*unsafe { self.inner.get_unchecked(index as usize) })
+    }
+
+    /// # Safety
+    /// `index` must be within `0..PARAM_M` range
+    #[cfg(target_arch = "spirv")]
+    #[inline(always)]
+    unsafe fn get_r(&self, index: u32) -> u32 {
+        // SAFETY: Guaranteed by function contract
+        let base = *unsafe { self.inner.get_unchecked(index as usize / 2) };
+        // Compute shift: 0 for even index, 16 for odd index
+        let shift = (index & 1) * u16::BITS;
+        // Shift and extract `u16`
+        (base >> shift) & u32::from(u16::MAX)
+    }
+}
+
+/// Mapping from `parity` to `r` to `m`
+pub type LeftTargets = [[LeftTargetsR; PARAM_BC as usize]; 2];
+
+#[derive(Debug)]
+pub struct SharedScratchSpace {
+    bucket_size_a: [MaybeUninit<u32>; REDUCED_BUCKETS_SIZE],
+    bucket_size_b: [MaybeUninit<u32>; REDUCED_BUCKETS_SIZE],
+    num_subgroups_size_a: [MaybeUninit<u32>; MAX_SUBGROUPS],
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(C)]
+pub struct Match {
+    pub left_position: Position,
+    // TODO: Would it be efficient to not store it here since `left_position` already points to the
+    //  correct `y` in the parent table?
+    pub left_y: Y,
+    pub right_position: Position,
+}
+
+// TODO: Reuse code from `ab-proof-of-space` after https://github.com/Rust-GPU/rust-gpu/pull/249 and
+//  https://github.com/Rust-GPU/rust-gpu/discussions/301
+/// Returns the number of matches found.
+///
+/// # Safety
+/// Left and right bucket positions must correspond to the parent table. Must be called from
+/// [`WORKGROUP_SIZE`] threads with `local_invocation_id` corresponding to the thread index.
+/// `num_subgroups` must be at most [`MAX_SUBGROUPS`] and `subgroup_id` must be within
+/// `0..num_subgroups`.
+// TODO: Try to reduce the `matches` size further by processing `left_bucket` in chunks (like halves
+//  for example)
+#[expect(clippy::too_many_arguments, reason = "Function is inlined anyway")]
+#[inline(always)]
+pub(super) unsafe fn find_matches_in_buckets_impl(
+    subgroup_id: u32,
+    num_subgroups: u32,
+    local_invocation_id: u32,
+    left_bucket_index: u32,
+    left_bucket: &[Position; REDUCED_BUCKETS_SIZE],
+    right_bucket: &[Position; REDUCED_BUCKETS_SIZE],
+    parent_table_ys: &[Y],
+    matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
+    left_targets: &LeftTargets,
+    scratch_space: &mut SharedScratchSpace,
+    rmap: &mut MaybeUninit<Rmap>,
+) -> u32 {
+    let SharedScratchSpace {
+        bucket_size_a,
+        bucket_size_b,
+        num_subgroups_size_a,
+    } = scratch_space;
+
+    let left_base = left_bucket_index * u32::from(PARAM_BC);
+    let right_base = left_base + u32::from(PARAM_BC);
+
+    // Zero-initialize `rmap`
+    let rmap = {
+        const {
+            assert!(size_of::<Rmap>().is_multiple_of(size_of::<u32>()));
+            assert!(align_of::<Rmap>() == align_of::<u32>());
+
+            const fn assert_copy<T: Copy>() {}
+            assert_copy::<Rmap>();
+        }
+        // TODO: Proper parallel version currently doesn't compile, remove zeroing hack once it
+        //  does: https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+        // // SAFETY: `Rmap` is a simple `Copy` struct for which zero-initialization is valid
+        // let rmap_words = unsafe {
+        //     rmap.as_mut_ptr()
+        //         .cast::<[MaybeUninit<u32>; size_of::<Rmap>() / size_of::<u32>()]>()
+        //         .as_mut_unchecked()
+        // };
+        // for word_index in (0..size_of::<Rmap>())
+        //     .skip(local_invocation_id as usize)
+        //     .step_by(WORKGROUP_SIZE as usize)
+        // {
+        //     // SAFETY: `word_index` is within bounds of `Rmap`
+        //     unsafe {
+        //         rmap_words.get_unchecked_mut(word_index).write(0);
+        //     }
+        // }
+        Rmap::zeroing_hack(rmap);
+
+        // No barrier here, but `rmap` is not used until after the barrier below (as part of reading
+        // right bucket), so it will be synchronized there together
+
+        // SAFETY: Initialized with zeroes
+        unsafe { rmap.assume_init_mut() }
+    };
+
+    // Load both into shared memory and precompute `rmap_bit_positions`. `rmap_bit_position`s for
+    // non-sentinel positions are guaranteed to be initialized
+    let (right_bucket_positions, right_rmap_bit_positions) = {
+        let right_bucket_positions =
+            <Position as PositionExt>::uninit_array_from_repr_mut(bucket_size_a);
+        let rmap_bit_positions =
+            <RmapBitPosition as RmapBitPositionExt>::uninit_array_from_repr_mut(bucket_size_b);
+        // TODO: More idiomatic version currently doesn't compile:
+        //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+        // for ((&right_position, position), rmap_bit_position) in right_bucket
+        //     .iter()
+        //     .zip(right_bucket_positions.iter_mut())
+        //     .zip(rmap_bit_positions.iter_mut())
+        //     .skip(local_invocation_id as usize)
+        //     .step_by(WORKGROUP_SIZE as usize)
+        // {
+        for index in
+            (local_invocation_id as usize..right_bucket.len()).step_by(WORKGROUP_SIZE as usize)
+        {
+            let right_position = right_bucket[index];
+            let position = &mut right_bucket_positions[index];
+            let rmap_bit_position = &mut rmap_bit_positions[index];
+
+            position.write(right_position);
+
+            if right_position == Position::SENTINEL {
+                break;
+            }
+
+            // TODO: Correct version currently doesn't compile:
+            //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+            // // SAFETY: Guaranteed by function contract
+            // let y = *unsafe { parent_table_ys.get_unchecked(usize::from(right_position)) };
+            let y = *unsafe { parent_table_ys.get_unchecked(right_position as usize) };
+            let r = u32::from(y) - right_base;
+
+            // SAFETY: `r` is within `0..PARAM_BC` range by definition
+            rmap_bit_position.write(unsafe { RmapBitPosition::new(r) });
+        }
+
+        workgroup_memory_barrier_with_group_sync();
+
+        // TODO: Correct version currently doesn't compile:
+        //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+        // // SAFETY: Just initialized
+        // let right_bucket_positions = unsafe {
+        //     mem::transmute::<
+        //         &mut [MaybeUninit<Position>; REDUCED_BUCKETS_SIZE],
+        //         &mut [Position; REDUCED_BUCKETS_SIZE],
+        //     >(right_bucket_positions)
+        // };
+        //
+        // (&*right_bucket_positions, &*rmap_bit_positions)
+        (right_bucket_positions, &*rmap_bit_positions)
+    };
+
+    // Fill `rmap`
+    // TODO: Try to parallelize this part
+    if local_invocation_id == 0 {
+        let mut next_physical_pointer = NextPhysicalPointer::default();
+
+        // TODO: More idiomatic version currently doesn't compile:
+        //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+        // for (&right_position, rmap_bit_position) in
+        //     right_bucket_positions.iter().zip(right_rmap_bit_positions)
+        // {
+        for index in 0..right_bucket_positions.len() {
+            let right_position = unsafe { right_bucket_positions[index].assume_init() };
+            let rmap_bit_position = right_rmap_bit_positions[index];
+
+            if right_position == Position::SENTINEL {
+                break;
+            }
+
+            // SAFETY: `rmap_bit_position` for non-sentinel positions were initialized above
+            let rmap_bit_position = unsafe { rmap_bit_position.assume_init() };
+
+            // SAFETY: The right bucket is limited to `REDUCED_BUCKETS_SIZE`, same
+            // `next_physical_pointer` is used here exclusively
+            unsafe {
+                rmap.add(
+                    rmap_bit_position,
+                    right_position,
+                    &mut next_physical_pointer,
+                );
+            }
+        }
+    }
+
+    workgroup_memory_barrier_with_group_sync();
+
+    // Load both into shared memory and precompute `rmap_bit_positions`. `rmap_bit_position`s for
+    // non-sentinel positions are guaranteed to be initialized
+    let (left_bucket_positions, left_rs) = {
+        let left_bucket_positions =
+            <Position as PositionExt>::uninit_array_from_repr_mut(bucket_size_a);
+        let left_rs = bucket_size_b;
+        // TODO: More idiomatic version currently doesn't compile:
+        //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+        // for ((&left_position, position), r) in left_bucket
+        //     .iter()
+        //     .zip(left_bucket_positions.iter_mut())
+        //     .zip(left_rs.iter_mut())
+        //     .skip(local_invocation_id as usize)
+        //     .step_by(WORKGROUP_SIZE as usize)
+        // {
+        for index in
+            (local_invocation_id as usize..left_bucket.len()).step_by(WORKGROUP_SIZE as usize)
+        {
+            let left_position = left_bucket[index];
+            let position = &mut left_bucket_positions[index];
+            let r = &mut left_rs[index];
+
+            position.write(left_position);
+
+            if left_position == Position::SENTINEL {
+                break;
+            }
+
+            // TODO: Correct version currently doesn't compile:
+            //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+            // // SAFETY: Guaranteed by function contract
+            // let y = *unsafe { parent_table_ys.get_unchecked(usize::from(left_position)) };
+            let y = *unsafe { parent_table_ys.get_unchecked(left_position as usize) };
+
+            r.write(u32::from(y) - left_base);
+        }
+
+        workgroup_memory_barrier_with_group_sync();
+
+        // TODO: Correct version currently doesn't compile:
+        //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+        // // SAFETY: Just initialized
+        // let left_bucket_positions = unsafe {
+        //     mem::transmute::<
+        //         &mut [MaybeUninit<Position>; REDUCED_BUCKETS_SIZE],
+        //         &mut [Position; REDUCED_BUCKETS_SIZE],
+        //     >(left_bucket_positions)
+        // };
+        //
+        // (&*left_bucket_positions, &*left_rs)
+        (left_bucket_positions, &*left_rs)
+    };
+
+    let parity = left_base % 2;
+    let left_targets_parity = &left_targets[parity as usize];
+
+    const CHUNK_SIZE: usize = WORKGROUP_SIZE as usize / PARAM_M as usize;
+    const {
+        // `CHUNK_SIZE` with `PARAM_M` must cover workgroup exactly
+        assert!(CHUNK_SIZE as u32 * PARAM_M as u32 == WORKGROUP_SIZE);
+        // The bucket size should be possible to iterate in exact chunks
+        assert!(REDUCED_BUCKETS_SIZE.is_multiple_of(CHUNK_SIZE));
+    }
+    let shared_subgroup_totals = num_subgroups_size_a;
+    let mut global_match_batch_offset = 0_u32;
+    // TODO: More idiomatic version currently doesn't compile:
+    //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+    // for (&left_positions, left_rs) in left_bucket_positions
+    //     .as_chunks::<CHUNK_SIZE>()
+    //     .0
+    //     .iter()
+    //     .zip(left_rs.as_chunks::<CHUNK_SIZE>().0)
+    // {
+    //     let left_positions = &left_bucket_positions.as_chunks::<CHUNK_SIZE>().0[index];
+    //     let left_rs = &left_rs.as_chunks::<CHUNK_SIZE>().0[index];
+    //
+    //     let index_within_chunk = local_invocation_id as usize / CHUNK_SIZE;
+    //     let left_position = left_positions[index_within_chunk];
+    for chunk_index in 0..left_bucket_positions.len() / CHUNK_SIZE {
+        // First `PARAM_M` invocations in a workgroup process the first chunk index, next
+        // `PARAM_M` process the second chunk index and so on, with each chunk index corresponding
+        // to `PARAM_M` `r_target` values
+        let index_within_chunk = local_invocation_id as usize / PARAM_M as usize;
+        let left_position = unsafe {
+            left_bucket_positions[chunk_index * CHUNK_SIZE + index_within_chunk].assume_init()
+        };
+
+        // Check if reached the end of the bucket
+        let ([right_position_a, right_position_b], left_r) = if left_position == Position::SENTINEL
+        {
+            // `left_r` value doesn't matter here, it will not be read/used anyway
+            ([Position::ZERO; _], 0)
+        } else {
+            // TODO: More idiomatic version currently doesn't compile:
+            //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+            // // SAFETY: `left_position` is not sentinel, hence `left_r` must be initialized
+            // let left_r = unsafe { left_rs[chunk_index * CHUNK_SIZE + index_within_chunk].assume_init() };
+            let left_r =
+                unsafe { left_rs[chunk_index * CHUNK_SIZE + index_within_chunk].assume_init() };
+            // SAFETY: `left_r` is within a bucket and exists by definition
+            let left_targets_r = unsafe { left_targets_parity.get_unchecked(left_r as usize) };
+            let r_target_index = local_invocation_id % PARAM_M as u32;
+            // SAFETY: `r_target_index` is within `0..PARAM_M` range
+            let r_target = unsafe { left_targets_r.get_r(r_target_index) };
+
+            // SAFETY: Targets are always limited to `PARAM_BC`
+            let positions = unsafe { rmap.get(RmapBitPosition::new(r_target)) };
+
+            (positions, left_r)
+        };
+
+        let local_matches_count = (right_position_a != Position::ZERO) as u32
+            + (right_position_b != Position::ZERO) as u32;
+
+        // Add up the numbers of matches in the subgroup up to the current lane (exclusive)
+        let local_matches_prefix = subgroup_exclusive_i_add(local_matches_count);
+        {
+            // Add up the numbers of matches in the subgroup (total)
+            let subgroup_matches_count = subgroup_i_add(local_matches_count);
+
+            // SAFETY: Guaranteed by function contract
+            unsafe { shared_subgroup_totals.get_unchecked_mut(subgroup_id as usize) }
+                .write(subgroup_matches_count);
+        }
+
+        workgroup_memory_barrier_with_group_sync();
+
+        // Calculate offset for matches written by this subgroup and update global match batch
+        // offset
+        let mut subgroup_matches_offset = global_match_batch_offset;
+        for current_subgroup_id in 0..num_subgroups {
+            // SAFETY: Guaranteed by function contract
+            let subgroup_matches_count = unsafe {
+                shared_subgroup_totals
+                    .get_unchecked(current_subgroup_id as usize)
+                    .assume_init()
+            };
+            if current_subgroup_id < subgroup_id {
+                subgroup_matches_offset += subgroup_matches_count;
+            }
+            global_match_batch_offset += subgroup_matches_count;
+        }
+
+        // Calculate offset where to write local matches into
+        let mut local_matches_offset = subgroup_matches_offset + local_matches_prefix;
+
+        if right_position_a != Position::ZERO {
+            let y = Y::from(left_r + left_base);
+
+            // TODO: More idiomatic version currently doesn't compile:
+            //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+            // let Some(m) = matches.get_mut(local_matches_offset as usize) else {
+            //     continue;
+            // };
+            if (local_matches_offset as usize) >= matches.len() {
+                continue;
+            }
+            let m = &mut matches[local_matches_offset as usize];
+
+            m.write(Match {
+                left_position,
+                left_y: y,
+                right_position: right_position_a,
+            });
+
+            local_matches_offset += 1;
+
+            if right_position_b != Position::ZERO {
+                // TODO: More idiomatic version currently doesn't compile:
+                //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+                // let Some(m) = matches.get_mut(local_matches_offset as usize) else {
+                //     continue;
+                // };
+                if (local_matches_offset as usize) >= matches.len() {
+                    continue;
+                }
+                let m = &mut matches[local_matches_offset as usize];
+
+                m.write(Match {
+                    left_position,
+                    left_y: y,
+                    right_position: right_position_b,
+                });
+            }
+        }
+
+        // Make sure workgroup progresses predictably in phases for offsets to work properly
+        control_barrier::<
+            { Scope::Workgroup as u32 },
+            { Scope::Workgroup as u32 },
+            { Semantics::NONE.bits() },
+        >();
+    }
+
+    global_match_batch_offset.min(REDUCED_MATCHES_COUNT as u32)
+}
+
+/// # Safety
+/// Left and right bucket positions must correspond to the parent table. Must be called from
+/// [`WORKGROUP_SIZE`] threads. `num_subgroups` must be at most [`MAX_SUBGROUPS`].
+#[spirv(compute(threads(256), entry_point_name = "find_matches_in_buckets"))]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Both I/O and Vulkan stuff together take a lot of arguments"
+)]
+pub unsafe fn find_matches_in_buckets(
+    #[spirv(local_invocation_id)] local_invocation_id: UVec3,
+    #[spirv(workgroup_id)] workgroup_id: UVec3,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    #[spirv(subgroup_id)] subgroup_id: u32,
+    #[spirv(num_subgroups)] num_subgroups: u32,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
+    buckets: &[[Position; REDUCED_BUCKETS_SIZE]],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] parent_table_ys: &[Y],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)]
+    matches: &mut [[MaybeUninit<Match>; REDUCED_MATCHES_COUNT]],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] matches_counts: &mut [MaybeUninit<
+        u32,
+    >],
+    #[spirv(workgroup)] scratch_space: &mut SharedScratchSpace,
+    // Non-modern GPUs do not have enough space in the shared memory
+    #[cfg(all(target_arch = "spirv", feature = "__modern-gpu"))]
+    #[spirv(workgroup)]
+    rmap: &mut MaybeUninit<Rmap>,
+    #[cfg(not(all(target_arch = "spirv", feature = "__modern-gpu")))]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)]
+    rmap: &mut MaybeUninit<Rmap>,
+) {
+    let local_invocation_id = local_invocation_id.x;
+    let workgroup_id = workgroup_id.x;
+    let num_workgroups = num_workgroups.x;
+
+    // TODO: More idiomatic version currently doesn't compile:
+    //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+    // for (left_bucket_index, (([left_bucket, right_bucket], matches), matches_count)) in buckets
+    //     .array_windows::<2>()
+    //     .zip(matches)
+    //     .zip(matches_counts)
+    //     .enumerate()
+    //     .skip(workgroup_id as usize)
+    //     .step_by(num_workgroups as usize)
+    // {
+    for left_bucket_index in
+        (workgroup_id as usize..buckets.len() - 1).step_by(num_workgroups as usize)
+    {
+        let left_bucket = &buckets[left_bucket_index];
+        let right_bucket = &buckets[left_bucket_index + 1];
+        let matches = &mut matches[left_bucket_index];
+        let matches_count = &mut matches_counts[left_bucket_index];
+
+        matches_count.write(unsafe {
+            find_matches_in_buckets_impl(
+                subgroup_id,
+                num_subgroups,
+                local_invocation_id,
+                left_bucket_index as u32,
+                left_bucket,
+                right_bucket,
+                parent_table_ys,
+                matches,
+                left_targets,
+                scratch_space,
+                rmap,
+            )
+        });
+    }
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/cpu_tests.rs
@@ -1,0 +1,200 @@
+use crate::shader::constants::{
+    PARAM_B, PARAM_BC, PARAM_C, PARAM_M, REDUCED_BUCKETS_SIZE, REDUCED_MATCHES_COUNT,
+};
+use crate::shader::find_matches_in_buckets::{LeftTargets, LeftTargetsR, Match};
+use crate::shader::types::{Position, PositionExt, Y};
+use std::mem::MaybeUninit;
+use std::{array, mem};
+
+pub(super) fn calculate_left_targets() -> Box<LeftTargets> {
+    let mut left_targets = Box::<LeftTargets>::new_uninit();
+    // TODO: Consider a helper method here to avoid the need for `unsafe`
+    // SAFETY: Same layout and uninitialized in both cases (`LeftTargetsR` is `#[repr(C)]`)
+    let left_targets_slice = unsafe {
+        mem::transmute::<
+            &mut MaybeUninit<[[LeftTargetsR; PARAM_BC as usize]; 2]>,
+            &mut [[MaybeUninit<[u16; PARAM_M as usize]>; PARAM_BC as usize]; 2],
+        >(left_targets.as_mut())
+    };
+
+    for parity in 0..=1 {
+        for r in 0..PARAM_BC {
+            let c = r / PARAM_C;
+
+            let mut arr = array::from_fn(|m| {
+                let m = m as u16;
+                ((c + m) % PARAM_B) * PARAM_C
+                    + (((2 * m + parity) * (2 * m + parity) + r) % PARAM_C)
+            });
+            arr.sort_unstable();
+            left_targets_slice[parity as usize][r as usize].write(arr);
+        }
+    }
+
+    // SAFETY: Initialized all entries
+    unsafe { left_targets.assume_init() }
+}
+
+struct Rmap {
+    /// `0` is a sentinel value indicating no virtual pointer is stored yet.
+    ///
+    /// Physical pointer must be increased by `1` to get a virtual pointer before storing. Virtual
+    /// pointer must be decreased by `1` before reading to get a physical pointer.
+    virtual_pointers: [u16; PARAM_BC as usize],
+    positions: [[Position; 2]; REDUCED_BUCKETS_SIZE],
+    next_physical_pointer: u16,
+}
+
+impl Rmap {
+    #[inline(always)]
+    fn new() -> Self {
+        Self {
+            virtual_pointers: [0; _],
+            positions: [[Position::ZERO; 2]; _],
+            next_physical_pointer: 0,
+        }
+    }
+
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
+    /// inserted
+    #[inline(always)]
+    unsafe fn insertion_item(&mut self, r: u32) -> &mut [Position; 2] {
+        // SAFETY: Guaranteed by function contract
+        let virtual_pointer = unsafe { self.virtual_pointers.get_unchecked_mut(r as usize) };
+
+        if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+            // SAFETY: Internal pointers are always valid
+            return unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) };
+        }
+
+        let physical_pointer = self.next_physical_pointer;
+        self.next_physical_pointer += 1;
+        *virtual_pointer = physical_pointer + 1;
+
+        // SAFETY: It is guaranteed by the function contract that the number of added elements will
+        // never exceed `REDUCED_BUCKETS_SIZE`, hence allocated pointers will always be within
+        // bounds
+        unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) }
+    }
+
+    /// Note that `position == Position::ZERO` is effectively ignored here, supporting it cost too
+    /// much in terms of performance and not required for correctness.
+    ///
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
+    /// inserted
+    #[inline(always)]
+    unsafe fn add(&mut self, r: u32, position: Position) {
+        // SAFETY: Guaranteed by function contract
+        let rmap_item = unsafe { self.insertion_item(r) };
+
+        // The same `r` can appear in the table multiple times, one duplicate is supported here
+        if rmap_item[0] == Position::ZERO {
+            rmap_item[0] = position;
+        } else if rmap_item[1] == Position::ZERO {
+            rmap_item[1] = position;
+        }
+    }
+
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`
+    #[inline(always)]
+    unsafe fn get(&self, r: u32) -> [Position; 2] {
+        // SAFETY: Guaranteed by function contract
+        let virtual_pointer = *unsafe { self.virtual_pointers.get_unchecked(r as usize) };
+
+        if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+            // SAFETY: Internal pointers are always valid
+            *unsafe { self.positions.get_unchecked(physical_pointer as usize) }
+        } else {
+            [Position::ZERO; 2]
+        }
+    }
+}
+
+/// For verification use [`has_match`] instead.
+///
+/// # Safety
+/// Left and right bucket positions must correspond to the parent table.
+pub(super) unsafe fn find_matches_in_buckets_correct<'a>(
+    left_bucket_index: u32,
+    left_bucket: &[Position; REDUCED_BUCKETS_SIZE],
+    right_bucket: &[Position; REDUCED_BUCKETS_SIZE],
+    parent_table_ys: &[Y],
+    // `PARAM_M as usize * 2` corresponds to the upper bound number of matches a single `y` in the
+    // left bucket might have here
+    matches: &'a mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT + PARAM_M as usize * 2],
+    left_targets: &LeftTargets,
+) -> &'a [Match] {
+    let left_base = left_bucket_index * u32::from(PARAM_BC);
+    let right_base = left_base + u32::from(PARAM_BC);
+
+    let mut rmap = Rmap::new();
+    for &right_position in right_bucket {
+        if right_position == Position::SENTINEL {
+            break;
+        }
+        // SAFETY: Guaranteed by function contract
+        let y = *unsafe { parent_table_ys.get_unchecked(right_position as usize) };
+        let r = u32::from(y) - right_base;
+        // SAFETY: `r` is within `0..PARAM_BC` range by definition, the right bucket is limited to
+        // `REDUCED_BUCKETS_SIZE`
+        unsafe {
+            rmap.add(r, right_position);
+        }
+    }
+
+    let parity = left_base % 2;
+    let left_targets_parity = &left_targets[parity as usize];
+    let mut next_match_index = 0;
+
+    // TODO: Simd read for left bucket? It might be more efficient in terms of memory access to
+    //  process chunks of the left bucket against one right value for each at a time
+    for &left_position in left_bucket {
+        // `next_match_index >= REDUCED_MATCHES_COUNT` is crucial to make sure
+        if left_position == Position::SENTINEL || next_match_index >= REDUCED_MATCHES_COUNT {
+            // Sentinel values are padded to the end of the bucket
+            break;
+        }
+
+        // SAFETY: Guaranteed by function contract
+        let y = *unsafe { parent_table_ys.get_unchecked(left_position as usize) };
+        let r = u32::from(y) - left_base;
+        // SAFETY: `r` is within a bucket and exists by definition
+        let left_targets_r = unsafe { left_targets_parity.get_unchecked(r as usize) };
+
+        for index in 0..PARAM_M {
+            // SAFETY: `index` is within `0..PARAM_M`
+            let r_target = unsafe { left_targets_r.get_r(u32::from(index)) };
+            // SAFETY: Targets are always limited to `PARAM_BC`
+            let [right_position_a, right_position_b] = unsafe { rmap.get(r_target) };
+
+            // The right bucket position is never zero
+            if right_position_a != Position::ZERO {
+                // SAFETY: Iteration will stop before `REDUCED_MATCHES_COUNT + PARAM_M * 2`
+                // elements is inserted
+                unsafe { matches.get_unchecked_mut(next_match_index) }.write(Match {
+                    left_position,
+                    left_y: y,
+                    right_position: right_position_a,
+                });
+                next_match_index += 1;
+
+                if right_position_b != Position::ZERO {
+                    // SAFETY: Iteration will stop before
+                    // `REDUCED_MATCHES_COUNT + PARAM_M * 2` elements is inserted
+                    unsafe { matches.get_unchecked_mut(next_match_index) }.write(Match {
+                        left_position,
+                        left_y: y,
+                        right_position: right_position_b,
+                    });
+                    next_match_index += 1;
+                }
+            }
+        }
+    }
+
+    // SAFETY: Initialized this many matches, limited to `REDUCED_MATCHES_COUNT`
+    unsafe { matches[..next_match_index.min(REDUCED_MATCHES_COUNT)].assume_init_ref() }
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
@@ -1,0 +1,385 @@
+use crate::shader::constants::{PARAM_BC, REDUCED_BUCKETS_SIZE, REDUCED_MATCHES_COUNT};
+use crate::shader::find_matches_in_buckets::cpu_tests::{
+    calculate_left_targets, find_matches_in_buckets_correct,
+};
+use crate::shader::find_matches_in_buckets::rmap::Rmap;
+use crate::shader::find_matches_in_buckets::{LeftTargets, Match};
+use crate::shader::select_shader_features_limits;
+use crate::shader::types::{Position, PositionExt, Y};
+use chacha20::ChaCha8Rng;
+use chacha20::rand_core::{RngCore, SeedableRng};
+use futures::executor::block_on;
+use std::mem::MaybeUninit;
+use std::slice;
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use wgpu::{
+    Adapter, BackendOptions, Backends, BindGroupDescriptor, BindGroupEntry,
+    BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BufferAddress, BufferBindingType,
+    BufferDescriptor, BufferUsages, CommandEncoderDescriptor, ComputePipelineDescriptor,
+    DeviceDescriptor, Instance, InstanceDescriptor, InstanceFlags, MapMode, MemoryBudgetThresholds,
+    MemoryHints, PipelineLayoutDescriptor, PollType, ShaderStages, Trace,
+};
+
+const NUM_BUCKETS: usize = 3;
+
+#[test]
+fn find_matches_in_buckets_gpu() {
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+    let parent_table_size = 1000_usize;
+
+    // Generate `y`s within `0..PARAM_BC*NUM_BUCKETS` range to fill the first `NUM_BUCKETS` buckets
+    let parent_table_ys = (0..parent_table_size)
+        .map(|_| Y::from(rng.next_u32() % (PARAM_BC as u32 * NUM_BUCKETS as u32)))
+        .collect::<Vec<_>>();
+    let buckets = {
+        let mut buckets = [[Position::SENTINEL; REDUCED_BUCKETS_SIZE]; 3];
+
+        let mut total_found = [0_usize; 3];
+        for (position, &y) in parent_table_ys.iter().enumerate() {
+            let bucket_index = u32::from(y) / PARAM_BC as u32;
+            let next_index = total_found[bucket_index as usize];
+            if next_index < REDUCED_BUCKETS_SIZE {
+                buckets[bucket_index as usize][next_index] = Position::from_u32(position as u32);
+                total_found[bucket_index as usize] += 1;
+            }
+        }
+
+        buckets
+    };
+    let left_targets = calculate_left_targets();
+
+    let Some(actual_matches) = block_on(find_matches_in_buckets(
+        &left_targets,
+        &buckets,
+        &parent_table_ys,
+    )) else {
+        if cfg!(feature = "__force-gpu-tests") {
+            panic!("Skipping tests, no compatible device detected");
+        } else {
+            eprintln!("Skipping tests, no compatible device detected");
+            return;
+        }
+    };
+
+    let expected_matches = buckets
+        .array_windows()
+        .enumerate()
+        .map(|(left_bucket_index, [left_bucket, right_bucket])| {
+            let mut matches = [MaybeUninit::uninit(); _];
+            unsafe {
+                find_matches_in_buckets_correct(
+                    left_bucket_index as u32,
+                    left_bucket,
+                    right_bucket,
+                    &parent_table_ys,
+                    &mut matches,
+                    &left_targets,
+                )
+            }
+            .to_vec()
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(actual_matches.len(), expected_matches.len());
+    for (bucket_pair, (expected, actual)) in
+        expected_matches.into_iter().zip(actual_matches).enumerate()
+    {
+        assert_eq!(expected.len(), actual.len(), "bucket_pair={bucket_pair}");
+        for (index, (expected, actual)) in expected.into_iter().zip(actual).enumerate() {
+            assert_eq!(expected, actual, "bucket_pair={bucket_pair}, index={index}");
+        }
+    }
+}
+
+async fn find_matches_in_buckets(
+    left_targets: &LeftTargets,
+    buckets: &[[Position; REDUCED_BUCKETS_SIZE]],
+    parent_table_ys: &[Y],
+) -> Option<Vec<Vec<Match>>> {
+    let backends = Backends::from_env().unwrap_or(Backends::METAL | Backends::VULKAN);
+    let instance = Instance::new(&InstanceDescriptor {
+        backends,
+        flags: InstanceFlags::GPU_BASED_VALIDATION.with_env(),
+        memory_budget_thresholds: MemoryBudgetThresholds::default(),
+        backend_options: BackendOptions::from_env_or_default(),
+    });
+
+    let adapters = instance.enumerate_adapters(backends);
+    let mut result = None;
+
+    for adapter in adapters {
+        println!("Testing adapter {:?}", adapter.get_info());
+
+        let adapter_result =
+            find_matches_in_buckets_adapter(left_targets, buckets, parent_table_ys, adapter)
+                .await?;
+
+        match &result {
+            Some(result) => {
+                assert!(result == &adapter_result);
+            }
+            None => {
+                result.replace(adapter_result);
+            }
+        }
+    }
+
+    result
+}
+
+async fn find_matches_in_buckets_adapter(
+    left_targets: &LeftTargets,
+    buckets: &[[Position; REDUCED_BUCKETS_SIZE]],
+    parent_table_ys: &[Y],
+    adapter: Adapter,
+) -> Option<Vec<Vec<Match>>> {
+    let num_bucket_pairs = buckets.len() - 1;
+
+    let (shader, required_features, required_limits, modern) =
+        select_shader_features_limits(adapter.features());
+    println!("modern={modern}");
+
+    let (device, queue) = adapter
+        .request_device(&DeviceDescriptor {
+            label: None,
+            required_features,
+            required_limits,
+            memory_hints: MemoryHints::Performance,
+            trace: Trace::default(),
+        })
+        .await
+        .unwrap();
+
+    let module = device.create_shader_module(shader);
+
+    let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+        label: None,
+        entries: &[
+            BindGroupLayoutEntry {
+                binding: 0,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: true },
+                },
+            },
+            BindGroupLayoutEntry {
+                binding: 1,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: true },
+                },
+            },
+            BindGroupLayoutEntry {
+                binding: 2,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: true },
+                },
+            },
+            BindGroupLayoutEntry {
+                binding: 3,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: false },
+                },
+            },
+            BindGroupLayoutEntry {
+                binding: 4,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: false },
+                },
+            },
+            BindGroupLayoutEntry {
+                binding: 5,
+                count: None,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                    ty: BufferBindingType::Storage { read_only: false },
+                },
+            },
+        ],
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+        label: None,
+        bind_group_layouts: &[&bind_group_layout],
+        push_constant_ranges: &[],
+    });
+
+    let compute_pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+        compilation_options: Default::default(),
+        cache: None,
+        label: None,
+        layout: Some(&pipeline_layout),
+        module: &module,
+        entry_point: Some("find_matches_in_buckets"),
+    });
+
+    let left_targets_gpu = device.create_buffer_init(&BufferInitDescriptor {
+        label: None,
+        contents: unsafe {
+            slice::from_raw_parts(
+                left_targets.as_ptr().cast::<u8>(),
+                size_of_val(left_targets),
+            )
+        },
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+    });
+
+    let buckets_gpu = device.create_buffer_init(&BufferInitDescriptor {
+        label: None,
+        contents: unsafe {
+            slice::from_raw_parts(buckets.as_ptr().cast::<u8>(), size_of_val(buckets))
+        },
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+    });
+
+    let parent_table_ys_gpu = device.create_buffer_init(&BufferInitDescriptor {
+        label: None,
+        contents: unsafe {
+            slice::from_raw_parts(
+                parent_table_ys.as_ptr().cast::<u8>(),
+                size_of_val(parent_table_ys),
+            )
+        },
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+    });
+
+    let matches_host = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: (size_of::<[Match; REDUCED_MATCHES_COUNT]>() * num_bucket_pairs) as BufferAddress,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let matches_gpu = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: matches_host.size(),
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let matches_counts_host = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: (size_of::<u32>() * num_bucket_pairs) as BufferAddress,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let matches_counts_gpu = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: matches_counts_host.size(),
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let rmap_gpu = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: if modern {
+            // A dummy buffer if `1` byte just because it can't be zero in wgpu
+            1
+        } else {
+            size_of::<Rmap>() as BufferAddress
+        },
+        usage: BufferUsages::STORAGE,
+        mapped_at_creation: false,
+    });
+
+    let bind_group = device.create_bind_group(&BindGroupDescriptor {
+        label: None,
+        layout: &bind_group_layout,
+        entries: &[
+            BindGroupEntry {
+                binding: 0,
+                resource: left_targets_gpu.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 1,
+                resource: buckets_gpu.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 2,
+                resource: parent_table_ys_gpu.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 3,
+                resource: matches_gpu.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 4,
+                resource: matches_counts_gpu.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 5,
+                resource: rmap_gpu.as_entire_binding(),
+            },
+        ],
+    });
+
+    let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+
+    {
+        let mut cpass = encoder.begin_compute_pass(&Default::default());
+        cpass.set_bind_group(0, &bind_group, &[]);
+        cpass.set_pipeline(&compute_pipeline);
+        cpass.dispatch_workgroups(device.limits().max_compute_workgroups_per_dimension, 1, 1);
+    }
+
+    encoder.copy_buffer_to_buffer(&matches_gpu, 0, &matches_host, 0, matches_host.size());
+    encoder.copy_buffer_to_buffer(
+        &matches_counts_gpu,
+        0,
+        &matches_counts_host,
+        0,
+        matches_counts_host.size(),
+    );
+
+    queue.submit([encoder.finish()]);
+
+    matches_host.map_async(MapMode::Read, .., |r| r.unwrap());
+    matches_counts_host.map_async(MapMode::Read, .., |r| r.unwrap());
+    device.poll(PollType::Wait).unwrap();
+
+    let matches = {
+        let matches_host_ptr = matches_host
+            .get_mapped_range(..)
+            .as_ptr()
+            .cast::<[Match; REDUCED_MATCHES_COUNT]>();
+        let matches_counts_host_ptr = matches_counts_host
+            .get_mapped_range(..)
+            .as_ptr()
+            .cast::<u32>();
+
+        let matches = unsafe { slice::from_raw_parts(matches_host_ptr, num_bucket_pairs) };
+        let matches_counts =
+            unsafe { slice::from_raw_parts(matches_counts_host_ptr, num_bucket_pairs) };
+
+        matches
+            .iter()
+            .zip(matches_counts)
+            .map(|(matches, &matches_count)| matches[..matches_count as usize].to_vec())
+            .collect()
+    };
+    matches_host.unmap();
+    matches_counts_host.unmap();
+
+    Some(matches)
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/rmap.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/rmap.rs
@@ -1,0 +1,262 @@
+#[cfg(all(test, not(target_arch = "spirv")))]
+mod tests;
+
+use crate::shader::constants::{PARAM_BC, REDUCED_BUCKETS_SIZE};
+#[cfg(target_arch = "spirv")]
+use crate::shader::find_matches_in_buckets::ArrayIndexingPolyfill;
+use crate::shader::types::{Position, PositionExt};
+use core::mem::MaybeUninit;
+
+// TODO: Benchmark on different GPUs to see if the complexity of dealing with 9-bit pointers is
+//  worth it or maybe using u16s would be better despite using more shared memory
+/// Number of bits necessary to address a single pair of positions in the rmap
+const POINTER_BITS: u32 = REDUCED_BUCKETS_SIZE.next_power_of_two().ilog2();
+const POINTERS_BITS: usize = PARAM_BC as usize * POINTER_BITS as usize;
+const POINTERS_WORDS: usize = POINTERS_BITS.div_ceil(u32::BITS as usize);
+
+// Ensure `u32` is sufficiently large as a container
+const _: () = assert!(POINTER_BITS <= u32::BITS);
+
+#[derive(Debug, Default)]
+pub(super) struct NextPhysicalPointer {
+    next_physical_pointer: u32,
+}
+
+impl NextPhysicalPointer {
+    /// Increments next physical pointer and returns previous value
+    #[inline(always)]
+    fn inc(&mut self) -> u32 {
+        let physical_pointer = self.next_physical_pointer;
+        self.next_physical_pointer += 1;
+        physical_pointer
+    }
+}
+
+// TODO: The struct in this form currently doesn't compile:
+//  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+// #[derive(Debug, Copy, Clone)]
+// #[repr(C)]
+// pub(super) struct RmapBitPosition(u32);
+//
+// impl RmapBitPosition {
+//     /// # Safety
+//     /// `r` must be in the range `0..PARAM_BC`
+//     #[inline(always)]
+//     pub(super) unsafe fn new(r: u32) -> Self {
+//         Self(r * POINTER_BITS)
+//     }
+//
+//     /// Extract `rmap_bit_position` out of the inner value
+//     #[inline(always)]
+//     fn get(self) -> u32 {
+//         self.0
+//     }
+//
+//     #[inline(always)]
+//     pub(super) const fn uninit_array_from_repr_mut<const N: usize>(
+//         array: &mut [MaybeUninit<u32>; N],
+//     ) -> &mut [MaybeUninit<Self>; N] {
+//         // SAFETY: `RmapBitPosition` is `#[repr(C)]` and guaranteed to have the same memory layout
+//         unsafe { mem::transmute(array) }
+//     }
+// }
+
+pub(super) type RmapBitPosition = u32;
+
+// TODO: Remove once normal `RmapBitPosition` struct can be used
+pub(super) trait RmapBitPositionExt: Sized {
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`
+    unsafe fn new(r: u32) -> Self;
+
+    /// Extract `rmap_bit_position` out of the inner value
+    fn get(self) -> u32;
+
+    fn uninit_array_from_repr_mut<const N: usize>(
+        array: &mut [MaybeUninit<u32>; N],
+    ) -> &mut [MaybeUninit<Self>; N];
+}
+
+impl RmapBitPositionExt for RmapBitPosition {
+    /// # Safety
+    /// `r` must be in the range `0..PARAM_BC`
+    #[inline(always)]
+    unsafe fn new(r: u32) -> Self {
+        r * POINTER_BITS
+    }
+
+    /// Extract `rmap_bit_position` out of the inner value
+    #[inline(always)]
+    fn get(self) -> u32 {
+        self
+    }
+
+    #[inline(always)]
+    fn uninit_array_from_repr_mut<const N: usize>(
+        array: &mut [MaybeUninit<u32>; N],
+    ) -> &mut [MaybeUninit<Self>; N] {
+        array
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Rmap {
+    /// `0` is a sentinel value indicating no virtual pointer is stored yet.
+    ///
+    /// Physical pointer must be increased by `1` to get a virtual pointer before storing. Virtual
+    /// pointer must be decreased by `1` before reading to get a physical pointer.
+    virtual_pointers: [u32; POINTERS_WORDS],
+    positions: [[Position; 2]; REDUCED_BUCKETS_SIZE],
+}
+
+impl Rmap {
+    #[cfg(test)]
+    #[inline(always)]
+    fn new() -> Self {
+        Self {
+            virtual_pointers: [0; _],
+            positions: [[Position::ZERO; 2]; _],
+        }
+    }
+
+    /// # Safety
+    /// There must be at most [`REDUCED_BUCKETS_SIZE`] items inserted. `NextPhysicalPointer` and
+    /// `Rmap` must have 1:1 mapping and not mixed with anything else.
+    #[inline(always)]
+    fn insertion_item_physical_pointer(
+        &mut self,
+        rmap_bit_position: RmapBitPosition,
+        next_physical_pointer: &mut NextPhysicalPointer,
+    ) -> u32 {
+        let bit_position = rmap_bit_position.get();
+        let word_offset = (bit_position / u32::BITS) as usize;
+        let bit_offset = bit_position % u32::BITS;
+
+        // SAFETY: Offset comes from `RmapBitPosition`, whose constructor guarantees bounds
+        let mut word = *unsafe { self.virtual_pointers.get_unchecked_mut(word_offset) };
+
+        if bit_offset + POINTER_BITS > u32::BITS {
+            // SAFETY: Offset comes from `RmapBitPosition`, whose constructor guarantees bounds
+            let mut word_next =
+                *unsafe { self.virtual_pointers.get_unchecked_mut(word_offset + 1) };
+            {
+                let value = (word >> bit_offset) | (word_next << (u32::BITS - bit_offset));
+                let virtual_pointer = value & (u32::MAX >> (u32::BITS - POINTER_BITS));
+
+                if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+                    return physical_pointer;
+                }
+            }
+
+            let physical_pointer = next_physical_pointer.inc();
+            let virtual_pointer = physical_pointer + 1;
+
+            word |= virtual_pointer << bit_offset;
+            word_next |= virtual_pointer >> (u32::BITS - bit_offset);
+
+            *unsafe { self.virtual_pointers.get_unchecked_mut(word_offset) } = word;
+            *unsafe { self.virtual_pointers.get_unchecked_mut(word_offset + 1) } = word_next;
+
+            physical_pointer
+        } else {
+            {
+                let virtual_pointer =
+                    (word >> bit_offset) & (u32::MAX >> (u32::BITS - POINTER_BITS));
+
+                if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+                    return physical_pointer;
+                }
+            }
+
+            let physical_pointer = next_physical_pointer.inc();
+            let virtual_pointer = physical_pointer + 1;
+
+            word |= virtual_pointer << bit_offset;
+
+            *unsafe { self.virtual_pointers.get_unchecked_mut(word_offset) } = word;
+
+            physical_pointer
+        }
+    }
+
+    /// # Safety
+    /// There must be at most [`REDUCED_BUCKETS_SIZE`] items inserted. `NextPhysicalPointer` and
+    /// `Rmap` must have 1:1 mapping and not mixed with anything else.
+    #[inline(always)]
+    unsafe fn insertion_item(
+        &mut self,
+        rmap_bit_position: RmapBitPosition,
+        next_physical_pointer: &mut NextPhysicalPointer,
+    ) -> &mut [Position; 2] {
+        let physical_pointer =
+            self.insertion_item_physical_pointer(rmap_bit_position, next_physical_pointer);
+        // SAFETY: Internal pointers are always valid
+        unsafe { self.positions.get_unchecked_mut(physical_pointer as usize) }
+    }
+
+    /// Note that `position == Position::ZERO` is effectively ignored here, supporting it cost too
+    /// much in terms of performance and not required for correctness.
+    ///
+    /// # Safety
+    /// There must be at most [`REDUCED_BUCKETS_SIZE`] items inserted. `NextPhysicalPointer` and
+    /// `Rmap` must have 1:1 mapping and not mixed with anything else.
+    #[inline(always)]
+    pub(super) unsafe fn add(
+        &mut self,
+        rmap_bit_position: RmapBitPosition,
+        position: Position,
+        next_physical_pointer: &mut NextPhysicalPointer,
+    ) {
+        // SAFETY: Guaranteed by function contract
+        let rmap_item = unsafe { self.insertion_item(rmap_bit_position, next_physical_pointer) };
+
+        // The same `r` can appear in the table multiple times, one duplicate is supported here
+        if rmap_item[0] == Position::ZERO {
+            rmap_item[0] = position;
+        } else if rmap_item[1] == Position::ZERO {
+            rmap_item[1] = position;
+        }
+    }
+
+    #[inline(always)]
+    pub(super) fn get(&self, rmap_bit_position: RmapBitPosition) -> [Position; 2] {
+        let bit_position = rmap_bit_position.get();
+        let word_offset = (bit_position / u32::BITS) as usize;
+        let bit_offset = bit_position % u32::BITS;
+
+        let virtual_pointer = if bit_offset + POINTER_BITS > u32::BITS {
+            // SAFETY: Offset comes from `RmapBitPosition`, whose constructor guarantees bounds
+            let word = unsafe { *self.virtual_pointers.get_unchecked(word_offset) };
+            // SAFETY: Offset comes from `RmapBitPosition`, whose constructor guarantees bounds
+            let word_next = unsafe { *self.virtual_pointers.get_unchecked(word_offset + 1) };
+
+            let value = (word >> bit_offset) | (word_next << (u32::BITS - bit_offset));
+            value & (u32::MAX >> (u32::BITS - POINTER_BITS))
+        } else {
+            // SAFETY: Offset comes from `RmapBitPosition`, whose constructor guarantees bounds
+            let word = unsafe { *self.virtual_pointers.get_unchecked(word_offset) };
+
+            (word >> bit_offset) & (u32::MAX >> (u32::BITS - POINTER_BITS))
+        };
+
+        if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
+            // SAFETY: Internal pointers are always valid
+            *unsafe { self.positions.get_unchecked(physical_pointer as usize) }
+        } else {
+            [Position::ZERO; 2]
+        }
+    }
+
+    // TODO: Remove as soon as non-hacky version compiles
+    #[inline(always)]
+    pub(super) fn zeroing_hack(rmap: &mut MaybeUninit<Self>) {
+        let rmap = unsafe { rmap.assume_init_mut() };
+        for index in 0..rmap.positions.len() {
+            rmap.positions[index][0] = Position::ZERO;
+            rmap.positions[index][1] = Position::ZERO;
+        }
+        for index in 0..rmap.virtual_pointers.len() {
+            rmap.virtual_pointers[index] = 0;
+        }
+    }
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/rmap/tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/rmap/tests.rs
@@ -1,0 +1,171 @@
+use crate::shader::find_matches_in_buckets::rmap::{
+    NextPhysicalPointer, Rmap, RmapBitPosition, RmapBitPositionExt,
+};
+use crate::shader::types::{Position, PositionExt};
+
+#[test]
+fn test_rmap_basic() {
+    let mut next_physical_pointer = NextPhysicalPointer::default();
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        rmap.add(
+            RmapBitPosition::new(0),
+            Position::from_u32(100),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(0)),
+            [Position::from_u32(100), Position::from_u32(0)]
+        );
+
+        rmap.add(
+            RmapBitPosition::new(0),
+            Position::from_u32(101),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(0)),
+            [Position::from_u32(100), Position::from_u32(101)]
+        );
+
+        // Ignored as duplicate `r`
+        rmap.add(
+            RmapBitPosition::new(0),
+            Position::from_u32(102),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(0)),
+            [Position::from_u32(100), Position::from_u32(101)]
+        );
+
+        rmap.add(
+            RmapBitPosition::new(1),
+            Position::from_u32(200),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(1)),
+            [Position::from_u32(200), Position::from_u32(0)]
+        );
+    }
+}
+
+#[test]
+fn test_rmap_spanning_across_words() {
+    let mut next_physical_pointer = NextPhysicalPointer::default();
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        rmap.add(
+            RmapBitPosition::new(24),
+            Position::from_u32(300),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(24)),
+            [Position::from_u32(300), Position::from_u32(0)]
+        );
+
+        rmap.add(
+            RmapBitPosition::new(24),
+            Position::from_u32(301),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(24)),
+            [Position::from_u32(300), Position::from_u32(301)]
+        );
+
+        // Ignored as duplicate `r`
+        rmap.add(
+            RmapBitPosition::new(24),
+            Position::from_u32(302),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(24)),
+            [Position::from_u32(300), Position::from_u32(301)]
+        );
+    }
+}
+
+#[test]
+fn test_rmap_zero_position() {
+    let mut next_physical_pointer = NextPhysicalPointer::default();
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        // Zero position is effectively ignored
+        rmap.add(
+            RmapBitPosition::new(2),
+            Position::from_u32(0),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(2)),
+            [Position::from_u32(0), Position::from_u32(0)]
+        );
+
+        rmap.add(
+            RmapBitPosition::new(2),
+            Position::from_u32(400),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(2)),
+            [Position::from_u32(400), Position::from_u32(0)]
+        );
+
+        // Zero position is effectively ignored
+        rmap.add(
+            RmapBitPosition::new(2),
+            Position::from_u32(0),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(2)),
+            [Position::from_u32(400), Position::from_u32(0)]
+        );
+
+        rmap.add(
+            RmapBitPosition::new(2),
+            Position::from_u32(401),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(2)),
+            [Position::from_u32(400), Position::from_u32(401)]
+        );
+    }
+}
+
+#[test]
+fn test_rmap_zero_when_full() {
+    let mut next_physical_pointer = NextPhysicalPointer::default();
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        rmap.add(
+            RmapBitPosition::new(3),
+            Position::from_u32(500),
+            &mut next_physical_pointer,
+        );
+        rmap.add(
+            RmapBitPosition::new(3),
+            Position::from_u32(501),
+            &mut next_physical_pointer,
+        );
+        // Ignored as duplicate `r`
+        rmap.add(
+            RmapBitPosition::new(3),
+            Position::from_u32(0),
+            &mut next_physical_pointer,
+        );
+        assert_eq!(
+            rmap.get(RmapBitPosition::new(3)),
+            [Position::from_u32(500), Position::from_u32(501)]
+        );
+    }
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/types.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/types.rs
@@ -1,5 +1,6 @@
 use crate::shader::num::{U128, U128T};
 use core::iter::Step;
+use core::mem::MaybeUninit;
 use derive_more::{From, Into};
 
 /// Stores data in lower bits
@@ -41,14 +42,67 @@ impl From<Y> for U128 {
     }
 }
 
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, From, Into)]
-#[repr(C)]
-pub struct Position(u32);
+// TODO: The struct in this form currently doesn't compile:
+//  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+// #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, From, Into)]
+// #[repr(C)]
+// pub struct Position(u32);
+//
+// impl From<Position> for usize {
+//     #[inline(always)]
+//     fn from(value: Position) -> Self {
+//         value.0 as Self
+//     }
+// }
+//
+// impl Position {
+//     pub(super) const ZERO: Self = Self(0);
+//     /// Position that can't exist
+//     pub(super) const SENTINEL: Self = Self(u32::MAX);
+// }
+//
+// impl Position {
+//     #[inline(always)]
+//     pub(super) const fn uninit_array_from_repr_mut<const N: usize>(
+//         array: &mut [MaybeUninit<u32>; N],
+//     ) -> &mut [MaybeUninit<Self>; N] {
+//         // SAFETY: `Position` is `#[repr(C)]` and guaranteed to have the same memory layout
+//         unsafe { mem::transmute(array) }
+//     }
+// }
 
-impl From<Position> for usize {
+pub type Position = u32;
+
+// TODO: Remove once normal `Position` struct can be used
+pub(super) trait PositionExt: Sized {
+    const ZERO: Self;
+    /// Position that can't exist
+    const SENTINEL: Self;
+
+    fn uninit_array_from_repr_mut<const N: usize>(
+        array: &mut [MaybeUninit<u32>; N],
+    ) -> &mut [MaybeUninit<Self>; N];
+
+    // TODO: This is just `Position::from()` usually
+    #[cfg(test)]
+    fn from_u32(value: u32) -> Self;
+}
+
+impl PositionExt for Position {
+    const ZERO: Self = 0;
+    const SENTINEL: Self = u32::MAX;
+
     #[inline(always)]
-    fn from(value: Position) -> Self {
-        value.0 as Self
+    fn uninit_array_from_repr_mut<const N: usize>(
+        array: &mut [MaybeUninit<u32>; N],
+    ) -> &mut [MaybeUninit<Self>; N] {
+        array
+    }
+
+    #[cfg(test)]
+    #[inline(always)]
+    fn from_u32(value: u32) -> Self {
+        value
     }
 }
 

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -1260,8 +1260,8 @@ where
 
                 for (left_bucket_index, [left_bucket, right_bucket]) in buckets_batch {
                     let mut matches = [MaybeUninit::uninit(); _];
-                    // SAFETY: Positions are taken from `Table::buckets()` and correspond to initialized
-                    // values
+                    // SAFETY: Positions are taken from `Table::buckets()` and correspond to
+                    // initialized values
                     let matches = unsafe {
                         find_matches_in_buckets(
                             left_bucket_index as u32,
@@ -1275,19 +1275,19 @@ where
                     // Throw away some successful matches that are not that necessary
                     let matches = &matches[..matches.len().min(REDUCED_MATCHES_COUNT)];
 
-                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed at
-                    // this time, and it is guaranteed to be in range
+                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed
+                    // at this time, and it is guaranteed to be in range
                     let ys = unsafe { &mut *ys.get_unchecked(left_bucket_index).get() };
-                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed at
-                    // this time, and it is guaranteed to be in range
+                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed
+                    // at this time, and it is guaranteed to be in range
                     let positions =
                         unsafe { &mut *positions.get_unchecked(left_bucket_index).get() };
-                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed at
-                    // this time, and it is guaranteed to be in range
+                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed
+                    // at this time, and it is guaranteed to be in range
                     let metadatas =
                         unsafe { &mut *metadatas.get_unchecked(left_bucket_index).get() };
-                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed at
-                    // this time, and it is guaranteed to be in range
+                    // SAFETY: This is the only place where `left_bucket_index`'s entry is accessed
+                    // at this time, and it is guaranteed to be in range
                     let count = unsafe {
                         &mut *global_results_counts.get_unchecked(left_bucket_index).get()
                     };

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
@@ -137,7 +137,7 @@ fn test_matches() {
     let bucket_ys = bucket_ys.into_values().collect::<Vec<_>>();
     let mut total_matches = 0_usize;
     for (left_bucket_index, [left_bucket_ys, right_bucket_ys]) in
-        bucket_ys.array_windows::<2>().cloned().enumerate()
+        bucket_ys.array_windows::<2>().enumerate()
     {
         let mut left_bucket = [Position::SENTINEL; _];
         assert!(left_bucket_ys.len() <= left_bucket.len());


### PR DESCRIPTION
This is a GPU implementation for `find_matches_in_buckets`.

I had to jump through a lot of hoops to get it to compile and there is tons of TODOs in all new files that should eventually be cleaned up. But I did get it to compile and run in the end.

This introduces more differences between compiled shader variants. The modern version expects 32 kiB of shared memory and will store `Rmap` there, while fallback version will use global memory for this purpose. Otherwise they are very similar and runtime detection will pick the right version. There is no handling of completely unsupported GPUs, but I think it is fine for tests and will be implemented in non-test code.

The next step is to implement bucketing logic, which I think I'll start by experimenting some more with CPU version since I think the whole design may change slightly even on CPU for better performance, which will likely involve changes to `find_matches_in_buckets` as well, so more experiments are needed there before fully committing to the current design.