### PR TITLE
Change the way challenge indices are interpreted to improve spatial locality during proof searching

### DIFF
--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1.rs
@@ -10,7 +10,7 @@ use crate::shader::num::{U64, U64T};
 use crate::shader::types::{Position, PositionExt, PositionY, X, Y};
 use ab_chacha8::{ChaCha8Block, ChaCha8State};
 use core::mem::MaybeUninit;
-use spirv_std::arch::atomic_i_add;
+use spirv_std::arch::atomic_i_increment;
 use spirv_std::glam::{UVec3, UVec4};
 use spirv_std::memory::{Scope, Semantics};
 use spirv_std::spirv;
@@ -209,9 +209,8 @@ pub unsafe fn compute_f1(
             // TODO: Probably should not be unsafe to begin with:
             //  https://github.com/Rust-GPU/rust-gpu/pull/394#issuecomment-3316594485
             let bucket_offset = unsafe {
-                atomic_i_add::<_, { Scope::QueueFamily as u32 }, { Semantics::NONE.bits() }>(
+                atomic_i_increment::<_, { Scope::QueueFamily as u32 }, { Semantics::NONE.bits() }>(
                     bucket_count,
-                    1,
                 )
             };
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn.rs
@@ -13,7 +13,7 @@ use crate::shader::find_matches_in_buckets::{
 };
 use crate::shader::types::{Metadata, Position, PositionExt, PositionY};
 use core::mem::MaybeUninit;
-use spirv_std::arch::{atomic_i_add, workgroup_memory_barrier_with_group_sync};
+use spirv_std::arch::{atomic_i_increment, workgroup_memory_barrier_with_group_sync};
 use spirv_std::glam::UVec3;
 use spirv_std::memory::{Scope, Semantics};
 use spirv_std::spirv;
@@ -101,9 +101,8 @@ unsafe fn compute_fn_into_buckets<const TABLE_NUMBER: u8, const PARENT_TABLE_NUM
         // TODO: Probably should not be unsafe to begin with:
         //  https://github.com/Rust-GPU/rust-gpu/pull/394#issuecomment-3316594485
         let bucket_offset = unsafe {
-            atomic_i_add::<_, { Scope::QueueFamily as u32 }, { Semantics::NONE.bits() }>(
+            atomic_i_increment::<_, { Scope::QueueFamily as u32 }, { Semantics::NONE.bits() }>(
                 bucket_count,
-                1,
             )
         };
 

--- a/crates/shared/ab-proof-of-space/benches/pos.rs
+++ b/crates/shared/ab-proof-of-space/benches/pos.rs
@@ -1,6 +1,8 @@
 #![feature(const_trait_impl)]
 
 #[cfg(feature = "alloc")]
+use ab_core_primitives::pieces::Record;
+#[cfg(feature = "alloc")]
 use ab_core_primitives::pos::PosSeed;
 use ab_proof_of_space::Table;
 #[cfg(feature = "alloc")]
@@ -211,6 +213,22 @@ fn pos_bench<PosTable>(
                     .find_proof(black_box(challenge_index_with_solution))
                     .is_some()
             );
+        });
+    });
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("proof/for-record", |b| {
+        b.iter(|| {
+            let mut found_proofs = 0_usize;
+            for challenge_index in 0..Record::NUM_S_BUCKETS as u32 {
+                if table.find_proof(black_box(challenge_index)).is_some() {
+                    found_proofs += 1;
+
+                    if found_proofs == Record::NUM_CHUNKS {
+                        break;
+                    }
+                }
+            }
         });
     });
 

--- a/crates/shared/ab-proof-of-space/benches/pos.rs
+++ b/crates/shared/ab-proof-of-space/benches/pos.rs
@@ -249,10 +249,10 @@ fn pos_bench<PosTable>(
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     {
-        // This challenge index with above seed is known to not have a solution
-        let challenge_index_without_solution = 1232460437;
-        // This challenge index with above seed is known to have a solution
-        let challenge_index_with_solution = 600426542;
+        // This challenge index with the above seed is known to not have a solution
+        let challenge_index_without_solution = 15651;
+        // This challenge index with the above seed is known to have a solution
+        let challenge_index_with_solution = 31500;
 
         pos_bench::<ab_proof_of_space::chia::ChiaTable>(
             c,

--- a/crates/shared/ab-proof-of-space/src/chia.rs
+++ b/crates/shared/ab-proof-of-space/src/chia.rs
@@ -45,7 +45,7 @@ pub struct ChiaTable {
 
 impl ab_core_primitives::solutions::SolutionPotVerifier for ChiaTable {
     fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
-        Tables::<K>::verify_only(seed, challenge_index.to_le_bytes(), proof)
+        Tables::<K>::verify_only_raw(seed, challenge_index, proof)
     }
 }
 
@@ -56,10 +56,8 @@ impl Table for ChiaTable {
 
     #[cfg(feature = "alloc")]
     fn find_proof(&self, challenge_index: u32) -> Option<PosProof> {
-        let first_challenge_bytes = challenge_index.to_le_bytes();
-
         self.tables
-            .find_proof(first_challenge_bytes)
+            .find_proof_raw(challenge_index)
             .next()
             .map(PosProof::from)
     }
@@ -90,12 +88,12 @@ mod tests {
         #[cfg(feature = "parallel")]
         let table_parallel = generator.generate_parallel(&seed);
 
-        assert!(table.find_proof(1232460437).is_none());
+        assert!(table.find_proof(15651).is_none());
         #[cfg(feature = "parallel")]
-        assert!(table_parallel.find_proof(1232460437).is_none());
+        assert!(table_parallel.find_proof(15651).is_none());
 
         {
-            let challenge_index = 600426542;
+            let challenge_index = 31500;
             let proof = table.find_proof(challenge_index).unwrap();
             #[cfg(feature = "parallel")]
             assert_eq!(proof, table_parallel.find_proof(challenge_index).unwrap());

--- a/crates/shared/ab-proof-of-space/src/chia.rs
+++ b/crates/shared/ab-proof-of-space/src/chia.rs
@@ -45,9 +45,7 @@ pub struct ChiaTable {
 
 impl ab_core_primitives::solutions::SolutionPotVerifier for ChiaTable {
     fn is_proof_valid(seed: &PosSeed, challenge_index: u32, proof: &PosProof) -> bool {
-        let mut challenge = [0; 32];
-        challenge[..size_of::<u32>()].copy_from_slice(&challenge_index.to_le_bytes());
-        Tables::<K>::verify(seed, &challenge, proof).is_some()
+        Tables::<K>::verify_only(seed, challenge_index.to_le_bytes(), proof)
     }
 }
 

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -49,7 +49,7 @@ impl Tables<$k> {
         ))
     }
 
-    /// Find proof of space quality for given challenge.
+    /// Find proof of space quality for a given challenge.
     #[cfg(all(feature = "alloc", any(feature = "full-chiapos", test)))]
     pub fn find_quality<'a>(
         &'a self,
@@ -58,7 +58,7 @@ impl Tables<$k> {
         self.0.find_quality(challenge)
     }
 
-    /// Find proof of space for given challenge.
+    /// Find proof of space for a given challenge.
     #[cfg(feature = "alloc")]
     pub fn find_proof<'a>(
         &'a self,
@@ -67,7 +67,7 @@ impl Tables<$k> {
         self.0.find_proof(first_challenge_bytes)
     }
 
-    /// Verify proof of space for given seed and challenge.
+    /// Verify proof of space for a given seed and challenge.
     pub fn verify(
         seed: &Seed,
         challenge: &Challenge,
@@ -80,7 +80,7 @@ impl Tables<$k> {
     }
 }
 
-// Only these k values are supported by current implementation
+// Only these k values are supported by the current implementation
 #[cfg(feature = "full-chiapos")]
 impl_any!(15, 16, 18, 19, 21, 22, 23, 24, 25);
 #[cfg(any(feature = "full-chiapos", test))]

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -40,7 +40,7 @@ impl Tables<$k> {
     }
 
     /// Almost the same as [`Self::create()`], but uses parallelism internally for better
-    /// latency and performance (though higher memory usage).
+    /// latency and performance (though higher memory usage)
     #[cfg(feature = "parallel")]
     pub fn create_parallel(seed: Seed, cache: &TablesCache) -> Self {
         Self(TablesGeneric::<$k>::create_parallel(
@@ -48,7 +48,7 @@ impl Tables<$k> {
         ))
     }
 
-    /// Find proof of space quality for a given challenge.
+    /// Find proof of space quality for a given challenge
     #[cfg(all(feature = "alloc", any(feature = "full-chiapos", test)))]
     pub fn find_quality<'a>(
         &'a self,
@@ -57,8 +57,18 @@ impl Tables<$k> {
         self.0.find_quality(challenge)
     }
 
-    /// Find proof of space for a given challenge.
+    /// Similar to `Self::find_proof()`, but takes the first `k` challenge bits in the least
+    /// significant bits of `u32` as a challenge instead
     #[cfg(feature = "alloc")]
+    pub fn find_proof_raw<'a>(
+        &'a self,
+        first_k_challenge_bits: u32,
+    ) -> impl Iterator<Item = [u8; 64 * $k / 8]> + 'a {
+        self.0.find_proof_raw(first_k_challenge_bits)
+    }
+
+    /// Find proof of space for a given challenge
+    #[cfg(all(feature = "alloc", any(feature = "full-chiapos", test)))]
     pub fn find_proof<'a>(
         &'a self,
         first_challenge_bytes: [u8; 4],
@@ -66,18 +76,17 @@ impl Tables<$k> {
         self.0.find_proof(first_challenge_bytes)
     }
 
-    /// Verify proof of space for a given seed and challenge
-    pub fn verify_only(
+    /// Similar to `Self::verify()`, but takes the first `k` challenge bits in the least significant
+    /// bits of `u32` as a challenge instead and doesn't compute quality
+    pub fn verify_only_raw(
         seed: &Seed,
-        first_challenge_bytes: [u8; 4],
+        first_k_challenge_bits: u32,
         proof_of_space: &[u8; 64 * $k as usize / 8],
     ) -> bool {
-        TablesGeneric::<$k>::verify_only(seed, first_challenge_bytes, proof_of_space)
+        TablesGeneric::<$k>::verify_only_raw(seed, first_k_challenge_bits, proof_of_space)
     }
 
-    /// Verify proof of space for a given seed and challenge.
-    ///
-    /// Similar to [`Self::verify_only()`], but also returns quality on successful verification.
+    /// Verify proof of space for a given seed and challenge
     #[cfg(any(feature = "full-chiapos", test))]
     pub fn verify(
         seed: &Seed,

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -12,9 +12,8 @@ use crate::chiapos::tables::TablesGeneric;
 use crate::chiapos::utils::EvaluatableUsize;
 
 type Seed = [u8; 32];
+#[cfg(any(feature = "full-chiapos", test))]
 type Challenge = [u8; 32];
-#[cfg(not(any(feature = "full-chiapos", test)))]
-type Quality = ();
 #[cfg(any(feature = "full-chiapos", test))]
 type Quality = [u8; 32];
 
@@ -67,7 +66,19 @@ impl Tables<$k> {
         self.0.find_proof(first_challenge_bytes)
     }
 
+    /// Verify proof of space for a given seed and challenge
+    pub fn verify_only(
+        seed: &Seed,
+        first_challenge_bytes: [u8; 4],
+        proof_of_space: &[u8; 64 * $k as usize / 8],
+    ) -> bool {
+        TablesGeneric::<$k>::verify_only(seed, first_challenge_bytes, proof_of_space)
+    }
+
     /// Verify proof of space for a given seed and challenge.
+    ///
+    /// Similar to [`Self::verify_only()`], but also returns quality on successful verification.
+    #[cfg(any(feature = "full-chiapos", test))]
     pub fn verify(
         seed: &Seed,
         challenge: &Challenge,

--- a/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tables.rs
@@ -123,8 +123,6 @@ where
     ) -> impl Iterator<Item = Quality> + 'a {
         let last_5_challenge_bits = challenge[challenge.len() - 1] & 0b00011111;
 
-        // We take advantage of the fact that entries are sorted by `y` (as big-endian numbers) to
-        // quickly seek to desired offset
         let first_k_challenge_bits = u32::from_be_bytes(
             challenge[..size_of::<u32>()]
                 .try_into()
@@ -190,8 +188,6 @@ where
         &'a self,
         first_challenge_bytes: [u8; 4],
     ) -> impl Iterator<Item = [u8; 64 * K as usize / 8]> + 'a {
-        // We take advantage of the fact that entries are sorted by `y` (as big-endian numbers) to
-        // quickly seek to desired offset
         let first_k_challenge_bits =
             u32::from_be_bytes(first_challenge_bytes) >> (u32::BITS as usize - usize::from(K));
 

--- a/crates/shared/ab-proof-of-space/src/lib.rs
+++ b/crates/shared/ab-proof-of-space/src/lib.rs
@@ -46,12 +46,12 @@ pub enum PosTableType {
 pub trait TableGenerator<T: Table>:
     fmt::Debug + Default + Clone + Send + Sync + Sized + 'static
 {
-    /// Generate new table with 32 bytes seed.
+    /// Generate a new table with 32 bytes seed.
     ///
     /// There is also [`Self::generate_parallel()`] that can achieve lower latency.
     fn generate(&self, seed: &PosSeed) -> T;
 
-    /// Generate new table with 32 bytes seed using parallelism.
+    /// Generate a new table with 32 bytes seed using parallelism.
     ///
     /// This implementation will trade efficiency of CPU and memory usage for lower latency, prefer
     /// [`Self::generate()`] unless lower latency is critical.

--- a/specs/00-subspace-diff.md
+++ b/specs/00-subspace-diff.md
@@ -108,3 +108,6 @@ performance reasons. So as a result, some of the proofs that must exist will not
 
 Since the tables are no longer sorted, proof searching now does full scan of the buckets where matching `y` values are
 potentially located, which while is a bit slower, is more than compensated by table creation performance improvements.
+
+Proofs searching has changed to not converting challenge indices to big-endian numbers and moving them around, which
+breaks compatibility with Subspace but improves performance due to better spatial locality.


### PR DESCRIPTION
All commits except last are minor refactoring and preparation.

The last commit is based on the observation that proofs are searched for essentially 32-bit challenge indices (only 16 of which are ever occupied due to s-bucket sizes), but due to the fact that challenge was converted into big endian, nearby indices actually hit different and not even adjacent buckets: 0, 17, 34, 52, 69...

That wasn't great for spatial locality and potential SIMD usage. The bucketing can and will change in upcoming PR and while doing so it is possible to make bucketing such that it'll cluster the values in a way that makes them close for big-endian challenge indices, since there is no goal to make it Subspace-compatible, a simpler strategy is chosen instead. For Subspace backport, the bucketing in upcoming PR will need to be updated to reflect this difference.

Without big endian conversion nearby indices now hit the same or nearby buckets, which is great for SIMD and GPU implementation (and the reason this PR is done in the first place).

I also introduced a new benchmark that finds all proofs. The results of this PR are wildly variable, from 5% to 20% faster than before, but due to variability I'll just leave rough "after" values before making massive performance improvements in the upcoming PRs:
```
chia/proof/for-record   time:   [46.369 ms 47.493 ms 48.808 ms]
                        thrpt:  [20.489  elem/s 21.056  elem/s 21.566  elem/s]
```

Note that it takes a very substantial amount of time per table, which I actually expected to be significantly lower from the individual proof benchmark, but that benchmark was hitting the same index all the time, while this benchmark actually iterates over the the indices as plotter would. So there is a room and need to optimize it.