### PR TITLE
Optimize `sort_buckets` shader with only using subgroup operations

### DIFF
--- a/crates/farmer/ab-proof-of-space-gpu/build.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/build.rs
@@ -46,7 +46,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             })
             .release(profile != "debug")
             // TODO: This should not be needed: https://github.com/Rust-GPU/rust-gpu/issues/386
-            .capability(Capability::GroupNonUniformArithmetic);
+            .capability(Capability::GroupNonUniformArithmetic)
+            // TODO: This should not be needed: https://github.com/Rust-GPU/rust-gpu/issues/386
+            .capability(Capability::GroupNonUniformShuffle);
 
         thread::scope(|scope| -> Result<(), Box<dyn Error>> {
             // Compile SPIR-V shader for GPU that only supports baseline Vulkan features

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/sort_buckets/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/sort_buckets/gpu_tests.rs
@@ -70,7 +70,7 @@ async fn sort_buckets(
     });
 
     let adapters = instance.enumerate_adapters(backends);
-    let mut result = None;
+    let mut result = None::<Box<[[PositionY; MAX_BUCKET_SIZE]; NUM_BUCKETS]>>;
 
     for adapter in adapters {
         println!("Testing adapter {:?}", adapter.get_info());
@@ -79,7 +79,18 @@ async fn sort_buckets(
 
         match &result {
             Some(result) => {
-                assert!(result == &adapter_result);
+                for (bucket_index, (result, adapter_result)) in
+                    result.iter().zip(adapter_result.iter()).enumerate()
+                {
+                    for (index, (result, adapter_result)) in
+                        result.iter().zip(adapter_result.iter()).enumerate()
+                    {
+                        assert_eq!(
+                            result, adapter_result,
+                            "bucket_index={bucket_index}, index={index}"
+                        );
+                    }
+                }
             }
             None => {
                 result.replace(adapter_result);

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/types.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/types.rs
@@ -139,3 +139,13 @@ pub struct PositionY {
     /// Y
     pub y: Y,
 }
+
+impl Default for PositionY {
+    #[inline(always)]
+    fn default() -> Self {
+        Self {
+            position: 0,
+            y: Y::from(0),
+        }
+    }
+}


### PR DESCRIPTION
This should be quite awesome performance-wise, though is very hard to understand. Thankfully there are tests to ensure correctness.