### PR TITLE
Remove `ReadSectorRecordChunksMode`

### DIFF
--- a/crates/farmer/ab-farmer-components/benches/proving.rs
+++ b/crates/farmer/ab-farmer-components/benches/proving.rs
@@ -14,7 +14,6 @@ use ab_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use ab_farmer_components::plotting::{
     CpuRecordsEncoder, PlotSectorOptions, PlottedSector, plot_sector,
 };
-use ab_farmer_components::reading::ReadSectorRecordChunksMode;
 use ab_farmer_components::sector::{
     SectorContentsMap, SectorMetadata, SectorMetadataChecksummed, sector_size,
 };
@@ -179,11 +178,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         if !solution_candidates
             .clone()
-            .into_solutions(
-                erasure_coding,
-                ReadSectorRecordChunksMode::ConcurrentChunks,
-                |seed: &PosSeed| table_generator.generate_parallel(seed),
-            )
+            .into_solutions(erasure_coding, |seed: &PosSeed| {
+                table_generator.generate_parallel(seed)
+            })
             .unwrap()
             .is_empty()
         {
@@ -200,7 +197,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     .clone()
                     .into_solutions(
                         black_box(erasure_coding),
-                        black_box(ReadSectorRecordChunksMode::ConcurrentChunks),
                         black_box(|seed: &PosSeed| table_generator.generate_parallel(seed)),
                     )
                     .unwrap()
@@ -266,7 +262,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                             solution_candidates
                                 .into_solutions(
                                     black_box(erasure_coding),
-                                    black_box(ReadSectorRecordChunksMode::ConcurrentChunks),
                                     black_box(|seed: &PosSeed| {
                                         table_generator.generate_parallel(seed)
                                     }),

--- a/crates/farmer/ab-farmer-components/benches/reading.rs
+++ b/crates/farmer/ab-farmer-components/benches/reading.rs
@@ -8,7 +8,7 @@ use ab_farmer_components::file_ext::{FileExt, OpenOptionsExt};
 use ab_farmer_components::plotting::{
     CpuRecordsEncoder, PlotSectorOptions, PlottedSector, plot_sector,
 };
-use ab_farmer_components::reading::{ReadSectorRecordChunksMode, read_piece};
+use ab_farmer_components::reading::read_piece;
 use ab_farmer_components::sector::{
     SectorContentsMap, SectorMetadata, SectorMetadataChecksummed, sector_size,
 };
@@ -161,7 +161,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 black_box(&plotted_sector.sector_metadata),
                 black_box(&ReadAt::from_sync(&plotted_sector_bytes)),
                 black_box(&erasure_coding),
-                black_box(ReadSectorRecordChunksMode::ConcurrentChunks),
                 black_box(&table_generator),
             )
             .now_or_never()
@@ -205,7 +204,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         black_box(&plotted_sector.sector_metadata),
                         black_box(&ReadAt::from_sync(&sector)),
                         black_box(&erasure_coding),
-                        black_box(ReadSectorRecordChunksMode::ConcurrentChunks),
                         black_box(&table_generator),
                     )
                     .now_or_never()

--- a/crates/farmer/ab-farmer-components/src/proving.rs
+++ b/crates/farmer/ab-farmer-components/src/proving.rs
@@ -5,8 +5,7 @@
 
 use crate::auditing::ChunkCandidate;
 use crate::reading::{
-    ReadSectorRecordChunksMode, ReadingError, read_record_metadata, read_sector_record_chunks,
-    recover_extended_record_chunks,
+    ReadingError, read_record_metadata, read_sector_record_chunks, recover_extended_record_chunks,
 };
 use crate::sector::{
     SectorContentsMap, SectorContentsMapFromBytesError, SectorMetadataChecksummed,
@@ -144,7 +143,6 @@ where
     pub fn into_solutions<PosTable, TableGenerator>(
         self,
         erasure_coding: &'a ErasureCoding,
-        mode: ReadSectorRecordChunksMode,
         table_generator: TableGenerator,
     ) -> Result<impl ProvableSolutions<Item = MaybeSolution> + 'a, ProvingError>
     where
@@ -159,7 +157,6 @@ where
             self.sector_metadata,
             erasure_coding,
             self.chunk_candidates,
-            mode,
             table_generator,
         )
     }
@@ -184,7 +181,6 @@ where
     winning_chunks: VecDeque<WinningChunk>,
     count: usize,
     best_solution_distance: Option<SolutionDistance>,
-    mode: ReadSectorRecordChunksMode,
     table_generator: TableGenerator,
 }
 
@@ -226,7 +222,6 @@ where
                 &self.sector_contents_map,
                 &pos_table,
                 &self.sector,
-                self.mode,
             );
             let sector_record_chunks = sector_record_chunks_fut
                 .now_or_never()
@@ -328,7 +323,6 @@ where
         sector_metadata: &'a SectorMetadataChecksummed,
         erasure_coding: &'a ErasureCoding,
         chunk_candidates: VecDeque<ChunkCandidate>,
-        mode: ReadSectorRecordChunksMode,
         table_generator: TableGenerator,
     ) -> Result<Self, ProvingError> {
         let sector_contents_map = {
@@ -381,7 +375,6 @@ where
             winning_chunks,
             count,
             best_solution_distance,
-            mode,
             table_generator,
         })
     }

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/cluster/farmer.rs
@@ -3,7 +3,6 @@
 use crate::commands::shared::DiskFarm;
 use ab_core_primitives::ed25519::Ed25519PublicKey;
 use ab_erasure_coding::ErasureCoding;
-use ab_farmer_components::reading::ReadSectorRecordChunksMode;
 use ab_proof_of_space::Table;
 use anyhow::anyhow;
 use async_lock::Mutex as AsyncMutex;
@@ -178,7 +177,6 @@ where
         disk_farms = vec![DiskFarm {
             directory: tmp_directory.as_ref().to_path_buf(),
             allocated_space: plot_size.as_u64(),
-            read_sector_record_chunks_mode: Some(ReadSectorRecordChunksMode::ConcurrentChunks),
         }];
 
         Some(tmp_directory)
@@ -278,9 +276,6 @@ where
                             global_mutex,
                             max_plotting_sectors_per_farm,
                             disable_farm_locking,
-                            read_sector_record_chunks_mode: disk_farm
-                                .read_sector_record_chunks_mode
-                                .unwrap_or(ReadSectorRecordChunksMode::ConcurrentChunks),
                             registry: Some(registry),
                             create,
                         },

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/farm.rs
@@ -4,7 +4,6 @@ use crate::utils::shutdown_signal;
 use ab_core_primitives::ed25519::Ed25519PublicKey;
 use ab_data_retrieval::piece_getter::PieceGetter;
 use ab_erasure_coding::ErasureCoding;
-use ab_farmer_components::reading::ReadSectorRecordChunksMode;
 use ab_proof_of_space::Table;
 use anyhow::anyhow;
 use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock, Semaphore};
@@ -363,7 +362,6 @@ where
         disk_farms = vec![DiskFarm {
             directory: tmp_directory.as_ref().to_path_buf(),
             allocated_space: plot_size.as_u64(),
-            read_sector_record_chunks_mode: Some(ReadSectorRecordChunksMode::ConcurrentChunks),
         }];
 
         Some(tmp_directory)
@@ -599,9 +597,6 @@ where
                             global_mutex,
                             max_plotting_sectors_per_farm,
                             disable_farm_locking,
-                            read_sector_record_chunks_mode: disk_farm
-                                .read_sector_record_chunks_mode
-                                .unwrap_or(ReadSectorRecordChunksMode::ConcurrentChunks),
                             registry: Some(registry),
                             create,
                         },

--- a/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared.rs
+++ b/subspace/crates/subspace-farmer/src/bin/subspace-farmer/commands/shared.rs
@@ -1,6 +1,5 @@
 pub(super) mod network;
 
-use ab_farmer_components::reading::ReadSectorRecordChunksMode;
 use bytesize::ByteSize;
 use clap::Parser;
 use std::fmt;
@@ -64,8 +63,6 @@ pub(in super::super) struct DiskFarm {
     pub(in super::super) directory: PathBuf,
     /// How much space in bytes can farm use
     pub(in super::super) allocated_space: u64,
-    /// Which mode to use for reading of sector record chunks
-    pub(in super::super) read_sector_record_chunks_mode: Option<ReadSectorRecordChunksMode>,
 }
 
 impl FromStr for DiskFarm {
@@ -80,7 +77,6 @@ impl FromStr for DiskFarm {
 
         let mut plot_directory = None;
         let mut allocated_space = None;
-        let mut read_sector_record_chunks_mode = None;
 
         for part in parts {
             let part = part.splitn(2, '=').collect::<Vec<_>>();
@@ -105,15 +101,6 @@ impl FromStr for DiskFarm {
                             .as_u64(),
                     );
                 }
-                "record-chunks-mode" => {
-                    read_sector_record_chunks_mode.replace(
-                        value
-                            .parse::<ReadSectorRecordChunksMode>()
-                            .map_err(|error| {
-                                format!("Failed to parse `record-chunks-mode` \"{value}\": {error}")
-                            })?,
-                    );
-                }
                 key => {
                     return Err(format!(
                         "Key \"{key}\" is not supported, only `path`, `size` or \
@@ -128,7 +115,6 @@ impl FromStr for DiskFarm {
                 .ok_or("`path` key is required with path to directory where farm will be stored")?,
             allocated_space: allocated_space
                 .ok_or("`size` key is required with allocated amount of disk space")?,
-            read_sector_record_chunks_mode,
         })
     }
 }

--- a/subspace/crates/subspace-farmer/src/single_disk_farm.rs
+++ b/subspace/crates/subspace-farmer/src/single_disk_farm.rs
@@ -49,7 +49,6 @@ use ab_core_primitives::segments::{HistorySize, SegmentIndex};
 use ab_erasure_coding::ErasureCoding;
 use ab_farmer_components::FarmerProtocolInfo;
 use ab_farmer_components::file_ext::FileExt;
-use ab_farmer_components::reading::ReadSectorRecordChunksMode;
 use ab_farmer_components::sector::{SectorMetadata, SectorMetadataChecksummed, sector_size};
 use ab_proof_of_space::Table;
 use async_lock::{Mutex as AsyncMutex, RwLock as AsyncRwLock};
@@ -310,8 +309,6 @@ where
     pub max_plotting_sectors_per_farm: NonZeroUsize,
     /// Disable farm locking, for example if file system doesn't support it
     pub disable_farm_locking: bool,
-    /// Mode to use for reading of sector record chunks instead
-    pub read_sector_record_chunks_mode: ReadSectorRecordChunksMode,
     /// Prometheus registry
     pub registry: Option<&'a Mutex<&'a mut Registry>>,
     /// Whether to create a farm if it doesn't yet exist
@@ -845,7 +842,6 @@ impl SingleDiskFarm {
             global_mutex,
             max_plotting_sectors_per_farm,
             disable_farm_locking,
-            read_sector_record_chunks_mode,
             registry,
             create,
         } = options;
@@ -1109,7 +1105,6 @@ impl SingleDiskFarm {
                         sectors_being_modified,
                         slot_info_notifications: slot_info_forwarder_receiver,
                         thread_pool: farming_thread_pool,
-                        read_sector_record_chunks_mode,
                         global_mutex,
                         metrics,
                     };
@@ -1154,7 +1149,6 @@ impl SingleDiskFarm {
             Arc::clone(&sectors_metadata),
             erasure_coding,
             sectors_being_modified,
-            read_sector_record_chunks_mode,
             global_mutex,
         );
 


### PR DESCRIPTION
While it may help certain SSDs with proving, it is very rarely needed and for SSDs of meaningful size will likely still be somewhat problematic during auditing.

This was a useful experiment at a time, but it is probably time to let it go.