### PR TITLE
Optimize CPU PoS

### DIFF
--- a/crates/farmer/ab-farmer-components/benches/auditing.rs
+++ b/crates/farmer/ab-farmer-components/benches/auditing.rs
@@ -54,7 +54,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     rng.fill_bytes(input.as_mut().as_mut());
     let erasure_coding = ErasureCoding::new();
     let mut archiver = Archiver::new(erasure_coding.clone());
-    let mut table_generator = PosTable::generator();
+    let table_generator = PosTable::generator();
     let archived_history_segment = archiver
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
@@ -131,7 +131,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             downloading_semaphore: black_box(None),
             encoding_semaphore: black_box(None),
             records_encoder: &mut CpuRecordsEncoder::<PosTable>::new(
-                slice::from_mut(&mut table_generator),
+                slice::from_ref(&table_generator),
                 &erasure_coding,
                 &Default::default(),
             ),

--- a/crates/farmer/ab-farmer-components/benches/plotting.rs
+++ b/crates/farmer/ab-farmer-components/benches/plotting.rs
@@ -12,9 +12,9 @@ use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use futures::executor::block_on;
 use rand_chacha::ChaCha8Rng;
 use rand_core::{RngCore, SeedableRng};
-use std::env;
 use std::hint::black_box;
 use std::num::NonZeroU64;
+use std::{array, env};
 
 type PosTable = ChiaTable;
 
@@ -34,16 +34,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     rng.fill_bytes(input.as_mut().as_mut());
     let erasure_coding = ErasureCoding::new();
     let mut archiver = Archiver::new(erasure_coding.clone());
-    let mut table_generators = [
-        PosTable::generator(),
-        PosTable::generator(),
-        PosTable::generator(),
-        PosTable::generator(),
-        PosTable::generator(),
-        PosTable::generator(),
-        PosTable::generator(),
-        PosTable::generator(),
-    ];
+    let table_generators = array::repeat::<_, 8>(PosTable::generator());
     let archived_history_segment = archiver
         .add_block(
             AsRef::<[u8]>::as_ref(input.as_ref()).to_vec(),
@@ -84,7 +75,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 downloading_semaphore: black_box(None),
                 encoding_semaphore: black_box(None),
                 records_encoder: black_box(&mut CpuRecordsEncoder::<PosTable>::new(
-                    &mut table_generators,
+                    &table_generators,
                     &erasure_coding,
                     &Default::default(),
                 )),

--- a/crates/farmer/ab-farmer-components/src/plotting.rs
+++ b/crates/farmer/ab-farmer-components/src/plotting.rs
@@ -328,7 +328,7 @@ pub struct CpuRecordsEncoder<'a, PosTable>
 where
     PosTable: Table,
 {
-    table_generators: &'a mut [PosTable::Generator],
+    table_generators: &'a [PosTable::Generator],
     erasure_coding: &'a ErasureCoding,
     global_mutex: &'a AsyncMutex<()>,
 }
@@ -354,7 +354,6 @@ where
         let mut sector_contents_map = SectorContentsMap::new(pieces_in_sector);
 
         {
-            let table_generators = &mut *self.table_generators;
             let global_mutex = self.global_mutex;
             let erasure_coding = self.erasure_coding;
 
@@ -365,7 +364,7 @@ where
             );
 
             rayon::scope(|scope| {
-                for table_generator in table_generators {
+                for table_generator in self.table_generators {
                     scope.spawn(|_scope| {
                         let mut chunks_scratch = Vec::with_capacity(Record::NUM_S_BUCKETS);
 
@@ -410,7 +409,7 @@ where
 {
     /// Create a new instance
     pub fn new(
-        table_generators: &'a mut [PosTable::Generator],
+        table_generators: &'a [PosTable::Generator],
         erasure_coding: &'a ErasureCoding,
         global_mutex: &'a AsyncMutex<()>,
     ) -> Self {
@@ -603,7 +602,7 @@ fn record_encoding<PosTable>(
     pos_seed: &PosSeed,
     record: &mut Record,
     mut encoded_chunks_used: EncodedChunksUsed<'_>,
-    table_generator: &mut PosTable::Generator,
+    table_generator: &PosTable::Generator,
     erasure_coding: &ErasureCoding,
     chunks_scratch: &mut Vec<[u8; RecordChunk::SIZE]>,
 ) where

--- a/crates/farmer/ab-farmer-components/src/reading.rs
+++ b/crates/farmer/ab-farmer-components/src/reading.rs
@@ -449,7 +449,7 @@ pub async fn read_piece<PosTable, S, A>(
     sector: &ReadAt<S, A>,
     erasure_coding: &ErasureCoding,
     mode: ReadSectorRecordChunksMode,
-    table_generator: &mut PosTable::Generator,
+    table_generator: &PosTable::Generator,
 ) -> Result<Piece, ReadingError>
 where
     PosTable: Table,

--- a/crates/shared/ab-proof-of-space/Cargo.toml
+++ b/crates/shared/ab-proof-of-space/Cargo.toml
@@ -21,15 +21,17 @@ bench = false
 ab-blake3 = { workspace = true }
 ab-chacha8 = { workspace = true }
 ab-core-primitives = { workspace = true }
-chacha20 = { workspace = true, features = ["cipher"] }
+chacha20 = { workspace = true, features = ["cipher"], optional = true }
 derive_more = { workspace = true, features = ["full"] }
 rayon = { workspace = true, optional = true }
-seq-macro = { workspace = true }
+seq-macro = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+chacha20 = { workspace = true, features = ["cipher"] }
 rayon = { workspace = true }
+seq-macro = { workspace = true }
 sha2 = { workspace = true }
 
 [[bench]]
@@ -38,10 +40,9 @@ harness = false
 
 [features]
 default = []
-alloc = []
-std = [
-    "alloc",
-    "derive_more/std",
+alloc = [
+    "dep:chacha20",
+    "dep:seq-macro",
 ]
 # Enabling this feature exposes quality search on `chiapos` module as well as enables support for K=15..=25 (by default
 # only K=20 is exposed)

--- a/crates/shared/ab-proof-of-space/benches/pos.rs
+++ b/crates/shared/ab-proof-of-space/benches/pos.rs
@@ -57,25 +57,24 @@ fn pos_bench<PosTable>(
 
     let mut group = c.benchmark_group(name);
 
-    let mut generator_instance = PosTable::generator();
+    let generator = PosTable::generator();
     group.throughput(Throughput::Elements(1));
     group.bench_function("table/single/1x", |b| {
         b.iter(|| {
-            generator_instance.generate(black_box(&seed));
+            generator.generate(black_box(&seed));
         });
     });
 
     #[cfg(feature = "parallel")]
     {
         {
-            let mut generator_instances = [PosTable::generator(), PosTable::generator()];
             group.throughput(Throughput::Elements(2));
             group.bench_function("table/single/2x", |b| {
                 b.iter(|| {
                     rayon::scope(|scope| {
-                        for g in &mut generator_instances {
+                        for _ in 0..2 {
                             scope.spawn(|_scope| {
-                                g.generate(black_box(&seed));
+                                generator.generate(black_box(&seed));
                             });
                         }
                     });
@@ -84,19 +83,13 @@ fn pos_bench<PosTable>(
         }
 
         {
-            let mut generator_instances = [
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-            ];
             group.throughput(Throughput::Elements(4));
             group.bench_function("table/single/4x", |b| {
                 b.iter(|| {
                     rayon::scope(|scope| {
-                        for g in &mut generator_instances {
+                        for _ in 0..4 {
                             scope.spawn(|_scope| {
-                                g.generate(black_box(&seed));
+                                generator.generate(black_box(&seed));
                             });
                         }
                     });
@@ -105,23 +98,13 @@ fn pos_bench<PosTable>(
         }
 
         {
-            let mut generator_instances = [
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-            ];
             group.throughput(Throughput::Elements(8));
             group.bench_function("table/single/8x", |b| {
                 b.iter(|| {
                     rayon::scope(|scope| {
-                        for g in &mut generator_instances {
+                        for _ in 0..8 {
                             scope.spawn(|_scope| {
-                                g.generate(black_box(&seed));
+                                generator.generate(black_box(&seed));
                             });
                         }
                     });
@@ -130,31 +113,13 @@ fn pos_bench<PosTable>(
         }
 
         {
-            let mut generator_instances = [
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-                PosTable::generator(),
-            ];
             group.throughput(Throughput::Elements(16));
             group.bench_function("table/single/16x", |b| {
                 b.iter(|| {
                     rayon::scope(|scope| {
-                        for g in &mut generator_instances {
+                        for _ in 0..16 {
                             scope.spawn(|_scope| {
-                                g.generate(black_box(&seed));
+                                generator.generate(black_box(&seed));
                             });
                         }
                     });
@@ -165,95 +130,59 @@ fn pos_bench<PosTable>(
 
     #[cfg(feature = "parallel")]
     {
-        let mut generator_instance = PosTable::generator();
         group.throughput(Throughput::Elements(1));
         group.bench_function("table/parallel/1x", |b| {
             b.iter(|| {
-                generator_instance.generate_parallel(black_box(&seed));
+                generator.generate_parallel(black_box(&seed));
             });
         });
 
-        let mut generator_instances = [PosTable::generator(), PosTable::generator()];
         group.throughput(Throughput::Elements(2));
         group.bench_function("table/parallel/2x", |b| {
             b.iter(|| {
                 rayon::scope(|scope| {
-                    for g in &mut generator_instances {
+                    for _ in 0..2 {
                         scope.spawn(|_scope| {
-                            g.generate_parallel(black_box(&seed));
+                            generator.generate_parallel(black_box(&seed));
                         });
                     }
                 });
             });
         });
 
-        let mut generator_instances = [
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-        ];
         group.throughput(Throughput::Elements(4));
         group.bench_function("table/parallel/4x", |b| {
             b.iter(|| {
                 rayon::scope(|scope| {
-                    for g in &mut generator_instances {
+                    for _ in 0..4 {
                         scope.spawn(|_scope| {
-                            g.generate_parallel(black_box(&seed));
+                            generator.generate_parallel(black_box(&seed));
                         });
                     }
                 });
             });
         });
 
-        let mut generator_instances = [
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-        ];
         group.throughput(Throughput::Elements(8));
         group.bench_function("table/parallel/8x", |b| {
             b.iter(|| {
                 rayon::scope(|scope| {
-                    for g in &mut generator_instances {
+                    for _ in 0..8 {
                         scope.spawn(|_scope| {
-                            g.generate_parallel(black_box(&seed));
+                            generator.generate_parallel(black_box(&seed));
                         });
                     }
                 });
             });
         });
 
-        let mut generator_instances = [
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-            PosTable::generator(),
-        ];
         group.throughput(Throughput::Elements(16));
         group.bench_function("table/parallel/16x", |b| {
             b.iter(|| {
                 rayon::scope(|scope| {
-                    for g in &mut generator_instances {
+                    for _ in 0..16 {
                         scope.spawn(|_scope| {
-                            g.generate_parallel(black_box(&seed));
+                            generator.generate_parallel(black_box(&seed));
                         });
                     }
                 });
@@ -261,7 +190,7 @@ fn pos_bench<PosTable>(
         });
     }
 
-    let table = generator_instance.generate(&seed);
+    let table = generator.generate(&seed);
 
     group.throughput(Throughput::Elements(1));
     group.bench_function("proof/missing", |b| {

--- a/crates/shared/ab-proof-of-space/src/chia.rs
+++ b/crates/shared/ab-proof-of-space/src/chia.rs
@@ -26,7 +26,7 @@ impl TableGenerator<ChiaTable> for ChiaTableGenerator {
         }
     }
 
-    #[cfg(any(feature = "parallel", test))]
+    #[cfg(feature = "parallel")]
     fn generate_parallel(&mut self, seed: &PosSeed) -> ChiaTable {
         ChiaTable {
             tables: Tables::<K>::create_parallel((*seed).into(), &self.tables_cache),
@@ -63,7 +63,7 @@ impl Table for ChiaTable {
         }
     }
 
-    #[cfg(all(feature = "alloc", any(feature = "parallel", test)))]
+    #[cfg(feature = "parallel")]
     fn generate_parallel(seed: &PosSeed) -> ChiaTable {
         Self {
             tables: Tables::<K>::create_parallel((*seed).into(), &TablesCache::default()),
@@ -102,14 +102,17 @@ mod tests {
         ]);
 
         let table = ChiaTable::generate(&seed);
+        #[cfg(feature = "parallel")]
         let table_parallel = ChiaTable::generate_parallel(&seed);
 
         assert!(table.find_proof(1232460437).is_none());
+        #[cfg(feature = "parallel")]
         assert!(table_parallel.find_proof(1232460437).is_none());
 
         {
             let challenge_index = 600426542;
             let proof = table.find_proof(challenge_index).unwrap();
+            #[cfg(feature = "parallel")]
             assert_eq!(proof, table_parallel.find_proof(challenge_index).unwrap());
             assert!(ChiaTable::is_proof_valid(&seed, challenge_index, &proof));
         }

--- a/crates/shared/ab-proof-of-space/src/chia.rs
+++ b/crates/shared/ab-proof-of-space/src/chia.rs
@@ -20,14 +20,14 @@ pub struct ChiaTableGenerator {
 
 #[cfg(feature = "alloc")]
 impl TableGenerator<ChiaTable> for ChiaTableGenerator {
-    fn generate(&mut self, seed: &PosSeed) -> ChiaTable {
+    fn generate(&self, seed: &PosSeed) -> ChiaTable {
         ChiaTable {
             tables: Tables::<K>::create((*seed).into(), &self.tables_cache),
         }
     }
 
     #[cfg(feature = "parallel")]
-    fn generate_parallel(&mut self, seed: &PosSeed) -> ChiaTable {
+    fn generate_parallel(&self, seed: &PosSeed) -> ChiaTable {
         ChiaTable {
             tables: Tables::<K>::create_parallel((*seed).into(), &self.tables_cache),
         }
@@ -55,20 +55,6 @@ impl Table for ChiaTable {
     const TABLE_TYPE: PosTableType = PosTableType::Chia;
     #[cfg(feature = "alloc")]
     type Generator = ChiaTableGenerator;
-
-    #[cfg(feature = "alloc")]
-    fn generate(seed: &PosSeed) -> ChiaTable {
-        Self {
-            tables: Tables::<K>::create((*seed).into(), &TablesCache::default()),
-        }
-    }
-
-    #[cfg(feature = "parallel")]
-    fn generate_parallel(seed: &PosSeed) -> ChiaTable {
-        Self {
-            tables: Tables::<K>::create_parallel((*seed).into(), &TablesCache::default()),
-        }
-    }
 
     #[cfg(feature = "alloc")]
     fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
@@ -101,9 +87,10 @@ mod tests {
             198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
         ]);
 
-        let table = ChiaTable::generate(&seed);
+        let generator = ChiaTableGenerator::default();
+        let table = generator.generate(&seed);
         #[cfg(feature = "parallel")]
-        let table_parallel = ChiaTable::generate_parallel(&seed);
+        let table_parallel = generator.generate_parallel(&seed);
 
         assert!(table.find_proof(1232460437).is_none());
         #[cfg(feature = "parallel")]

--- a/crates/shared/ab-proof-of-space/src/chia.rs
+++ b/crates/shared/ab-proof-of-space/src/chia.rs
@@ -15,21 +15,21 @@ const K: u8 = PosProof::K;
 #[derive(Debug, Default, Clone)]
 #[cfg(feature = "alloc")]
 pub struct ChiaTableGenerator {
-    tables_cache: TablesCache<K>,
+    tables_cache: TablesCache,
 }
 
 #[cfg(feature = "alloc")]
 impl TableGenerator<ChiaTable> for ChiaTableGenerator {
     fn generate(&mut self, seed: &PosSeed) -> ChiaTable {
         ChiaTable {
-            tables: Tables::<K>::create((*seed).into(), &mut self.tables_cache),
+            tables: Tables::<K>::create((*seed).into(), &self.tables_cache),
         }
     }
 
     #[cfg(any(feature = "parallel", test))]
     fn generate_parallel(&mut self, seed: &PosSeed) -> ChiaTable {
         ChiaTable {
-            tables: Tables::<K>::create_parallel((*seed).into(), &mut self.tables_cache),
+            tables: Tables::<K>::create_parallel((*seed).into(), &self.tables_cache),
         }
     }
 }
@@ -59,14 +59,14 @@ impl Table for ChiaTable {
     #[cfg(feature = "alloc")]
     fn generate(seed: &PosSeed) -> ChiaTable {
         Self {
-            tables: Tables::<K>::create_simple((*seed).into()),
+            tables: Tables::<K>::create((*seed).into(), &TablesCache::default()),
         }
     }
 
     #[cfg(all(feature = "alloc", any(feature = "parallel", test)))]
     fn generate_parallel(seed: &PosSeed) -> ChiaTable {
         Self {
-            tables: Tables::<K>::create_parallel((*seed).into(), &mut TablesCache::default()),
+            tables: Tables::<K>::create_parallel((*seed).into(), &TablesCache::default()),
         }
     }
 

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -21,12 +21,6 @@ type Quality = [u8; 32];
 #[derive(Debug)]
 pub struct Tables<const K: u8>(TablesGeneric<K>)
 where
-    EvaluatableUsize<{ metadata_size_bytes(K, 1) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 2) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 3) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 4) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 5) }>: Sized,
-    EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
     EvaluatableUsize<{ metadata_size_bytes(K, 7) }>: Sized,
     [(); 1 << K]:,
     [(); num_buckets(K)]:;

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -30,30 +30,20 @@ macro_rules! impl_any {
         $(
 impl Tables<$k> {
     /// Create Chia proof of space tables. There also exists [`Self::create_parallel()`] that trades
-    /// CPU efficiency and memory usage for lower latency.
-    ///
-    /// Advanced version of [`Self::create_simple`] that allows to reuse cache.
-    pub fn create(seed: Seed, cache: &mut TablesCache<$k>) -> Self {
+    /// memory usage for lower latency and higher CPU efficiency.
+    pub fn create(seed: Seed, cache: &TablesCache) -> Self {
         Self(TablesGeneric::<$k>::create(
             seed, cache,
         ))
     }
 
     /// Almost the same as [`Self::create()`], but uses parallelism internally for better
-    /// performance (though not efficiency of CPU and memory usage), if you create multiple tables
-    /// in parallel, prefer [`Self::create()`] for better overall performance.
+    /// latency and performance (though higher memory usage).
     #[cfg(any(feature = "parallel", test))]
-    pub fn create_parallel(seed: Seed, cache: &mut TablesCache<$k>) -> Self {
+    pub fn create_parallel(seed: Seed, cache: &TablesCache) -> Self {
         Self(TablesGeneric::<$k>::create_parallel(
             seed, cache,
         ))
-    }
-
-    /// Create Chia proof of space tables.
-    ///
-    /// Simpler version of [`Self::create`].
-    pub fn create_simple(seed: Seed) -> Self {
-        Self::create(seed, &mut TablesCache::default())
     }
 
     /// Find proof of space quality for given challenge.

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -5,6 +5,7 @@ mod table;
 mod tables;
 mod utils;
 
+#[cfg(feature = "alloc")]
 pub use crate::chiapos::table::TablesCache;
 use crate::chiapos::table::{metadata_size_bytes, num_buckets};
 use crate::chiapos::tables::TablesGeneric;
@@ -31,6 +32,7 @@ macro_rules! impl_any {
 impl Tables<$k> {
     /// Create Chia proof of space tables. There also exists [`Self::create_parallel()`] that trades
     /// memory usage for lower latency and higher CPU efficiency.
+    #[cfg(feature = "alloc")]
     pub fn create(seed: Seed, cache: &TablesCache) -> Self {
         Self(TablesGeneric::<$k>::create(
             seed, cache,
@@ -39,7 +41,7 @@ impl Tables<$k> {
 
     /// Almost the same as [`Self::create()`], but uses parallelism internally for better
     /// latency and performance (though higher memory usage).
-    #[cfg(any(feature = "parallel", test))]
+    #[cfg(feature = "parallel")]
     pub fn create_parallel(seed: Seed, cache: &TablesCache) -> Self {
         Self(TablesGeneric::<$k>::create_parallel(
             seed, cache,
@@ -47,7 +49,7 @@ impl Tables<$k> {
     }
 
     /// Find proof of space quality for given challenge.
-    #[cfg(any(feature = "full-chiapos", test))]
+    #[cfg(all(feature = "alloc", any(feature = "full-chiapos", test)))]
     pub fn find_quality<'a>(
         &'a self,
         challenge: &'a Challenge,
@@ -56,7 +58,8 @@ impl Tables<$k> {
     }
 
     /// Find proof of space for given challenge.
-    pub fn find_proof<'a>(
+        #[cfg(feature = "alloc")]
+pub fn find_proof<'a>(
         &'a self,
         first_challenge_bytes: [u8; 4],
     ) -> impl Iterator<Item = [u8; 64 * $k / 8]> + 'a {

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -281,11 +281,11 @@ fn calculate_left_target_on_demand(parity: u32, r: u32, m: u32) -> u32 {
 
 /// Caches that can be used to optimize the creation of multiple [`Tables`](super::Tables).
 #[derive(Debug, Clone)]
-pub struct TablesCache<const K: u8> {
+pub struct TablesCache {
     left_targets: Box<LeftTargets>,
 }
 
-impl<const K: u8> Default for TablesCache<K> {
+impl Default for TablesCache {
     /// Create a new instance
     fn default() -> Self {
         Self {
@@ -1161,7 +1161,7 @@ where
     /// better overall performance.
     pub(super) fn create<const PARENT_TABLE_NUMBER: u8>(
         parent_table: Table<K, PARENT_TABLE_NUMBER>,
-        cache: &mut TablesCache<K>,
+        cache: &TablesCache,
     ) -> (Self, PrunedTable<K, PARENT_TABLE_NUMBER>)
     where
         Table<K, PARENT_TABLE_NUMBER>: private::NotLastTable,
@@ -1252,7 +1252,7 @@ where
     #[cfg(any(feature = "parallel", test))]
     pub(super) fn create_parallel<const PARENT_TABLE_NUMBER: u8>(
         parent_table: Table<K, PARENT_TABLE_NUMBER>,
-        cache: &mut TablesCache<K>,
+        cache: &TablesCache,
     ) -> (Self, PrunedTable<K, PARENT_TABLE_NUMBER>)
     where
         Table<K, PARENT_TABLE_NUMBER>: private::NotLastTable,

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/rmap.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/rmap.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use crate::chiapos::constants::PARAM_BC;
 use crate::chiapos::table::REDUCED_BUCKETS_SIZE;
 use crate::chiapos::table::types::{Position, R};

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/rmap/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/rmap/tests.rs
@@ -1,0 +1,80 @@
+use crate::chiapos::table::rmap::Rmap;
+use crate::chiapos::table::types::{Position, R};
+
+#[test]
+fn test_rmap_basic() {
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        rmap.add(R::from(0), Position::from(100));
+        assert_eq!(
+            rmap.get(R::from(0)),
+            [Position::from(100), Position::from(0)]
+        );
+
+        rmap.add(R::from(0), Position::from(101));
+        assert_eq!(
+            rmap.get(R::from(0)),
+            [Position::from(100), Position::from(101)]
+        );
+
+        // Ignored as duplicate `r`
+        rmap.add(R::from(0), Position::from(102));
+        assert_eq!(
+            rmap.get(R::from(0)),
+            [Position::from(100), Position::from(101)]
+        );
+
+        rmap.add(R::from(1), Position::from(200));
+        assert_eq!(
+            rmap.get(R::from(1)),
+            [Position::from(200), Position::from(0)]
+        );
+    }
+}
+
+#[test]
+fn test_rmap_zero_position() {
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        // Zero position is effectively ignored
+        rmap.add(R::from(2), Position::from(0));
+        assert_eq!(rmap.get(R::from(2)), [Position::from(0), Position::from(0)]);
+
+        rmap.add(R::from(2), Position::from(400));
+        assert_eq!(
+            rmap.get(R::from(2)),
+            [Position::from(400), Position::from(0)]
+        );
+
+        // Zero position is effectively ignored
+        rmap.add(R::from(2), Position::from(0));
+        assert_eq!(
+            rmap.get(R::from(2)),
+            [Position::from(400), Position::from(0)]
+        );
+
+        rmap.add(R::from(2), Position::from(401));
+        assert_eq!(
+            rmap.get(R::from(2)),
+            [Position::from(400), Position::from(401)]
+        );
+    }
+}
+
+#[test]
+fn test_rmap_zero_when_full() {
+    let mut rmap = Rmap::new();
+
+    unsafe {
+        rmap.add(R::from(3), Position::from(500));
+        rmap.add(R::from(3), Position::from(501));
+        // Ignored as duplicate `r`
+        rmap.add(R::from(3), Position::from(0));
+        assert_eq!(
+            rmap.get(R::from(3)),
+            [Position::from(500), Position::from(501)]
+        );
+    }
+}

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/tests.rs
@@ -1,19 +1,24 @@
 //! Tests translated into Rust from
 //! https://github.com/Chia-Network/chiapos/blob/a2049c5367fe60930533a995f7ffded538f04dc4/tests/test.cpp
 
-extern crate alloc;
-
 use crate::chiapos::Seed;
+#[cfg(feature = "alloc")]
 use crate::chiapos::constants::{PARAM_B, PARAM_BC, PARAM_C, PARAM_EXT};
-use crate::chiapos::table::types::{Metadata, Position, X, Y};
+#[cfg(feature = "alloc")]
+use crate::chiapos::table::types::Position;
+use crate::chiapos::table::types::{Metadata, X, Y};
 use crate::chiapos::table::{
-    COMPUTE_F1_SIMD_FACTOR, calculate_left_targets, compute_f1, compute_f1_simd, compute_fn,
-    compute_fn_simd, find_matches_in_buckets, metadata_size_bytes,
+    COMPUTE_F1_SIMD_FACTOR, compute_f1, compute_f1_simd, compute_fn, compute_fn_simd,
+    metadata_size_bytes,
 };
+#[cfg(feature = "alloc")]
+use crate::chiapos::table::{calculate_left_targets, find_matches_in_buckets};
 use crate::chiapos::utils::EvaluatableUsize;
+#[cfg(feature = "alloc")]
 use alloc::collections::BTreeMap;
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
 use core::mem::MaybeUninit;
 use core::simd::prelude::*;
 
@@ -74,6 +79,7 @@ fn test_compute_f1_k22() {
     }
 }
 
+#[cfg(feature = "alloc")]
 fn check_match(yl: usize, yr: usize) -> bool {
     let yl = yl as i64;
     let yr = yr as i64;
@@ -102,6 +108,7 @@ fn check_match(yl: usize, yr: usize) -> bool {
 
 // TODO: This test should be rewritten into something more readable, currently it is more or less
 //  direct translation from C++
+#[cfg(feature = "alloc")]
 #[test]
 #[cfg_attr(miri, ignore)]
 fn test_matches() {

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/types.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/types.rs
@@ -1,8 +1,12 @@
-use crate::chiapos::constants::{PARAM_BC, PARAM_EXT};
+#[cfg(feature = "alloc")]
+use crate::chiapos::constants::PARAM_BC;
+use crate::chiapos::constants::PARAM_EXT;
 use crate::chiapos::table::metadata_size_bytes;
 use crate::chiapos::utils::EvaluatableUsize;
 use core::iter::Step;
+#[cfg(any(feature = "alloc", test))]
 use core::mem;
+#[cfg(feature = "alloc")]
 use core::ops::RangeInclusive;
 use derive_more::{Add, AddAssign, From, Into};
 
@@ -43,6 +47,7 @@ impl From<X> for u128 {
 }
 
 impl X {
+    #[cfg(feature = "alloc")]
     pub(in super::super) const ZERO: Self = Self(0);
 }
 
@@ -67,9 +72,11 @@ impl From<Y> for usize {
 
 impl Y {
     /// Y that can't exist
+    #[cfg(feature = "alloc")]
     pub(in super::super) const SENTINEL: Self = Self(u32::MAX);
 
     /// The range of buckets where `Y`s with the provided first `K` bits are located
+    #[cfg(feature = "alloc")]
     #[inline(always)]
     pub(in super::super) fn bucket_range_from_first_k_bits(value: u32) -> RangeInclusive<usize> {
         let from = value << PARAM_EXT;
@@ -83,6 +90,7 @@ impl Y {
         self.0 >> PARAM_EXT
     }
 
+    #[cfg(any(feature = "alloc", test))]
     #[inline(always)]
     pub(super) const fn array_from_repr<const N: usize>(array: [u32; N]) -> [Self; N] {
         // TODO: Should have been transmute, but https://github.com/rust-lang/rust/issues/61956
@@ -120,8 +128,10 @@ impl From<Position> for usize {
 }
 
 impl Position {
+    #[cfg(any(feature = "alloc", test))]
     pub(in super::super) const ZERO: Self = Self(0);
     /// Position that can't exist
+    #[cfg(feature = "alloc")]
     pub(in super::super) const SENTINEL: Self = Self(u32::MAX);
 }
 

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
@@ -63,7 +63,7 @@ where
 {
     /// Create Chia proof of space tables. There also exists [`Self::create_parallel()`] that trades
     /// CPU efficiency and memory usage for lower latency.
-    pub(super) fn create(seed: Seed, cache: &mut TablesCache<K>) -> Self {
+    pub(super) fn create(seed: Seed, cache: &TablesCache) -> Self {
         let table_1 = Table::<K, 1>::create(seed);
         let (table_2, _) = Table::<K, 2>::create(table_1, cache);
         let (table_3, table_2) = Table::<K, 3>::create(table_2, cache);
@@ -86,7 +86,7 @@ where
     /// performance (though not efficiency of CPU and memory usage), if you create multiple tables
     /// in parallel, prefer [`Self::create()`] for better overall performance.
     #[cfg(any(feature = "parallel", test))]
-    pub(super) fn create_parallel(seed: Seed, cache: &mut TablesCache<K>) -> Self {
+    pub(super) fn create_parallel(seed: Seed, cache: &TablesCache) -> Self {
         let table_1 = Table::<K, 1>::create_parallel(seed);
         let (table_2, _) = Table::<K, 2>::create_parallel(table_1, cache);
         let (table_3, table_2) = Table::<K, 3>::create_parallel(table_2, cache);

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables/tests.rs
@@ -12,8 +12,9 @@ const K: u8 = 17;
 #[test]
 fn self_verification() {
     let seed = [1; 32];
-    let tables = Tables::<K>::create_simple(seed);
-    let tables_parallel = Tables::<K>::create_parallel(seed, &mut TablesCache::default());
+    let cache = TablesCache::default();
+    let tables = Tables::<K>::create(seed, &cache);
+    let tables_parallel = Tables::<K>::create_parallel(seed, &cache);
 
     for challenge_index in 0..1000_u32 {
         let mut challenge = [0; 32];

--- a/crates/shared/ab-proof-of-space/src/lib.rs
+++ b/crates/shared/ab-proof-of-space/src/lib.rs
@@ -1,5 +1,5 @@
 //! Proof of space implementation
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
 #![feature(
@@ -20,6 +20,9 @@
 pub mod chia;
 pub mod chiapos;
 pub mod shim;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 use ab_core_primitives::pos::{PosProof, PosSeed};
 use ab_core_primitives::solutions::SolutionPotVerifier;
@@ -47,7 +50,7 @@ pub trait TableGenerator<T: Table>: fmt::Debug + Default + Clone + Send + Sized 
     ///
     /// This implementation will trade efficiency of CPU and memory usage for lower latency, prefer
     /// [`Self::generate()`] unless lower latency is critical.
-    #[cfg(any(feature = "parallel", test))]
+    #[cfg(feature = "parallel")]
     fn generate_parallel(&mut self, seed: &PosSeed) -> T {
         self.generate(seed)
     }
@@ -71,7 +74,7 @@ pub trait Table: SolutionPotVerifier + Sized + Send + Sync + 'static {
     ///
     /// This implementation will trade efficiency of CPU and memory usage for lower latency, prefer
     /// [`Self::generate()`] unless lower latency is critical.
-    #[cfg(all(feature = "alloc", any(feature = "parallel", test)))]
+    #[cfg(feature = "parallel")]
     fn generate_parallel(seed: &PosSeed) -> Self {
         Self::generate(seed)
     }

--- a/crates/shared/ab-proof-of-space/src/lib.rs
+++ b/crates/shared/ab-proof-of-space/src/lib.rs
@@ -8,6 +8,7 @@
     const_trait_impl,
     exact_size_is_empty,
     generic_const_exprs,
+    get_mut_unchecked,
     maybe_uninit_fill,
     maybe_uninit_slice,
     maybe_uninit_write_slice,
@@ -38,20 +39,24 @@ pub enum PosTableType {
     Shim,
 }
 
-/// Stateful table generator with better performance
+/// Stateful table generator with better performance.
+///
+/// Prefer cloning it over creating multiple separate generators.
 #[cfg(feature = "alloc")]
-pub trait TableGenerator<T: Table>: fmt::Debug + Default + Clone + Send + Sized + 'static {
+pub trait TableGenerator<T: Table>:
+    fmt::Debug + Default + Clone + Send + Sync + Sized + 'static
+{
     /// Generate new table with 32 bytes seed.
     ///
     /// There is also [`Self::generate_parallel()`] that can achieve lower latency.
-    fn generate(&mut self, seed: &PosSeed) -> T;
+    fn generate(&self, seed: &PosSeed) -> T;
 
     /// Generate new table with 32 bytes seed using parallelism.
     ///
     /// This implementation will trade efficiency of CPU and memory usage for lower latency, prefer
     /// [`Self::generate()`] unless lower latency is critical.
     #[cfg(feature = "parallel")]
-    fn generate_parallel(&mut self, seed: &PosSeed) -> T {
+    fn generate_parallel(&self, seed: &PosSeed) -> T {
         self.generate(seed)
     }
 }
@@ -63,21 +68,6 @@ pub trait Table: SolutionPotVerifier + Sized + Send + Sync + 'static {
     /// Instance that can be used to generate tables with better performance
     #[cfg(feature = "alloc")]
     type Generator: TableGenerator<Self>;
-
-    /// Generate new table with 32 bytes seed.
-    ///
-    /// There is also [`Self::generate_parallel()`] that can achieve lower latency.
-    #[cfg(feature = "alloc")]
-    fn generate(seed: &PosSeed) -> Self;
-
-    /// Generate new table with 32 bytes seed using parallelism.
-    ///
-    /// This implementation will trade efficiency of CPU and memory usage for lower latency, prefer
-    /// [`Self::generate()`] unless lower latency is critical.
-    #[cfg(feature = "parallel")]
-    fn generate_parallel(seed: &PosSeed) -> Self {
-        Self::generate(seed)
-    }
 
     /// Try to find proof at `challenge_index` if it exists
     #[cfg(feature = "alloc")]

--- a/crates/shared/ab-proof-of-space/src/shim.rs
+++ b/crates/shared/ab-proof-of-space/src/shim.rs
@@ -16,8 +16,8 @@ pub struct ShimTableGenerator;
 
 #[cfg(feature = "alloc")]
 impl TableGenerator<ShimTable> for ShimTableGenerator {
-    fn generate(&mut self, seed: &PosSeed) -> ShimTable {
-        ShimTable::generate(seed)
+    fn generate(&self, seed: &PosSeed) -> ShimTable {
+        ShimTable { seed: *seed }
     }
 }
 
@@ -44,11 +44,6 @@ impl Table for ShimTable {
     const TABLE_TYPE: PosTableType = PosTableType::Shim;
     #[cfg(feature = "alloc")]
     type Generator = ShimTableGenerator;
-
-    #[cfg(feature = "alloc")]
-    fn generate(seed: &PosSeed) -> ShimTable {
-        Self { seed: *seed }
-    }
 
     #[cfg(feature = "alloc")]
     fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
@@ -93,7 +88,7 @@ mod tests {
             198, 204, 10, 9, 10, 11, 129, 139, 171, 15, 23,
         ]);
 
-        let table = ShimTable::generate(&seed);
+        let table = ShimTable::generator().generate(&seed);
 
         assert!(table.find_proof(1).is_none());
 

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/benchmark.rs
@@ -9,7 +9,6 @@ use ab_proof_of_space::Table;
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 use criterion::{BatchSize, Criterion, Throughput};
-use parking_lot::Mutex;
 use rayon::{ThreadPool, ThreadPoolBuildError, ThreadPoolBuilder};
 use std::collections::HashSet;
 use std::fs::OpenOptions;
@@ -157,7 +156,7 @@ where
     let public_key_hash = &single_disk_farm_info.public_key().hash();
     let sector_size = sector_size(single_disk_farm_info.pieces_in_sector());
     let erasure_coding = ErasureCoding::new();
-    let table_generator = Mutex::new(PosTable::generator());
+    let table_generator = PosTable::generator();
 
     let sectors_metadata = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)
         .map_err(|error| anyhow::anyhow!("Failed to read sectors metadata: {error}"))?;
@@ -321,7 +320,7 @@ where
 
     let public_key_hash = &single_disk_farm_info.public_key().hash();
     let erasure_coding = ErasureCoding::new();
-    let table_generator = Mutex::new(PosTable::generator());
+    let table_generator = PosTable::generator();
 
     let mut sectors_metadata = SingleDiskFarm::read_all_sectors_metadata(&disk_farm)
         .map_err(|error| anyhow::anyhow!("Failed to read sectors metadata: {error}"))?;

--- a/subspace/crates/subspace-farmer/src/plotter/cpu.rs
+++ b/subspace/crates/subspace-farmer/src/plotter/cpu.rs
@@ -351,11 +351,13 @@ where
                         };
 
                         let encoded_sector = thread_pool.install(|| {
-                            let mut generators = (0..record_encoding_concurrency.get())
-                                .map(|_| PosTable::generator())
+                            // TODO: Reuse global table generator (this comment is in many files)
+                            let generator = PosTable::generator();
+                            let generators = (0..record_encoding_concurrency.get())
+                                .map(|_| generator.clone())
                                 .collect::<Vec<_>>();
                             let mut records_encoder = CpuRecordsEncoder::<PosTable>::new(
-                                &mut generators,
+                                &generators,
                                 &erasure_coding,
                                 &global_mutex,
                             );

--- a/subspace/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
+++ b/subspace/crates/subspace-farmer/src/single_disk_farm/piece_reader.rs
@@ -123,7 +123,8 @@ async fn read_pieces<PosTable, S>(
     PosTable: Table,
     S: ReadAtSync,
 {
-    let mut table_generator = PosTable::generator();
+    // TODO: Reuse global table generator (this comment is in many files)
+    let table_generator = PosTable::generator();
 
     while let Some(read_piece_request) = read_piece_receiver.next().await {
         let ReadPieceRequest {
@@ -202,7 +203,7 @@ async fn read_pieces<PosTable, S>(
             &ReadAt::from_sync(&sector),
             &erasure_coding,
             mode,
-            &mut table_generator,
+            &table_generator,
         )
         .await;
 
@@ -218,7 +219,7 @@ async fn read_piece<PosTable, S, A>(
     sector: &ReadAt<S, A>,
     erasure_coding: &ErasureCoding,
     mode: ReadSectorRecordChunksMode,
-    table_generator: &mut PosTable::Generator,
+    table_generator: &PosTable::Generator,
 ) -> Option<Piece>
 where
     PosTable: Table,

--- a/subspace/shared/subspace-proof-of-space-gpu/src/cuda/tests.rs
+++ b/subspace/shared/subspace-proof-of-space-gpu/src/cuda/tests.rs
@@ -19,11 +19,11 @@ fn basic() {
         .next()
         .expect("Need CUDA device to run this test");
 
-    let mut table_generator = PosTable::generator();
+    let table_generator = PosTable::generator();
     let erasure_coding = ErasureCoding::new();
     let global_mutex = Default::default();
     let mut cpu_records_encoder = CpuRecordsEncoder::<PosTable>::new(
-        slice::from_mut(&mut table_generator),
+        slice::from_ref(&table_generator),
         &erasure_coding,
         &global_mutex,
     );

--- a/subspace/shared/subspace-proof-of-space-gpu/src/rocm/tests.rs
+++ b/subspace/shared/subspace-proof-of-space-gpu/src/rocm/tests.rs
@@ -19,11 +19,11 @@ fn basic() {
         .next()
         .expect("Need ROCm device to run this test");
 
-    let mut table_generator = PosTable::generator();
+    let table_generator = PosTable::generator();
     let erasure_coding = ErasureCoding::new();
     let global_mutex = Default::default();
     let mut cpu_records_encoder = CpuRecordsEncoder::<PosTable>::new(
-        slice::from_mut(&mut table_generator),
+        slice::from_ref(&table_generator),
         &erasure_coding,
         &global_mutex,
     );


### PR DESCRIPTION
A bunch of optimizations here:
* better cleanup for unused memory using new `PrunedTable` abstraction and some fixes
* faster proof verification without heap allocations
* refactored features in `ab-proof-of-space` and fixes to make crate actually usable without `alloc`
* `LeftTargets` is now reused across multiple table generator instances
* table generator instances take `&self` rather than `&mut self` and are cheap to clone, which makes them much easier to use and doesn't require locks for shared access

Verification performance change:
```
Before:
chia/verification       time:   [7.0819 µs 7.0908 µs 7.0961 µs]
                        thrpt:  [140.92 Kelem/s 141.03 Kelem/s 141.21 Kelem/s]
After:
chia/verification       time:   [6.4624 µs 6.4689 µs 6.4758 µs]
                        thrpt:  [154.42 Kelem/s 154.59 Kelem/s 154.74 Kelem/s]
```