### PR TITLE
Sort buckets shader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "chacha20",
  "derive_more 2.0.1",
  "futures",
+ "rand 0.9.2",
  "spirv-std",
  "wgpu",
 ]

--- a/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
+++ b/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
@@ -33,6 +33,7 @@ wgpu = { workspace = true }
 [target.'cfg(not(target_arch = "spirv"))'.dev-dependencies]
 chacha20 = { workspace = true, features = ["rng"] }
 futures = { workspace = true, features = ["executor"] }
+rand = { workspace = true }
 
 # TODO: This will be built in the shader as well, figure out a way to avoid that
 [build-dependencies]

--- a/crates/farmer/ab-proof-of-space-gpu/build.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/build.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 SpirvMetadata::None
             })
             .release(profile != "debug")
-            // TODO: This should not be needed: https://github.com/Rust-GPU/rust-gpu/discussions/385
+            // TODO: This should not be needed: https://github.com/Rust-GPU/rust-gpu/issues/386
             .capability(Capability::GroupNonUniformArithmetic);
 
         thread::scope(|scope| -> Result<(), Box<dyn Error>> {

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -4,7 +4,13 @@
 //! structures used (`ab-proof-of-space` also supports `K=25`, but this crate doesn't for now).
 
 #![cfg_attr(target_arch = "spirv", no_std)]
-#![feature(array_windows, bigint_helper_methods, ptr_as_ref_unchecked, step_trait)]
+#![feature(
+    array_windows,
+    bigint_helper_methods,
+    ptr_as_ref_unchecked,
+    step_trait,
+    uint_bit_width
+)]
 #![cfg_attr(
     all(test, not(miri), not(target_arch = "spirv")),
     feature(
@@ -12,6 +18,7 @@
         const_trait_impl,
         maybe_uninit_fill,
         maybe_uninit_slice,
+        maybe_uninit_write_slice,
         new_zeroed_alloc
     )
 )]

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -11,6 +11,7 @@
     step_trait,
     uint_bit_width
 )]
+#![cfg_attr(all(test, not(target_arch = "spirv")), feature(new_zeroed_alloc))]
 #![cfg_attr(
     all(test, not(miri), not(target_arch = "spirv")),
     feature(
@@ -18,8 +19,7 @@
         const_trait_impl,
         maybe_uninit_fill,
         maybe_uninit_slice,
-        maybe_uninit_write_slice,
-        new_zeroed_alloc
+        maybe_uninit_write_slice
     )
 )]
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -7,7 +7,13 @@
 #![feature(array_windows, bigint_helper_methods, ptr_as_ref_unchecked, step_trait)]
 #![cfg_attr(
     all(test, not(miri), not(target_arch = "spirv")),
-    feature(const_convert, const_trait_impl, maybe_uninit_fill, maybe_uninit_slice)
+    feature(
+        const_convert,
+        const_trait_impl,
+        maybe_uninit_fill,
+        maybe_uninit_slice,
+        new_zeroed_alloc
+    )
 )]
 
 // This is used for benchmarks of isolated shaders externally, not for general use

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
@@ -7,6 +7,7 @@ pub mod find_matches_in_buckets;
 mod num;
 #[cfg(not(target_arch = "spirv"))]
 mod shader_bytes;
+pub mod sort_buckets;
 // TODO: Reuse types from `ab-proof-of-space` once it compiles with `rust-gpu`
 pub mod types;
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
@@ -7,7 +7,7 @@ pub mod find_matches_in_buckets;
 mod num;
 #[cfg(not(target_arch = "spirv"))]
 mod shader_bytes;
-// TODO: Reuse constants from `ab-proof-of-space` once it compiles with `rust-gpu`
+// TODO: Reuse types from `ab-proof-of-space` once it compiles with `rust-gpu`
 pub mod types;
 
 #[cfg(not(target_arch = "spirv"))]

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1.rs
@@ -3,22 +3,49 @@ mod cpu_tests;
 #[cfg(all(test, not(miri), not(target_arch = "spirv")))]
 mod gpu_tests;
 
-use crate::shader::constants::{K, PARAM_EXT};
+use crate::shader::constants::{
+    K, MAX_BUCKET_SIZE, MAX_TABLE_SIZE, NUM_BUCKETS, PARAM_BC, PARAM_EXT,
+};
 use crate::shader::num::{U64, U64T};
-use crate::shader::types::{X, Y};
+use crate::shader::types::{Position, PositionExt, PositionY, X, Y};
+use core::mem::MaybeUninit;
+use spirv_std::arch::atomic_i_add;
 use spirv_std::glam::UVec3;
+use spirv_std::memory::{Scope, Semantics};
 use spirv_std::spirv;
 
 // TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` below, can be removed once
 //  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
 const WORKGROUP_SIZE: u32 = 256;
+// `+1` is needed due to the way `compute_fn_impl` does slightly outside what it, strictly speaking,
+// needs (for efficiency purposes)
+const KEYSTREAM_LEN_WORDS: usize = (K as usize * MAX_TABLE_SIZE as usize)
+    .div_ceil(u8::BITS as usize)
+    .div_ceil(size_of::<u32>())
+    + 1;
+
+// TODO: This is a polyfill to work around for this issue:
+//  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+#[cfg(target_arch = "spirv")]
+trait ArrayIndexingPolyfill<T> {
+    /// The same as [`<[T]>::get_unchecked_mut()`]
+    unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T;
+}
+
+#[cfg(target_arch = "spirv")]
+impl<const N: usize, T> ArrayIndexingPolyfill<T> for [T; N] {
+    #[inline(always)]
+    unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
+        &mut self[index]
+    }
+}
 
 // TODO: Make unsafe and avoid bounds check
 // TODO: Reuse code from `ab-proof-of-space` after https://github.com/Rust-GPU/rust-gpu/pull/249 and
 //  https://github.com/Rust-GPU/rust-gpu/discussions/301
 /// `partial_y_offset` is in bits within `partial_y`
 #[inline(always)]
-fn compute_f1_impl(x: X, chacha8_keystream: &[u32]) -> Y {
+fn compute_f1_impl(x: X, chacha8_keystream: &[u32; KEYSTREAM_LEN_WORDS]) -> Y {
     let skip_bits = u32::from(K) * u32::from(x);
     let skip_u32s = skip_bits / u32::BITS;
     let partial_y_offset = skip_bits % u32::BITS;
@@ -41,13 +68,26 @@ fn compute_f1_impl(x: X, chacha8_keystream: &[u32]) -> Y {
     Y::from((pre_y & pre_y_mask) | pre_ext)
 }
 
-/// Compute Chia's `f1()` function using the previously computed ChaCha8 keystream
+/// Compute Chia's `f1()` function for the whole table using the previously computed ChaCha8
+/// keystream straight into buckets of the first table.
+///
+/// Buckets need to be sorted by position afterward due to concurrent writes that do not have
+/// deterministic order.
+///
+/// # Safety
+/// `bucket_counts` must be zero-initialized, which is the case by default in `wgpu`.
 #[spirv(compute(threads(256), entry_point_name = "compute_f1"))]
-pub fn compute_f1(
+pub unsafe fn compute_f1(
     #[spirv(global_invocation_id)] global_invocation_id: UVec3,
     #[spirv(num_workgroups)] num_workgroups: UVec3,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] chacha8_keystream: &[u32],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] ys: &mut [Y],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)]
+    chacha8_keystream: &[u32; KEYSTREAM_LEN_WORDS],
+    // TODO: Should have been `MaybeUninit<u32>`, but currently doesn't compile:
+    //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] bucket_counts: &mut [u32;
+             NUM_BUCKETS],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
+             NUM_BUCKETS],
 ) {
     // TODO: Make a single input bounds check and use unsafe to avoid bounds check later
     let global_invocation_id = global_invocation_id.x;
@@ -57,7 +97,31 @@ pub fn compute_f1(
 
     // TODO: More idiomatic version currently doesn't compile:
     //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
-    for x in (global_invocation_id..ys.len() as u32).step_by(global_size as usize) {
-        ys[x as usize] = compute_f1_impl(X::from(x), chacha8_keystream);
+    for x in (global_invocation_id..MAX_TABLE_SIZE).step_by(global_size as usize) {
+        let y = compute_f1_impl(X::from(x), chacha8_keystream);
+
+        let bucket_index = (u32::from(y) / u32::from(PARAM_BC)) as usize;
+        // SAFETY: Bucket is obtained using division by `PARAM_BC` and fits by definition
+        let bucket_count = unsafe { bucket_counts.get_unchecked_mut(bucket_index) };
+        // TODO: Probably should not be unsafe to begin with:
+        //  https://github.com/Rust-GPU/rust-gpu/pull/394#issuecomment-3316594485
+        let position_in_bucket = unsafe {
+            atomic_i_add::<_, { Scope::QueueFamily as u32 }, { Semantics::NONE.bits() }>(
+                bucket_count,
+                1,
+            )
+        };
+        // SAFETY: Bucket is obtained using division by `PARAM_BC` and fits by definition. Bucket
+        // size upper bound is known statically to be [`MAX_BUCKET_SIZE`], so `position_in_bucket`
+        // is also always within bounds.
+        unsafe {
+            buckets
+                .get_unchecked_mut(bucket_index)
+                .get_unchecked_mut(position_in_bucket as usize)
+        }
+        .write(PositionY {
+            position: Position::from_u32(x),
+            y,
+        });
     }
 }

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/constants.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/constants.rs
@@ -28,7 +28,7 @@ pub(super) const PARAM_BC: u16 = PARAM_B * PARAM_C;
 pub(super) const MAX_TABLE_SIZE: u32 = 1 << K;
 
 /// Compute the size of `y` in bits
-const fn y_size_bits(k: u8) -> usize {
+pub(super) const fn y_size_bits(k: u8) -> usize {
     k as usize + PARAM_EXT as usize
 }
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/constants.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/constants.rs
@@ -5,6 +5,7 @@ pub(super) const K: u8 = 20;
 const _: () = {
     assert!(K == ab_core_primitives::pos::PosProof::K);
 };
+pub(super) const MAX_BUCKET_SIZE: usize = 512;
 /// Reducing bucket size for better performance.
 ///
 /// The number should be sufficient to produce enough proofs for sector encoding with high
@@ -23,3 +24,19 @@ pub(super) const PARAM_M: u16 = 1 << PARAM_EXT;
 pub(super) const PARAM_B: u16 = 119;
 pub(super) const PARAM_C: u16 = 127;
 pub(super) const PARAM_BC: u16 = PARAM_B * PARAM_C;
+/// Size of the first table and max size for other tables
+pub(super) const MAX_TABLE_SIZE: u32 = 1 << K;
+
+/// Compute the size of `y` in bits
+const fn y_size_bits(k: u8) -> usize {
+    k as usize + PARAM_EXT as usize
+}
+
+/// Number of buckets for a given `k`
+const fn num_buckets(k: u8) -> usize {
+    2_usize
+        .pow(y_size_bits(k) as u32)
+        .div_ceil(PARAM_BC as usize)
+}
+
+pub(super) const NUM_BUCKETS: usize = num_buckets(K);

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/constants.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/constants.rs
@@ -9,13 +9,13 @@ const _: () = {
 ///
 /// The number should be sufficient to produce enough proofs for sector encoding with high
 /// probability.
-// TODO: Statistical analysis if possible.
-pub(super) const REDUCED_BUCKETS_SIZE: usize = 272;
+// TODO: Statistical analysis if possible, confirming there will be enough proofs
+pub(super) const REDUCED_BUCKET_SIZE: usize = 272;
 /// Reducing matches count for better performance.
 ///
 /// The number should be sufficient to produce enough proofs for sector encoding with high
 /// probability.
-// TODO: Statistical analysis if possible.
+// TODO: Statistical analysis if possible, confirming there will be enough proofs
 pub(super) const REDUCED_MATCHES_COUNT: usize = 288;
 /// PRNG extension parameter to avoid collisions
 pub(super) const PARAM_EXT: u8 = 6;

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets.rs
@@ -5,7 +5,7 @@ mod gpu_tests;
 pub mod rmap;
 
 use crate::shader::MIN_SUBGROUP_SIZE;
-use crate::shader::constants::{PARAM_BC, PARAM_M, REDUCED_BUCKETS_SIZE, REDUCED_MATCHES_COUNT};
+use crate::shader::constants::{PARAM_BC, PARAM_M, REDUCED_BUCKET_SIZE, REDUCED_MATCHES_COUNT};
 use crate::shader::find_matches_in_buckets::rmap::{
     NextPhysicalPointer, Rmap, RmapBitPosition, RmapBitPositionExt,
 };
@@ -89,8 +89,8 @@ pub type LeftTargets = [[LeftTargetsR; PARAM_BC as usize]; 2];
 
 #[derive(Debug)]
 pub struct SharedScratchSpace {
-    bucket_size_a: [MaybeUninit<u32>; REDUCED_BUCKETS_SIZE],
-    bucket_size_b: [MaybeUninit<u32>; REDUCED_BUCKETS_SIZE],
+    bucket_size_a: [MaybeUninit<u32>; REDUCED_BUCKET_SIZE],
+    bucket_size_b: [MaybeUninit<u32>; REDUCED_BUCKET_SIZE],
     num_subgroups_size_a: [MaybeUninit<u32>; MAX_SUBGROUPS],
 }
 
@@ -122,8 +122,8 @@ pub(super) unsafe fn find_matches_in_buckets_impl(
     num_subgroups: u32,
     local_invocation_id: u32,
     left_bucket_index: u32,
-    left_bucket: &[Position; REDUCED_BUCKETS_SIZE],
-    right_bucket: &[Position; REDUCED_BUCKETS_SIZE],
+    left_bucket: &[Position; REDUCED_BUCKET_SIZE],
+    right_bucket: &[Position; REDUCED_BUCKET_SIZE],
     parent_table_ys: &[Y],
     matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
     left_targets: &LeftTargets,
@@ -326,7 +326,7 @@ pub(super) unsafe fn find_matches_in_buckets_impl(
         // `CHUNK_SIZE` with `PARAM_M` must cover workgroup exactly
         assert!(CHUNK_SIZE as u32 * PARAM_M as u32 == WORKGROUP_SIZE);
         // The bucket size should be possible to iterate in exact chunks
-        assert!(REDUCED_BUCKETS_SIZE.is_multiple_of(CHUNK_SIZE));
+        assert!(REDUCED_BUCKET_SIZE.is_multiple_of(CHUNK_SIZE));
     }
     let shared_subgroup_totals = num_subgroups_size_a;
     let mut global_match_batch_offset = 0_u32;
@@ -477,8 +477,8 @@ pub unsafe fn find_matches_in_buckets(
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
-    buckets: &[[Position; REDUCED_BUCKETS_SIZE]],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] buckets: &[[Position;
+          REDUCED_BUCKET_SIZE]],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] parent_table_ys: &[Y],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 3)]
     matches: &mut [[MaybeUninit<Match>; REDUCED_MATCHES_COUNT]],

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/cpu_tests.rs
@@ -1,5 +1,5 @@
 use crate::shader::constants::{
-    PARAM_B, PARAM_BC, PARAM_C, PARAM_M, REDUCED_BUCKETS_SIZE, REDUCED_MATCHES_COUNT,
+    PARAM_B, PARAM_BC, PARAM_C, PARAM_M, REDUCED_BUCKET_SIZE, REDUCED_MATCHES_COUNT,
 };
 use crate::shader::find_matches_in_buckets::{LeftTargets, LeftTargetsR, Match};
 use crate::shader::types::{Position, PositionExt, Y};
@@ -41,7 +41,7 @@ struct Rmap {
     /// Physical pointer must be increased by `1` to get a virtual pointer before storing. Virtual
     /// pointer must be decreased by `1` before reading to get a physical pointer.
     virtual_pointers: [u16; PARAM_BC as usize],
-    positions: [[Position; 2]; REDUCED_BUCKETS_SIZE],
+    positions: [[Position; 2]; REDUCED_BUCKET_SIZE],
     next_physical_pointer: u16,
 }
 
@@ -56,7 +56,7 @@ impl Rmap {
     }
 
     /// # Safety
-    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKET_SIZE`] items
     /// inserted
     #[inline(always)]
     unsafe fn insertion_item(&mut self, r: u32) -> &mut [Position; 2] {
@@ -82,7 +82,7 @@ impl Rmap {
     /// much in terms of performance and not required for correctness.
     ///
     /// # Safety
-    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKET_SIZE`] items
     /// inserted
     #[inline(always)]
     unsafe fn add(&mut self, r: u32, position: Position) {
@@ -119,8 +119,8 @@ impl Rmap {
 /// Left and right bucket positions must correspond to the parent table.
 pub(super) unsafe fn find_matches_in_buckets_correct<'a>(
     left_bucket_index: u32,
-    left_bucket: &[Position; REDUCED_BUCKETS_SIZE],
-    right_bucket: &[Position; REDUCED_BUCKETS_SIZE],
+    left_bucket: &[Position; REDUCED_BUCKET_SIZE],
+    right_bucket: &[Position; REDUCED_BUCKET_SIZE],
     parent_table_ys: &[Y],
     // `PARAM_M as usize * 2` corresponds to the upper bound number of matches a single `y` in the
     // left bucket might have here

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
@@ -1,4 +1,4 @@
-use crate::shader::constants::{PARAM_BC, REDUCED_BUCKETS_SIZE, REDUCED_MATCHES_COUNT};
+use crate::shader::constants::{PARAM_BC, REDUCED_BUCKET_SIZE, REDUCED_MATCHES_COUNT};
 use crate::shader::find_matches_in_buckets::cpu_tests::{
     calculate_left_targets, find_matches_in_buckets_correct,
 };
@@ -32,13 +32,13 @@ fn find_matches_in_buckets_gpu() {
         .map(|_| Y::from(rng.next_u32() % (PARAM_BC as u32 * NUM_BUCKETS as u32)))
         .collect::<Vec<_>>();
     let buckets = {
-        let mut buckets = [[Position::SENTINEL; REDUCED_BUCKETS_SIZE]; 3];
+        let mut buckets = [[Position::SENTINEL; REDUCED_BUCKET_SIZE]; 3];
 
         let mut total_found = [0_usize; 3];
         for (position, &y) in parent_table_ys.iter().enumerate() {
             let bucket_index = u32::from(y) / PARAM_BC as u32;
             let next_index = total_found[bucket_index as usize];
-            if next_index < REDUCED_BUCKETS_SIZE {
+            if next_index < REDUCED_BUCKET_SIZE {
                 buckets[bucket_index as usize][next_index] = Position::from_u32(position as u32);
                 total_found[bucket_index as usize] += 1;
             }
@@ -93,7 +93,7 @@ fn find_matches_in_buckets_gpu() {
 
 async fn find_matches_in_buckets(
     left_targets: &LeftTargets,
-    buckets: &[[Position; REDUCED_BUCKETS_SIZE]],
+    buckets: &[[Position; REDUCED_BUCKET_SIZE]],
     parent_table_ys: &[Y],
 ) -> Option<Vec<Vec<Match>>> {
     let backends = Backends::from_env().unwrap_or(Backends::METAL | Backends::VULKAN);
@@ -129,7 +129,7 @@ async fn find_matches_in_buckets(
 
 async fn find_matches_in_buckets_adapter(
     left_targets: &LeftTargets,
-    buckets: &[[Position; REDUCED_BUCKETS_SIZE]],
+    buckets: &[[Position; REDUCED_BUCKET_SIZE]],
     parent_table_ys: &[Y],
     adapter: Adapter,
 ) -> Option<Vec<Vec<Match>>> {

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/rmap.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/rmap.rs
@@ -1,7 +1,7 @@
 #[cfg(all(test, not(target_arch = "spirv")))]
 mod tests;
 
-use crate::shader::constants::{PARAM_BC, REDUCED_BUCKETS_SIZE};
+use crate::shader::constants::{PARAM_BC, REDUCED_BUCKET_SIZE};
 #[cfg(target_arch = "spirv")]
 use crate::shader::find_matches_in_buckets::ArrayIndexingPolyfill;
 use crate::shader::types::{Position, PositionExt};
@@ -10,7 +10,7 @@ use core::mem::MaybeUninit;
 // TODO: Benchmark on different GPUs to see if the complexity of dealing with 9-bit pointers is
 //  worth it or maybe using u16s would be better despite using more shared memory
 /// Number of bits necessary to address a single pair of positions in the rmap
-const POINTER_BITS: u32 = REDUCED_BUCKETS_SIZE.next_power_of_two().ilog2();
+const POINTER_BITS: u32 = REDUCED_BUCKET_SIZE.next_power_of_two().ilog2();
 const POINTERS_BITS: usize = PARAM_BC as usize * POINTER_BITS as usize;
 const POINTERS_WORDS: usize = POINTERS_BITS.div_ceil(u32::BITS as usize);
 
@@ -106,7 +106,7 @@ pub struct Rmap {
     /// Physical pointer must be increased by `1` to get a virtual pointer before storing. Virtual
     /// pointer must be decreased by `1` before reading to get a physical pointer.
     virtual_pointers: [u32; POINTERS_WORDS],
-    positions: [[Position; 2]; REDUCED_BUCKETS_SIZE],
+    positions: [[Position; 2]; REDUCED_BUCKET_SIZE],
 }
 
 impl Rmap {
@@ -120,7 +120,7 @@ impl Rmap {
     }
 
     /// # Safety
-    /// There must be at most [`REDUCED_BUCKETS_SIZE`] items inserted. `NextPhysicalPointer` and
+    /// There must be at most [`REDUCED_BUCKET_SIZE`] items inserted. `NextPhysicalPointer` and
     /// `Rmap` must have 1:1 mapping and not mixed with anything else.
     #[inline(always)]
     fn insertion_item_physical_pointer(
@@ -180,7 +180,7 @@ impl Rmap {
     }
 
     /// # Safety
-    /// There must be at most [`REDUCED_BUCKETS_SIZE`] items inserted. `NextPhysicalPointer` and
+    /// There must be at most [`REDUCED_BUCKET_SIZE`] items inserted. `NextPhysicalPointer` and
     /// `Rmap` must have 1:1 mapping and not mixed with anything else.
     #[inline(always)]
     unsafe fn insertion_item(
@@ -198,7 +198,7 @@ impl Rmap {
     /// much in terms of performance and not required for correctness.
     ///
     /// # Safety
-    /// There must be at most [`REDUCED_BUCKETS_SIZE`] items inserted. `NextPhysicalPointer` and
+    /// There must be at most [`REDUCED_BUCKET_SIZE`] items inserted. `NextPhysicalPointer` and
     /// `Rmap` must have 1:1 mapping and not mixed with anything else.
     #[inline(always)]
     pub(super) unsafe fn add(

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/sort_buckets.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/sort_buckets.rs
@@ -1,0 +1,121 @@
+#[cfg(all(test, not(miri), not(target_arch = "spirv")))]
+mod gpu_tests;
+
+use crate::shader::constants::{MAX_BUCKET_SIZE, NUM_BUCKETS};
+use crate::shader::types::PositionY;
+use spirv_std::arch::workgroup_memory_barrier_with_group_sync;
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+// TODO: Same number as hardcoded in `#[spirv(compute(threads(..)))]` below, can be removed once
+//  https://github.com/Rust-GPU/rust-gpu/discussions/287 is resolved
+pub const WORKGROUP_SIZE: u32 = 256;
+
+#[inline(always)]
+fn perform_compare_swap(
+    local_invocation_id: u32,
+    block_size: usize,
+    bit_position: u32,
+    bucket: &mut [PositionY; MAX_BUCKET_SIZE],
+) {
+    // Map contiguous `local_invocation_id` (0-255) to sparse `a_offset` (positions where bit
+    // `bit_position == 0`). This "inserts" a `0` at bit position `bit_position` in the binary
+    // representation of `local_invocation_id`, effectively treating `local_invocation_id` as an
+    // 8-bit number and expanding it to 9 bits by skipping bit `bit_position`.
+    //
+    // Result: 256 unique `a_offset` in [0..511] with bit `bit_position` unset, in order.
+    //
+    // For `bit_position=0 (`distance=1`):
+    //   `a_offset = local_invocation_id << 1 = even ids 0,2,...,510`
+    // For `bit_position=1` (`distance=2`):
+    //   `a_offset = (local_invocation_id & 1) | ((local_invocation_id >> 1) << 2) = 0,1,4,5,...`
+    //
+    // And similarly for `b_offset`, but setting `bit_position`th bit to `1`.
+    // This ensures each of the 256 threads handles one unique disjoint pair without overlap or
+    // idling.
+
+    // Bits above `bit_position`
+    let high = (local_invocation_id & (u32::MAX << bit_position)) << 1;
+    // Bits below `bit_position`
+    let low = local_invocation_id & u32::MAX.unbounded_shr(u32::BITS - bit_position);
+    // `a_offset` and `b_offset` differ in `bit_position`th bit only: `a_offset` has it set to `0`
+    // and `b_offset` to `1`
+    let a_offset = (high | low) as usize;
+    let b_offset = (high | (1u32 << bit_position) | low) as usize;
+
+    let a = bucket[a_offset];
+    let b = bucket[b_offset];
+
+    let (smaller, larger) = if a.position <= b.position {
+        (a, b)
+    } else {
+        (b, a)
+    };
+    let ascending = (a_offset & block_size) == 0;
+    let (final_a, final_b) = if ascending {
+        (smaller, larger)
+    } else {
+        (larger, smaller)
+    };
+
+    bucket[a_offset] = final_a;
+    bucket[b_offset] = final_b;
+}
+
+// TODO: Make unsafe and avoid bounds check
+// TODO: This can be heavily optimized by sorting a bucket per subgroup and storing everything in
+//  registers instead of shared memory
+/// Sort a bucket using bitonic sort
+#[inline(always)]
+fn sort_bucket_impl(
+    local_invocation_id: u32,
+    bucket: &mut [PositionY; MAX_BUCKET_SIZE],
+    shared_bucket: &mut [PositionY; MAX_BUCKET_SIZE],
+) {
+    let bucket_offset_a = local_invocation_id;
+    let bucket_offset_b = local_invocation_id + WORKGROUP_SIZE;
+
+    shared_bucket[bucket_offset_a as usize] = bucket[bucket_offset_a as usize];
+    shared_bucket[bucket_offset_b as usize] = bucket[bucket_offset_b as usize];
+
+    workgroup_memory_barrier_with_group_sync();
+
+    // TODO: More idiomatic version currently doesn't compile:
+    //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+    let mut block_size = 2usize;
+    let mut merger_stage = 1u32;
+    while block_size <= MAX_BUCKET_SIZE {
+        for bit_position in (0..merger_stage).rev() {
+            perform_compare_swap(local_invocation_id, block_size, bit_position, shared_bucket);
+            workgroup_memory_barrier_with_group_sync();
+        }
+        block_size *= 2;
+        merger_stage += 1;
+    }
+    bucket[bucket_offset_a as usize] = shared_bucket[bucket_offset_a as usize];
+    bucket[bucket_offset_b as usize] = shared_bucket[bucket_offset_b as usize];
+}
+
+#[spirv(compute(threads(256), entry_point_name = "sort_buckets"))]
+pub fn sort_buckets(
+    #[spirv(local_invocation_id)] local_invocation_id: UVec3,
+    #[spirv(workgroup_id)] workgroup_id: UVec3,
+    #[spirv(num_workgroups)] num_workgroups: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] buckets: &mut [[PositionY; MAX_BUCKET_SIZE];
+             NUM_BUCKETS],
+    #[spirv(workgroup)] shared_bucket: &mut [PositionY; MAX_BUCKET_SIZE],
+) {
+    let local_invocation_id = local_invocation_id.x;
+    let workgroup_id = workgroup_id.x;
+    let num_workgroups = num_workgroups.x;
+
+    // TODO: More idiomatic version currently doesn't compile:
+    //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
+    for bucket_index in (workgroup_id as usize..NUM_BUCKETS).step_by(num_workgroups as usize) {
+        sort_bucket_impl(
+            local_invocation_id,
+            &mut buckets[bucket_index],
+            shared_bucket,
+        );
+    }
+}

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/types.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/types.rs
@@ -31,7 +31,7 @@ impl X {
 }
 
 /// Stores data in lower bits
-#[derive(Debug, Copy, Clone, Eq, PartialEq, From, Into)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, From, Into)]
 #[repr(C)]
 pub struct Y(u32);
 
@@ -84,7 +84,6 @@ pub(super) trait PositionExt: Sized {
     ) -> &mut [MaybeUninit<Self>; N];
 
     // TODO: This is just `Position::from()` usually
-    #[cfg(test)]
     fn from_u32(value: u32) -> Self;
 }
 
@@ -99,7 +98,6 @@ impl PositionExt for Position {
         array
     }
 
-    #[cfg(test)]
     #[inline(always)]
     fn from_u32(value: u32) -> Self {
         value
@@ -130,4 +128,14 @@ impl From<U128> for Metadata {
     fn from(value: U128) -> Self {
         Self(value)
     }
+}
+
+/// A tuple of [`Position`] and [`Y`] with guaranteed memory layout
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[repr(C)]
+pub struct PositionY {
+    /// Position
+    pub position: Position,
+    /// Y
+    pub y: Y,
 }

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -58,8 +58,8 @@ impl Tables<$k> {
     }
 
     /// Find proof of space for given challenge.
-        #[cfg(feature = "alloc")]
-pub fn find_proof<'a>(
+    #[cfg(feature = "alloc")]
+    pub fn find_proof<'a>(
         &'a self,
         first_challenge_bytes: [u8; 4],
     ) -> impl Iterator<Item = [u8; 64 * $k / 8]> + 'a {

--- a/crates/shared/ab-proof-of-space/src/chiapos/table/rmap.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table/rmap.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use crate::chiapos::constants::PARAM_BC;
-use crate::chiapos::table::REDUCED_BUCKETS_SIZE;
+use crate::chiapos::table::REDUCED_BUCKET_SIZE;
 use crate::chiapos::table::types::{Position, R};
 
 pub(super) struct Rmap {
@@ -11,7 +11,7 @@ pub(super) struct Rmap {
     /// Physical pointer must be increased by `1` to get a virtual pointer before storing. Virtual
     /// pointer must be decreased by `1` before reading to get a physical pointer.
     virtual_pointers: [u16; PARAM_BC as usize],
-    positions: [[Position; 2]; REDUCED_BUCKETS_SIZE],
+    positions: [[Position; 2]; REDUCED_BUCKET_SIZE],
     next_physical_pointer: u16,
 }
 
@@ -26,7 +26,7 @@ impl Rmap {
     }
 
     /// # Safety
-    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKET_SIZE`] items
     /// inserted
     #[inline(always)]
     unsafe fn insertion_item(&mut self, r: R) -> &mut [Position; 2] {
@@ -52,7 +52,7 @@ impl Rmap {
     /// much in terms of performance and not required for correctness.
     ///
     /// # Safety
-    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKETS_SIZE`] items
+    /// `r` must be in the range `0..PARAM_BC`, there must be at most [`REDUCED_BUCKET_SIZE`] items
     /// inserted
     #[inline(always)]
     pub(super) unsafe fn add(&mut self, r: R, position: Position) {


### PR DESCRIPTION
First of all, `f1()` shader was modified to write output straight into intended buckets rather than doing data movement with a separate shader. The order in buckets is undefined due to use of global atomic increments.

Second, `sort_buckets()` shader is implemented that implements bitonic sort to fix up order within bucket after shaders like `f1()` wrote their output.

With these all that is left is to combine find_matches with compute_fn into a single shader for efficiency and have another shader that can find proofs and apply them to record chunks. With that an initial implementation of GPU plotting will be complete.