### PR TITLE
Only encoded sector chunks

### DIFF
--- a/crates/farmer/ab-farmer-components/src/auditing.rs
+++ b/crates/farmer/ab-farmer-components/src/auditing.rs
@@ -40,8 +40,7 @@ pub struct AuditResult<'a, Sector> {
     pub solution_candidates: SolutionCandidates<'a, Sector>,
 }
 
-/// Chunk candidate, contains one or more potentially winning audit chunks (in case chunk itself was
-/// encoded and eligible for claiming a reward)
+/// Chunk candidate, contains one or more winning audit chunks
 #[derive(Debug, Clone)]
 pub(crate) struct ChunkCandidate {
     /// Chunk offset within s-bucket

--- a/crates/farmer/ab-farmer-components/src/proving.rs
+++ b/crates/farmer/ab-farmer-components/src/proving.rs
@@ -337,21 +337,21 @@ where
             )?
         };
 
-        let s_bucket_records = sector_contents_map
-            .iter_s_bucket_records(s_bucket)
+        let s_bucket_piece_offsets = sector_contents_map
+            .iter_s_bucket_piece_offsets(s_bucket)
             .expect("S-bucket audit index is guaranteed to be in range; qed")
             .collect::<Vec<_>>();
         let winning_chunks = chunk_candidates
             .into_iter()
-            .filter_map(move |chunk_candidate| {
-                let (piece_offset, encoded_chunk_used) = s_bucket_records
+            .map(move |chunk_candidate| {
+                let piece_offset = s_bucket_piece_offsets
                     .get(chunk_candidate.chunk_offset as usize)
                     .expect("Wouldn't be a candidate if wasn't within s-bucket; qed");
 
-                encoded_chunk_used.then_some(WinningChunk {
+                WinningChunk {
                     piece_offset: *piece_offset,
                     solution_distance: chunk_candidate.solution_distance,
-                })
+                }
             })
             .collect::<VecDeque<_>>();
 

--- a/crates/farmer/ab-farmer-components/src/reading.rs
+++ b/crates/farmer/ab-farmer-components/src/reading.rs
@@ -19,7 +19,6 @@ use futures::stream::FuturesUnordered;
 use parity_scale_codec::Decode;
 use rayon::prelude::*;
 use std::io;
-use std::mem::ManuallyDrop;
 use std::simd::Simd;
 use thiserror::Error;
 use tracing::debug;
@@ -128,17 +127,12 @@ where
                 .zip(s_bucket_offsets.par_iter()),
         )
         .map(
-            |((maybe_record_chunk, maybe_chunk_details), (s_bucket, &s_bucket_offset))| {
-                let (chunk_offset, encoded_chunk_used) = maybe_chunk_details?;
+            |((maybe_record_chunk, maybe_chunk_offset), (s_bucket, &s_bucket_offset))| {
+                let chunk_offset = maybe_chunk_offset?;
 
                 let chunk_location = chunk_offset as u64 + u64::from(s_bucket_offset);
 
-                Some((
-                    maybe_record_chunk,
-                    chunk_location,
-                    encoded_chunk_used,
-                    s_bucket,
-                ))
+                Some((maybe_record_chunk, chunk_location, s_bucket))
             },
         );
 
@@ -146,7 +140,7 @@ where
     match sector {
         ReadAt::Sync(sector) => {
             read_chunks_inputs.flatten().try_for_each(
-                |(maybe_record_chunk, chunk_location, encoded_chunk_used, s_bucket)| {
+                |(maybe_record_chunk, chunk_location, s_bucket)| {
                     let mut record_chunk = [0; RecordChunk::SIZE];
                     sector
                         .read_at(
@@ -158,15 +152,13 @@ where
                             error,
                         })?;
 
-                    // Decode chunk if necessary
-                    if encoded_chunk_used {
-                        let proof = pos_table
-                            .find_proof(s_bucket.into())
-                            .ok_or(ReadingError::MissingPosProof { s_bucket })?;
+                    // Decode chunk
+                    let proof = pos_table
+                        .find_proof(s_bucket.into())
+                        .ok_or(ReadingError::MissingPosProof { s_bucket })?;
 
-                        record_chunk =
-                            Simd::to_array(Simd::from(record_chunk) ^ Simd::from(*proof.hash()));
-                    }
+                    record_chunk =
+                        Simd::to_array(Simd::from(record_chunk) ^ Simd::from(*proof.hash()));
 
                     maybe_record_chunk.replace(RecordChunk::from(record_chunk));
 
@@ -180,31 +172,29 @@ where
                 .into_iter()
                 .flatten()
                 .map(
-                    |(maybe_record_chunk, chunk_location, encoded_chunk_used, s_bucket)| async move {
+                    |(maybe_record_chunk, chunk_location, s_bucket)| async move {
                         let mut record_chunk = [0; RecordChunk::SIZE];
                         record_chunk.copy_from_slice(
                             &sector
                                 .read_at(
                                     vec![0; RecordChunk::SIZE],
-                                    sector_contents_map_size + chunk_location * RecordChunk::SIZE as u64,
+                                    sector_contents_map_size
+                                        + chunk_location * RecordChunk::SIZE as u64,
                                 )
                                 .await
                                 .map_err(|error| ReadingError::FailedToReadChunk {
                                     chunk_location,
                                     error,
-                                })?
+                                })?,
                         );
 
+                        // Decode chunk
+                        let proof = pos_table
+                            .find_proof(s_bucket.into())
+                            .ok_or(ReadingError::MissingPosProof { s_bucket })?;
 
-                        // Decode chunk if necessary
-                        if encoded_chunk_used {
-                            let proof = pos_table.find_proof(s_bucket.into())
-                                .ok_or(ReadingError::MissingPosProof { s_bucket })?;
-
-                            record_chunk = Simd::to_array(
-                                Simd::from(record_chunk) ^ Simd::from(*proof.hash()),
-                            );
-                        }
+                        record_chunk =
+                            Simd::to_array(Simd::from(record_chunk) ^ Simd::from(*proof.hash()));
 
                         maybe_record_chunk.replace(RecordChunk::from(record_chunk));
 
@@ -212,9 +202,7 @@ where
                     },
                 )
                 .collect::<FuturesUnordered<_>>()
-                .filter_map(|result| async move {
-                    result.err()
-                });
+                .filter_map(|result| async move { result.err() });
 
             std::pin::pin!(processing_chunks)
                 .next()
@@ -279,9 +267,10 @@ pub fn recover_extended_record_chunks(
         .into_iter()
         .map(RecordChunk::from)
         .collect::<Box<_>>();
-    let mut record_chunks = ManuallyDrop::new(record_chunks);
-    // SAFETY: Original memory is not dropped, size of the data checked above
-    let record_chunks = unsafe { Box::from_raw(record_chunks.as_mut_ptr() as *mut _) };
+    // SAFETY: Size of the data is guaranteed above
+    let record_chunks = unsafe {
+        Box::from_raw(Box::into_raw(record_chunks).cast::<[RecordChunk; Record::NUM_S_BUCKETS]>())
+    };
 
     Ok(record_chunks)
 }

--- a/crates/farmer/ab-farmer-components/src/reading.rs
+++ b/crates/farmer/ab-farmer-components/src/reading.rs
@@ -140,13 +140,12 @@ where
                     s_bucket,
                 ))
             },
-        )
-        .collect::<Vec<_>>();
+        );
 
     let sector_contents_map_size = SectorContentsMap::encoded_size(pieces_in_sector) as u64;
     match sector {
         ReadAt::Sync(sector) => {
-            read_chunks_inputs.into_par_iter().flatten().try_for_each(
+            read_chunks_inputs.flatten().try_for_each(
                 |(maybe_record_chunk, chunk_location, encoded_chunk_used, s_bucket)| {
                     let mut record_chunk = [0; RecordChunk::SIZE];
                     sector
@@ -177,6 +176,7 @@ where
         }
         ReadAt::Async(sector) => {
             let processing_chunks = read_chunks_inputs
+                .collect::<Vec<_>>()
                 .into_iter()
                 .flatten()
                 .map(

--- a/crates/shared/ab-proof-of-space/src/chia.rs
+++ b/crates/shared/ab-proof-of-space/src/chia.rs
@@ -71,8 +71,7 @@ impl Table for ChiaTable {
     }
 }
 
-#[cfg(all(feature = "alloc", test))]
-#[cfg(not(miri))]
+#[cfg(all(feature = "alloc", test, not(miri)))]
 mod tests {
     use super::*;
 

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -46,19 +46,17 @@ pub(super) const COMPUTE_F1_SIMD_FACTOR: usize = 8;
 #[cfg(any(feature = "alloc", test))]
 const COMPUTE_FN_SIMD_FACTOR: usize = 16;
 const MAX_BUCKET_SIZE: usize = 512;
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", test))]
 const BUCKET_SIZE_UPPER_BOUND_SECURITY_BITS: u8 = 128;
 /// Reducing bucket size for better performance.
 ///
 /// The number should be sufficient to produce enough proofs for sector encoding with high
 /// probability.
-// TODO: Statistical analysis if possible, confirming there will be enough proofs
 const REDUCED_BUCKET_SIZE: usize = 272;
 /// Reducing matches count for better performance.
 ///
 /// The number should be sufficient to produce enough proofs for sector encoding with high
 /// probability.
-// TODO: Statistical analysis if possible, confirming there will be enough proofs
 const REDUCED_MATCHES_COUNT: usize = 288;
 #[cfg(feature = "parallel")]
 const CACHE_LINE_SIZE: usize = 64;

--- a/crates/shared/ab-proof-of-space/src/lib.rs
+++ b/crates/shared/ab-proof-of-space/src/lib.rs
@@ -7,6 +7,7 @@
     const_convert,
     const_trait_impl,
     exact_size_is_empty,
+    float_erf,
     generic_const_exprs,
     get_mut_unchecked,
     maybe_uninit_fill,

--- a/subspace/crates/subspace-farmer/src/plotter/gpu/cuda.rs
+++ b/subspace/crates/subspace-farmer/src/plotter/gpu/cuda.rs
@@ -42,7 +42,7 @@ impl RecordsEncoder for CudaRecordsEncoder {
             let iter = Mutex::new(
                 (PieceOffset::ZERO..)
                     .zip(records.iter_mut())
-                    .zip(sector_contents_map.iter_record_bitfields_mut()),
+                    .zip(sector_contents_map.iter_record_chunks_used_mut()),
             );
             let plotting_error = Mutex::new(None::<String>);
 
@@ -54,7 +54,7 @@ impl RecordsEncoder for CudaRecordsEncoder {
 
                         // This instead of `while` above because otherwise mutex will be held for the
                         // duration of the loop and will limit concurrency to 1 record
-                        let Some(((piece_offset, record), mut encoded_chunks_used)) =
+                        let Some(((piece_offset, record), mut record_chunks_used)) =
                             iter.lock().next()
                         else {
                             return;
@@ -64,7 +64,7 @@ impl RecordsEncoder for CudaRecordsEncoder {
                         if let Err(error) = self.cuda_device.generate_and_encode_pospace(
                             &pos_seed,
                             record,
-                            encoded_chunks_used.iter_mut(),
+                            record_chunks_used.iter_mut(),
                         ) {
                             plotting_error.lock().replace(error);
                             return;

--- a/subspace/crates/subspace-farmer/src/plotter/gpu/rocm.rs
+++ b/subspace/crates/subspace-farmer/src/plotter/gpu/rocm.rs
@@ -42,7 +42,7 @@ impl RecordsEncoder for RocmRecordsEncoder {
             let iter = Mutex::new(
                 (PieceOffset::ZERO..)
                     .zip(records.iter_mut())
-                    .zip(sector_contents_map.iter_record_bitfields_mut()),
+                    .zip(sector_contents_map.iter_record_chunks_used_mut()),
             );
             let plotting_error = Mutex::new(None::<String>);
 
@@ -54,7 +54,7 @@ impl RecordsEncoder for RocmRecordsEncoder {
 
                         // This instead of `while` above because otherwise mutex will be held for the
                         // duration of the loop and will limit concurrency to 1 record
-                        let Some(((piece_offset, record), mut encoded_chunks_used)) =
+                        let Some(((piece_offset, record), mut record_chunks_used)) =
                             iter.lock().next()
                         else {
                             return;
@@ -64,7 +64,7 @@ impl RecordsEncoder for RocmRecordsEncoder {
                         if let Err(error) = self.rocm_device.generate_and_encode_pospace(
                             &pos_seed,
                             record,
-                            encoded_chunks_used.iter_mut(),
+                            record_chunks_used.iter_mut(),
                         ) {
                             plotting_error.lock().replace(error);
                             return;

--- a/subspace/shared/subspace-proof-of-space-gpu/src/cuda/tests.rs
+++ b/subspace/shared/subspace-proof-of-space-gpu/src/cuda/tests.rs
@@ -53,7 +53,7 @@ fn basic() {
             &sector_id.derive_evaluation_seed(PieceOffset::ZERO),
             &mut gpu_encoded_records[0],
             gpu_sector_contents_map
-                .iter_record_bitfields_mut()
+                .iter_record_chunks_used_mut()
                 .next()
                 .unwrap()
                 .iter_mut(),
@@ -64,7 +64,7 @@ fn basic() {
             &sector_id.derive_evaluation_seed(PieceOffset::ONE),
             &mut gpu_encoded_records[1],
             gpu_sector_contents_map
-                .iter_record_bitfields_mut()
+                .iter_record_chunks_used_mut()
                 .nth(1)
                 .unwrap()
                 .iter_mut(),

--- a/subspace/shared/subspace-proof-of-space-gpu/src/rocm/tests.rs
+++ b/subspace/shared/subspace-proof-of-space-gpu/src/rocm/tests.rs
@@ -53,7 +53,7 @@ fn basic() {
             &sector_id.derive_evaluation_seed(PieceOffset::ZERO),
             &mut gpu_encoded_records[0],
             gpu_sector_contents_map
-                .iter_record_bitfields_mut()
+                .iter_record_chunks_used_mut()
                 .next()
                 .unwrap()
                 .iter_mut(),
@@ -64,7 +64,7 @@ fn basic() {
             &sector_id.derive_evaluation_seed(PieceOffset::ONE),
             &mut gpu_encoded_records[1],
             gpu_sector_contents_map
-                .iter_record_bitfields_mut()
+                .iter_record_chunks_used_mut()
                 .nth(1)
                 .unwrap()
                 .iter_mut(),


### PR DESCRIPTION
I observed some time ago that all chunks in a sector end up being encoded. As such, support for unencoded chunks that do not actually exist results in unnecessary complexity and performance overhead.

Here I added a test case that ensures current parameters produce enough proofs to encode the whole sector (the math behind probabilities was generated by LLM and I don't have 100% confidence in it, but the number of proofs is so large, it seems plausible).

This simplification will be helpful for further optimizations, especially with GPU plotting.