### PR TITLE
Improve PoS performance with better data layout

### DIFF
--- a/crates/shared/ab-proof-of-space/src/chiapos/table/rmap.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/rmap.rs
@@ -1,6 +1,6 @@
 use crate::chiapos::constants::PARAM_BC;
 use crate::chiapos::table::REDUCED_BUCKETS_SIZE;
-use crate::chiapos::table::types::Position;
+use crate::chiapos::table::types::{Position, R};
 
 pub(super) struct Rmap {
     /// `0` is a sentinel value indicating no virtual pointer is stored yet.
@@ -26,9 +26,9 @@ impl Rmap {
     /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
     /// inserted
     #[inline(always)]
-    unsafe fn insertion_item(&mut self, r: u32) -> &mut [Position; 2] {
+    unsafe fn insertion_item(&mut self, r: R) -> &mut [Position; 2] {
         // SAFETY: Guaranteed by function contract
-        let virtual_pointer = unsafe { self.virtual_pointers.get_unchecked_mut(r as usize) };
+        let virtual_pointer = unsafe { self.virtual_pointers.get_unchecked_mut(usize::from(r)) };
 
         if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
             // SAFETY: Internal pointers are always valid
@@ -52,7 +52,7 @@ impl Rmap {
     /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
     /// inserted
     #[inline(always)]
-    pub(super) unsafe fn add(&mut self, r: u32, position: Position) {
+    pub(super) unsafe fn add(&mut self, r: R, position: Position) {
         // SAFETY: Guaranteed by function contract
         let rmap_item = unsafe { self.insertion_item(r) };
 
@@ -67,9 +67,9 @@ impl Rmap {
     /// # Safety
     /// `r` must be in the range `0..PARAM_BC`
     #[inline(always)]
-    pub(super) unsafe fn get(&self, r: u32) -> [Position; 2] {
+    pub(super) unsafe fn get(&self, r: R) -> [Position; 2] {
         // SAFETY: Guaranteed by function contract
-        let virtual_pointer = *unsafe { self.virtual_pointers.get_unchecked(r as usize) };
+        let virtual_pointer = *unsafe { self.virtual_pointers.get_unchecked(usize::from(r)) };
 
         if let Some(physical_pointer) = virtual_pointer.checked_sub(1) {
             // SAFETY: Internal pointers are always valid

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/types.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/types.rs
@@ -66,6 +66,9 @@ impl From<Y> for usize {
 }
 
 impl Y {
+    /// Y that can't exist
+    pub(in super::super) const SENTINEL: Self = Self(u32::MAX);
+
     /// The range of buckets where `Y`s with the provided first `K` bits are located
     #[inline(always)]
     pub(in super::super) fn bucket_range_from_first_k_bits(value: u32) -> RangeInclusive<usize> {
@@ -178,5 +181,17 @@ where
     #[inline(always)]
     fn from(value: X) -> Self {
         Self::from(u128::from(value))
+    }
+}
+
+/// `r` is a value of `y` minus bucket base
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, From, Into)]
+#[repr(C)]
+pub(in super::super) struct R(u16);
+
+impl From<R> for usize {
+    #[inline(always)]
+    fn from(value: R) -> Self {
+        Self::from(value.0)
     }
 }

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
@@ -137,16 +137,10 @@ where
             .flat_map(move |positions| {
                 positions
                     .iter()
-                    .take_while(|&&position| position != Position::SENTINEL)
-                    .filter(move |&&position| {
-                        // SAFETY: `position` comes from `self.table_7.buckets()` and is not a
-                        // sentinel value
-                        let y = unsafe { self.table_7.y(position) };
-
-                        y.first_k_bits() == first_k_challenge_bits
-                    })
+                    .take_while(|&&(position, _y)| position != Position::SENTINEL)
+                    .filter(move |&&(_position, y)| y.first_k_bits() == first_k_challenge_bits)
             })
-            .map(move |&position| {
+            .map(move |&(position, _y)| {
                 // SAFETY: Internally generated positions that come from the parent table
                 let positions = unsafe { self.table_7.position(position) };
                 // SAFETY: Internally generated positions that come from the parent table
@@ -206,16 +200,10 @@ where
             .flat_map(move |positions| {
                 positions
                     .iter()
-                    .take_while(|&&position| position != Position::SENTINEL)
-                    .filter(move |&&position| {
-                        // SAFETY: `position` comes from `self.table_7.buckets()` and is not a
-                        // sentinel value
-                        let y = unsafe { self.table_7.y(position) };
-
-                        y.first_k_bits() == first_k_challenge_bits
-                    })
+                    .take_while(|&&(position, _y)| position != Position::SENTINEL)
+                    .filter(move |&&(_position, y)| y.first_k_bits() == first_k_challenge_bits)
             })
-            .map(move |&position| {
+            .map(move |&(position, _y)| {
                 let mut proof = [0u8; 64 * K as usize / 8];
 
                 // SAFETY: Internally generated positions that come from the parent table


### PR DESCRIPTION
I looked at buckets recently and noticed that especially after recent refactoring random lookups for `y` needed during both tables creation and proving are actually happening in sync with reading corresponding positions. Since reading positions without reading `y`s is not really happening, why not storing both together?

Moreover, storing full `y` is not actually necessary, we could store just `r` and do cheap addition based on a bucket value is in, but it ended up being a tiny bit slower from my testing (but it would use a bit less memory).

With a sprinkle of cache alignment for `LeftTargets` we have another major performance improvement and I think that actually sorting revisit might be happening soon, but this time using a custom radix sort implementation.

Results are still a bit flaky, but the minimums are in fact moving down:
```
Before:
chia/table/single/1x    time:   [702.17 ms 707.33 ms 712.59 ms]
                        thrpt:  [1.4033  elem/s 1.4138  elem/s 1.4242  elem/s]
chia/table/parallel/8x  time:   [502.50 ms 505.77 ms 509.35 ms]
                        thrpt:  [15.706  elem/s 15.818  elem/s 15.920  elem/s]
chia/proof/missing      time:   [107.29 ns 108.80 ns 111.58 ns]
                        thrpt:  [8.9618 Melem/s 9.1915 Melem/s 9.3207 Melem/s]
chia/proof/present      time:   [374.03 ns 375.88 ns 377.16 ns]
                        thrpt:  [2.6514 Melem/s 2.6604 Melem/s 2.6736 Melem/s]
After:
chia/table/single/1x    time:   [638.21 ms 642.97 ms 649.77 ms]
                        thrpt:  [1.5390  elem/s 1.5553  elem/s 1.5669  elem/s]
chia/table/parallel/8x  time:   [426.94 ms 431.49 ms 436.70 ms]
                        thrpt:  [18.319  elem/s 18.540  elem/s 18.738  elem/s]
chia/proof/missing      time:   [76.806 ns 76.913 ns 77.038 ns]
                        thrpt:  [12.981 Melem/s 13.002 Melem/s 13.020 Melem/s]
chia/proof/present      time:   [351.19 ns 352.22 ns 354.05 ns]
                        thrpt:  [2.8245 Melem/s 2.8391 Melem/s 2.8474 Melem/s]
```

Overall, performance more than doubled since May when the last (as of right now) Subspace backport has happened. And as a bonus, this PR actually removes more code than adds, which is not always the case.

I'll check whether storing metadata next to positions and `y` is worth it (probably not) separately.