### PR TITLE
Update Rust toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -593,9 +593,9 @@ jobs:
         with:
           context: /tmp/empty
           file: crates/execution/ab-riscv-act4-runner/res/Dockerfile
-          cache-from: type=gha,scope=act4-build
+          cache-from: type=gha,scope=act4-build-${{ runner.arch }}
           # Only save on `main` branch
-          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=min,scope=act4-build' || '' }}
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=gha,mode=min,scope=act4-build-{0}', runner.arch) || '' }}
           load: true
 
       - name: ACT4 tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,8 +1468,8 @@ dependencies = [
 
 [[package]]
 name = "cargo-gpu-install"
-version = "0.1.0"
-source = "git+https://github.com/Rust-GPU/cargo-gpu?rev=e837b29efe63c98b08b7b25d0ac35ab28a2b5933#e837b29efe63c98b08b7b25d0ac35ab28a2b5933"
+version = "0.9.0"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=003dde7b4c4517e0143d1a1f143f0b737ded5aaa#003dde7b4c4517e0143d1a1f143f0b737ded5aaa"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.21.0",
@@ -5265,7 +5265,7 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 [[package]]
 name = "rustc_codegen_spirv-types"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=003dde7b4c4517e0143d1a1f143f0b737ded5aaa#003dde7b4c4517e0143d1a1f143f0b737ded5aaa"
 dependencies = [
  "rspirv",
  "semver",
@@ -5765,7 +5765,7 @@ dependencies = [
 [[package]]
 name = "spirv-builder"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=003dde7b4c4517e0143d1a1f143f0b737ded5aaa#003dde7b4c4517e0143d1a1f143f0b737ded5aaa"
 dependencies = [
  "cargo_metadata 0.21.0",
  "log",
@@ -5781,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "spirv-std"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=003dde7b4c4517e0143d1a1f143f0b737ded5aaa#003dde7b4c4517e0143d1a1f143f0b737ded5aaa"
 dependencies = [
  "bitflags 1.3.2",
  "glam",
@@ -5794,7 +5794,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-macros"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=003dde7b4c4517e0143d1a1f143f0b737ded5aaa#003dde7b4c4517e0143d1a1f143f0b737ded5aaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5805,7 +5805,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-types"
 version = "0.9.0"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=877bd8697a15f3e6d09446a5e1807e6237ca1dac#877bd8697a15f3e6d09446a5e1807e6237ca1dac"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=003dde7b4c4517e0143d1a1f143f0b737ded5aaa#003dde7b4c4517e0143d1a1f143f0b737ded5aaa"
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ bech32 = { version = "0.11.1", default-features = false }
 blake3 = { version = "1.8.4", default-features = false }
 bytes = { version = "1.11.1", default-features = false }
 bytesize = { version = "2.3.1", default-features = false }
-cargo-gpu-install = { git = "https://github.com/Rust-GPU/cargo-gpu", rev = "e837b29efe63c98b08b7b25d0ac35ab28a2b5933", default-features = false }
+cargo-gpu-install = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "003dde7b4c4517e0143d1a1f143f0b737ded5aaa", default-features = false }
 cargo_metadata = { version = "0.23.1" }
 chacha20 = { version = "0.10.0", default-features = false }
 clap = { version = "4.6.0", features = ["derive"] }
@@ -130,7 +130,7 @@ serde_json = "1.0.149"
 serde-big-array = "0.5.1"
 sha2 = { version = "0.11.0", default-features = false }
 smallvec = { version = "1.15.1", features = ["union"] }
-spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "877bd8697a15f3e6d09446a5e1807e6237ca1dac" }
+spirv-std = { git = "https://github.com/Rust-GPU/rust-gpu", rev = "003dde7b4c4517e0143d1a1f143f0b737ded5aaa" }
 stable_deref_trait = { version = "1.2.1", default-features = false }
 strum = { version = "0.28.0", default-features = false, features = ["derive"] }
 syn = "2.0.117"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-03-12"
+channel = "nightly-2026-04-08"
 components = ["miri", "rust-src"]
 targets = []
 profile = "default"


### PR DESCRIPTION
This also updates rust-gpu, which now contains cargo-gpu-install in the same repo and uses the same toolchain version as the one I've upgraded too, which should help a tiny bit with CI time, at least for now