### PR TITLE
Enable LLVMpipe on Windows for shader testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -297,13 +297,6 @@ jobs:
           }
         if: matrix.miri == false && runner.os == 'Windows' && matrix.type == 'together'
 
-      - name: Force shader testing
-        shell: bash
-        run: |
-          echo "EXTRA_OPTIONS=--features=__force-gpu-tests" >> $GITHUB_ENV
-        # NOTE: `macOS` has paravirtualized GPU available out of the box, LLVMpipe is used on Linux and Windows
-        if: matrix.miri == false && matrix.type == 'together'
-
       - name: cargo ${{ env.command }}
         run: |
           cargo -Zgitoxide -Zgit ${{ env.command }} --locked ${{ env.EXTRA_OPTIONS }}

--- a/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
+++ b/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
@@ -50,9 +50,6 @@ rand = { workspace = true }
 cargo-gpu = { workspace = true }
 
 [features]
-# GPU tests search for compatible GPU. If no compatible GPU is found, tests are skipped unless this feature is
-# specified.
-__force-gpu-tests = []
 # Internal feature used by the build script for shader compilation. Should not be used externally.
 __modern-gpu = []
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1/gpu_tests.rs
@@ -23,12 +23,7 @@ fn compute_f1_gpu() {
     let initial_state = ChaCha8State::init(&seed, &[0; _]);
 
     let Some(actual_output) = block_on(compute_f1(&initial_state)) else {
-        if cfg!(feature = "__force-gpu-tests") {
-            panic!("Skipping tests, no compatible device detected");
-        } else {
-            eprintln!("Skipping tests, no compatible device detected");
-            return;
-        }
+        panic!("No compatible device detected, can't run tests");
     };
 
     let expected_output = (X::ZERO..)

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_fn/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_fn/gpu_tests.rs
@@ -77,12 +77,7 @@ fn compute_fn_gpu<const TABLE_NUMBER: u8, const PARENT_TABLE_NUMBER: u8>() {
     let Some((actual_ys, actual_metadatas)) =
         block_on(compute_fn::<TABLE_NUMBER>(&matches, &parent_metadatas))
     else {
-        if cfg!(feature = "__force-gpu-tests") {
-            panic!("Skipping tests, no compatible device detected");
-        } else {
-            eprintln!("Skipping tests, no compatible device detected");
-            return;
-        }
+        panic!("No compatible device detected, can't run tests");
     };
 
     let (expected_ys, expected_metadatas) = matches

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f2/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f2/gpu_tests.rs
@@ -64,12 +64,7 @@ fn find_matches_and_compute_f2_gpu() {
     let Some((actual_bucket_sizes, actual_buckets, actual_positions, actual_metadatas)) =
         block_on(find_matches_and_compute_f2(&parent_buckets))
     else {
-        if cfg!(feature = "__force-gpu-tests") {
-            panic!("Skipping tests, no compatible device detected");
-        } else {
-            eprintln!("Skipping tests, no compatible device detected");
-            return;
-        }
+        panic!("No compatible device detected, can't run tests");
     };
 
     let mut expected_buckets = unsafe {

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7/gpu_tests.rs
@@ -82,12 +82,7 @@ fn find_matches_and_compute_f7_gpu() {
     let Some((actual_table_6_proof_targets_sizes, table_6_proof_targets)) = block_on(
         find_matches_and_compute_f7(&parent_buckets, &parent_metadatas),
     ) else {
-        if cfg!(feature = "__force-gpu-tests") {
-            panic!("Skipping tests, no compatible device detected");
-        } else {
-            eprintln!("Skipping tests, no compatible device detected");
-            return;
-        }
+        panic!("No compatible device detected, can't run tests");
     };
 
     let mut expected_table_6_proof_targets = unsafe {

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/gpu_tests.rs
@@ -98,12 +98,7 @@ fn find_matches_and_compute_fn_gpu<const TABLE_NUMBER: u8, const PARENT_TABLE_NU
     let Some((actual_bucket_sizes, actual_buckets, actual_positions, actual_metadatas)) = block_on(
         find_matches_and_compute_fn::<TABLE_NUMBER>(&parent_buckets, &parent_metadatas),
     ) else {
-        if cfg!(feature = "__force-gpu-tests") {
-            panic!("Skipping tests, no compatible device detected");
-        } else {
-            eprintln!("Skipping tests, no compatible device detected");
-            return;
-        }
+        panic!("No compatible device detected, can't run tests");
     };
 
     let mut expected_buckets = unsafe {

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
@@ -54,12 +54,7 @@ fn find_matches_in_buckets_gpu() {
     };
 
     let Some(actual_matches) = block_on(find_matches_in_buckets(&buckets)) else {
-        if cfg!(feature = "__force-gpu-tests") {
-            panic!("Skipping tests, no compatible device detected");
-        } else {
-            eprintln!("Skipping tests, no compatible device detected");
-            return;
-        }
+        panic!("No compatible device detected, can't run tests");
     };
 
     let expected_matches = buckets

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_proofs/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_proofs/gpu_tests.rs
@@ -111,12 +111,7 @@ fn find_proofs_gpu() {
         &bucket_sizes,
         &buckets,
     )) else {
-        if cfg!(feature = "__force-gpu-tests") {
-            panic!("Skipping tests, no compatible device detected");
-        } else {
-            eprintln!("Skipping tests, no compatible device detected");
-            return;
-        }
+        panic!("No compatible device detected, can't run tests");
     };
 
     let (expected_found_proofs, expected_proofs) = find_proofs_correct(

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/sort_buckets/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/sort_buckets/gpu_tests.rs
@@ -37,12 +37,7 @@ fn sort_buckets_gpu() {
     *bucket_sizes.last_mut().unwrap() = reduced_last_bucket_size;
 
     let Some(actual_output) = block_on(sort_buckets(&bucket_sizes, &buckets)) else {
-        if cfg!(feature = "__force-gpu-tests") {
-            panic!("Skipping tests, no compatible device detected");
-        } else {
-            eprintln!("Skipping tests, no compatible device detected");
-            return;
-        }
+        panic!("No compatible device detected, can't run tests");
     };
 
     let mut expected_output = buckets;


### PR DESCRIPTION
Also GPU tests are now running unconditionally and fail if no compatible devices are found, which is not the case in CI and easy to make not the case in development environment too