### PR TITLE
Precompute left targets on demand on GPU, remove sorting of left targets

### DIFF
--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn.rs
@@ -9,7 +9,7 @@ use crate::shader::constants::{
 };
 use crate::shader::find_matches_in_buckets::rmap::Rmap;
 use crate::shader::find_matches_in_buckets::{
-    LeftTargets, Match, SharedScratchSpace, find_matches_in_buckets_impl,
+    Match, SharedScratchSpace, find_matches_in_buckets_impl,
 };
 use crate::shader::types::{Metadata, Position, PositionExt, PositionY};
 use core::mem::MaybeUninit;
@@ -143,7 +143,6 @@ pub unsafe fn find_matches_and_compute_fn<const TABLE_NUMBER: u8, const PARENT_T
     num_workgroups: UVec3,
     subgroup_id: u32,
     num_subgroups: u32,
-    left_targets: &LeftTargets,
     parent_buckets: &[[PositionY; MAX_BUCKET_SIZE]; NUM_BUCKETS],
     parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
     bucket_sizes: &mut [u32; NUM_BUCKETS],
@@ -190,7 +189,6 @@ pub unsafe fn find_matches_and_compute_fn<const TABLE_NUMBER: u8, const PARENT_T
                 left_bucket,
                 right_bucket,
                 matches,
-                left_targets,
                 scratch_space,
                 rmap,
             )
@@ -237,17 +235,16 @@ pub unsafe fn find_matches_and_compute_f2(
     #[spirv(num_workgroups)] num_workgroups: UVec3,
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
          NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
     parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] bucket_sizes: &mut [u32; NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] bucket_sizes: &mut [u32; NUM_BUCKETS],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
              NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
     #[spirv(workgroup)] matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
     #[spirv(workgroup)] scratch_space: &mut SharedScratchSpace,
@@ -256,7 +253,7 @@ pub unsafe fn find_matches_and_compute_f2(
     #[spirv(workgroup)]
     rmap: &mut MaybeUninit<Rmap>,
     #[cfg(not(all(target_arch = "spirv", feature = "__modern-gpu")))]
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 7)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)]
     rmap: &mut MaybeUninit<Rmap>,
 ) {
     // SAFETY: Guaranteed by function contract
@@ -267,7 +264,6 @@ pub unsafe fn find_matches_and_compute_f2(
             num_workgroups,
             subgroup_id,
             num_subgroups,
-            left_targets,
             parent_buckets,
             parent_metadatas,
             bucket_sizes,
@@ -301,17 +297,16 @@ pub unsafe fn find_matches_and_compute_f3(
     #[spirv(num_workgroups)] num_workgroups: UVec3,
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
          NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
     parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] bucket_sizes: &mut [u32; NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] bucket_sizes: &mut [u32; NUM_BUCKETS],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
              NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
     #[spirv(workgroup)] matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
     #[spirv(workgroup)] scratch_space: &mut SharedScratchSpace,
@@ -320,7 +315,7 @@ pub unsafe fn find_matches_and_compute_f3(
     #[spirv(workgroup)]
     rmap: &mut MaybeUninit<Rmap>,
     #[cfg(not(all(target_arch = "spirv", feature = "__modern-gpu")))]
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 7)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)]
     rmap: &mut MaybeUninit<Rmap>,
 ) {
     // SAFETY: Guaranteed by function contract
@@ -331,7 +326,6 @@ pub unsafe fn find_matches_and_compute_f3(
             num_workgroups,
             subgroup_id,
             num_subgroups,
-            left_targets,
             parent_buckets,
             parent_metadatas,
             bucket_sizes,
@@ -365,17 +359,16 @@ pub unsafe fn find_matches_and_compute_f4(
     #[spirv(num_workgroups)] num_workgroups: UVec3,
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
          NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
     parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] bucket_sizes: &mut [u32; NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] bucket_sizes: &mut [u32; NUM_BUCKETS],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
              NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
     #[spirv(workgroup)] matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
     #[spirv(workgroup)] scratch_space: &mut SharedScratchSpace,
@@ -384,7 +377,7 @@ pub unsafe fn find_matches_and_compute_f4(
     #[spirv(workgroup)]
     rmap: &mut MaybeUninit<Rmap>,
     #[cfg(not(all(target_arch = "spirv", feature = "__modern-gpu")))]
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 7)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)]
     rmap: &mut MaybeUninit<Rmap>,
 ) {
     // SAFETY: Guaranteed by function contract
@@ -395,7 +388,6 @@ pub unsafe fn find_matches_and_compute_f4(
             num_workgroups,
             subgroup_id,
             num_subgroups,
-            left_targets,
             parent_buckets,
             parent_metadatas,
             bucket_sizes,
@@ -429,17 +421,16 @@ pub unsafe fn find_matches_and_compute_f5(
     #[spirv(num_workgroups)] num_workgroups: UVec3,
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
          NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
     parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] bucket_sizes: &mut [u32; NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] bucket_sizes: &mut [u32; NUM_BUCKETS],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
              NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
     #[spirv(workgroup)] matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
     #[spirv(workgroup)] scratch_space: &mut SharedScratchSpace,
@@ -448,7 +439,7 @@ pub unsafe fn find_matches_and_compute_f5(
     #[spirv(workgroup)]
     rmap: &mut MaybeUninit<Rmap>,
     #[cfg(not(all(target_arch = "spirv", feature = "__modern-gpu")))]
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 7)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)]
     rmap: &mut MaybeUninit<Rmap>,
 ) {
     // SAFETY: Guaranteed by function contract
@@ -459,7 +450,6 @@ pub unsafe fn find_matches_and_compute_f5(
             num_workgroups,
             subgroup_id,
             num_subgroups,
-            left_targets,
             parent_buckets,
             parent_metadatas,
             bucket_sizes,
@@ -493,17 +483,16 @@ pub unsafe fn find_matches_and_compute_f6(
     #[spirv(num_workgroups)] num_workgroups: UVec3,
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
          NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
     parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] bucket_sizes: &mut [u32; NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] bucket_sizes: &mut [u32; NUM_BUCKETS],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
              NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
     #[spirv(workgroup)] matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
     #[spirv(workgroup)] scratch_space: &mut SharedScratchSpace,
@@ -512,7 +501,7 @@ pub unsafe fn find_matches_and_compute_f6(
     #[spirv(workgroup)]
     rmap: &mut MaybeUninit<Rmap>,
     #[cfg(not(all(target_arch = "spirv", feature = "__modern-gpu")))]
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 7)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)]
     rmap: &mut MaybeUninit<Rmap>,
 ) {
     // SAFETY: Guaranteed by function contract
@@ -523,7 +512,6 @@ pub unsafe fn find_matches_and_compute_f6(
             num_workgroups,
             subgroup_id,
             num_subgroups,
-            left_targets,
             parent_buckets,
             parent_metadatas,
             bucket_sizes,
@@ -557,17 +545,16 @@ pub unsafe fn find_matches_and_compute_f7(
     #[spirv(num_workgroups)] num_workgroups: UVec3,
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
          NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
     parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] bucket_sizes: &mut [u32; NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] bucket_sizes: &mut [u32; NUM_BUCKETS],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] buckets: &mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE];
              NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] positions: &mut [[MaybeUninit<[Position; 2]>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] metadatas: &mut [[MaybeUninit<Metadata>; REDUCED_MATCHES_COUNT];
              NUM_MATCH_BUCKETS],
     #[spirv(workgroup)] matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
     #[spirv(workgroup)] scratch_space: &mut SharedScratchSpace,
@@ -576,7 +563,7 @@ pub unsafe fn find_matches_and_compute_f7(
     #[spirv(workgroup)]
     rmap: &mut MaybeUninit<Rmap>,
     #[cfg(not(all(target_arch = "spirv", feature = "__modern-gpu")))]
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 7)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)]
     rmap: &mut MaybeUninit<Rmap>,
 ) {
     // SAFETY: Guaranteed by function contract
@@ -587,7 +574,6 @@ pub unsafe fn find_matches_and_compute_f7(
             num_workgroups,
             subgroup_id,
             num_subgroups,
-            left_targets,
             parent_buckets,
             parent_metadatas,
             bucket_sizes,

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/cpu_tests.rs
@@ -3,7 +3,6 @@ use crate::shader::constants::{
     MAX_BUCKET_SIZE, NUM_BUCKETS, NUM_MATCH_BUCKETS, PARAM_BC, REDUCED_BUCKET_SIZE,
     REDUCED_MATCHES_COUNT,
 };
-use crate::shader::find_matches_in_buckets::LeftTargets;
 use crate::shader::find_matches_in_buckets::cpu_tests::find_matches_in_buckets_correct;
 use crate::shader::types::{Metadata, Position, PositionExt, PositionY, Y};
 use std::mem::MaybeUninit;
@@ -13,7 +12,6 @@ pub(super) fn find_matches_and_compute_fn_correct<
     const TABLE_NUMBER: u8,
     const PARENT_TABLE_NUMBER: u8,
 >(
-    left_targets: &LeftTargets,
     parent_buckets: &[[PositionY; MAX_BUCKET_SIZE]; NUM_BUCKETS],
     parent_metadatas: &[[Metadata; REDUCED_MATCHES_COUNT]; NUM_MATCH_BUCKETS],
     buckets: &'a mut [[MaybeUninit<PositionY>; MAX_BUCKET_SIZE]; NUM_BUCKETS],
@@ -37,7 +35,6 @@ pub(super) fn find_matches_and_compute_fn_correct<
             left_bucket,
             right_bucket,
             &mut matches,
-            left_targets,
         );
 
         for (index, ((m, match_positions), match_metadata)) in

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_last.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_last.rs
@@ -9,7 +9,7 @@ use crate::shader::constants::{
 };
 use crate::shader::find_matches_in_buckets::rmap::Rmap;
 use crate::shader::find_matches_in_buckets::{
-    LeftTargets, Match, SharedScratchSpace, find_matches_in_buckets_impl,
+    Match, SharedScratchSpace, find_matches_in_buckets_impl,
 };
 use crate::shader::types::{Metadata, Position, PositionY};
 use core::mem::MaybeUninit;
@@ -194,14 +194,13 @@ pub unsafe fn find_matches_and_compute_last(
     #[spirv(num_workgroups)] num_workgroups: UVec3,
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] left_targets: &LeftTargets,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] parent_buckets: &[[PositionY; MAX_BUCKET_SIZE];
          NUM_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)]
     parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] bucket_sizes: &mut [u32;
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] bucket_sizes: &mut [u32;
              NUM_S_BUCKETS],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)]
     table_6_proof_targets: &mut [[MaybeUninit<[Position; 2]>; NUM_ELEMENTS_PER_S_BUCKET];
              NUM_S_BUCKETS],
     #[spirv(workgroup)] matches: &mut [MaybeUninit<Match>; REDUCED_MATCHES_COUNT],
@@ -211,7 +210,7 @@ pub unsafe fn find_matches_and_compute_last(
     #[spirv(workgroup)]
     rmap: &mut MaybeUninit<Rmap>,
     #[cfg(not(all(target_arch = "spirv", feature = "__modern-gpu")))]
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)]
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)]
     rmap: &mut MaybeUninit<Rmap>,
 ) {
     let local_invocation_id = local_invocation_id.x;
@@ -247,7 +246,6 @@ pub unsafe fn find_matches_and_compute_last(
                 left_bucket,
                 right_bucket,
                 matches,
-                left_targets,
                 scratch_space,
                 rmap,
             )

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_last/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_last/cpu_tests.rs
@@ -5,13 +5,11 @@ use crate::shader::constants::{
 use crate::shader::find_matches_and_compute_last::{
     NUM_ELEMENTS_PER_S_BUCKET, PARENT_TABLE_NUMBER, TABLE_NUMBER,
 };
-use crate::shader::find_matches_in_buckets::LeftTargets;
 use crate::shader::find_matches_in_buckets::cpu_tests::find_matches_in_buckets_correct;
 use crate::shader::types::{Metadata, Position, PositionExt, PositionY};
 use std::mem::MaybeUninit;
 
 pub(super) fn find_matches_and_compute_last_correct<'a>(
-    left_targets: &LeftTargets,
     parent_buckets: &[[PositionY; MAX_BUCKET_SIZE]; NUM_BUCKETS],
     parent_metadatas: &[[Metadata; REDUCED_MATCHES_COUNT]; NUM_MATCH_BUCKETS],
     table_6_proof_targets: &mut [[MaybeUninit<[Position; 2]>; NUM_ELEMENTS_PER_S_BUCKET];
@@ -29,7 +27,6 @@ pub(super) fn find_matches_and_compute_last_correct<'a>(
             left_bucket,
             right_bucket,
             &mut matches,
-            left_targets,
         );
 
         for m in matches {

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -275,14 +275,13 @@ fn calculate_left_targets() -> Arc<LeftTargets> {
         for r in 0..PARAM_BC {
             let c = r / PARAM_C;
 
-            let mut arr = array::from_fn(|m| {
+            let arr = array::from_fn(|m| {
                 let m = m as u16;
                 R::from(
                     ((c + m) % PARAM_B) * PARAM_C
                         + (((2 * m + parity) * (2 * m + parity) + r) % PARAM_C),
                 )
             });
-            arr.sort_unstable();
             left_targets_slice[parity as usize][r as usize].write(CacheLineAligned(arr));
         }
     }


### PR DESCRIPTION
Sorting was supposed to help, but it didn't really seem to help beyond run to run variance of the benchmark. And it hurts GPU implementation.

On the GPU due to very high parallelism, small caches and high memory access latency, it makes more sense to compute left targets on demand rather than loading from memory like on CPU. It also simplifies the implementation a bit.