### PR TITLE
Move proof targets to the heap

### DIFF
--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -1480,13 +1480,18 @@ where
     pub(super) fn create_proof_targets(
         parent_table: Table<K, 6>,
         cache: &TablesCache,
-    ) -> ([[Position; 2]; Record::NUM_S_BUCKETS], PrunedTable<K, 6>)
+    ) -> (
+        Box<[[Position; 2]; Record::NUM_S_BUCKETS]>,
+        PrunedTable<K, 6>,
+    )
     where
         Table<K, 6>: private::NotLastTable,
         EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
     {
         let left_targets = &*cache.left_targets;
-        let mut table_6_proof_targets = [[Position::ZERO; 2]; Record::NUM_S_BUCKETS];
+        // SAFETY: Zero is a valid invariant
+        let mut table_6_proof_targets =
+            unsafe { Box::<[[Position; 2]; Record::NUM_S_BUCKETS]>::new_zeroed().assume_init() };
 
         for ([left_bucket, right_bucket], left_bucket_index) in
             parent_table.buckets().array_windows().zip(0..)
@@ -1562,7 +1567,10 @@ where
     pub(super) fn create_proof_targets_parallel(
         parent_table: Table<K, 6>,
         cache: &TablesCache,
-    ) -> ([[Position; 2]; Record::NUM_S_BUCKETS], PrunedTable<K, 6>)
+    ) -> (
+        Box<[[Position; 2]; Record::NUM_S_BUCKETS]>,
+        PrunedTable<K, 6>,
+    )
     where
         Table<K, 6>: private::NotLastTable,
         EvaluatableUsize<{ metadata_size_bytes(K, 6) }>: Sized,
@@ -1674,7 +1682,9 @@ where
 
         let buckets_positions = strip_sync_unsafe_cell(buckets_positions);
 
-        let mut table_6_proof_targets = [[Position::ZERO; 2]; Record::NUM_S_BUCKETS];
+        // SAFETY: Zero is a valid invariant
+        let mut table_6_proof_targets =
+            unsafe { Box::<[[Position; 2]; Record::NUM_S_BUCKETS]>::new_zeroed().assume_init() };
 
         for (bucket, results_count) in buckets_positions.iter().zip(
             global_results_counts


### PR DESCRIPTION
I actually meant to inline the producing functions initially, but this seems to result in better performance:
```
Before:
chia/proofs/single/1x   time:   [710.02 ms 713.94 ms 718.19 ms]
                        thrpt:  [1.3924  elem/s 1.4007  elem/s 1.4084  elem/s]
chia/proofs/parallel/8x time:   [567.42 ms 574.66 ms 581.51 ms]
                        thrpt:  [13.757  elem/s 13.921  elem/s 14.099  elem/s]
After:
chia/proofs/single/1x   time:   [681.83 ms 683.49 ms 685.20 ms]
                        thrpt:  [1.4594  elem/s 1.4631  elem/s 1.4666  elem/s]
chia/proofs/parallel/8x time:   [554.84 ms 558.87 ms 562.89 ms]
                        thrpt:  [14.212  elem/s 14.315  elem/s 14.419  elem/s]
```