### PR TITLE
Fix wrong function usage

### DIFF
--- a/crates/shared/ab-core-primitives/src/pos.rs
+++ b/crates/shared/ab-core-primitives/src/pos.rs
@@ -1,7 +1,7 @@
 //! Proof of space-related data structures.
 
 use crate::hashes::Blake3Hash;
-use ab_blake3::single_block_hash;
+use ab_blake3::single_chunk_hash;
 use ab_io_type::trivial_type::TrivialType;
 use core::fmt;
 use derive_more::{Deref, DerefMut, From, Into};
@@ -108,7 +108,7 @@ impl PosProof {
     /// Proof hash.
     pub fn hash(&self) -> Blake3Hash {
         Blake3Hash::new(
-            single_block_hash(&self.0).expect("Less than a single block worth of bytes; qed"),
+            single_chunk_hash(&self.0).expect("Less than a single chunk worth of bytes; qed"),
         )
     }
 }


### PR DESCRIPTION
I incorrectly read the size of the data structure as bits instead of bytes before. It clearly doesn't fit into a single block, but it will fit into a single chunk even if `k` is increased.