### PR TITLE
Compressed instructions in contracts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ reed-solomon-simd = { opt-level = 3 }
 [profile.contract]
 inherits = "release"
 codegen-units = 1
+lto = "fat"
 
 [profile.production]
 inherits = "release"

--- a/crates/contracts/core/ab-contract-file/src/contract_instruction_prototype.rs
+++ b/crates/contracts/core/ab-contract-file/src/contract_instruction_prototype.rs
@@ -30,6 +30,9 @@ use core::ops::ControlFlow;
         Sh1add,
     ],
     inherit = [
+        Rv64ZcaInstruction,
+        Rv64ZcbInstruction,
+        Rv64ZcmpInstruction,
         Rv64Instruction,
         Rv64MInstruction,
         Rv64BInstruction,
@@ -68,7 +71,7 @@ where
 #[instruction]
 impl<Reg> fmt::Display for ContractInstructionPrototype<Reg>
 where
-    Reg: fmt::Display + Copy,
+    Reg: Register,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {}
@@ -94,5 +97,30 @@ where
         state: &mut InterpreterState<Reg, ExtState, Memory, PC, InstructionHandler, CustomError>,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
+    }
+}
+
+impl<Reg> ContractInstructionPrototype<Reg> {
+    /// Check if the instruction is a jump instruction of any kind (affects program counter)
+    #[inline]
+    pub fn is_jump(&self) -> bool {
+        matches!(
+            self,
+            Self::CJ { .. }
+                | Self::CBeqz { .. }
+                | Self::CBnez { .. }
+                | Self::CJr { .. }
+                | Self::CJalr { .. }
+                | Self::CmPopretz { .. }
+                | Self::CmPopret { .. }
+                | Self::Jalr { .. }
+                | Self::Beq { .. }
+                | Self::Bne { .. }
+                | Self::Blt { .. }
+                | Self::Bge { .. }
+                | Self::Bltu { .. }
+                | Self::Bgeu { .. }
+                | Self::Jal { .. }
+        )
     }
 }

--- a/crates/contracts/core/ab-contract-file/src/lib.rs
+++ b/crates/contracts/core/ab-contract-file/src/lib.rs
@@ -9,8 +9,8 @@
 //! * read-only data section: contains contract metadata among other things, allowing to decode
 //!   names and ABI of the methods mentioned above, and the number of methods in this metadata must
 //!   match the number of methods in the header
-//! * code section: contains only valid/supported RISC-V instructions, always ending with some kind
-//!   of jump instruction
+//! * code section: contains only valid/supported RISC-V instructions or 16-bit zero padding, always
+//!   ending with some kind of jump instruction
 //!
 //! This file is created from an ELF source file and can, technically, be converted back to it. Note
 //! that due to the intentional lack of the `.bss` section equivalent and many other features, only
@@ -28,6 +28,8 @@
 //! programmatically and using CLI interface.
 
 #![feature(
+    const_block_items,
+    const_cmp,
     const_trait_impl,
     maybe_uninit_fill,
     trusted_len,
@@ -63,6 +65,11 @@ pub const CONTRACT_FILE_MAGIC: [u8; 4] = *b"ABC0";
 pub type ContractRegister = Reg<u64>;
 /// An instruction type used by contracts
 pub type ContractInstruction = ContractInstructionPrototype<ContractRegister>;
+
+// Ensure expected size of the instruction enum
+const {
+    assert!(size_of::<ContractInstruction>() == 8);
+}
 
 /// Header of the contract file
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TrivialType)]
@@ -246,7 +253,7 @@ pub enum ContractFileParseError {
         metadata_num_methods: u16,
     },
     /// Invalid instruction encountered while parsing the code section
-    #[error("Invalid instruction encountered while parsing the code section: {instruction}")]
+    #[error("Invalid instruction encountered while parsing the code section: {instruction:#x}")]
     InvalidInstruction {
         /// Instruction
         instruction: u32,
@@ -427,7 +434,7 @@ impl<'a> ContractFile<'a> {
                     let address = contract_file_method_metadata.offset - read_only_section_offset
                         + read_only_padding_size;
 
-                    if !address.is_multiple_of(size_of::<u32>() as u32) {
+                    if !address.is_multiple_of(size_of::<u16>() as u32) {
                         return Err(ContractFileParseError::MethodUnaligned {
                             file_offset: contract_file_method_metadata.offset,
                             memory_address: address,
@@ -536,7 +543,7 @@ impl<'a> ContractFile<'a> {
             let address =
                 header.host_call_fn_offset - read_only_section_offset + read_only_padding_size;
 
-            if !address.is_multiple_of(size_of::<u32>() as u32) {
+            if !address.is_multiple_of(size_of::<u16>() as u32) {
                 return Err(ContractFileParseError::HostCallFnUnaligned {
                     file_offset: header.host_call_fn_offset,
                     memory_address: address,
@@ -546,44 +553,45 @@ impl<'a> ContractFile<'a> {
 
         // Ensure code only consists of expected instructions
         {
-            let mut remaining_code_file_bytes = &file_bytes[code_section_offset as usize..];
+            let mut offset = code_section_offset as usize;
 
             let mut instruction = ContractInstruction::Unimp;
-            while let Some(instruction_bytes) =
-                remaining_code_file_bytes.split_off(..size_of::<u32>())
-            {
-                let instruction_word = u32::from_le_bytes([
-                    instruction_bytes[0],
-                    instruction_bytes[1],
-                    instruction_bytes[2],
-                    instruction_bytes[3],
-                ]);
-                instruction = ContractInstruction::try_decode(instruction_word).ok_or(
-                    ContractFileParseError::InvalidInstruction {
-                        instruction: instruction_word,
-                    },
-                )?;
+            while offset < file_bytes.len() {
+                let remaining = &file_bytes[offset..];
+
+                let instruction_word = if remaining.len() >= size_of::<u32>() {
+                    u32::from_le_bytes([remaining[0], remaining[1], remaining[2], remaining[3]])
+                } else if remaining.len() >= size_of::<u16>() {
+                    u32::from_le_bytes([remaining[0], remaining[1], 0, 0])
+                } else {
+                    // Need at least 2 bytes to read a compressed instruction
+                    return Err(ContractFileParseError::UnexpectedTrailingCodeBytes {
+                        num_bytes: remaining.len(),
+                    });
+                };
+
+                instruction = match ContractInstruction::try_decode(instruction_word) {
+                    Some(instruction) => instruction,
+                    None => {
+                        // TODO: LLVM uses zeroes for padding instead of something like c.nop, maybe
+                        //  rewrite during conversion from ELF?:
+                        //  https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/497
+                        if instruction_word as u16 == 0 {
+                            offset += 2;
+                            continue;
+                        } else {
+                            return Err(ContractFileParseError::InvalidInstruction {
+                                instruction: instruction_word,
+                            });
+                        }
+                    }
+                };
+
+                offset += usize::from(instruction.size());
             }
 
-            let is_jump_instruction = matches!(
-                instruction,
-                ContractInstruction::Jalr { .. }
-                    | ContractInstruction::Beq { .. }
-                    | ContractInstruction::Bne { .. }
-                    | ContractInstruction::Blt { .. }
-                    | ContractInstruction::Bge { .. }
-                    | ContractInstruction::Bltu { .. }
-                    | ContractInstruction::Bgeu { .. }
-                    | ContractInstruction::Jal { .. }
-            );
-            if !is_jump_instruction {
+            if !instruction.is_jump() {
                 return Err(ContractFileParseError::LastInstructionMustBeJump { instruction });
-            }
-
-            if !remaining_code_file_bytes.is_empty() {
-                return Err(ContractFileParseError::UnexpectedTrailingCodeBytes {
-                    num_bytes: remaining_code_file_bytes.len(),
-                });
             }
         }
 

--- a/crates/contracts/core/ab-contracts-tooling/src/convert.rs
+++ b/crates/contracts/core/ab-contracts-tooling/src/convert.rs
@@ -7,10 +7,10 @@ use ab_contracts_common::{HOST_CALL_FN, HOST_CALL_FN_IMPORT, METADATA_STATIC_NAM
 use ab_io_type::trivial_type::TrivialType;
 use anyhow::Context;
 use object::elf::{
-    ELFCLASS64, ELFDATA2LSB, ELFMAG, ELFOSABI_GNU, EM_RISCV, ET_DYN, FileHeader64, Ident,
-    R_RISCV_JUMP_SLOT, SHN_LORESERVE, STB_GLOBAL, STV_DEFAULT,
+    EF_RISCV_RVC, ELFCLASS64, ELFDATA2LSB, ELFMAG, ELFOSABI_GNU, EM_RISCV, ET_DYN, FileHeader64,
+    Ident, R_RISCV_JUMP_SLOT, SHN_LORESERVE, STB_GLOBAL, STV_DEFAULT,
 };
-use object::read::elf::{ElfFile, ElfFile64};
+use object::read::elf::{ElfFile, ElfFile64, FileHeader};
 use object::{
     CompressedData, CompressionFormat, LittleEndian, Object, ObjectSection, ObjectSymbol,
     ObjectSymbolTable, RelocationFlags, RelocationTarget, SymbolKind, SymbolSection, U16, U32, U64,
@@ -36,7 +36,7 @@ fn is_correct_header(header: &FileHeader64<LittleEndian>) -> bool {
         e_entry: U64::new(LittleEndian, 0),
         e_phoff: header.e_phoff,
         e_shoff: header.e_shoff,
-        e_flags: U32::new(LittleEndian, 0),
+        e_flags: U32::new(LittleEndian, header.e_flags(LittleEndian) & EF_RISCV_RVC),
         e_ehsize: U16::new(LittleEndian, 64),
         e_phentsize: header.e_phentsize,
         e_phnum: header.e_phnum,

--- a/crates/contracts/core/ab-contracts-tooling/src/riscv64-unknown-none-abundance.json
+++ b/crates/contracts/core/ab-contracts-tooling/src/riscv64-unknown-none-abundance.json
@@ -7,7 +7,7 @@
   "only-cdylib": true,
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+m,+b,+zbc,+zicond,+zkn,+unaligned-scalar-mem",
+  "features": "+m,+b,+zbc,+zca,+zcb,+zcmp,+zicond,+zkn,+unaligned-scalar-mem",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-abiname": "lp64",

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
@@ -1,5 +1,6 @@
 use crate::abundance_rv32i_max::instruction::AbundanceRv32IMaxInstruction;
-use crate::interpreter::{Act4InstructionFetcher, Act4Memory, Act4SystemHandler};
+use crate::interpreter::{Act4Memory, Act4SystemHandler};
+use ab_riscv_interpreter::basic::BasicInstructionFetcher;
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use std::collections::BTreeMap;
@@ -99,7 +100,7 @@ impl Csrs<<AbundanceRv32IMaxInstruction as Instruction>::Reg> for AbundanceRv32I
                 <AbundanceRv32IMaxInstruction as Instruction>::Reg,
                 Self,
                 Act4Memory<0, 0>,
-                Act4InstructionFetcher<AbundanceRv32IMaxInstruction>,
+                BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
                 Act4SystemHandler,
                 _,
             >,
@@ -119,7 +120,7 @@ impl Csrs<<AbundanceRv32IMaxInstruction as Instruction>::Reg> for AbundanceRv32I
                 <AbundanceRv32IMaxInstruction as Instruction>::Reg,
                 Self,
                 Act4Memory<0, 0>,
-                Act4InstructionFetcher<AbundanceRv32IMaxInstruction>,
+                BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
                 Act4SystemHandler,
                 _,
             >,

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
@@ -1,5 +1,6 @@
 use crate::abundance_rv64i_max::instruction::AbundanceRv64IMaxInstruction;
-use crate::interpreter::{Act4InstructionFetcher, Act4Memory, Act4SystemHandler};
+use crate::interpreter::{Act4Memory, Act4SystemHandler};
+use ab_riscv_interpreter::basic::BasicInstructionFetcher;
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use std::collections::BTreeMap;
@@ -99,7 +100,7 @@ impl Csrs<<AbundanceRv64IMaxInstruction as Instruction>::Reg> for AbundanceRv64I
                 <AbundanceRv64IMaxInstruction as Instruction>::Reg,
                 Self,
                 Act4Memory<0, 0>,
-                Act4InstructionFetcher<AbundanceRv64IMaxInstruction>,
+                BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
                 Act4SystemHandler,
                 _,
             >,
@@ -119,7 +120,7 @@ impl Csrs<<AbundanceRv64IMaxInstruction as Instruction>::Reg> for AbundanceRv64I
                 <AbundanceRv64IMaxInstruction as Instruction>::Reg,
                 Self,
                 Act4Memory<0, 0>,
-                Act4InstructionFetcher<AbundanceRv64IMaxInstruction>,
+                BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
                 Act4SystemHandler,
                 _,
             >,

--- a/crates/execution/ab-riscv-act4-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/interpreter.rs
@@ -127,64 +127,6 @@ impl<const BASE_ADDR: u64, const SIZE: usize> Act4Memory<BASE_ADDR, SIZE> {
     }
 }
 
-pub(crate) struct Act4InstructionFetcher<I>
-where
-    I: Instruction,
-{
-    pc: <I::Reg as Register>::Type,
-}
-
-impl<I, Memory> ProgramCounter<<I::Reg as Register>::Type, Memory> for Act4InstructionFetcher<I>
-where
-    I: Instruction,
-    Memory: VirtualMemory,
-{
-    #[inline(always)]
-    fn get_pc(&self) -> <I::Reg as Register>::Type {
-        self.pc
-    }
-
-    fn set_pc(
-        &mut self,
-        memory: &Memory,
-        pc: <I::Reg as Register>::Type,
-    ) -> Result<ControlFlow<()>, ProgramCounterError<<I::Reg as Register>::Type>> {
-        if !pc.as_u64().is_multiple_of(u64::from(I::alignment())) {
-            return Err(ProgramCounterError::UnalignedInstruction { address: pc });
-        }
-        memory.read::<u32>(pc.as_u64())?;
-        self.pc = pc;
-        Ok(ControlFlow::Continue(()))
-    }
-}
-
-impl<I, Memory> InstructionFetcher<I, Memory> for Act4InstructionFetcher<I>
-where
-    I: Instruction,
-    Memory: VirtualMemory,
-{
-    fn fetch_instruction(
-        &mut self,
-        memory: &Memory,
-    ) -> Result<FetchInstructionResult<I>, ExecutionError<<I::Reg as Register>::Type>> {
-        let instruction = memory.read(self.pc.as_u64())?;
-        let instruction = I::try_decode(instruction)
-            .ok_or(ExecutionError::IllegalInstruction { address: self.pc })?;
-        self.pc += instruction.size().into();
-
-        Ok(FetchInstructionResult::Instruction(instruction))
-    }
-}
-
-impl<I> Act4InstructionFetcher<I>
-where
-    I: Instruction,
-{
-    pub(crate) fn new(pc: <I::Reg as Register>::Type) -> Self {
-        Self { pc }
-    }
-}
-
 pub(crate) struct Act4SystemHandler;
 
 impl<Reg, Memory, PC> SystemInstructionHandler<Reg, Memory, PC> for Act4SystemHandler

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -19,7 +19,8 @@ use crate::abundance_rv32i_max::instruction::AbundanceRv32IMaxInstruction;
 use crate::abundance_rv32i_max::interpreter::AbundanceRv32IMaxExtState;
 use crate::abundance_rv64i_max::instruction::AbundanceRv64IMaxInstruction;
 use crate::abundance_rv64i_max::interpreter::AbundanceRv64IMaxExtState;
-use crate::interpreter::{Act4InstructionFetcher, Act4SystemHandler};
+use crate::interpreter::Act4SystemHandler;
+use ab_riscv_interpreter::basic::BasicInstructionFetcher;
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use anyhow::Context;
@@ -237,7 +238,10 @@ fn run_rv32i_max_test(
         regs: Registers::default(),
         ext_state: AbundanceRv32IMaxExtState::new(),
         memory: ram,
-        instruction_fetcher: Act4InstructionFetcher::<AbundanceRv32IMaxInstruction>::new(elf.entry),
+        instruction_fetcher: BasicInstructionFetcher::<AbundanceRv32IMaxInstruction>::new(
+            // Not used, setting to something that is unlikely to be used
+            0, elf.entry,
+        ),
         system_instruction_handler: Act4SystemHandler,
         custom_error: PhantomData,
     };
@@ -354,7 +358,10 @@ fn run_rv64i_max_test(
         regs: Registers::default(),
         ext_state: AbundanceRv64IMaxExtState::new(),
         memory: ram,
-        instruction_fetcher: Act4InstructionFetcher::<AbundanceRv64IMaxInstruction>::new(elf.entry),
+        instruction_fetcher: BasicInstructionFetcher::<AbundanceRv64IMaxInstruction>::new(
+            // Not used, setting to something that is unlikely to be used
+            0, elf.entry,
+        ),
         system_instruction_handler: Act4SystemHandler,
         custom_error: PhantomData,
     };

--- a/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
+++ b/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
@@ -107,6 +107,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let internal_args_addr = MEMORY_BASE_ADDRESS + MEMORY_SIZE as u64
         - size_of::<Blake3HashChunkInternalArgs>().max(size_of::<Ed25519VerifyInternalArgs>())
             as u64;
+    // Stack pointer must be 16-byte aligned, according to the psABI
+    let stack_pointer = (internal_args_addr - 16).next_multiple_of(16);
     let benchmarks_blake3_hash_chunk_addr = MEMORY_BASE_ADDRESS
         + u64::from(
             *methods
@@ -204,9 +206,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .regs
                     .write(ContractRegister::A0, internal_args_addr);
                 // Stack is between internal arguments and contract memory
-                lazy_state
-                    .regs
-                    .write(ContractRegister::Sp, internal_args_addr);
+                lazy_state.regs.write(ContractRegister::Sp, stack_pointer);
 
                 black_box(execute(black_box(&mut lazy_state))).unwrap();
             });
@@ -224,9 +224,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .regs
                     .write(ContractRegister::A0, internal_args_addr);
                 // Stack is between internal arguments and contract memory
-                eager_state
-                    .regs
-                    .write(ContractRegister::Sp, internal_args_addr);
+                eager_state.regs.write(ContractRegister::Sp, stack_pointer);
 
                 black_box(execute(black_box(&mut eager_state))).unwrap();
             });
@@ -286,9 +284,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .regs
                     .write(ContractRegister::A0, internal_args_addr);
                 // Stack is between internal arguments and contract memory
-                lazy_state
-                    .regs
-                    .write(ContractRegister::Sp, internal_args_addr);
+                lazy_state.regs.write(ContractRegister::Sp, stack_pointer);
 
                 black_box(execute(black_box(&mut lazy_state))).unwrap();
             });
@@ -306,9 +302,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .regs
                     .write(ContractRegister::A0, internal_args_addr);
                 // Stack is between internal arguments and contract memory
-                eager_state
-                    .regs
-                    .write(ContractRegister::Sp, internal_args_addr);
+                eager_state.regs.write(ContractRegister::Sp, stack_pointer);
 
                 black_box(execute(black_box(&mut eager_state))).unwrap();
             });

--- a/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
+++ b/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
@@ -4,7 +4,7 @@
 #![feature(generic_const_exprs)]
 
 use ab_blake3::CHUNK_LEN;
-use ab_contract_file::{ContractFile, ContractInstruction, ContractRegister};
+use ab_contract_file::{ContractFile, ContractRegister};
 use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_riscv_benchmarks::Benchmarks;
 use ab_riscv_benchmarks::host_utils::{
@@ -36,6 +36,15 @@ fn criterion_benchmark(c: &mut Criterion) {
         Ok(())
     })
     .unwrap();
+
+    let benchmarks_blake3_hash_chunk_addr = MEMORY_BASE_ADDRESS
+        + u64::from(
+            *methods
+                .get("benchmarks_blake3_hash_chunk".as_bytes())
+                .unwrap(),
+        );
+    let benchmarks_ed25519_verify_addr = MEMORY_BASE_ADDRESS
+        + u64::from(*methods.get("benchmarks_ed25519_verify".as_bytes()).unwrap());
 
     {
         let mut group = c.benchmark_group("file");
@@ -70,19 +79,21 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
 
         let code = contract_file.get_code();
+        // Decoding is measured through instruction fetcher since that is basically all it does
+        // internally (+ memory allocation)
         group.bench_function("decode-instructions", |b| {
             b.iter(|| {
-                let mut instructions = Vec::with_capacity(code.len() / size_of::<u32>());
-                for instruction in code.chunks_exact(size_of::<u32>()) {
-                    let instruction = u32::from_le_bytes([
-                        instruction[0],
-                        instruction[1],
-                        instruction[2],
-                        instruction[3],
-                    ]);
-                    instructions.push(ContractInstruction::try_decode(instruction).unwrap());
-                }
-                black_box(instructions);
+                // SAFETY: Program counter is set later to the correct address
+                let instruction_fetcher = unsafe {
+                    EagerTestInstructionFetcher::new(
+                        code,
+                        TRAP_ADDRESS,
+                        MEMORY_BASE_ADDRESS
+                            + contract_file.header().read_only_section_memory_size as u64,
+                        benchmarks_blake3_hash_chunk_addr,
+                    )
+                };
+                black_box(instruction_fetcher);
             });
         });
     }
@@ -109,14 +120,6 @@ fn criterion_benchmark(c: &mut Criterion) {
             as u64;
     // Stack pointer must be 16-byte aligned, according to the psABI
     let stack_pointer = (internal_args_addr - 16).next_multiple_of(16);
-    let benchmarks_blake3_hash_chunk_addr = MEMORY_BASE_ADDRESS
-        + u64::from(
-            *methods
-                .get("benchmarks_blake3_hash_chunk".as_bytes())
-                .unwrap(),
-        );
-    let benchmarks_ed25519_verify_addr = MEMORY_BASE_ADDRESS
-        + u64::from(*methods.get("benchmarks_ed25519_verify".as_bytes()).unwrap());
 
     let mut lazy_state = InterpreterState {
         regs: Registers::default(),
@@ -138,19 +141,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         // SAFETY: Program counter is set later to the correct address
         instruction_fetcher: unsafe {
             EagerTestInstructionFetcher::new(
-                contract_file
-                    .get_code()
-                    .chunks_exact(size_of::<u32>())
-                    .map(|instruction| {
-                        let instruction = u32::from_le_bytes([
-                            instruction[0],
-                            instruction[1],
-                            instruction[2],
-                            instruction[3],
-                        ]);
-                        Instruction::try_decode(instruction).unwrap()
-                    })
-                    .collect(),
+                contract_file.get_code(),
                 TRAP_ADDRESS,
                 MEMORY_BASE_ADDRESS + contract_file.header().read_only_section_memory_size as u64,
                 benchmarks_blake3_hash_chunk_addr,

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -276,6 +276,9 @@ where
             return Err(ProgramCounterError::UnalignedInstruction { address: pc });
         }
 
+        // Note: This will not allow reading a 16-bit instruction at the very end of memory range,
+        // but that is going to be the case here anyway since code is followed by read-write memory
+        // anyway
         memory.read::<u32>(pc)?;
 
         self.pc = pc;
@@ -294,7 +297,7 @@ where
         memory: &Memory,
     ) -> Result<FetchInstructionResult<ContractInstruction>, ExecutionError<u64>> {
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
-        // through `Self::set_pc()` method that does bound check. Otherwise, advancing forward by
+        // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
         let instruction = unsafe { memory.read_unchecked(self.pc) };
         // SAFETY: All instructions are valid, according to the constructor contract
@@ -340,7 +343,7 @@ where
 {
     #[inline(always)]
     fn get_pc(&self) -> u64 {
-        self.base_addr + self.instruction_offset as u64 * size_of::<u32>() as u64
+        self.base_addr + self.instruction_offset as u64 * size_of::<u16>() as u64
     }
 
     #[inline]
@@ -355,14 +358,14 @@ where
             return Ok(ControlFlow::Break(()));
         }
 
-        if !address.is_multiple_of(size_of::<u32>() as u64) {
+        if !address.is_multiple_of(size_of::<u16>() as u64) {
             return Err(ProgramCounterError::UnalignedInstruction { address });
         }
 
         let offset = address
             .checked_sub(self.base_addr)
             .ok_or(VirtualMemoryError::OutOfBoundsRead { address })? as usize;
-        let instruction_offset = offset / size_of::<u32>();
+        let instruction_offset = offset / size_of::<u16>();
 
         if instruction_offset >= self.instructions.len() {
             return Err(VirtualMemoryError::OutOfBoundsRead { address }.into());
@@ -384,10 +387,10 @@ where
         _memory: &Memory,
     ) -> Result<FetchInstructionResult<ContractInstruction>, ExecutionError<u64>> {
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
-        // through `Self::set_pc()` method that does bound check. Otherwise, advancing forward by
+        // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
         let instruction = *unsafe { self.instructions.get_unchecked(self.instruction_offset) };
-        self.instruction_offset += usize::from(instruction.size()) / size_of::<u32>();
+        self.instruction_offset += usize::from(instruction.size()) / size_of::<u16>();
 
         Ok(FetchInstructionResult::Instruction(instruction))
     }
@@ -396,8 +399,8 @@ where
 impl EagerTestInstructionFetcher {
     /// Create a new instance with the specified instructions and base address.
     ///
-    /// Instructions are in the same order as they appear in the binary, and the base address
-    /// corresponds to the first instruction.
+    /// Instructions are decoded during instantiation of the instruction fetcher, and the base
+    /// address corresponds to the first instruction.
     ///
     /// `return_trap_address` is the address at which the interpreter will stop execution
     /// (gracefully).
@@ -407,16 +410,83 @@ impl EagerTestInstructionFetcher {
     /// jump instruction.
     #[inline(always)]
     pub unsafe fn new(
-        instructions: Vec<ContractInstruction>,
+        instructions: &[u8],
         return_trap_address: u64,
         base_addr: u64,
         pc: u64,
     ) -> Self {
+        let mut decoded_instructions = Vec::with_capacity(instructions.len() / size_of::<u16>());
+
+        let mut offset = 0;
+        while let Some(instruction_bytes) = instructions.get(offset..offset + size_of::<u32>()) {
+            let decoded_instruction = u32::from_le_bytes([
+                instruction_bytes[0],
+                instruction_bytes[1],
+                instruction_bytes[2],
+                instruction_bytes[3],
+            ]);
+            // TODO: LLVM uses zeroes for padding instead of something like c.nop, maybe
+            //  rewrite during conversion from ELF?:
+            //  https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/497
+            let Some(decoded_instruction) = Instruction::try_decode(decoded_instruction) else {
+                decoded_instructions.push(ContractInstruction::Unimp);
+                offset += 2;
+                continue;
+            };
+            decoded_instructions.push(decoded_instruction);
+            match decoded_instruction.size() {
+                2 => {
+                    offset += 2;
+                }
+                4 => {
+                    // The second half of a 32-bit instruction is a valid offset and may or may not
+                    // decode to a valid instruction on its own. Try to decode it but ignore
+                    // decoding failures.
+
+                    offset += 2;
+
+                    // Could be both 16-bit and 32-bit instruction, need to handle end of the
+                    // instruction stream
+                    let instruction_word = if let Some(instruction_bytes) =
+                        instructions.get(offset..offset + size_of::<u32>())
+                    {
+                        u32::from_le_bytes([
+                            instruction_bytes[0],
+                            instruction_bytes[1],
+                            instruction_bytes[2],
+                            instruction_bytes[3],
+                        ])
+                    } else {
+                        u32::from_le_bytes([instruction_bytes[2], instruction_bytes[3], 0, 0])
+                    };
+
+                    decoded_instructions.push(
+                        Instruction::try_decode(instruction_word)
+                            .unwrap_or(ContractInstruction::Unimp),
+                    );
+                    offset += 2;
+                }
+                instruction_size => {
+                    unreachable!("Invalid instruction size {instruction_size}, expected 2 or 4");
+                }
+            }
+        }
+
+        let remainder_bytes = instructions.get(offset..).unwrap_or(&[]);
+
+        if remainder_bytes.len() == size_of::<u16>() {
+            let instruction_word =
+                u32::from_le_bytes([remainder_bytes[0], remainder_bytes[1], 0, 0]);
+            decoded_instructions.push(
+                Instruction::try_decode(instruction_word).unwrap_or(ContractInstruction::Unimp),
+            );
+        };
+
         Self {
-            instructions,
+            instructions: decoded_instructions,
             return_trap_address,
             base_addr,
-            instruction_offset: (pc - base_addr) as usize / size_of::<u32>(),
+            instruction_offset: (pc - base_addr) as usize / size_of::<u16>(),
         }
     }
 }

--- a/crates/execution/ab-riscv-benchmarks/tests/basic.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/basic.rs
@@ -105,19 +105,7 @@ where
             // SAFETY: Program counter is trusted
             let instruction_fetcher = unsafe {
                 EagerTestInstructionFetcher::new(
-                    contract_file
-                        .get_code()
-                        .chunks_exact(size_of::<u32>())
-                        .map(|instruction| {
-                            let instruction = u32::from_le_bytes([
-                                instruction[0],
-                                instruction[1],
-                                instruction[2],
-                                instruction[3],
-                            ]);
-                            Instruction::try_decode(instruction).unwrap()
-                        })
-                        .collect(),
+                    contract_file.get_code(),
                     TRAP_ADDRESS,
                     MEMORY_BASE_ADDRESS
                         + contract_file.header().read_only_section_memory_size as u64,

--- a/crates/execution/ab-riscv-benchmarks/tests/basic.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/basic.rs
@@ -63,6 +63,8 @@ where
     let mut regs = Registers::default();
     // Internal arguments are the end of the memory region
     let internal_args_addr = MEMORY_BASE_ADDRESS + MEMORY_SIZE as u64 - size_of::<IA>() as u64;
+    // Stack pointer must be 16-byte aligned, according to the psABI
+    let stack_pointer = (internal_args_addr - 16).next_multiple_of(16);
 
     {
         let internal_args = create_internal_args(internal_args_addr);
@@ -79,7 +81,7 @@ where
 
     regs.write(ContractRegister::A0, internal_args_addr);
     // Stack is between internal arguments and contract memory
-    regs.write(ContractRegister::Sp, internal_args_addr);
+    regs.write(ContractRegister::Sp, stack_pointer);
 
     let pc = MEMORY_BASE_ADDRESS + u64::from(*methods.get(method_name.as_bytes()).unwrap());
     let memory = match run_type {

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -1,16 +1,19 @@
 //! Basic implementations of various interpreter traits
 
 use crate::{
-    Address, ExecutionError, FetchInstructionResult, InstructionFetcher, ProgramCounter,
-    ProgramCounterError, VirtualMemory,
+    Address, CustomErrorPlaceholder, ExecutionError, FetchInstructionResult, InstructionFetcher,
+    ProgramCounter, ProgramCounterError, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
 use core::marker::PhantomData;
 use core::ops::ControlFlow;
 
-/// Basic instruction fetcher implementation
+/// Basic instruction fetcher implementation.
+///
+/// Note that it loads instructions from anywhere in memory. This works, but it is likely that you
+/// want to restrict this to a specific executable region of memory.
 #[derive(Debug, Copy, Clone)]
-pub struct BasicInstructionFetcher<I, CustomError>
+pub struct BasicInstructionFetcher<I, CustomError = CustomErrorPlaceholder>
 where
     I: Instruction,
 {
@@ -33,7 +36,7 @@ where
     #[inline]
     fn set_pc(
         &mut self,
-        memory: &Memory,
+        _memory: &Memory,
         pc: Address<I>,
     ) -> Result<ControlFlow<()>, ProgramCounterError<Address<I>, CustomError>> {
         if pc == self.return_trap_address {
@@ -43,8 +46,6 @@ where
         if !pc.as_u64().is_multiple_of(u64::from(I::alignment())) {
             return Err(ProgramCounterError::UnalignedInstruction { address: pc });
         }
-
-        memory.read::<u32>(pc.as_u64())?;
 
         self.pc = pc;
 
@@ -63,12 +64,18 @@ where
         &mut self,
         memory: &Memory,
     ) -> Result<FetchInstructionResult<I>, ExecutionError<Address<I>, CustomError>> {
-        // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
-        // through `Self::set_pc()` method that does bound check. Otherwise, advancing forward by
-        // one instruction can't result in out-of-bounds access.
-        let instruction = unsafe { memory.read_unchecked(self.pc.as_u64()) };
-        // SAFETY: All instructions are valid, according to the constructor contract
-        let instruction = unsafe { I::try_decode(instruction).unwrap_unchecked() };
+        let instruction = memory.read(self.pc.as_u64()).or_else(|error| {
+            // Attempt to read a 16-bit compressed instruction
+            if let Ok(instruction) = memory.read::<u16>(self.pc.as_u64())
+                && (instruction & 0b11) != 0b11
+            {
+                return Ok(u32::from(instruction));
+            }
+            Err(error)
+        })?;
+
+        let instruction = I::try_decode(instruction)
+            .ok_or(ExecutionError::IllegalInstruction { address: self.pc })?;
         self.pc += instruction.size().into();
 
         Ok(FetchInstructionResult::Instruction(instruction))
@@ -83,12 +90,8 @@ where
     ///
     /// `return_trap_address` is the address at which the interpreter will stop execution
     /// (gracefully).
-    ///
-    /// # Safety
-    /// The program counter must be valid and aligned, the instructions processed must be valid and
-    /// end with a jump instruction.
     #[inline(always)]
-    pub unsafe fn new(return_trap_address: Address<I>, pc: Address<I>) -> Self {
+    pub fn new(return_trap_address: Address<I>, pc: Address<I>) -> Self {
         Self {
             return_trap_address,
             pc,

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
@@ -119,7 +119,10 @@ where
     /// Iterator over the absolute register numbers in this list.
     ///
     /// Order matches the spec push/pop order: ra first, then s0 ascending.
-    /// ra=x1, s0=x8, s1=x9, s2=x18..s9=x25, s11=x27 (s10=x26 absent).
+    /// ra=x1, s0=x8, s1=x9, s2=x18..s9=x25, s10=x26, s11=x27.
+    ///
+    /// Note: urlist=15 is {ra, s0-s11} (13 registers, including s10);
+    /// {ra, s0-s10} has no encoding.
     #[inline]
     pub fn reg_list(self) -> impl Iterator<Item = Reg> {
         let regs: &[u8] = match self.inner {
@@ -134,8 +137,7 @@ where
             ZcmpUrlistInner::RaS0S7 => &[1, 8, 9, 18, 19, 20, 21, 22, 23],
             ZcmpUrlistInner::RaS0S8 => &[1, 8, 9, 18, 19, 20, 21, 22, 23, 24],
             ZcmpUrlistInner::RaS0S9 => &[1, 8, 9, 18, 19, 20, 21, 22, 23, 24, 25],
-            // s10(x26) is skipped; urlist=15 saves ra+s0-s9+s11
-            ZcmpUrlistInner::RaS0S11 => &[1, 8, 9, 18, 19, 20, 21, 22, 23, 24, 25, 27],
+            ZcmpUrlistInner::RaS0S11 => &[1, 8, 9, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27],
         };
 
         regs.iter().map(|&bits| {
@@ -277,23 +279,21 @@ where
                 let stack_adj = urlist.stack_adj_base() + spimm * 16;
                 match op_sel {
                     0b00 => Some(Self::CmPush { urlist, stack_adj }),
-                    0b01 => Some(Self::CmPopretz { urlist, stack_adj }),
-                    0b10 => Some(Self::CmPop { urlist, stack_adj }),
+                    0b01 => Some(Self::CmPop { urlist, stack_adj }),
+                    0b10 => Some(Self::CmPopretz { urlist, stack_adj }),
                     0b11 => Some(Self::CmPopret { urlist, stack_adj }),
                     _ => None,
                 }
             }
-            // CM.MVA01S / CM.MVSA01
+            // CM.MVA01S / CM.MVSA01: require bit 10 = 1 (full funct6 = 101_011)
             0b01 => {
-                let which = (inst >> 10) & 1;
-                let r1s_bits = ((inst >> 7) & 0b111) as u8;
-                let funct2b = ((inst >> 5) & 0b11) as u8;
-                let r2s_bits = ((inst >> 2) & 0b111) as u8;
-
-                // funct2b must be 0b11 for both instructions
-                if funct2b != 0b11 {
+                if (inst >> 10) & 1 != 1 {
                     None?;
                 }
+
+                let r1s_bits = ((inst >> 7) & 0b111) as u8;
+                let funct2 = ((inst >> 5) & 0b11) as u8;
+                let r2s_bits = ((inst >> 2) & 0b111) as u8;
 
                 // Reg::from_bits returns None for registers inaccessible in the current ISA
                 // variant. Under RVE this covers field > 1 (i.e. r1sc/r2sc > 1 in the spec
@@ -302,14 +302,17 @@ where
                 let r1s = Reg::from_bits(sreg_bits(r1s_bits))?;
                 let r2s = Reg::from_bits(sreg_bits(r2s_bits))?;
 
-                if which == 1 {
-                    Some(Self::CmMva01s { r1s, r2s })
-                } else {
-                    // CM.MVSA01 requires r1s' != r2s'
-                    if r1s_bits == r2s_bits {
-                        None?;
+                // funct2[6:5]: 0b11 -> CM.MVA01S, 0b01 -> CM.MVSA01, others reserved
+                match funct2 {
+                    0b11 => Some(Self::CmMva01s { r1s, r2s }),
+                    0b01 => {
+                        // CM.MVSA01 requires r1s' != r2s'
+                        if r1s_bits == r2s_bits {
+                            None?;
+                        }
+                        Some(Self::CmMvsa01 { r1s, r2s })
                     }
-                    Some(Self::CmMvsa01 { r1s, r2s })
+                    _ => None,
                 }
             }
             // funct2_12_11 values 0b00 and 0b10 are not defined by Zcmp
@@ -335,22 +338,16 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::CmPush { urlist, stack_adj } => {
-                // Recover the original spimm field for display:
-                // stack_adj = stack_adj_base + spimm * 16
-                let spimm = (stack_adj - urlist.stack_adj_base()) / 16;
-                write!(f, "cm.push {urlist}, -{spimm}")
+                write!(f, "cm.push {urlist}, -{stack_adj}")
             }
             Self::CmPop { urlist, stack_adj } => {
-                let spimm = (stack_adj - urlist.stack_adj_base()) / 16;
-                write!(f, "cm.pop {urlist}, {spimm}")
+                write!(f, "cm.pop {urlist}, {stack_adj}")
             }
             Self::CmPopretz { urlist, stack_adj } => {
-                let spimm = (stack_adj - urlist.stack_adj_base()) / 16;
-                write!(f, "cm.popretz {urlist}, {spimm}")
+                write!(f, "cm.popretz {urlist}, {stack_adj}")
             }
             Self::CmPopret { urlist, stack_adj } => {
-                let spimm = (stack_adj - urlist.stack_adj_base()) / 16;
-                write!(f, "cm.popret {urlist}, {spimm}")
+                write!(f, "cm.popret {urlist}, {stack_adj}")
             }
             Self::CmMva01s { r1s, r2s } => write!(f, "cm.mva01s {r1s}, {r2s}"),
             Self::CmMvsa01 { r1s, r2s } => write!(f, "cm.mvsa01 {r1s}, {r2s}"),

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp/tests.rs
@@ -5,20 +5,34 @@ use crate::instructions::rv32::zce::zcmp::{Rv32ZcmpInstruction, ZcmpUrlist};
 use crate::registers::general_purpose::{EReg, Reg};
 
 /// Build a Zcmp push/pop instruction word.
-/// funct3=101, funct2_12_11=11, op_sel=bits\[10:9], urlist=bits\[7:4], spimm=bits\[3:2].
+///
+/// funct3=101 at bits\[15:13], funct2_12_11=11 at bits\[12:11],
+/// op_sel at bits\[10:9] (00=push, 01=pop, 10=popretz, 11=popret),
+/// urlist at bits\[7:4], spimm at bits\[3:2], quadrant=10.
 const fn make_push_pop(op_sel: u16, urlist: u16, spimm: u16) -> u32 {
     let inst: u16 =
         (0b101 << 13) | (0b11 << 11) | (op_sel << 9) | (urlist << 4) | (spimm << 2) | 0b10;
     u32::from(inst)
 }
 
+/// op_sel values from the Zcmp spec / binutils MATCH_CM_* constants.
+const OP_PUSH: u16 = 0b00;
+const OP_POP: u16 = 0b01;
+const OP_POPRETZ: u16 = 0b10;
+const OP_POPRET: u16 = 0b11;
+
 /// Build a CM.MVA01S or CM.MVSA01 instruction word.
-/// which=1 -> CM.MVA01S, which=0 -> CM.MVSA01.
-const fn make_mv_pair(which: u16, r1s: u16, r2s: u16) -> u32 {
-    let inst: u16 =
-        (0b101 << 13) | (0b01 << 11) | (which << 10) | (r1s << 7) | (0b11 << 5) | (r2s << 2) | 0b10;
+///
+/// Encoding (common): funct3=101 at bits\[15:13], bits\[12:10]=011, bit\[1:0]=10.
+/// r1s' occupies bits\[9:7], r2s' occupies bits\[4:2], and the funct2 field at
+/// bits\[6:5] discriminates: 0b11 -> CM.MVA01S, 0b01 -> CM.MVSA01.
+const fn make_mv_pair(funct2: u16, r1s: u16, r2s: u16) -> u32 {
+    let inst: u16 = (0b101 << 13) | (0b011 << 10) | (r1s << 7) | (funct2 << 5) | (r2s << 2) | 0b10;
     u32::from(inst)
 }
+
+const MV_FUNCT2_MVA01S: u16 = 0b11;
+const MV_FUNCT2_MVSA01: u16 = 0b01;
 
 /// Compute the expected stack_adj for a given urlist raw value and spimm.
 fn expected_stack_adj(urlist_raw: u8, spimm: u32) -> u32 {
@@ -33,7 +47,7 @@ fn expected_stack_adj(urlist_raw: u8, spimm: u32) -> u32 {
 #[test]
 fn test_cm_push_ra_only() {
     // urlist=4 = {ra}, spimm=0 -> stack_adj = 16 + 0 = 16
-    let inst = make_push_pop(0b00, 4, 0);
+    let inst = make_push_pop(OP_PUSH, 4, 0);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -47,7 +61,7 @@ fn test_cm_push_ra_only() {
 #[test]
 fn test_cm_push_ra_s0_s11() {
     // urlist=15 = {ra, s0-s11}, spimm=3 -> stack_adj = 64 + 48 = 112
-    let inst = make_push_pop(0b00, 15, 3);
+    let inst = make_push_pop(OP_PUSH, 15, 3);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -61,7 +75,7 @@ fn test_cm_push_ra_s0_s11() {
 #[test]
 fn test_cm_push_all_valid_urlists() {
     for urlist in 4u16..=15 {
-        let inst = make_push_pop(0b00, urlist, 0);
+        let inst = make_push_pop(OP_PUSH, urlist, 0);
         let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
         assert_eq!(
             decoded,
@@ -78,10 +92,36 @@ fn test_cm_push_all_valid_urlists() {
 fn test_cm_push_reserved_urlist() {
     // urlist 0..=3 are reserved; decoder must return None
     for urlist in 0u16..4 {
-        let inst = make_push_pop(0b00, urlist, 0);
+        let inst = make_push_pop(OP_PUSH, urlist, 0);
         assert!(
             Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none(),
             "urlist={urlist} should be reserved"
+        );
+    }
+}
+
+/// Reference encodings anchored to binutils MATCH_CM_PUSH=0xb802
+/// and a real RP2350 firmware disassembly sample (0xb842 -> cm.push {ra},-16).
+#[test]
+fn test_cm_push_binutils_reference_encodings() {
+    // (raw, urlist_raw, stack_adj_rv32)
+    let cases = &[
+        (0xb842u32, 4, 16),
+        (0xb84e, 4, 64),
+        (0xb882, 8, 32),
+        (0xb88e, 8, 80),
+        (0xb8f2, 15, 64),
+        (0xb8fe, 15, 112),
+    ];
+    for &(raw, urlist_raw, stack_adj) in cases {
+        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv32ZcmpInstruction::CmPush {
+                urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
+                stack_adj,
+            },
+            "raw={raw:#06x}"
         );
     }
 }
@@ -91,7 +131,7 @@ fn test_cm_push_reserved_urlist() {
 #[test]
 fn test_cm_pop_basic() {
     // urlist=5 = {ra, s0}, spimm=1 -> stack_adj = 16 + 16 = 32
-    let inst = make_push_pop(0b10, 5, 1);
+    let inst = make_push_pop(OP_POP, 5, 1);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -105,7 +145,7 @@ fn test_cm_pop_basic() {
 #[test]
 fn test_cm_pop_ra_s0_s9() {
     // urlist=14 = {ra, s0-s9}, spimm=2 -> stack_adj = 48 + 32 = 80
-    let inst = make_push_pop(0b10, 14, 2);
+    let inst = make_push_pop(OP_POP, 14, 2);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -116,13 +156,43 @@ fn test_cm_pop_ra_s0_s9() {
     );
 }
 
+/// Reference encodings anchored to binutils MATCH_CM_POP=0xba02.
+#[test]
+fn test_cm_pop_binutils_reference_encodings() {
+    let cases = &[(0xba56u32, 5, 32), (0xbaea, 14, 80)];
+    for &(raw, urlist_raw, stack_adj) in cases {
+        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv32ZcmpInstruction::CmPop {
+                urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
+                stack_adj,
+            },
+            "raw={raw:#06x}"
+        );
+    }
+}
+
 // CM.POPRETZ
 
 #[test]
 fn test_cm_popretz_basic() {
     // urlist=4 = {ra}, spimm=0 -> stack_adj = 16
-    let inst = make_push_pop(0b01, 4, 0);
+    let inst = make_push_pop(OP_POPRETZ, 4, 0);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    assert_eq!(
+        decoded,
+        Rv32ZcmpInstruction::CmPopretz {
+            urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
+            stack_adj: 16,
+        }
+    );
+}
+
+/// Reference encoding anchored to binutils MATCH_CM_POPRETZ=0xbc02.
+#[test]
+fn test_cm_popretz_binutils_reference_encodings() {
+    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(0xbc42).unwrap();
     assert_eq!(
         decoded,
         Rv32ZcmpInstruction::CmPopretz {
@@ -137,7 +207,7 @@ fn test_cm_popretz_basic() {
 #[test]
 fn test_cm_popret_basic() {
     // urlist=6 = {ra, s0-s1}, spimm=0 -> stack_adj = 16
-    let inst = make_push_pop(0b11, 6, 0);
+    let inst = make_push_pop(OP_POPRET, 6, 0);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -154,7 +224,7 @@ fn test_cm_popret_all_spimm_values() {
     // spimm=0 -> 32, spimm=1 -> 48, spimm=2 -> 64, spimm=3 -> 80
     let expected_adjs = [32, 48, 64, 80];
     for (spimm, &expected) in expected_adjs.iter().enumerate() {
-        let inst = make_push_pop(0b11, 8, spimm as u16);
+        let inst = make_push_pop(OP_POPRET, 8, spimm as u16);
         let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
         assert_eq!(
             decoded,
@@ -167,12 +237,65 @@ fn test_cm_popret_all_spimm_values() {
     }
 }
 
+/// Reference encodings anchored to binutils MATCH_CM_POPRET=0xbe02
+/// and a real RP2350 firmware sample (0xbe42 -> cm.popret {ra},16).
+#[test]
+fn test_cm_popret_binutils_reference_encodings() {
+    // (raw, urlist_raw, stack_adj_rv32)
+    let cases = &[
+        (0xbe42u32, 4, 16),
+        (0xbe62, 6, 16),
+        (0xbe66, 6, 32),
+        (0xbe82, 8, 32),
+        (0xbe8e, 8, 80),
+    ];
+    for &(raw, urlist_raw, stack_adj) in cases {
+        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv32ZcmpInstruction::CmPopret {
+                urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
+                stack_adj,
+            },
+            "raw={raw:#06x}"
+        );
+    }
+}
+
+// Op_sel cross-check: distinct instructions at each op_sel value
+
+#[test]
+fn test_push_pop_op_sel_distinct_variants() {
+    // Same urlist/spimm, each op_sel must decode to a distinct variant.
+    let urlist = 4u16;
+    let spimm = 0u16;
+
+    assert!(matches!(
+        Rv32ZcmpInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_PUSH, urlist, spimm)).unwrap(),
+        Rv32ZcmpInstruction::CmPush { .. }
+    ));
+    assert!(matches!(
+        Rv32ZcmpInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POP, urlist, spimm)).unwrap(),
+        Rv32ZcmpInstruction::CmPop { .. }
+    ));
+    assert!(matches!(
+        Rv32ZcmpInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POPRETZ, urlist, spimm))
+            .unwrap(),
+        Rv32ZcmpInstruction::CmPopretz { .. }
+    ));
+    assert!(matches!(
+        Rv32ZcmpInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POPRET, urlist, spimm))
+            .unwrap(),
+        Rv32ZcmpInstruction::CmPopret { .. }
+    ));
+}
+
 // CM.MVA01S
 
 #[test]
 fn test_cm_mva01s_s0_s1() {
     // r1s field=0 -> s0(x8), r2s field=1 -> s1(x9)
-    let inst = make_mv_pair(1, 0, 1);
+    let inst = make_mv_pair(MV_FUNCT2_MVA01S, 0, 1);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -186,7 +309,7 @@ fn test_cm_mva01s_s0_s1() {
 #[test]
 fn test_cm_mva01s_same_reg() {
     // r1s == r2s is allowed for CM.MVA01S
-    let inst = make_mv_pair(1, 2, 2);
+    let inst = make_mv_pair(MV_FUNCT2_MVA01S, 2, 2);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -211,7 +334,7 @@ fn test_cm_mva01s_all_s_regs() {
         Reg::S7,
     ];
     for (field, &expected) in expected_regs.iter().enumerate() {
-        let inst = make_mv_pair(1, field as u16, 0);
+        let inst = make_mv_pair(MV_FUNCT2_MVA01S, field as u16, 0);
         let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
         if let Rv32ZcmpInstruction::CmMva01s { r1s, .. } = decoded {
             assert_eq!(r1s, expected, "field={field}");
@@ -221,12 +344,36 @@ fn test_cm_mva01s_all_s_regs() {
     }
 }
 
+/// Reference encodings from the binutils gas test suite (zcmp-mv.d).
+/// The mv-pair encoding is XLEN-independent, so RV32 and RV64 share these.
+#[test]
+fn test_cm_mva01s_binutils_reference_encodings() {
+    let cases: &[(u32, Reg<u32>, Reg<u32>)] = &[
+        (0xac7e, Reg::S0, Reg::S7),
+        (0xac7a, Reg::S0, Reg::S6),
+        (0xacfe, Reg::S1, Reg::S7),
+        (0xacfa, Reg::S1, Reg::S6),
+        (0xafee, Reg::S7, Reg::S3),
+        (0xade2, Reg::S3, Reg::S0),
+        (0xaef2, Reg::S5, Reg::S4),
+        (0xaefa, Reg::S5, Reg::S6),
+    ];
+    for &(raw, r1s, r2s) in cases {
+        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv32ZcmpInstruction::CmMva01s { r1s, r2s },
+            "raw={raw:#06x}"
+        );
+    }
+}
+
 // CM.MVSA01
 
 #[test]
 fn test_cm_mvsa01_distinct_regs() {
     // r1s=s0, r2s=s2 (distinct)
-    let inst = make_mv_pair(0, 0, 2);
+    let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 2);
     let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -240,8 +387,53 @@ fn test_cm_mvsa01_distinct_regs() {
 #[test]
 fn test_cm_mvsa01_reserved_same_reg() {
     // r1s == r2s is reserved for CM.MVSA01; decoder must return None
-    let inst = make_mv_pair(0, 3, 3);
+    let inst = make_mv_pair(MV_FUNCT2_MVSA01, 3, 3);
     assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+}
+
+/// Reference encodings from the binutils gas test suite (zcmp-mv.d).
+#[test]
+fn test_cm_mvsa01_binutils_reference_encodings() {
+    let cases: &[(u32, Reg<u32>, Reg<u32>)] = &[
+        (0xafa2, Reg::S7, Reg::S0),
+        (0xaf22, Reg::S6, Reg::S0),
+        (0xafa6, Reg::S7, Reg::S1),
+        (0xaf26, Reg::S6, Reg::S1),
+        (0xadbe, Reg::S3, Reg::S7),
+        (0xada2, Reg::S3, Reg::S0),
+        (0xaeb2, Reg::S5, Reg::S4),
+        (0xaeba, Reg::S5, Reg::S6),
+    ];
+    for &(raw, r1s, r2s) in cases {
+        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv32ZcmpInstruction::CmMvsa01 { r1s, r2s },
+            "raw={raw:#06x}"
+        );
+    }
+}
+
+#[test]
+fn test_cm_mv_reserved_funct2_00() {
+    // funct2[6:5]=00 is reserved for the mv-pair family
+    let inst = make_mv_pair(0b00, 0, 1);
+    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+}
+
+#[test]
+fn test_cm_mv_reserved_funct2_10() {
+    // funct2[6:5]=10 is reserved for the mv-pair family
+    let inst = make_mv_pair(0b10, 0, 1);
+    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+}
+
+#[test]
+fn test_cm_mv_reserved_bit10_zero() {
+    // funct2_12_11=01 with bit 10 = 0 is not a defined Zcmp encoding
+    // (funct6 must be 101_011 for mv-pair)
+    let inst: u16 = (0b101 << 13) | (0b01 << 11) | (0b11 << 5) | 0b10;
+    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
 }
 
 // Wrong quadrant / funct3
@@ -332,15 +524,16 @@ fn test_reg_list_ra_s0_s11() {
         Reg::S7,
         Reg::S8,
         Reg::S9,
+        Reg::S10,
         Reg::S11,
     ]));
 }
 
 #[test]
 fn test_reg_list_count_matches_urlist() {
-    // urlist=4: 1 reg, urlist=5: 2 regs, ..., urlist=14: 11 regs, urlist=15: 12 regs
-    // (urlist=15 has 12 regs but skips s10, so it's not simply raw-3)
-    let expected_counts = [1usize, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    // urlist=4: 1 reg (ra), urlist=5: 2 regs (ra, s0), ..., urlist=14: 11 regs (ra, s0-s9),
+    // urlist=15: 13 regs (ra, s0-s11) - jumps by 2 because {ra, s0-s10} has no encoding
+    let expected_counts = [1usize, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13];
     for (i, &expected) in expected_counts.iter().enumerate() {
         let raw = (i + 4) as u8;
         let urlist = ZcmpUrlist::<Reg<u32>>::try_from_raw(raw).unwrap();
@@ -361,14 +554,14 @@ fn test_rve_urlist_max_is_ra_s0_s1() {
 #[test]
 fn test_rve_push_reserved_urlist() {
     // urlist=7 names s2(x18) which does not exist in RVE
-    let inst = make_push_pop(0b00, 7, 0);
+    let inst = make_push_pop(OP_PUSH, 7, 0);
     assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_rve_mva01s_accessible_regs() {
     // Under RVE only s0(field=0) and s1(field=1) are accessible
-    let inst = make_mv_pair(1, 0, 1);
+    let inst = make_mv_pair(MV_FUNCT2_MVA01S, 0, 1);
     assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_some());
 }
 
@@ -376,14 +569,14 @@ fn test_rve_mva01s_accessible_regs() {
 fn test_rve_mva01s_inaccessible_reg_returns_none() {
     // field=2 maps to s2(x18) which does not exist in RVE;
     // corresponds to r1sc > 1 in the spec reserved() pseudocode
-    let inst = make_mv_pair(1, 2, 0);
+    let inst = make_mv_pair(MV_FUNCT2_MVA01S, 2, 0);
     assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_rve_mvsa01_accessible_regs() {
     // Under RVE, s0 and s1 are distinct and accessible
-    let inst = make_mv_pair(0, 0, 1);
+    let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 1);
     assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_some());
 }
 
@@ -391,6 +584,6 @@ fn test_rve_mvsa01_accessible_regs() {
 fn test_rve_mvsa01_inaccessible_reg_returns_none() {
     // field=2 maps to s2(x18) which does not exist in RVE;
     // corresponds to r2sc > 1 in the spec reserved() pseudocode
-    let inst = make_mv_pair(0, 0, 2);
+    let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 2);
     assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_none());
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
@@ -81,23 +81,21 @@ where
                 let stack_adj = urlist.stack_adj_base() + spimm * 16;
                 match op_sel {
                     0b00 => Some(Self::CmPush { urlist, stack_adj }),
-                    0b01 => Some(Self::CmPopretz { urlist, stack_adj }),
-                    0b10 => Some(Self::CmPop { urlist, stack_adj }),
+                    0b01 => Some(Self::CmPop { urlist, stack_adj }),
+                    0b10 => Some(Self::CmPopretz { urlist, stack_adj }),
                     0b11 => Some(Self::CmPopret { urlist, stack_adj }),
                     _ => None,
                 }
             }
-            // CM.MVA01S / CM.MVSA01
+            // CM.MVA01S / CM.MVSA01: require bit 10 = 1 (full funct6 = 101_011)
             0b01 => {
-                let which = (inst >> 10) & 1;
-                let r1s_bits = ((inst >> 7) & 0b111) as u8;
-                let funct2b = ((inst >> 5) & 0b11) as u8;
-                let r2s_bits = ((inst >> 2) & 0b111) as u8;
-
-                // funct2b must be 0b11 for both instructions
-                if funct2b != 0b11 {
+                if (inst >> 10) & 1 != 1 {
                     None?;
                 }
+
+                let r1s_bits = ((inst >> 7) & 0b111) as u8;
+                let funct2 = ((inst >> 5) & 0b11) as u8;
+                let r2s_bits = ((inst >> 2) & 0b111) as u8;
 
                 // Reg::from_bits returns None for registers inaccessible in the current ISA
                 // variant. Under RVE this covers field > 1 (i.e. r1sc/r2sc > 1 in the spec
@@ -106,14 +104,17 @@ where
                 let r1s = Reg::from_bits(sreg_bits(r1s_bits))?;
                 let r2s = Reg::from_bits(sreg_bits(r2s_bits))?;
 
-                if which == 1 {
-                    Some(Self::CmMva01s { r1s, r2s })
-                } else {
-                    // CM.MVSA01 requires r1s' != r2s'
-                    if r1s_bits == r2s_bits {
-                        None?;
+                // funct2[6:5]: 0b11 -> CM.MVA01S, 0b01 -> CM.MVSA01, others reserved
+                match funct2 {
+                    0b11 => Some(Self::CmMva01s { r1s, r2s }),
+                    0b01 => {
+                        // CM.MVSA01 requires r1s' != r2s'
+                        if r1s_bits == r2s_bits {
+                            None?;
+                        }
+                        Some(Self::CmMvsa01 { r1s, r2s })
                     }
-                    Some(Self::CmMvsa01 { r1s, r2s })
+                    _ => None,
                 }
             }
             // funct2_12_11 values 0b00 and 0b10 are not defined by Zcmp
@@ -139,22 +140,16 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::CmPush { urlist, stack_adj } => {
-                // Recover the original spimm field for display:
-                // stack_adj = stack_adj_base + spimm * 16
-                let spimm = (stack_adj - urlist.stack_adj_base()) / 16;
-                write!(f, "cm.push {urlist}, -{spimm}")
+                write!(f, "cm.push {urlist}, -{stack_adj}")
             }
             Self::CmPop { urlist, stack_adj } => {
-                let spimm = (stack_adj - urlist.stack_adj_base()) / 16;
-                write!(f, "cm.pop {urlist}, {spimm}")
+                write!(f, "cm.pop {urlist}, {stack_adj}")
             }
             Self::CmPopretz { urlist, stack_adj } => {
-                let spimm = (stack_adj - urlist.stack_adj_base()) / 16;
-                write!(f, "cm.popretz {urlist}, {spimm}")
+                write!(f, "cm.popretz {urlist}, {stack_adj}")
             }
             Self::CmPopret { urlist, stack_adj } => {
-                let spimm = (stack_adj - urlist.stack_adj_base()) / 16;
-                write!(f, "cm.popret {urlist}, {spimm}")
+                write!(f, "cm.popret {urlist}, {stack_adj}")
             }
             Self::CmMva01s { r1s, r2s } => write!(f, "cm.mva01s {r1s}, {r2s}"),
             Self::CmMvsa01 { r1s, r2s } => write!(f, "cm.mvsa01 {r1s}, {r2s}"),

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp/tests.rs
@@ -5,20 +5,34 @@ use crate::instructions::rv64::zce::zcmp::{Rv64ZcmpInstruction, ZcmpUrlist};
 use crate::registers::general_purpose::{EReg, Reg};
 
 /// Build a Zcmp push/pop instruction word.
-/// funct3=101, funct2_12_11=11, op_sel=bits\[10:9], urlist=bits\[7:4], spimm=bits\[3:2].
+///
+/// funct3=101 at bits\[15:13], funct2_12_11=11 at bits\[12:11],
+/// op_sel at bits\[10:9] (00=push, 01=pop, 10=popretz, 11=popret),
+/// urlist at bits\[7:4], spimm at bits\[3:2], quadrant=10.
 const fn make_push_pop(op_sel: u16, urlist: u16, spimm: u16) -> u32 {
     let inst: u16 =
         (0b101 << 13) | (0b11 << 11) | (op_sel << 9) | (urlist << 4) | (spimm << 2) | 0b10;
     u32::from(inst)
 }
 
+/// op_sel values from the Zcmp spec / binutils MATCH_CM_* constants.
+const OP_PUSH: u16 = 0b00;
+const OP_POP: u16 = 0b01;
+const OP_POPRETZ: u16 = 0b10;
+const OP_POPRET: u16 = 0b11;
+
 /// Build a CM.MVA01S or CM.MVSA01 instruction word.
-/// which=1 -> CM.MVA01S, which=0 -> CM.MVSA01.
-const fn make_mv_pair(which: u16, r1s: u16, r2s: u16) -> u32 {
-    let inst: u16 =
-        (0b101 << 13) | (0b01 << 11) | (which << 10) | (r1s << 7) | (0b11 << 5) | (r2s << 2) | 0b10;
+///
+/// Encoding (common): funct3=101 at bits\[15:13], bits\[12:10]=011, bit\[1:0]=10.
+/// r1s' occupies bits\[9:7], r2s' occupies bits\[4:2], and the funct2 field at
+/// bits\[6:5] discriminates: 0b11 -> CM.MVA01S, 0b01 -> CM.MVSA01.
+const fn make_mv_pair(funct2: u16, r1s: u16, r2s: u16) -> u32 {
+    let inst: u16 = (0b101 << 13) | (0b011 << 10) | (r1s << 7) | (funct2 << 5) | (r2s << 2) | 0b10;
     u32::from(inst)
 }
+
+const MV_FUNCT2_MVA01S: u16 = 0b11;
+const MV_FUNCT2_MVSA01: u16 = 0b01;
 
 /// Compute the expected stack_adj for a given urlist raw value and spimm.
 fn expected_stack_adj(urlist_raw: u8, spimm: u32) -> u32 {
@@ -33,7 +47,7 @@ fn expected_stack_adj(urlist_raw: u8, spimm: u32) -> u32 {
 #[test]
 fn test_cm_push_ra_only() {
     // urlist=4 = {ra}, spimm=0 -> stack_adj = 16 + 0 = 16
-    let inst = make_push_pop(0b00, 4, 0);
+    let inst = make_push_pop(OP_PUSH, 4, 0);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -47,7 +61,7 @@ fn test_cm_push_ra_only() {
 #[test]
 fn test_cm_push_ra_s0_s11() {
     // urlist=15 = {ra, s0-s11}, spimm=3 -> stack_adj = 112 + 48 = 160
-    let inst = make_push_pop(0b00, 15, 3);
+    let inst = make_push_pop(OP_PUSH, 15, 3);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -61,7 +75,7 @@ fn test_cm_push_ra_s0_s11() {
 #[test]
 fn test_cm_push_all_valid_urlists() {
     for urlist in 4u16..=15 {
-        let inst = make_push_pop(0b00, urlist, 0);
+        let inst = make_push_pop(OP_PUSH, urlist, 0);
         let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
         assert_eq!(
             decoded,
@@ -78,10 +92,36 @@ fn test_cm_push_all_valid_urlists() {
 fn test_cm_push_reserved_urlist() {
     // urlist 0..=3 are reserved; decoder must return None
     for urlist in 0u16..4 {
-        let inst = make_push_pop(0b00, urlist, 0);
+        let inst = make_push_pop(OP_PUSH, urlist, 0);
         assert!(
             Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none(),
             "urlist={urlist} should be reserved"
+        );
+    }
+}
+
+/// Reference encodings anchored to binutils MATCH_CM_PUSH=0xb802
+/// and a real RP2350 firmware disassembly sample (0xb842 -> cm.push {ra},-16).
+#[test]
+fn test_cm_push_binutils_reference_encodings() {
+    // (raw, urlist_raw, stack_adj_rv64)
+    let cases = &[
+        (0xb842u32, 4, 16),
+        (0xb84e, 4, 64),
+        (0xb882, 8, 48),
+        (0xb88e, 8, 96),
+        (0xb8f2, 15, 112),
+        (0xb8fe, 15, 160),
+    ];
+    for &(raw, urlist_raw, stack_adj) in cases {
+        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv64ZcmpInstruction::CmPush {
+                urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
+                stack_adj,
+            },
+            "raw={raw:#06x}"
         );
     }
 }
@@ -91,7 +131,7 @@ fn test_cm_push_reserved_urlist() {
 #[test]
 fn test_cm_pop_basic() {
     // urlist=5 = {ra, s0}, spimm=1 -> stack_adj = 16 + 16 = 32
-    let inst = make_push_pop(0b10, 5, 1);
+    let inst = make_push_pop(OP_POP, 5, 1);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -105,7 +145,7 @@ fn test_cm_pop_basic() {
 #[test]
 fn test_cm_pop_ra_s0_s9() {
     // urlist=14 = {ra, s0-s9}, spimm=2 -> stack_adj = 96 + 32 = 128
-    let inst = make_push_pop(0b10, 14, 2);
+    let inst = make_push_pop(OP_POP, 14, 2);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -116,13 +156,43 @@ fn test_cm_pop_ra_s0_s9() {
     );
 }
 
+/// Reference encodings anchored to binutils MATCH_CM_POP=0xba02.
+#[test]
+fn test_cm_pop_binutils_reference_encodings() {
+    let cases = &[(0xba56u32, 5, 32), (0xbaea, 14, 128)];
+    for &(raw, urlist_raw, stack_adj) in cases {
+        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv64ZcmpInstruction::CmPop {
+                urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
+                stack_adj,
+            },
+            "raw={raw:#06x}"
+        );
+    }
+}
+
 // CM.POPRETZ
 
 #[test]
 fn test_cm_popretz_basic() {
     // urlist=4 = {ra}, spimm=0 -> stack_adj = 16
-    let inst = make_push_pop(0b01, 4, 0);
+    let inst = make_push_pop(OP_POPRETZ, 4, 0);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(
+        decoded,
+        Rv64ZcmpInstruction::CmPopretz {
+            urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
+            stack_adj: 16,
+        }
+    );
+}
+
+/// Reference encoding anchored to binutils MATCH_CM_POPRETZ=0xbc02.
+#[test]
+fn test_cm_popretz_binutils_reference_encodings() {
+    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(0xbc42).unwrap();
     assert_eq!(
         decoded,
         Rv64ZcmpInstruction::CmPopretz {
@@ -137,7 +207,7 @@ fn test_cm_popretz_basic() {
 #[test]
 fn test_cm_popret_basic() {
     // urlist=6 = {ra, s0-s1}, spimm=0 -> stack_adj = 32
-    let inst = make_push_pop(0b11, 6, 0);
+    let inst = make_push_pop(OP_POPRET, 6, 0);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -154,7 +224,7 @@ fn test_cm_popret_all_spimm_values() {
     // spimm=0 -> 48, spimm=1 -> 64, spimm=2 -> 80, spimm=3 -> 96
     let expected_adjs = [48, 64, 80, 96];
     for (spimm, &expected) in expected_adjs.iter().enumerate() {
-        let inst = make_push_pop(0b11, 8, spimm as u16);
+        let inst = make_push_pop(OP_POPRET, 8, spimm as u16);
         let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
         assert_eq!(
             decoded,
@@ -167,12 +237,65 @@ fn test_cm_popret_all_spimm_values() {
     }
 }
 
+/// Reference encodings anchored to binutils MATCH_CM_POPRET=0xbe02
+/// and a real RP2350 firmware sample (0xbe42 -> cm.popret {ra},16).
+#[test]
+fn test_cm_popret_binutils_reference_encodings() {
+    // (raw, urlist_raw, stack_adj_rv64)
+    let cases = &[
+        (0xbe42u32, 4, 16),
+        (0xbe62, 6, 32),
+        (0xbe66, 6, 48),
+        (0xbe82, 8, 48),
+        (0xbe8e, 8, 96),
+    ];
+    for &(raw, urlist_raw, stack_adj) in cases {
+        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv64ZcmpInstruction::CmPopret {
+                urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
+                stack_adj,
+            },
+            "raw={raw:#06x}"
+        );
+    }
+}
+
+// Op_sel cross-check: distinct instructions at each op_sel value
+
+#[test]
+fn test_push_pop_op_sel_distinct_variants() {
+    // Same urlist/spimm, each op_sel must decode to a distinct variant.
+    let urlist = 4u16;
+    let spimm = 0u16;
+
+    assert!(matches!(
+        Rv64ZcmpInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_PUSH, urlist, spimm)).unwrap(),
+        Rv64ZcmpInstruction::CmPush { .. }
+    ));
+    assert!(matches!(
+        Rv64ZcmpInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POP, urlist, spimm)).unwrap(),
+        Rv64ZcmpInstruction::CmPop { .. }
+    ));
+    assert!(matches!(
+        Rv64ZcmpInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POPRETZ, urlist, spimm))
+            .unwrap(),
+        Rv64ZcmpInstruction::CmPopretz { .. }
+    ));
+    assert!(matches!(
+        Rv64ZcmpInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POPRET, urlist, spimm))
+            .unwrap(),
+        Rv64ZcmpInstruction::CmPopret { .. }
+    ));
+}
+
 // CM.MVA01S
 
 #[test]
 fn test_cm_mva01s_s0_s1() {
     // r1s field=0 -> s0(x8), r2s field=1 -> s1(x9)
-    let inst = make_mv_pair(1, 0, 1);
+    let inst = make_mv_pair(MV_FUNCT2_MVA01S, 0, 1);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -186,7 +309,7 @@ fn test_cm_mva01s_s0_s1() {
 #[test]
 fn test_cm_mva01s_same_reg() {
     // r1s == r2s is allowed for CM.MVA01S
-    let inst = make_mv_pair(1, 2, 2);
+    let inst = make_mv_pair(MV_FUNCT2_MVA01S, 2, 2);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -211,7 +334,7 @@ fn test_cm_mva01s_all_s_regs() {
         Reg::S7,
     ];
     for (field, &expected) in expected_regs.iter().enumerate() {
-        let inst = make_mv_pair(1, field as u16, 0);
+        let inst = make_mv_pair(MV_FUNCT2_MVA01S, field as u16, 0);
         let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
         if let Rv64ZcmpInstruction::CmMva01s { r1s, .. } = decoded {
             assert_eq!(r1s, expected, "field={field}");
@@ -221,12 +344,36 @@ fn test_cm_mva01s_all_s_regs() {
     }
 }
 
+/// Reference encodings from the binutils gas test suite (zcmp-mv.d).
+/// Confirms the decoder matches the canonical binutils/gas disassembly.
+#[test]
+fn test_cm_mva01s_binutils_reference_encodings() {
+    let cases: &[(u32, Reg<u64>, Reg<u64>)] = &[
+        (0xac7e, Reg::S0, Reg::S7),
+        (0xac7a, Reg::S0, Reg::S6),
+        (0xacfe, Reg::S1, Reg::S7),
+        (0xacfa, Reg::S1, Reg::S6),
+        (0xafee, Reg::S7, Reg::S3),
+        (0xade2, Reg::S3, Reg::S0),
+        (0xaef2, Reg::S5, Reg::S4),
+        (0xaefa, Reg::S5, Reg::S6),
+    ];
+    for &(raw, r1s, r2s) in cases {
+        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv64ZcmpInstruction::CmMva01s { r1s, r2s },
+            "raw={raw:#06x}"
+        );
+    }
+}
+
 // CM.MVSA01
 
 #[test]
 fn test_cm_mvsa01_distinct_regs() {
     // r1s=s0, r2s=s2 (distinct)
-    let inst = make_mv_pair(0, 0, 2);
+    let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 2);
     let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
@@ -240,8 +387,53 @@ fn test_cm_mvsa01_distinct_regs() {
 #[test]
 fn test_cm_mvsa01_reserved_same_reg() {
     // r1s == r2s is reserved for CM.MVSA01; decoder must return None
-    let inst = make_mv_pair(0, 3, 3);
+    let inst = make_mv_pair(MV_FUNCT2_MVSA01, 3, 3);
     assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+}
+
+/// Reference encodings from the binutils gas test suite (zcmp-mv.d).
+#[test]
+fn test_cm_mvsa01_binutils_reference_encodings() {
+    let cases: &[(u32, Reg<u64>, Reg<u64>)] = &[
+        (0xafa2, Reg::S7, Reg::S0),
+        (0xaf22, Reg::S6, Reg::S0),
+        (0xafa6, Reg::S7, Reg::S1),
+        (0xaf26, Reg::S6, Reg::S1),
+        (0xadbe, Reg::S3, Reg::S7),
+        (0xada2, Reg::S3, Reg::S0),
+        (0xaeb2, Reg::S5, Reg::S4),
+        (0xaeba, Reg::S5, Reg::S6),
+    ];
+    for &(raw, r1s, r2s) in cases {
+        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        assert_eq!(
+            decoded,
+            Rv64ZcmpInstruction::CmMvsa01 { r1s, r2s },
+            "raw={raw:#06x}"
+        );
+    }
+}
+
+#[test]
+fn test_cm_mv_reserved_funct2_00() {
+    // funct2[6:5]=00 is reserved for the mv-pair family
+    let inst = make_mv_pair(0b00, 0, 1);
+    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+}
+
+#[test]
+fn test_cm_mv_reserved_funct2_10() {
+    // funct2[6:5]=10 is reserved for the mv-pair family
+    let inst = make_mv_pair(0b10, 0, 1);
+    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+}
+
+#[test]
+fn test_cm_mv_reserved_bit10_zero() {
+    // funct2_12_11=01 with bit 10 = 0 is not a defined Zcmp encoding
+    // (funct6 must be 101_011 for mv-pair)
+    let inst: u16 = (0b101 << 13) | (0b01 << 11) | (0b11 << 5) | 0b10;
+    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
 }
 
 // Wrong quadrant / funct3
@@ -332,15 +524,16 @@ fn test_reg_list_ra_s0_s11() {
         Reg::S7,
         Reg::S8,
         Reg::S9,
+        Reg::S10,
         Reg::S11,
     ]));
 }
 
 #[test]
 fn test_reg_list_count_matches_urlist() {
-    // urlist=4: 1 reg, urlist=5: 2 regs, ..., urlist=14: 11 regs, urlist=15: 12 regs
-    // (urlist=15 has 12 regs but skips s10, so it's not simply raw-3)
-    let expected_counts = [1usize, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    // urlist=4: 1 reg (ra), urlist=5: 2 regs (ra, s0), ..., urlist=14: 11 regs (ra, s0-s9),
+    // urlist=15: 13 regs (ra, s0-s11) - jumps by 2 because {ra, s0-s10} has no encoding
+    let expected_counts = [1usize, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13];
     for (i, &expected) in expected_counts.iter().enumerate() {
         let raw = (i + 4) as u8;
         let urlist = ZcmpUrlist::<Reg<u64>>::try_from_raw(raw).unwrap();
@@ -361,14 +554,14 @@ fn test_rve_urlist_max_is_ra_s0_s1() {
 #[test]
 fn test_rve_push_reserved_urlist() {
     // urlist=7 names s2(x18) which does not exist in RVE
-    let inst = make_push_pop(0b00, 7, 0);
+    let inst = make_push_pop(OP_PUSH, 7, 0);
     assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_rve_mva01s_accessible_regs() {
     // Under RVE only s0(field=0) and s1(field=1) are accessible
-    let inst = make_mv_pair(1, 0, 1);
+    let inst = make_mv_pair(MV_FUNCT2_MVA01S, 0, 1);
     assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_some());
 }
 
@@ -376,14 +569,14 @@ fn test_rve_mva01s_accessible_regs() {
 fn test_rve_mva01s_inaccessible_reg_returns_none() {
     // field=2 maps to s2(x18) which does not exist in RVE;
     // corresponds to r1sc > 1 in the spec reserved() pseudocode
-    let inst = make_mv_pair(1, 2, 0);
+    let inst = make_mv_pair(MV_FUNCT2_MVA01S, 2, 0);
     assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_rve_mvsa01_accessible_regs() {
     // Under RVE, s0 and s1 are distinct and accessible
-    let inst = make_mv_pair(0, 0, 1);
+    let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 1);
     assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_some());
 }
 
@@ -391,6 +584,6 @@ fn test_rve_mvsa01_accessible_regs() {
 fn test_rve_mvsa01_inaccessible_reg_returns_none() {
     // field=2 maps to s2(x18) which does not exist in RVE;
     // corresponds to r2sc > 1 in the spec reserved() pseudocode
-    let inst = make_mv_pair(0, 0, 2);
+    let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 2);
     assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_none());
 }


### PR DESCRIPTION
This fixes a few things, most notably multiple issues in Zcmp implementation (which is now tested against real code indirectly).

And with those fixes, it enabled compressed instruction support in contracts. While it is significantly less elegant, it is not too bad honestly and performance is about the same too. The contract size however decreases substantially from 42.0 kB to 31.4 kB, which is hard to ignore.

Since performance is not bad at all, I decided that it is fine to support it, at least for now. It'll be possible to remove it later if need be.

This also allows to enable `lto=fat`, which currently causes LLVM to produce RVC binaries (https://github.com/rust-lang/rust/issues/154436).