### PR TITLE
Implement `c.unimp` pseudo-instruction

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/lib.rs
+++ b/crates/contracts/core/ab-contract-file/src/lib.rs
@@ -570,22 +570,11 @@ impl<'a> ContractFile<'a> {
                     });
                 };
 
-                instruction = match ContractInstruction::try_decode(instruction_word) {
-                    Some(instruction) => instruction,
-                    None => {
-                        // TODO: LLVM uses zeroes for padding instead of something like c.nop, maybe
-                        //  rewrite during conversion from ELF?:
-                        //  https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/497
-                        if instruction_word as u16 == 0 {
-                            offset += 2;
-                            continue;
-                        } else {
-                            return Err(ContractFileParseError::InvalidInstruction {
-                                instruction: instruction_word,
-                            });
-                        }
-                    }
-                };
+                instruction = ContractInstruction::try_decode(instruction_word).ok_or(
+                    ContractFileParseError::InvalidInstruction {
+                        instruction: instruction_word,
+                    },
+                )?;
 
                 offset += usize::from(instruction.size());
             }

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -425,14 +425,10 @@ impl EagerTestInstructionFetcher {
                 instruction_bytes[2],
                 instruction_bytes[3],
             ]);
-            // TODO: LLVM uses zeroes for padding instead of something like c.nop, maybe
-            //  rewrite during conversion from ELF?:
-            //  https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/497
-            let Some(decoded_instruction) = Instruction::try_decode(decoded_instruction) else {
-                decoded_instructions.push(ContractInstruction::Unimp);
-                offset += 2;
-                continue;
-            };
+            // Use `Unimp` as a fallback, though contract is expected to only contain legal
+            // instructions
+            let decoded_instruction =
+                Instruction::try_decode(decoded_instruction).unwrap_or(ContractInstruction::Unimp);
             decoded_instructions.push(decoded_instruction);
             match decoded_instruction.size() {
                 2 => {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -186,6 +186,10 @@ where
                 let addr = state.regs.read(Reg::SP).wrapping_add(u32::from(uimm));
                 state.memory.write(u64::from(addr), state.regs.read(rs2))?;
             }
+            Self::CUnimp => {
+                let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
+                return Err(ExecutionError::IllegalInstruction { address: old_pc });
+            }
         }
 
         Ok(ControlFlow::Continue(()))

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
@@ -453,6 +453,18 @@ fn test_cswsp() {
     );
 }
 
+#[test]
+fn test_cunimp() {
+    let mut state = initialize_state([Rv32ZcaInstruction::CUnimp]);
+
+    let result = execute(&mut state);
+
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
 // Memory errors
 
 #[test]

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -204,6 +204,10 @@ where
                 let addr = state.regs.read(Reg::SP).wrapping_add(u64::from(uimm));
                 state.memory.write(addr, state.regs.read(rs2))?;
             }
+            Self::CUnimp => {
+                let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
+                return Err(ExecutionError::IllegalInstruction { address: old_pc });
+            }
         }
 
         Ok(ControlFlow::Continue(()))

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca/tests.rs
@@ -515,3 +515,15 @@ fn test_csd_out_of_bounds() {
     let result = execute(&mut state);
     assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
 }
+
+#[test]
+fn test_cunimp() {
+    let mut state = initialize_state([Rv64ZcaInstruction::CUnimp]);
+
+    let result = execute(&mut state);
+
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
@@ -11,6 +11,7 @@ use core::fmt;
 /// RISC-V RV32 Zca compressed instruction set
 #[instruction]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[rustfmt::skip]
 pub enum Rv32ZcaInstruction<Reg> {
     // Quadrant 00
     /// C.ADDI4SPN  rd' = sp + nzuimm  (nzuimm != 0)
@@ -71,6 +72,9 @@ pub enum Rv32ZcaInstruction<Reg> {
     CAdd { rd: Reg, rs2: Reg },
     /// C.SWSP  mem32\[sp + uimm] = rs2
     CSwsp { rs2: Reg, uimm: u8 },
+
+    // Unimplemented/illegal
+    CUnimp,
 }
 
 #[instruction]
@@ -166,12 +170,17 @@ where
                     let imm3 = (inst >> 5) & 1;
                     let nzuimm = (imm9_6 << 6) | (imm5_4 << 4) | (imm3 << 3) | (imm2 << 2);
                     if nzuimm == 0 {
-                        // Reserved encoding
-                        None?;
+                        if inst == 0 {
+                            Some(Self::CUnimp)
+                        } else {
+                            // Reserved encoding
+                            None
+                        }
+                    } else {
+                        let rd_bits = prime_reg_bits(((inst >> 2) & 0b111) as u8);
+                        let rd = Reg::from_bits(rd_bits)?;
+                        Some(Self::CAddi4spn { rd, nzuimm })
                     }
-                    let rd_bits = prime_reg_bits(((inst >> 2) & 0b111) as u8);
-                    let rd = Reg::from_bits(rd_bits)?;
-                    Some(Self::CAddi4spn { rd, nzuimm })
                 }
                 // C.LW
                 // uimm[5:3] = inst[12:10], uimm[2] = inst[6], uimm[6] = inst[5]
@@ -495,6 +504,7 @@ where
             Self::CJalr { rs1 } => write!(f, "c.jalr {rs1}"),
             Self::CAdd { rd, rs2 } => write!(f, "c.add {rd}, {rs2}"),
             Self::CSwsp { rs2, uimm } => write!(f, "c.swsp {rs2}, {uimm}(sp)"),
+            Self::CUnimp => write!(f, "c.unimp"),
         }
     }
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca/tests.rs
@@ -137,9 +137,11 @@ fn test_caddi4spn_large_uimm() {
 }
 
 #[test]
-fn test_caddi4spn_reserved_zero() {
-    let inst = make_addi4spn(0, 0);
-    assert!(Rv32ZcaInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
+fn test_caddi4spn_nzuimm0_nonzero_rd_reserved() {
+    // nzuimm=0 but rd'=1 (bits[4:2]=001): inst != 0, so reserved -> None
+    // bits[15:13]=000, bits[12:5]=0, bits[4:2]=001, bits[1:0]=00 => 0x0004
+    let inst = 0x0004;
+    assert!(Rv32ZcaInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
@@ -860,6 +862,22 @@ fn test_q10_funct3_111_reserved() {
     // C.FSWSP (Zcf) — not in Zca
     let inst = (0b111 << 13) | (0 << 12) | (10 << 7) | 0b10;
     assert!(Rv32ZcaInstruction::<Reg<u32>>::try_decode(inst).is_none());
+}
+
+// Unimplemented/illegal
+
+#[test]
+fn test_cunimp() {
+    let inst = 0;
+    let decoded = Rv32ZcaInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    assert_eq!(decoded, Rv32ZcaInstruction::CUnimp);
+}
+
+#[test]
+fn test_cunimp_ignores_upper_16_bits() {
+    let inst = 0xABCD_0000;
+    let decoded = Rv32ZcaInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    assert_eq!(decoded, Rv32ZcaInstruction::CUnimp);
 }
 
 // Invalid / Reserved

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
@@ -11,6 +11,7 @@ use core::fmt;
 /// RISC-V RV64 Zca compressed instruction set
 #[instruction]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[rustfmt::skip]
 pub enum Rv64ZcaInstruction<Reg> {
     // Quadrant 00
     /// C.ADDI4SPN  rd' = sp + nzuimm  (nzuimm ∈ 4..1020 step 4)
@@ -83,6 +84,9 @@ pub enum Rv64ZcaInstruction<Reg> {
     CSwsp { rs2: Reg, uimm: u8 },
     /// C.SDSP  mem64\[sp + uimm] = rs2
     CSdsp { rs2: Reg, uimm: u16 },
+
+    // Unimplemented/illegal
+    CUnimp,
 }
 
 #[instruction]
@@ -178,12 +182,17 @@ where
                     let imm3 = (inst >> 5) & 1;
                     let nzuimm = (imm9_6 << 6) | (imm5_4 << 4) | (imm3 << 3) | (imm2 << 2);
                     if nzuimm == 0 {
-                        // Reserved encoding
-                        None?;
+                        if inst == 0 {
+                            Some(Self::CUnimp)
+                        } else {
+                            // Reserved encoding
+                            None
+                        }
+                    } else {
+                        let rd_bits = prime_reg_bits(((inst >> 2) & 0b111) as u8);
+                        let rd = Reg::from_bits(rd_bits)?;
+                        Some(Self::CAddi4spn { rd, nzuimm })
                     }
-                    let rd_bits = prime_reg_bits(((inst >> 2) & 0b111) as u8);
-                    let rd = Reg::from_bits(rd_bits)?;
-                    Some(Self::CAddi4spn { rd, nzuimm })
                 }
                 // C.LW
                 // uimm[5:3] = inst[12:10], uimm[2] = inst[6], uimm[6] = inst[5]
@@ -565,6 +574,7 @@ where
             Self::CAdd { rd, rs2 } => write!(f, "c.add {rd}, {rs2}"),
             Self::CSwsp { rs2, uimm } => write!(f, "c.swsp {rs2}, {uimm}(sp)"),
             Self::CSdsp { rs2, uimm } => write!(f, "c.sdsp {rs2}, {uimm}(sp)"),
+            Self::CUnimp => write!(f, "c.unimp"),
         }
     }
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca/tests.rs
@@ -146,9 +146,11 @@ fn test_caddi4spn_large_uimm() {
 }
 
 #[test]
-fn test_caddi4spn_reserved_zero() {
-    let inst = make_addi4spn(0, 0);
-    assert!(Rv64ZcaInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
+fn test_caddi4spn_nzuimm0_nonzero_rd_reserved() {
+    // nzuimm=0 but rd'=1 (bits[4:2]=001): inst != 0, so reserved -> None
+    // bits[15:13]=000, bits[12:5]=0, bits[4:2]=001, bits[1:0]=00 => 0x0004
+    let inst = 0x0004;
+    assert!(Rv64ZcaInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
@@ -958,6 +960,22 @@ fn test_csdsp_max_uimm() {
             uimm: 504
         }
     );
+}
+
+// Unimplemented/illegal
+
+#[test]
+fn test_cunimp() {
+    let inst = 0;
+    let decoded = Rv64ZcaInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(decoded, Rv64ZcaInstruction::CUnimp);
+}
+
+#[test]
+fn test_cunimp_ignores_upper_16_bits() {
+    let inst = 0xABCD_0000;
+    let decoded = Rv64ZcaInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(decoded, Rv64ZcaInstruction::CUnimp);
 }
 
 // Invalid / Reserved


### PR DESCRIPTION
This is analogous to `unimp` pseudo-instruction already supported by uncompressed ISA, which simplifies handling of instructions elsewhere, but still results in runtime execution error when hit.