### PR TITLE
Replace `state` argument in `ExecutableInstruction::execute()` with explicit arguments

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/contract_instruction_prototype.rs
+++ b/crates/contracts/core/ab-contract-file/src/contract_instruction_prototype.rs
@@ -80,20 +80,19 @@ where
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for ContractInstructionPrototype<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for ContractInstructionPrototype<Reg>
 where
     Reg: Register<Type = u64>,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
@@ -62,19 +62,18 @@ where
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for AbundanceRv32IMaxInstructionPrototype<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for AbundanceRv32IMaxInstructionPrototype<Reg>
 where
     Reg: Register<Type = u32>,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
 {
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
@@ -96,15 +96,11 @@ impl Csrs<<AbundanceRv32IMaxInstruction as Instruction>::Reg> for AbundanceRv32I
     fn process_csr_read(&self, csr_index: u16, raw_value: u32) -> Result<u32, CsrError> {
         let mut out = 0;
         if !<AbundanceRv32IMaxInstruction as ExecutableInstruction<
-            InterpreterState<
-                BasicRegisters<<AbundanceRv32IMaxInstruction as Instruction>::Reg>,
-                Self,
-                Act4Memory<0, 0>,
-                BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
-                Act4SystemHandler,
-                _,
-            >,
-            _,
+            BasicRegisters<<AbundanceRv32IMaxInstruction as Instruction>::Reg>,
+            Self,
+            Act4Memory<0, 0>,
+            BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
+            Act4SystemHandler,
         >>::prepare_csr_read(self, csr_index, raw_value, &mut out)?
         {
             return Err(CsrError::IllegalRead { csr_index });
@@ -116,15 +112,11 @@ impl Csrs<<AbundanceRv32IMaxInstruction as Instruction>::Reg> for AbundanceRv32I
     fn process_csr_write(&mut self, csr_index: u16, write_value: u32) -> Result<u32, CsrError> {
         let mut out = 0;
         if !<AbundanceRv32IMaxInstruction as ExecutableInstruction<
-            InterpreterState<
-                BasicRegisters<<AbundanceRv32IMaxInstruction as Instruction>::Reg>,
-                Self,
-                Act4Memory<0, 0>,
-                BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
-                Act4SystemHandler,
-                _,
-            >,
-            _,
+            BasicRegisters<<AbundanceRv32IMaxInstruction as Instruction>::Reg>,
+            Self,
+            Act4Memory<0, 0>,
+            BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
+            Act4SystemHandler,
         >>::prepare_csr_write(self, csr_index, write_value, &mut out)?
         {
             return Err(CsrError::IllegalWrite { csr_index });

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
@@ -62,19 +62,18 @@ where
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for AbundanceRv64IMaxInstructionPrototype<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for AbundanceRv64IMaxInstructionPrototype<Reg>
 where
     Reg: Register<Type = u64>,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
 {
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
@@ -96,15 +96,11 @@ impl Csrs<<AbundanceRv64IMaxInstruction as Instruction>::Reg> for AbundanceRv64I
     fn process_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError> {
         let mut out = 0;
         if !<AbundanceRv64IMaxInstruction as ExecutableInstruction<
-            InterpreterState<
-                BasicRegisters<<AbundanceRv64IMaxInstruction as Instruction>::Reg>,
-                Self,
-                Act4Memory<0, 0>,
-                BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
-                Act4SystemHandler,
-                _,
-            >,
-            _,
+            BasicRegisters<<AbundanceRv64IMaxInstruction as Instruction>::Reg>,
+            Self,
+            Act4Memory<0, 0>,
+            BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
+            Act4SystemHandler,
         >>::prepare_csr_read(self, csr_index, raw_value, &mut out)?
         {
             return Err(CsrError::IllegalRead { csr_index });
@@ -116,15 +112,11 @@ impl Csrs<<AbundanceRv64IMaxInstruction as Instruction>::Reg> for AbundanceRv64I
     fn process_csr_write(&mut self, csr_index: u16, write_value: u64) -> Result<u64, CsrError> {
         let mut out = 0;
         if !<AbundanceRv64IMaxInstruction as ExecutableInstruction<
-            InterpreterState<
-                BasicRegisters<<AbundanceRv64IMaxInstruction as Instruction>::Reg>,
-                Self,
-                Act4Memory<0, 0>,
-                BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
-                Act4SystemHandler,
-                _,
-            >,
-            _,
+            BasicRegisters<<AbundanceRv64IMaxInstruction as Instruction>::Reg>,
+            Self,
+            Act4Memory<0, 0>,
+            BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
+            Act4SystemHandler,
         >>::prepare_csr_write(self, csr_index, write_value, &mut out)?
         {
             return Err(CsrError::IllegalWrite { csr_index });

--- a/crates/execution/ab-riscv-act4-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/instruction.rs
@@ -48,10 +48,8 @@ where
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for MachineModePlaceholder<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for MachineModePlaceholder<Reg>
 where
     Reg: Register,
 {
@@ -97,7 +95,11 @@ where
 
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -20,7 +20,7 @@ use crate::abundance_rv32i_max::interpreter::AbundanceRv32IMaxExtState;
 use crate::abundance_rv64i_max::instruction::AbundanceRv64IMaxInstruction;
 use crate::abundance_rv64i_max::interpreter::AbundanceRv64IMaxExtState;
 use crate::interpreter::Act4SystemHandler;
-use ab_riscv_interpreter::basic::{BasicInstructionFetcher, BasicRegisters};
+use ab_riscv_interpreter::basic::{BasicInstructionFetcher, BasicInterpreterState, BasicRegisters};
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use anyhow::Context;
@@ -29,7 +29,6 @@ use colored::Colorize;
 use interpreter::Act4Memory;
 use object::{Object, ObjectSegment, ObjectSymbol};
 use std::fs;
-use std::marker::PhantomData;
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 
@@ -234,7 +233,7 @@ fn run_rv32i_max_test(
             .map_err(ExecutionError::from)?;
     }
 
-    let mut state = InterpreterState {
+    let mut state = BasicInterpreterState {
         regs: BasicRegisters::default(),
         ext_state: AbundanceRv32IMaxExtState::new(),
         memory: ram,
@@ -243,7 +242,6 @@ fn run_rv32i_max_test(
             0, elf.entry,
         ),
         system_instruction_handler: Act4SystemHandler,
-        custom_error: PhantomData,
     };
 
     loop {
@@ -313,7 +311,13 @@ fn run_rv32i_max_test(
             }
         };
 
-        match instruction.execute(&mut state) {
+        match instruction.execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        ) {
             Ok(ControlFlow::Continue(())) => {
                 if state
                     .memory
@@ -354,7 +358,7 @@ fn run_rv64i_max_test(
             .map_err(ExecutionError::from)?;
     }
 
-    let mut state = InterpreterState {
+    let mut state = BasicInterpreterState {
         regs: BasicRegisters::default(),
         ext_state: AbundanceRv64IMaxExtState::new(),
         memory: ram,
@@ -363,7 +367,6 @@ fn run_rv64i_max_test(
             0, elf.entry,
         ),
         system_instruction_handler: Act4SystemHandler,
-        custom_error: PhantomData,
     };
 
     loop {
@@ -433,7 +436,13 @@ fn run_rv64i_max_test(
             }
         };
 
-        match instruction.execute(&mut state) {
+        match instruction.execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        ) {
             Ok(ControlFlow::Continue(())) => {
                 if state
                     .memory

--- a/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
+++ b/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
@@ -12,13 +12,12 @@ use ab_riscv_benchmarks::host_utils::{
     LazyInstructionFetcher, NoopRv64SystemInstructionHandler, RISCV_CONTRACT_BYTES, TestMemory,
     execute,
 };
-use ab_riscv_interpreter::basic::BasicRegisters;
+use ab_riscv_interpreter::basic::{BasicInterpreterState, BasicRegisters};
 use ab_riscv_interpreter::prelude::*;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use ed25519_dalek::{Signer, SigningKey};
 use std::collections::HashMap;
 use std::hint::black_box;
-use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::{mem, ptr, slice};
 
@@ -121,7 +120,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Stack pointer must be 16-byte aligned, according to the psABI
     let stack_pointer = (internal_args_addr - 16).next_multiple_of(16);
 
-    let mut lazy_state = InterpreterState {
+    let mut lazy_state = BasicInterpreterState {
         regs: BasicRegisters::default(),
         ext_state: (),
         memory,
@@ -131,10 +130,9 @@ fn criterion_benchmark(c: &mut Criterion) {
             LazyInstructionFetcher::new(TRAP_ADDRESS, MEMORY_BASE_ADDRESS)
         },
         system_instruction_handler: NoopRv64SystemInstructionHandler::default(),
-        custom_error: PhantomData,
     };
 
-    let mut eager_state = InterpreterState {
+    let mut eager_state = BasicInterpreterState {
         regs: BasicRegisters::default(),
         ext_state: (),
         memory,
@@ -148,7 +146,6 @@ fn criterion_benchmark(c: &mut Criterion) {
             )
         },
         system_instruction_handler: NoopRv64SystemInstructionHandler::default(),
-        custom_error: PhantomData,
     };
 
     {

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -5,6 +5,7 @@ use ab_contract_file::ContractInstruction;
 use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_io_type::IoType;
 use ab_io_type::bool::Bool;
+use ab_riscv_interpreter::basic::BasicInterpreterState;
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use alloc::vec::Vec;
@@ -525,7 +526,7 @@ where
 
 /// Execute [`ContractInstruction`]s
 pub fn execute<Regs, Memory, IF>(
-    state: &mut InterpreterState<
+    state: &mut BasicInterpreterState<
         Regs,
         (),
         Memory,
@@ -551,7 +552,13 @@ where
             }
         };
 
-        match instruction.execute(state)? {
+        match instruction.execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )? {
             ControlFlow::Continue(()) => {
                 continue;
             }

--- a/crates/execution/ab-riscv-benchmarks/tests/basic.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/basic.rs
@@ -12,11 +12,10 @@ use ab_riscv_benchmarks::host_utils::{
     LazyInstructionFetcher, NoopRv64SystemInstructionHandler, RISCV_CONTRACT_BYTES, TestMemory,
     execute,
 };
-use ab_riscv_interpreter::basic::BasicRegisters;
+use ab_riscv_interpreter::basic::{BasicInterpreterState, BasicRegisters};
 use ab_riscv_interpreter::prelude::*;
 use ed25519_dalek::{Signer, SigningKey};
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::{mem, ptr, slice};
 
@@ -89,13 +88,12 @@ where
             // SAFETY: Program counter and code are trusted
             let instruction_fetcher = unsafe { LazyInstructionFetcher::new(TRAP_ADDRESS, pc) };
 
-            let mut state = InterpreterState {
+            let mut state = BasicInterpreterState {
                 regs,
                 ext_state: (),
                 memory,
                 instruction_fetcher,
                 system_instruction_handler: NoopRv64SystemInstructionHandler::default(),
-                custom_error: PhantomData,
             };
             execute(&mut state).unwrap();
 
@@ -113,13 +111,12 @@ where
                 )
             };
 
-            let mut state = InterpreterState {
+            let mut state = BasicInterpreterState {
                 regs,
                 ext_state: (),
                 memory,
                 instruction_fetcher,
                 system_instruction_handler: NoopRv64SystemInstructionHandler::default(),
-                custom_error: PhantomData,
             };
             execute(&mut state).unwrap();
 

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -109,6 +109,25 @@ where
     }
 }
 
+/// Basic interpreter state
+#[derive(Debug)]
+pub struct BasicInterpreterState<Regs, ExtState, Memory, IF, InstructionHandler> {
+    /// General purpose registers
+    pub regs: Regs,
+    /// Extended state.
+    ///
+    /// Extensions might use this to place additional constraints on `ExtState` to require
+    /// additional registers or other resources. If no such extension is used, `()` can be used as
+    /// a placeholder.
+    pub ext_state: ExtState,
+    /// Memory
+    pub memory: Memory,
+    /// Instruction fetcher
+    pub instruction_fetcher: IF,
+    /// System instruction handler
+    pub system_instruction_handler: InstructionHandler,
+}
+
 /// Basic instruction fetcher implementation.
 ///
 /// Note that it loads instructions from anywhere in memory. This works, but it is likely that you

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -107,7 +107,6 @@ pub mod zicsr;
 use crate::private::BasicIntSealed;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
-use core::marker::PhantomData;
 use core::ops::{ControlFlow, Sub};
 
 type RegisterType<I> = <<I as Instruction>::Reg as Register>::Type;
@@ -445,37 +444,15 @@ where
     }
 }
 
-/// Base interpreter state
-#[derive(Debug)]
-pub struct InterpreterState<
+/// Trait for executable instructions
+pub trait ExecutableInstruction<
     Regs,
     ExtState,
     Memory,
-    IF,
+    PC,
     InstructionHandler,
     CustomError = CustomErrorPlaceholder,
-> {
-    /// General purpose registers
-    pub regs: Regs,
-    /// Extended state.
-    ///
-    /// Extensions might use this to place additional constraints on `ExtState` to require
-    /// additional registers or other resources. If no such extension is used, `()` can be used as
-    /// a placeholder.
-    pub ext_state: ExtState,
-    /// Memory
-    pub memory: Memory,
-    /// Instruction fetcher
-    pub instruction_fetcher: IF,
-    /// System instruction handler
-    pub system_instruction_handler: InstructionHandler,
-    /// Custom error phantom data
-    pub custom_error: PhantomData<CustomError>,
-}
-
-/// Trait for executable instructions
-pub trait ExecutableInstruction<State, CustomError = CustomErrorPlaceholder>
-where
+> where
     Self: Instruction,
 {
     /// Prepare CSR read.
@@ -542,9 +519,17 @@ where
         Ok(false)
     }
 
-    /// Execute instruction
+    /// Execute instruction.
+    ///
+    /// Instructions might place additional constraints on `ExtState` to require additional
+    /// registers or other resources. If no such constraint is used, `()` can be used as a
+    /// placeholder.
     fn execute(
         self,
-        state: &mut State,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Address<Self>, CustomError>>;
 }

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -30,6 +30,6 @@ pub use crate::v::zve64x::zve64x_helpers;
 pub use crate::zicsr::zicsr_helpers;
 pub use crate::{
     BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError, FetchInstructionResult,
-    InstructionFetcher, InterpreterState, ProgramCounter, ProgramCounterError, RegisterFile,
+    InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
     SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -11,8 +11,8 @@ pub mod zce;
 pub mod zk;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -20,10 +20,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32Instruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32Instruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -34,273 +32,224 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Add { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sub { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).wrapping_sub(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).wrapping_sub(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sll { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x1f;
-                let value = state.regs.read(rs1) << shamt;
-                state.regs.write(rd, value);
+                let shamt = regs.read(rs2) & 0x1f;
+                let value = regs.read(rs1) << shamt;
+                regs.write(rd, value);
             }
             Self::Slt { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).cast_signed() < state.regs.read(rs2).cast_signed();
-                state.regs.write(rd, value as u32);
+                let value = regs.read(rs1).cast_signed() < regs.read(rs2).cast_signed();
+                regs.write(rd, value as u32);
             }
             Self::Sltu { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) < state.regs.read(rs2);
-                state.regs.write(rd, value as u32);
+                let value = regs.read(rs1) < regs.read(rs2);
+                regs.write(rd, value as u32);
             }
             Self::Xor { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) ^ state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) ^ regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::Srl { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x1f;
-                let value = state.regs.read(rs1) >> shamt;
-                state.regs.write(rd, value);
+                let shamt = regs.read(rs2) & 0x1f;
+                let value = regs.read(rs1) >> shamt;
+                regs.write(rd, value);
             }
             Self::Sra { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x1f;
-                let value = state.regs.read(rs1).cast_signed() >> shamt;
-                state.regs.write(rd, value.cast_unsigned());
+                let shamt = regs.read(rs2) & 0x1f;
+                let value = regs.read(rs1).cast_signed() >> shamt;
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Or { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) | state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) | regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::And { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) & state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) & regs.read(rs2);
+                regs.write(rd, value);
             }
 
             Self::Addi { rd, rs1, imm } => {
-                let value = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                regs.write(rd, value);
             }
             Self::Slti { rd, rs1, imm } => {
-                let value = state.regs.read(rs1).cast_signed() < i32::from(imm);
-                state.regs.write(rd, value as u32);
+                let value = regs.read(rs1).cast_signed() < i32::from(imm);
+                regs.write(rd, value as u32);
             }
             Self::Sltiu { rd, rs1, imm } => {
-                let value = state.regs.read(rs1) < i32::from(imm).cast_unsigned();
-                state.regs.write(rd, value as u32);
+                let value = regs.read(rs1) < i32::from(imm).cast_unsigned();
+                regs.write(rd, value as u32);
             }
             Self::Xori { rd, rs1, imm } => {
-                let value = state.regs.read(rs1) ^ i32::from(imm).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) ^ i32::from(imm).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Ori { rd, rs1, imm } => {
-                let value = state.regs.read(rs1) | i32::from(imm).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) | i32::from(imm).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Andi { rd, rs1, imm } => {
-                let value = state.regs.read(rs1) & i32::from(imm).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) & i32::from(imm).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Slli { rd, rs1, shamt } => {
-                let value = state.regs.read(rs1) << shamt;
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) << shamt;
+                regs.write(rd, value);
             }
             Self::Srli { rd, rs1, shamt } => {
-                let value = state.regs.read(rs1) >> shamt;
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) >> shamt;
+                regs.write(rd, value);
             }
             Self::Srai { rd, rs1, shamt } => {
-                let value = state.regs.read(rs1).cast_signed() >> shamt;
-                state.regs.write(rd, value.cast_unsigned());
+                let value = regs.read(rs1).cast_signed() >> shamt;
+                regs.write(rd, value.cast_unsigned());
             }
 
             Self::Lb { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                let value = i32::from(state.memory.read::<i8>(u64::from(addr))?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                let value = i32::from(memory.read::<i8>(u64::from(addr))?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Lh { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                let value = i32::from(state.memory.read::<i16>(u64::from(addr))?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                let value = i32::from(memory.read::<i16>(u64::from(addr))?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Lw { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                let value = state.memory.read::<u32>(u64::from(addr))?;
-                state.regs.write(rd, value);
+                let addr = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                let value = memory.read::<u32>(u64::from(addr))?;
+                regs.write(rd, value);
             }
             Self::Lbu { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                let value = state.memory.read::<u8>(u64::from(addr))?;
-                state.regs.write(rd, value as u32);
+                let addr = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                let value = memory.read::<u8>(u64::from(addr))?;
+                regs.write(rd, value as u32);
             }
             Self::Lhu { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                let value = state.memory.read::<u16>(u64::from(addr))?;
-                state.regs.write(rd, value as u32);
+                let addr = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                let value = memory.read::<u16>(u64::from(addr))?;
+                regs.write(rd, value as u32);
             }
 
             Self::Jalr { rd, rs1, imm } => {
-                let target = (state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned()))
-                    & !1u32;
-                state.regs.write(rd, state.instruction_fetcher.get_pc());
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                let target = (regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned())) & !1u32;
+                regs.write(rd, program_counter.get_pc());
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
 
             Self::Sb { rs2, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                state
-                    .memory
-                    .write(u64::from(addr), state.regs.read(rs2) as u8)?;
+                let addr = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                memory.write(u64::from(addr), regs.read(rs2) as u8)?;
             }
             Self::Sh { rs2, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                state
-                    .memory
-                    .write(u64::from(addr), state.regs.read(rs2) as u16)?;
+                let addr = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                memory.write(u64::from(addr), regs.read(rs2) as u16)?;
             }
             Self::Sw { rs2, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i32::from(imm).cast_unsigned());
-                state.memory.write(u64::from(addr), state.regs.read(rs2))?;
+                let addr = regs.read(rs1).wrapping_add(i32::from(imm).cast_unsigned());
+                memory.write(u64::from(addr), regs.read(rs2))?;
             }
 
             Self::Beq { rs1, rs2, imm } => {
-                if state.regs.read(rs1) == state.regs.read(rs2) {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(&state.memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                if regs.read(rs1) == regs.read(rs2) {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Bne { rs1, rs2, imm } => {
-                if state.regs.read(rs1) != state.regs.read(rs2) {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(&state.memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                if regs.read(rs1) != regs.read(rs2) {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Blt { rs1, rs2, imm } => {
-                if state.regs.read(rs1).cast_signed() < state.regs.read(rs2).cast_signed() {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(&state.memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                if regs.read(rs1).cast_signed() < regs.read(rs2).cast_signed() {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Bge { rs1, rs2, imm } => {
-                if state.regs.read(rs1).cast_signed() >= state.regs.read(rs2).cast_signed() {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(&state.memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                if regs.read(rs1).cast_signed() >= regs.read(rs2).cast_signed() {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Bltu { rs1, rs2, imm } => {
-                if state.regs.read(rs1) < state.regs.read(rs2) {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(&state.memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                if regs.read(rs1) < regs.read(rs2) {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Bgeu { rs1, rs2, imm } => {
-                if state.regs.read(rs1) >= state.regs.read(rs2) {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(&state.memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                if regs.read(rs1) >= regs.read(rs2) {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
 
             Self::Lui { rd, imm } => {
-                state.regs.write(rd, imm.cast_unsigned());
+                regs.write(rd, imm.cast_unsigned());
             }
 
             Self::Auipc { rd, imm } => {
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                state
-                    .regs
-                    .write(rd, old_pc.wrapping_add(imm.cast_unsigned()));
+                let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                regs.write(rd, old_pc.wrapping_add(imm.cast_unsigned()));
             }
 
             Self::Jal { rd, imm } => {
-                let pc = state.instruction_fetcher.get_pc();
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                state.regs.write(rd, pc);
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                let pc = program_counter.get_pc();
+                let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                regs.write(rd, pc);
+                return program_counter
+                    .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
                     .map_err(ExecutionError::from);
             }
 
             Self::Fence { pred, succ } => {
-                state.system_instruction_handler.handle_fence(pred, succ);
+                system_instruction_handler.handle_fence(pred, succ);
             }
             Self::FenceTso => {
-                state.system_instruction_handler.handle_fence_tso();
+                system_instruction_handler.handle_fence_tso();
             }
 
             Self::Ecall => {
-                return state.system_instruction_handler.handle_ecall(
-                    &mut state.regs,
-                    &mut state.memory,
-                    &mut state.instruction_fetcher,
-                );
+                return system_instruction_handler.handle_ecall(regs, memory, program_counter);
             }
             Self::Ebreak => {
-                state.system_instruction_handler.handle_ebreak(
-                    &mut state.regs,
-                    &mut state.memory,
-                    state.instruction_fetcher.get_pc(),
-                );
+                system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
             }
 
             Self::Unimp => {
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
+                let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 return Err(ExecutionError::IllegalInstruction { address: old_pc });
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
@@ -6,24 +6,26 @@ pub mod zbc;
 pub mod zbs;
 
 use crate::rv32::b::zbb::rv32_zbb_helpers;
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32BInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32BInstruction<Reg>
 where
     Reg: Register<Type = u32>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
@@ -3,17 +3,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZbaInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZbaInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -21,20 +19,24 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Sh1add { rd, rs1, rs2 } => {
-                let value = (state.regs.read(rs1) << 1).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = (regs.read(rs1) << 1).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sh2add { rd, rs1, rs2 } => {
-                let value = (state.regs.read(rs1) << 2).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = (regs.read(rs1) << 2).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sh3add { rd, rs1, rs2 } => {
-                let value = (state.regs.read(rs1) << 3).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = (regs.read(rs1) << 3).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
@@ -4,17 +4,15 @@ pub mod rv32_zbb_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZbbInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZbbInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -22,87 +20,91 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Andn { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) & !state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) & !regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::Orn { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) | !state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) | !regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::Xnor { rd, rs1, rs2 } => {
-                let value = !(state.regs.read(rs1) ^ state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = !(regs.read(rs1) ^ regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Clz { rd, rs1 } => {
-                let value = state.regs.read(rs1).leading_zeros();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).leading_zeros();
+                regs.write(rd, value);
             }
             Self::Ctz { rd, rs1 } => {
-                let value = state.regs.read(rs1).trailing_zeros();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).trailing_zeros();
+                regs.write(rd, value);
             }
             Self::Cpop { rd, rs1 } => {
-                let value = state.regs.read(rs1).count_ones();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).count_ones();
+                regs.write(rd, value);
             }
             Self::Max { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1).cast_signed();
-                let b = state.regs.read(rs2).cast_signed();
+                let a = regs.read(rs1).cast_signed();
+                let b = regs.read(rs2).cast_signed();
                 let value = a.max(b).cast_unsigned();
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Maxu { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).max(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).max(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Min { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1).cast_signed();
-                let b = state.regs.read(rs2).cast_signed();
+                let a = regs.read(rs1).cast_signed();
+                let b = regs.read(rs2).cast_signed();
                 let value = a.min(b).cast_unsigned();
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Minu { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).min(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).min(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sextb { rd, rs1 } => {
-                let value = i32::from(state.regs.read(rs1) as i8).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = i32::from(regs.read(rs1) as i8).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Sexth { rd, rs1 } => {
-                let value = i32::from(state.regs.read(rs1) as i16).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = i32::from(regs.read(rs1) as i16).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Zexth { rd, rs1 } => {
-                let value = u32::from(state.regs.read(rs1) as u16);
-                state.regs.write(rd, value);
+                let value = u32::from(regs.read(rs1) as u16);
+                regs.write(rd, value);
             }
             Self::Rol { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x1f;
-                let value = state.regs.read(rs1).rotate_left(shamt);
-                state.regs.write(rd, value);
+                let shamt = regs.read(rs2) & 0x1f;
+                let value = regs.read(rs1).rotate_left(shamt);
+                regs.write(rd, value);
             }
             Self::Ror { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x1f;
-                let value = state.regs.read(rs1).rotate_right(shamt);
-                state.regs.write(rd, value);
+                let shamt = regs.read(rs2) & 0x1f;
+                let value = regs.read(rs1).rotate_right(shamt);
+                regs.write(rd, value);
             }
             Self::Rori { rd, rs1, shamt } => {
-                let value = state.regs.read(rs1).rotate_right(u32::from(shamt & 0x1f));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).rotate_right(u32::from(shamt & 0x1f));
+                regs.write(rd, value);
             }
             Self::Orcb { rd, rs1 } => {
-                let src = state.regs.read(rs1);
+                let src = regs.read(rs1);
 
-                state.regs.write(rd, rv32_zbb_helpers::orc_b(src));
+                regs.write(rd, rv32_zbb_helpers::orc_b(src));
             }
             Self::Rev8 { rd, rs1 } => {
-                let value = state.regs.read(rs1).swap_bytes();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).swap_bytes();
+                regs.write(rd, value);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
@@ -4,17 +4,15 @@ pub mod rv32_zbc_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZbcInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZbcInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -22,26 +20,30 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Clmul { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1);
-                let b = state.regs.read(rs2);
+                let a = regs.read(rs1);
+                let b = regs.read(rs2);
 
-                state.regs.write(rd, rv32_zbc_helpers::clmul(a, b));
+                regs.write(rd, rv32_zbc_helpers::clmul(a, b));
             }
             Self::Clmulh { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1);
-                let b = state.regs.read(rs2);
+                let a = regs.read(rs1);
+                let b = regs.read(rs2);
 
-                state.regs.write(rd, rv32_zbc_helpers::clmulh(a, b));
+                regs.write(rd, rv32_zbc_helpers::clmulh(a, b));
             }
             Self::Clmulr { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1);
-                let b = state.regs.read(rs2);
+                let a = regs.read(rs1);
+                let b = regs.read(rs2);
 
-                state.regs.write(rd, rv32_zbc_helpers::clmulr(a, b));
+                regs.write(rd, rv32_zbc_helpers::clmulr(a, b));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
@@ -3,17 +3,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZbsInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZbsInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -21,49 +19,53 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Bset { rd, rs1, rs2 } => {
                 // Only the bottom 5 bits for RV32
-                let index = state.regs.read(rs2) & 0x1f;
-                let result = state.regs.read(rs1) | (1u32 << index);
-                state.regs.write(rd, result);
+                let index = regs.read(rs2) & 0x1f;
+                let result = regs.read(rs1) | (1u32 << index);
+                regs.write(rd, result);
             }
             Self::Bseti { rd, rs1, shamt } => {
                 let index = shamt;
-                let result = state.regs.read(rs1) | (1u32 << index);
-                state.regs.write(rd, result);
+                let result = regs.read(rs1) | (1u32 << index);
+                regs.write(rd, result);
             }
             Self::Bclr { rd, rs1, rs2 } => {
-                let index = state.regs.read(rs2) & 0x1f;
-                let result = state.regs.read(rs1) & !(1u32 << index);
-                state.regs.write(rd, result);
+                let index = regs.read(rs2) & 0x1f;
+                let result = regs.read(rs1) & !(1u32 << index);
+                regs.write(rd, result);
             }
             Self::Bclri { rd, rs1, shamt } => {
                 let index = shamt;
-                let result = state.regs.read(rs1) & !(1u32 << index);
-                state.regs.write(rd, result);
+                let result = regs.read(rs1) & !(1u32 << index);
+                regs.write(rd, result);
             }
             Self::Binv { rd, rs1, rs2 } => {
-                let index = state.regs.read(rs2) & 0x1f;
-                let result = state.regs.read(rs1) ^ (1u32 << index);
-                state.regs.write(rd, result);
+                let index = regs.read(rs2) & 0x1f;
+                let result = regs.read(rs1) ^ (1u32 << index);
+                regs.write(rd, result);
             }
             Self::Binvi { rd, rs1, shamt } => {
                 let index = shamt;
-                let result = state.regs.read(rs1) ^ (1u32 << index);
-                state.regs.write(rd, result);
+                let result = regs.read(rs1) ^ (1u32 << index);
+                regs.write(rd, result);
             }
             Self::Bext { rd, rs1, rs2 } => {
-                let index = state.regs.read(rs2) & 0x1f;
-                let result = (state.regs.read(rs1) >> index) & 1;
-                state.regs.write(rd, result);
+                let index = regs.read(rs2) & 0x1f;
+                let result = (regs.read(rs1) >> index) & 1;
+                regs.write(rd, result);
             }
             Self::Bexti { rd, rs1, shamt } => {
                 let index = shamt;
-                let result = (state.regs.read(rs1) >> index) & 1;
-                state.regs.write(rd, result);
+                let result = (regs.read(rs1) >> index) & 1;
+                regs.write(rd, result);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -4,8 +4,8 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -13,10 +13,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZcaInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZcaInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -27,167 +25,145 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // Quadrant 00
             Self::CAddi4spn { rd, nzuimm } => {
-                let sp_val = state.regs.read(Reg::SP);
-                state.regs.write(rd, sp_val.wrapping_add(u32::from(nzuimm)));
+                let sp_val = regs.read(Reg::SP);
+                regs.write(rd, sp_val.wrapping_add(u32::from(nzuimm)));
             }
             Self::CLw { rd, rs1, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u32::from(uimm));
-                let value = state.memory.read::<i32>(u64::from(addr))?.cast_unsigned();
-                state.regs.write(rd, value);
+                let addr = regs.read(rs1).wrapping_add(u32::from(uimm));
+                let value = memory.read::<i32>(u64::from(addr))?.cast_unsigned();
+                regs.write(rd, value);
             }
             Self::CSw { rs1, rs2, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u32::from(uimm));
-                state.memory.write(u64::from(addr), state.regs.read(rs2))?;
+                let addr = regs.read(rs1).wrapping_add(u32::from(uimm));
+                memory.write(u64::from(addr), regs.read(rs2))?;
             }
 
             // Quadrant 01
             Self::CNop => {}
             Self::CAddi { rd, nzimm } => {
-                let value = state
-                    .regs
-                    .read(rd)
-                    .wrapping_add(i32::from(nzimm).cast_unsigned());
-                state.regs.write(rd, value);
+                let value = regs.read(rd).wrapping_add(i32::from(nzimm).cast_unsigned());
+                regs.write(rd, value);
             }
             Self::CJal { imm } => {
-                let return_addr = state.instruction_fetcher.get_pc();
-                state.regs.write(Reg::RA, return_addr);
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
-                return state
-                    .instruction_fetcher
-                    .set_pc(
-                        &state.memory,
-                        old_pc.wrapping_add(i32::from(imm).cast_unsigned()),
-                    )
+                let return_addr = program_counter.get_pc();
+                regs.write(Reg::RA, return_addr);
+                let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
+                return program_counter
+                    .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
                     .map_err(ExecutionError::from);
             }
             Self::CLi { rd, imm } => {
-                state.regs.write(rd, i32::from(imm).cast_unsigned());
+                regs.write(rd, i32::from(imm).cast_unsigned());
             }
             Self::CAddi16sp { nzimm } => {
-                let value = state
-                    .regs
+                let value = regs
                     .read(Reg::SP)
                     .wrapping_add(i32::from(nzimm).cast_unsigned());
-                state.regs.write(Reg::SP, value);
+                regs.write(Reg::SP, value);
             }
             Self::CLui { rd, nzimm } => {
-                state.regs.write(rd, nzimm.cast_unsigned());
+                regs.write(rd, nzimm.cast_unsigned());
             }
             Self::CSrli { rd, shamt } => {
-                let value = state.regs.read(rd) >> shamt;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) >> shamt;
+                regs.write(rd, value);
             }
             Self::CSrai { rd, shamt } => {
-                let value = state.regs.read(rd).cast_signed() >> shamt;
-                state.regs.write(rd, value.cast_unsigned());
+                let value = regs.read(rd).cast_signed() >> shamt;
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CAndi { rd, imm } => {
-                let value = state.regs.read(rd) & i32::from(imm).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & i32::from(imm).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::CSub { rd, rs2 } => {
-                let value = state.regs.read(rd).wrapping_sub(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rd).wrapping_sub(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::CXor { rd, rs2 } => {
-                let value = state.regs.read(rd) ^ state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rd) ^ regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::COr { rd, rs2 } => {
-                let value = state.regs.read(rd) | state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rd) | regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::CAnd { rd, rs2 } => {
-                let value = state.regs.read(rd) & state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::CJ { imm } => {
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
-                return state
-                    .instruction_fetcher
-                    .set_pc(
-                        &state.memory,
-                        old_pc.wrapping_add(i32::from(imm).cast_unsigned()),
-                    )
+                let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
+                return program_counter
+                    .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
                     .map_err(ExecutionError::from);
             }
             Self::CBeqz { rs1, imm } => {
-                if state.regs.read(rs1) == 0 {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i32::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1) == 0 {
+                    let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::CBnez { rs1, imm } => {
-                if state.regs.read(rs1) != 0 {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i32::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1) != 0 {
+                    let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
 
             // Quadrant 10
             Self::CSlli { rd, shamt } => {
-                let value = state.regs.read(rd) << shamt;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) << shamt;
+                regs.write(rd, value);
             }
             Self::CLwsp { rd, uimm } => {
-                let addr = state.regs.read(Reg::SP).wrapping_add(u32::from(uimm));
-                let value = state.memory.read::<i32>(u64::from(addr))?.cast_unsigned();
-                state.regs.write(rd, value);
+                let addr = regs.read(Reg::SP).wrapping_add(u32::from(uimm));
+                let value = memory.read::<i32>(u64::from(addr))?.cast_unsigned();
+                regs.write(rd, value);
             }
             Self::CJr { rs1 } => {
-                let target = state.regs.read(rs1) & !1;
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                let target = regs.read(rs1) & !1;
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
             Self::CMv { rd, rs2 } => {
-                state.regs.write(rd, state.regs.read(rs2));
+                regs.write(rd, regs.read(rs2));
             }
             Self::CEbreak => {
-                state.system_instruction_handler.handle_ebreak(
-                    &mut state.regs,
-                    &mut state.memory,
-                    state.instruction_fetcher.get_pc(),
-                );
+                system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
             }
             Self::CJalr { rs1 } => {
-                let target = state.regs.read(rs1) & !1;
-                let return_addr = state.instruction_fetcher.get_pc();
-                state.regs.write(Reg::RA, return_addr);
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                let target = regs.read(rs1) & !1;
+                let return_addr = program_counter.get_pc();
+                regs.write(Reg::RA, return_addr);
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
             Self::CAdd { rd, rs2 } => {
-                let value = state.regs.read(rd).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rd).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::CSwsp { rs2, uimm } => {
-                let addr = state.regs.read(Reg::SP).wrapping_add(u32::from(uimm));
-                state.memory.write(u64::from(addr), state.regs.read(rs2))?;
+                let addr = regs.read(Reg::SP).wrapping_add(u32::from(uimm));
+                memory.write(u64::from(addr), regs.read(rs2))?;
             }
             Self::CUnimp => {
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
+                let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
                 return Err(ExecutionError::IllegalInstruction { address: old_pc });
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
@@ -99,7 +99,13 @@ fn test_cjal_negative_offset() {
         instruction
     };
     instruction
-        .execute(&mut state)
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
         .unwrap()
         .continue_ok()
         .unwrap();

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
@@ -4,17 +4,15 @@
 mod tests;
 pub mod zmmul;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32MInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32MInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -22,38 +20,40 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Mul { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).wrapping_mul(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).wrapping_mul(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Mulh { rd, rs1, rs2 } => {
                 // Signed × signed: widen to i64, take upper 32 bits
-                let (_lo, prod) = state
-                    .regs
+                let (_lo, prod) = regs
                     .read(rs1)
                     .cast_signed()
-                    .widening_mul(state.regs.read(rs2).cast_signed());
-                state.regs.write(rd, prod.cast_unsigned());
+                    .widening_mul(regs.read(rs2).cast_signed());
+                regs.write(rd, prod.cast_unsigned());
             }
             Self::Mulhsu { rd, rs1, rs2 } => {
                 // Signed × unsigned: widen to i64, take upper 32 bits
-                let prod =
-                    i64::from(state.regs.read(rs1).cast_signed()) * i64::from(state.regs.read(rs2));
+                let prod = i64::from(regs.read(rs1).cast_signed()) * i64::from(regs.read(rs2));
                 let value = prod >> 32;
-                state.regs.write(rd, value.cast_unsigned() as u32);
+                regs.write(rd, value.cast_unsigned() as u32);
             }
             Self::Mulhu { rd, rs1, rs2 } => {
                 // Unsigned × unsigned: widen to u64, take upper 32 bits
-                let prod = u64::from(state.regs.read(rs1)) * u64::from(state.regs.read(rs2));
+                let prod = u64::from(regs.read(rs1)) * u64::from(regs.read(rs2));
                 let value = prod >> 32;
-                state.regs.write(rd, value as u32);
+                regs.write(rd, value as u32);
             }
             Self::Div { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1).cast_signed();
-                let divisor = state.regs.read(rs2).cast_signed();
+                let dividend = regs.read(rs1).cast_signed();
+                let divisor = regs.read(rs2).cast_signed();
                 let value = if divisor == 0 {
                     -1i32
                 } else if dividend == i32::MIN && divisor == -1 {
@@ -61,17 +61,17 @@ where
                 } else {
                     dividend / divisor
                 };
-                state.regs.write(rd, value.cast_unsigned());
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Divu { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1);
-                let divisor = state.regs.read(rs2);
+                let dividend = regs.read(rs1);
+                let divisor = regs.read(rs2);
                 let value = dividend.checked_div(divisor).unwrap_or(u32::MAX);
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Rem { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1).cast_signed();
-                let divisor = state.regs.read(rs2).cast_signed();
+                let dividend = regs.read(rs1).cast_signed();
+                let divisor = regs.read(rs2).cast_signed();
                 let value = if divisor == 0 {
                     dividend
                 } else if dividend == i32::MIN && divisor == -1 {
@@ -79,17 +79,17 @@ where
                 } else {
                     dividend % divisor
                 };
-                state.regs.write(rd, value.cast_unsigned());
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Remu { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1);
-                let divisor = state.regs.read(rs2);
+                let dividend = regs.read(rs1);
+                let divisor = regs.read(rs2);
                 let value = if divisor == 0 {
                     dividend
                 } else {
                     dividend % divisor
                 };
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
@@ -1,23 +1,25 @@
 //! RV32 Zmmul extension (multiplication subset of M extension)
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZmmulInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZmmulInstruction<Reg>
 where
     Reg: Register<Type = u32>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -1,15 +1,14 @@
 extern crate alloc;
 
-use crate::basic::BasicRegisters;
+use crate::basic::{BasicInterpreterState, BasicRegisters};
 use crate::{
-    Address, BasicInt, CustomErrorPlaceholder, ExecutableInstruction, ExecutionError,
-    FetchInstructionResult, InstructionFetcher, InterpreterState, ProgramCounter,
-    ProgramCounterError, RegisterFile, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    Address, BasicInt, ExecutableInstruction, ExecutionError, FetchInstructionResult,
+    InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
+    SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 use core::ops::ControlFlow;
 
 pub(crate) const TEST_BASE_ADDR: u32 = 0x1000;
@@ -257,7 +256,7 @@ where
     }
 }
 
-pub(crate) type TestInterpreterState<Instruction> = InterpreterState<
+pub(crate) type TestInterpreterState<Instruction> = BasicInterpreterState<
     BasicRegisters<Reg<u32>>,
     (),
     TestMemory,
@@ -272,7 +271,7 @@ where
     I: Instruction<Reg = Reg<u32>>,
     Instructions: IntoIterator<Item = I>,
 {
-    InterpreterState {
+    BasicInterpreterState {
         regs: BasicRegisters::default(),
         ext_state: (),
         memory: TestMemory::new(8192, u64::from(TEST_BASE_ADDR)),
@@ -283,7 +282,6 @@ where
             TEST_BASE_ADDR,
         ),
         system_instruction_handler: TestInstructionHandler,
-        custom_error: PhantomData,
     }
 }
 
@@ -292,7 +290,13 @@ pub(crate) fn execute<I>(
 ) -> Result<(), ExecutionError<Address<I>>>
 where
     I: Instruction<Reg = Reg<u32>>
-        + ExecutableInstruction<TestInterpreterState<I>, CustomErrorPlaceholder>,
+        + ExecutableInstruction<
+            BasicRegisters<Reg<u32>>,
+            (),
+            TestMemory,
+            TestInstructionFetcher<I>,
+            TestInstructionHandler,
+        >,
 {
     loop {
         let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory)? {
@@ -305,7 +309,13 @@ where
             }
         };
 
-        match instruction.execute(state)? {
+        match instruction.execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )? {
             ControlFlow::Continue(()) => {
                 continue;
             }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -6,8 +6,8 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -15,10 +15,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZcbInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZcbInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -29,55 +27,59 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::CLbu { rd, rs1, uimm } => {
-                let addr = u64::from(state.regs.read(rs1).wrapping_add(u32::from(uimm)));
-                let value = state.memory.read::<u8>(addr)?;
-                state.regs.write(rd, u32::from(value));
+                let addr = u64::from(regs.read(rs1).wrapping_add(u32::from(uimm)));
+                let value = memory.read::<u8>(addr)?;
+                regs.write(rd, u32::from(value));
             }
             Self::CLh { rd, rs1, uimm } => {
-                let addr = u64::from(state.regs.read(rs1).wrapping_add(u32::from(uimm)));
-                let value = i32::from(state.memory.read::<i16>(addr)?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = u64::from(regs.read(rs1).wrapping_add(u32::from(uimm)));
+                let value = i32::from(memory.read::<i16>(addr)?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CLhu { rd, rs1, uimm } => {
-                let addr = u64::from(state.regs.read(rs1).wrapping_add(u32::from(uimm)));
-                let value = state.memory.read::<u16>(addr)?;
-                state.regs.write(rd, u32::from(value));
+                let addr = u64::from(regs.read(rs1).wrapping_add(u32::from(uimm)));
+                let value = memory.read::<u16>(addr)?;
+                regs.write(rd, u32::from(value));
             }
             Self::CSb { rs1, rs2, uimm } => {
-                let addr = u64::from(state.regs.read(rs1).wrapping_add(u32::from(uimm)));
-                state.memory.write(addr, state.regs.read(rs2) as u8)?;
+                let addr = u64::from(regs.read(rs1).wrapping_add(u32::from(uimm)));
+                memory.write(addr, regs.read(rs2) as u8)?;
             }
             Self::CSh { rs1, rs2, uimm } => {
-                let addr = u64::from(state.regs.read(rs1).wrapping_add(u32::from(uimm)));
-                state.memory.write(addr, state.regs.read(rs2) as u16)?;
+                let addr = u64::from(regs.read(rs1).wrapping_add(u32::from(uimm)));
+                memory.write(addr, regs.read(rs2) as u16)?;
             }
             Self::CZextB { rd } => {
-                let value = state.regs.read(rd) & 0xff;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & 0xff;
+                regs.write(rd, value);
             }
             Self::CSextB { rd } => {
-                let value = i32::from(state.regs.read(rd) as i8);
-                state.regs.write(rd, value.cast_unsigned());
+                let value = i32::from(regs.read(rd) as i8);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CZextH { rd } => {
-                let value = state.regs.read(rd) & 0xffff;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & 0xffff;
+                regs.write(rd, value);
             }
             Self::CSextH { rd } => {
-                let value = i32::from(state.regs.read(rd) as i16);
-                state.regs.write(rd, value.cast_unsigned());
+                let value = i32::from(regs.read(rd) as i16);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CNot { rd } => {
-                let value = !state.regs.read(rd);
-                state.regs.write(rd, value);
+                let value = !regs.read(rd);
+                regs.write(rd, value);
             }
             Self::CMul { rd, rs2 } => {
-                let value = state.regs.read(rd).wrapping_mul(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rd).wrapping_mul(regs.read(rs2));
+                regs.write(rd, value);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -5,8 +5,8 @@ pub mod rv32_zcmp_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -14,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZcmpInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZcmpInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -28,48 +26,50 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::CmPush { urlist, stack_adj } => {
-                rv32_zcmp_helpers::do_push(state, urlist, stack_adj)?;
+                rv32_zcmp_helpers::do_push(regs, memory, urlist, stack_adj)?;
             }
             Self::CmPop { urlist, stack_adj } => {
-                rv32_zcmp_helpers::do_pop(state, urlist, stack_adj)?;
+                rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
             }
             Self::CmPopretz { urlist, stack_adj } => {
-                let ra_val = rv32_zcmp_helpers::do_pop(state, urlist, stack_adj)?;
+                let ra_val = rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
                 // Zero a0 before returning
-                state.regs.write(Reg::A0, 0);
+                regs.write(Reg::A0, 0);
                 // Jump to ra with LSB cleared (RISC-V mode bit)
                 let target = ra_val & !1;
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
             Self::CmPopret { urlist, stack_adj } => {
-                let ra_val = rv32_zcmp_helpers::do_pop(state, urlist, stack_adj)?;
+                let ra_val = rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
                 // Jump to ra with LSB cleared (RISC-V mode bit)
                 let target = ra_val & !1;
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
             Self::CmMva01s { r1s, r2s } => {
                 // Read both sources before any write to avoid aliasing
-                let v1 = state.regs.read(r1s);
-                let v2 = state.regs.read(r2s);
-                state.regs.write(Reg::A0, v1);
-                state.regs.write(Reg::A1, v2);
+                let v1 = regs.read(r1s);
+                let v2 = regs.read(r2s);
+                regs.write(Reg::A0, v1);
+                regs.write(Reg::A1, v2);
             }
             Self::CmMvsa01 { r1s, r2s } => {
                 // Read both sources before any write to avoid aliasing
-                let a0_val = state.regs.read(Reg::A0);
-                let a1_val = state.regs.read(Reg::A1);
-                state.regs.write(r1s, a0_val);
-                state.regs.write(r2s, a1_val);
+                let a0_val = regs.read(Reg::A0);
+                let a1_val = regs.read(Reg::A1);
+                regs.write(r1s, a0_val);
+                regs.write(r2s, a1_val);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
@@ -1,16 +1,14 @@
 //! Opaque helpers for Zcmp extension
 
-use crate::{
-    ExecutionError, InterpreterState, ProgramCounter, RegisterFile, SystemInstructionHandler,
-    VirtualMemory,
-};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
 
 /// Execute CM.PUSH: store registers below sp, then decrement sp
 #[inline(always)]
 #[doc(hidden)]
-pub fn do_push<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+pub fn do_push<Reg, Regs, Memory, CustomError>(
+    regs: &mut Regs,
+    memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u32,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
@@ -18,17 +16,15 @@ where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
 {
-    let sp = state.regs.read(Reg::SP);
+    let sp = regs.read(Reg::SP);
     // Store from sp-4 downward, highest-priority register first
     let mut store_addr = u64::from(sp.wrapping_sub(size_of::<Reg::Type>() as u32));
     for reg in urlist.reg_list() {
-        state.memory.write(store_addr, state.regs.read(reg))?;
+        memory.write(store_addr, regs.read(reg))?;
         store_addr = store_addr.wrapping_sub(size_of::<Reg::Type>() as u64);
     }
-    state.regs.write(Reg::SP, sp.wrapping_sub(stack_adj));
+    regs.write(Reg::SP, sp.wrapping_sub(stack_adj));
     Ok(())
 }
 
@@ -36,8 +32,9 @@ where
 /// Returns the value of ra (x1) for use with popret/popretz.
 #[inline(always)]
 #[doc(hidden)]
-pub fn do_pop<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+pub fn do_pop<Reg, Regs, Memory, CustomError>(
+    regs: &mut Regs,
+    memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u32,
 ) -> Result<u32, ExecutionError<Reg::Type, CustomError>>
@@ -45,18 +42,16 @@ where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
 {
-    let sp = state.regs.read(Reg::SP);
+    let sp = regs.read(Reg::SP);
     let new_sp = sp.wrapping_add(stack_adj);
     // Restore from [new_sp-4, new_sp-8, ...], matching push order
     let mut load_addr = u64::from(new_sp.wrapping_sub(size_of::<Reg::Type>() as u32));
     for reg in urlist.reg_list() {
-        let value = state.memory.read::<u32>(load_addr)?;
-        state.regs.write(reg, value);
+        let value = memory.read::<u32>(load_addr)?;
+        regs.write(reg, value);
         load_addr = load_addr.wrapping_sub(size_of::<Reg::Type>() as u64);
     }
-    state.regs.write(Reg::SP, new_sp);
-    Ok(state.regs.read(Reg::RA))
+    regs.write(Reg::SP, new_sp);
+    Ok(regs.read(Reg::RA))
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
@@ -4,17 +4,15 @@ pub mod rv32_zbkb_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZbkbInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZbkbInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -22,46 +20,50 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Pack { rd, rs1, rs2 } => {
                 // Pack low 16 bits of rs1 into rd[15:0],
                 // low 16 bits of rs2 into rd[31:16].
-                let lo = state.regs.read(rs1) & 0x0000_FFFFu32;
-                let hi = (state.regs.read(rs2) & 0x0000_FFFFu32) << 16;
-                state.regs.write(rd, lo | hi);
+                let lo = regs.read(rs1) & 0x0000_FFFFu32;
+                let hi = (regs.read(rs2) & 0x0000_FFFFu32) << 16;
+                regs.write(rd, lo | hi);
             }
             Self::Packh { rd, rs1, rs2 } => {
                 // Pack low byte of rs1 into bits [7:0], low byte of rs2 into bits [15:8].
                 // Upper bits of rd are zeroed.
-                let lo = state.regs.read(rs1) & 0xFF;
-                let hi = (state.regs.read(rs2) & 0xFF) << 8;
-                state.regs.write(rd, lo | hi);
+                let lo = regs.read(rs1) & 0xFF;
+                let hi = (regs.read(rs2) & 0xFF) << 8;
+                regs.write(rd, lo | hi);
             }
             Self::Brev8 { rd, rs1 } => {
                 // Reverse bits within each byte of rs1
-                let src = state.regs.read(rs1);
+                let src = regs.read(rs1);
                 let bytes = src.to_le_bytes().map(u8::reverse_bits);
-                state.regs.write(rd, u32::from_le_bytes(bytes));
+                regs.write(rd, u32::from_le_bytes(bytes));
             }
             Self::Zip { rd, rs1 } => {
                 // Bit-interleave: scatter bits of rs1 so that
                 // rs1[i]    -> rd[2*i]   (even positions, lower half source)
                 // rs1[i+16] -> rd[2*i+1] (odd positions, upper half source)
                 // for i in 0..16.
-                let src = state.regs.read(rs1);
+                let src = regs.read(rs1);
 
-                state.regs.write(rd, rv32_zbkb_helpers::zip(src));
+                regs.write(rd, rv32_zbkb_helpers::zip(src));
             }
             Self::Unzip { rd, rs1 } => {
                 // Inverse of zip: gather bits of rs1 so that
                 // rs1[2*i]   -> rd[i]    (even-position bits -> lower half)
                 // rs1[2*i+1] -> rd[i+16] (odd-position bits -> upper half)
                 // for i in 0..16.
-                let src = state.regs.read(rs1);
+                let src = regs.read(rs1);
 
-                state.regs.write(rd, rv32_zbkb_helpers::unzip(src));
+                regs.write(rd, rv32_zbkb_helpers::unzip(src));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
@@ -1,24 +1,26 @@
 //! RV32 Zbkc extension (subset of Zbc extension)
 
 use crate::rv32::b::zbc::rv32_zbc_helpers;
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZbkcInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZbkcInstruction<Reg>
 where
     Reg: Register<Type = u32>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
@@ -4,17 +4,15 @@ pub mod rv32_zbkx_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZbkxInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZbkxInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -22,24 +20,24 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Xperm4 { rd, rs1, rs2 } => {
-                let rs1_value = state.regs.read(rs1);
-                let rs2_value = state.regs.read(rs2);
+                let rs1_value = regs.read(rs1);
+                let rs2_value = regs.read(rs2);
 
-                state
-                    .regs
-                    .write(rd, rv32_zbkx_helpers::xperm4(rs1_value, rs2_value));
+                regs.write(rd, rv32_zbkx_helpers::xperm4(rs1_value, rs2_value));
             }
             Self::Xperm8 { rd, rs1, rs2 } => {
-                let rs1_value = state.regs.read(rs1);
-                let rs2_value = state.regs.read(rs2);
+                let rs1_value = regs.read(rs1);
+                let rs2_value = regs.read(rs2);
 
-                state
-                    .regs
-                    .write(rd, rv32_zbkx_helpers::xperm8(rs1_value, rs2_value));
+                regs.write(rd, rv32_zbkx_helpers::xperm8(rs1_value, rs2_value));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
@@ -10,24 +10,26 @@ use crate::rv32::zk::zbkx::rv32_zbkx_helpers;
 use crate::rv32::zk::zkn::zknd::rv32_zknd_helpers;
 use crate::rv32::zk::zkn::zkne::rv32_zkne_helpers;
 use crate::rv32::zk::zkn::zknh::rv32_zknh_helpers;
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZknInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZknInstruction<Reg>
 where
     Reg: Register<Type = u32>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
@@ -4,17 +4,15 @@ pub mod rv32_zknd_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZkndInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZkndInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -22,22 +20,22 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Aes32Dsi { rd, rs1, rs2, bs } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zknd_helpers::aes32dsi(v1, v2, bs));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv32_zknd_helpers::aes32dsi(v1, v2, bs));
             }
             Self::Aes32Dsmi { rd, rs1, rs2, bs } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zknd_helpers::aes32dsmi(v1, v2, bs));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv32_zknd_helpers::aes32dsmi(v1, v2, bs));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
@@ -4,17 +4,15 @@ pub mod rv32_zkne_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZkneInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZkneInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -22,22 +20,22 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Aes32Esi { rd, rs1, rs2, bs } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zkne_helpers::aes32esi(v1, v2, bs));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv32_zkne_helpers::aes32esi(v1, v2, bs));
             }
             Self::Aes32Esmi { rd, rs1, rs2, bs } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zkne_helpers::aes32esmi(v1, v2, bs));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv32_zkne_helpers::aes32esmi(v1, v2, bs));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
@@ -4,17 +4,15 @@ pub mod rv32_zknh_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv32ZknhInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZknhInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -22,25 +20,29 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // SHA-256 (single-register)
             Self::Sha256Sig0 { rd, rs1 } => {
-                let x = state.regs.read(rs1);
-                state.regs.write(rd, rv32_zknh_helpers::sha256sig0(x));
+                let x = regs.read(rs1);
+                regs.write(rd, rv32_zknh_helpers::sha256sig0(x));
             }
             Self::Sha256Sig1 { rd, rs1 } => {
-                let x = state.regs.read(rs1);
-                state.regs.write(rd, rv32_zknh_helpers::sha256sig1(x));
+                let x = regs.read(rs1);
+                regs.write(rd, rv32_zknh_helpers::sha256sig1(x));
             }
             Self::Sha256Sum0 { rd, rs1 } => {
-                let x = state.regs.read(rs1);
-                state.regs.write(rd, rv32_zknh_helpers::sha256sum0(x));
+                let x = regs.read(rs1);
+                regs.write(rd, rv32_zknh_helpers::sha256sum0(x));
             }
             Self::Sha256Sum1 { rd, rs1 } => {
-                let x = state.regs.read(rs1);
-                state.regs.write(rd, rv32_zknh_helpers::sha256sum1(x));
+                let x = regs.read(rs1);
+                regs.write(rd, rv32_zknh_helpers::sha256sum1(x));
             }
 
             // SHA-512 (two-register R-type)
@@ -58,46 +60,34 @@ where
             // The helpers receive (rs1, rs2) exactly as read from the register file;
             // they handle the asymmetric convention internally.
             Self::Sha512Sig0h { rd, rs1, rs2 } => {
-                let rs1_val = state.regs.read(rs1);
-                let rs2_val = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zknh_helpers::sha512sig0h(rs1_val, rs2_val));
+                let rs1_val = regs.read(rs1);
+                let rs2_val = regs.read(rs2);
+                regs.write(rd, rv32_zknh_helpers::sha512sig0h(rs1_val, rs2_val));
             }
             Self::Sha512Sig0l { rd, rs1, rs2 } => {
-                let rs1_val = state.regs.read(rs1);
-                let rs2_val = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zknh_helpers::sha512sig0l(rs1_val, rs2_val));
+                let rs1_val = regs.read(rs1);
+                let rs2_val = regs.read(rs2);
+                regs.write(rd, rv32_zknh_helpers::sha512sig0l(rs1_val, rs2_val));
             }
             Self::Sha512Sig1h { rd, rs1, rs2 } => {
-                let rs1_val = state.regs.read(rs1);
-                let rs2_val = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zknh_helpers::sha512sig1h(rs1_val, rs2_val));
+                let rs1_val = regs.read(rs1);
+                let rs2_val = regs.read(rs2);
+                regs.write(rd, rv32_zknh_helpers::sha512sig1h(rs1_val, rs2_val));
             }
             Self::Sha512Sig1l { rd, rs1, rs2 } => {
-                let rs1_val = state.regs.read(rs1);
-                let rs2_val = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zknh_helpers::sha512sig1l(rs1_val, rs2_val));
+                let rs1_val = regs.read(rs1);
+                let rs2_val = regs.read(rs2);
+                regs.write(rd, rv32_zknh_helpers::sha512sig1l(rs1_val, rs2_val));
             }
             Self::Sha512Sum0r { rd, rs1, rs2 } => {
-                let rs1_val = state.regs.read(rs1);
-                let rs2_val = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zknh_helpers::sha512sum0r(rs1_val, rs2_val));
+                let rs1_val = regs.read(rs1);
+                let rs2_val = regs.read(rs2);
+                regs.write(rd, rv32_zknh_helpers::sha512sum0r(rs1_val, rs2_val));
             }
             Self::Sha512Sum1r { rd, rs1, rs2 } => {
-                let rs1_val = state.regs.read(rs1);
-                let rs2_val = state.regs.read(rs2);
-                state
-                    .regs
-                    .write(rd, rv32_zknh_helpers::sha512sum1r(rs1_val, rs2_val));
+                let rs1_val = regs.read(rs1);
+                let rs2_val = regs.read(rs2);
+                regs.write(rd, rv32_zknh_helpers::sha512sum1r(rs1_val, rs2_val));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -11,8 +11,8 @@ pub mod zce;
 pub mod zk;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -20,10 +20,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64Instruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64Instruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -34,362 +32,279 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Add { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sub { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).wrapping_sub(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).wrapping_sub(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sll { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x3f;
-                let value = state.regs.read(rs1) << shamt;
-                state.regs.write(rd, value);
+                let shamt = regs.read(rs2) & 0x3f;
+                let value = regs.read(rs1) << shamt;
+                regs.write(rd, value);
             }
             Self::Slt { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).cast_signed() < state.regs.read(rs2).cast_signed();
-                state.regs.write(rd, value as u64);
+                let value = regs.read(rs1).cast_signed() < regs.read(rs2).cast_signed();
+                regs.write(rd, value as u64);
             }
             Self::Sltu { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) < state.regs.read(rs2);
-                state.regs.write(rd, value as u64);
+                let value = regs.read(rs1) < regs.read(rs2);
+                regs.write(rd, value as u64);
             }
             Self::Xor { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) ^ state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) ^ regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::Srl { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x3f;
-                let value = state.regs.read(rs1) >> shamt;
-                state.regs.write(rd, value);
+                let shamt = regs.read(rs2) & 0x3f;
+                let value = regs.read(rs1) >> shamt;
+                regs.write(rd, value);
             }
             Self::Sra { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x3f;
-                let value = state.regs.read(rs1).cast_signed() >> shamt;
-                state.regs.write(rd, value.cast_unsigned());
+                let shamt = regs.read(rs2) & 0x3f;
+                let value = regs.read(rs1).cast_signed() >> shamt;
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Or { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) | state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) | regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::And { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) & state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) & regs.read(rs2);
+                regs.write(rd, value);
             }
 
             Self::Addw { rd, rs1, rs2 } => {
-                let sum = (state.regs.read(rs1) as i32).wrapping_add(state.regs.read(rs2) as i32);
-                state.regs.write(rd, i64::from(sum).cast_unsigned());
+                let sum = (regs.read(rs1) as i32).wrapping_add(regs.read(rs2) as i32);
+                regs.write(rd, i64::from(sum).cast_unsigned());
             }
             Self::Subw { rd, rs1, rs2 } => {
-                let diff = (state.regs.read(rs1) as i32).wrapping_sub(state.regs.read(rs2) as i32);
-                state.regs.write(rd, i64::from(diff).cast_unsigned());
+                let diff = (regs.read(rs1) as i32).wrapping_sub(regs.read(rs2) as i32);
+                regs.write(rd, i64::from(diff).cast_unsigned());
             }
             Self::Sllw { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x1f;
-                let shifted = (state.regs.read(rs1) as u32) << shamt;
-                state
-                    .regs
-                    .write(rd, i64::from(shifted.cast_signed()).cast_unsigned());
+                let shamt = regs.read(rs2) & 0x1f;
+                let shifted = (regs.read(rs1) as u32) << shamt;
+                regs.write(rd, i64::from(shifted.cast_signed()).cast_unsigned());
             }
             Self::Srlw { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x1f;
-                let shifted = (state.regs.read(rs1) as u32) >> shamt;
-                state
-                    .regs
-                    .write(rd, i64::from(shifted.cast_signed()).cast_unsigned());
+                let shamt = regs.read(rs2) & 0x1f;
+                let shifted = (regs.read(rs1) as u32) >> shamt;
+                regs.write(rd, i64::from(shifted.cast_signed()).cast_unsigned());
             }
             Self::Sraw { rd, rs1, rs2 } => {
-                let shamt = state.regs.read(rs2) & 0x1f;
-                let shifted = (state.regs.read(rs1) as i32) >> shamt;
-                state.regs.write(rd, i64::from(shifted).cast_unsigned());
+                let shamt = regs.read(rs2) & 0x1f;
+                let shifted = (regs.read(rs1) as i32) >> shamt;
+                regs.write(rd, i64::from(shifted).cast_unsigned());
             }
 
             Self::Addi { rd, rs1, imm } => {
-                let value = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                regs.write(rd, value);
             }
             Self::Slti { rd, rs1, imm } => {
-                let value = state.regs.read(rs1).cast_signed() < i64::from(imm);
-                state.regs.write(rd, value as u64);
+                let value = regs.read(rs1).cast_signed() < i64::from(imm);
+                regs.write(rd, value as u64);
             }
             Self::Sltiu { rd, rs1, imm } => {
-                let value = state.regs.read(rs1) < i64::from(imm).cast_unsigned();
-                state.regs.write(rd, value as u64);
+                let value = regs.read(rs1) < i64::from(imm).cast_unsigned();
+                regs.write(rd, value as u64);
             }
             Self::Xori { rd, rs1, imm } => {
-                let value = state.regs.read(rs1) ^ i64::from(imm).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) ^ i64::from(imm).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Ori { rd, rs1, imm } => {
-                let value = state.regs.read(rs1) | i64::from(imm).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) | i64::from(imm).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Andi { rd, rs1, imm } => {
-                let value = state.regs.read(rs1) & i64::from(imm).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) & i64::from(imm).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Slli { rd, rs1, shamt } => {
-                let value = state.regs.read(rs1) << shamt;
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) << shamt;
+                regs.write(rd, value);
             }
             Self::Srli { rd, rs1, shamt } => {
-                let value = state.regs.read(rs1) >> shamt;
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) >> shamt;
+                regs.write(rd, value);
             }
             Self::Srai { rd, rs1, shamt } => {
-                let value = state.regs.read(rs1).cast_signed() >> shamt;
-                state.regs.write(rd, value.cast_unsigned());
+                let value = regs.read(rs1).cast_signed() >> shamt;
+                regs.write(rd, value.cast_unsigned());
             }
 
             Self::Addiw { rd, rs1, imm } => {
-                let sum = (state.regs.read(rs1) as i32).wrapping_add(i32::from(imm));
-                state.regs.write(rd, i64::from(sum).cast_unsigned());
+                let sum = (regs.read(rs1) as i32).wrapping_add(i32::from(imm));
+                regs.write(rd, i64::from(sum).cast_unsigned());
             }
             Self::Slliw { rd, rs1, shamt } => {
-                let shifted = (state.regs.read(rs1) as u32) << shamt;
-                state
-                    .regs
-                    .write(rd, i64::from(shifted.cast_signed()).cast_unsigned());
+                let shifted = (regs.read(rs1) as u32) << shamt;
+                regs.write(rd, i64::from(shifted.cast_signed()).cast_unsigned());
             }
             Self::Srliw { rd, rs1, shamt } => {
-                let shifted = (state.regs.read(rs1) as u32) >> shamt;
-                state
-                    .regs
-                    .write(rd, i64::from(shifted.cast_signed()).cast_unsigned());
+                let shifted = (regs.read(rs1) as u32) >> shamt;
+                regs.write(rd, i64::from(shifted.cast_signed()).cast_unsigned());
             }
             Self::Sraiw { rd, rs1, shamt } => {
-                let shifted = (state.regs.read(rs1) as i32) >> shamt;
-                state.regs.write(rd, i64::from(shifted).cast_unsigned());
+                let shifted = (regs.read(rs1) as i32) >> shamt;
+                regs.write(rd, i64::from(shifted).cast_unsigned());
             }
 
             Self::Lb { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                let value = i64::from(state.memory.read::<i8>(addr)?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                let value = i64::from(memory.read::<i8>(addr)?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Lh { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                let value = i64::from(state.memory.read::<i16>(addr)?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                let value = i64::from(memory.read::<i16>(addr)?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Lw { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                let value = i64::from(state.memory.read::<i32>(addr)?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                let value = i64::from(memory.read::<i32>(addr)?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Ld { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                let value = state.memory.read::<u64>(addr)?;
-                state.regs.write(rd, value);
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                let value = memory.read::<u64>(addr)?;
+                regs.write(rd, value);
             }
             Self::Lbu { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                let value = state.memory.read::<u8>(addr)?;
-                state.regs.write(rd, value as u64);
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                let value = memory.read::<u8>(addr)?;
+                regs.write(rd, value as u64);
             }
             Self::Lhu { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                let value = state.memory.read::<u16>(addr)?;
-                state.regs.write(rd, value as u64);
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                let value = memory.read::<u16>(addr)?;
+                regs.write(rd, value as u64);
             }
             Self::Lwu { rd, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                let value = state.memory.read::<u32>(addr)?;
-                state.regs.write(rd, value as u64);
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                let value = memory.read::<u32>(addr)?;
+                regs.write(rd, value as u64);
             }
 
             Self::Jalr { rd, rs1, imm } => {
-                let target = (state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned()))
-                    & !1u64;
-                state.regs.write(rd, state.instruction_fetcher.get_pc());
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                let target = (regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned())) & !1u64;
+                regs.write(rd, program_counter.get_pc());
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
 
             Self::Sb { rs2, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                state.memory.write(addr, state.regs.read(rs2) as u8)?;
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                memory.write(addr, regs.read(rs2) as u8)?;
             }
             Self::Sh { rs2, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                state.memory.write(addr, state.regs.read(rs2) as u16)?;
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                memory.write(addr, regs.read(rs2) as u16)?;
             }
             Self::Sw { rs2, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                state.memory.write(addr, state.regs.read(rs2) as u32)?;
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                memory.write(addr, regs.read(rs2) as u32)?;
             }
             Self::Sd { rs2, rs1, imm } => {
-                let addr = state
-                    .regs
-                    .read(rs1)
-                    .wrapping_add(i64::from(imm).cast_unsigned());
-                state.memory.write(addr, state.regs.read(rs2))?;
+                let addr = regs.read(rs1).wrapping_add(i64::from(imm).cast_unsigned());
+                memory.write(addr, regs.read(rs2))?;
             }
 
             Self::Beq { rs1, rs2, imm } => {
-                if state.regs.read(rs1) == state.regs.read(rs2) {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1) == regs.read(rs2) {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Bne { rs1, rs2, imm } => {
-                if state.regs.read(rs1) != state.regs.read(rs2) {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1) != regs.read(rs2) {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Blt { rs1, rs2, imm } => {
-                if state.regs.read(rs1).cast_signed() < state.regs.read(rs2).cast_signed() {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1).cast_signed() < regs.read(rs2).cast_signed() {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Bge { rs1, rs2, imm } => {
-                if state.regs.read(rs1).cast_signed() >= state.regs.read(rs2).cast_signed() {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1).cast_signed() >= regs.read(rs2).cast_signed() {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Bltu { rs1, rs2, imm } => {
-                if state.regs.read(rs1) < state.regs.read(rs2) {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1) < regs.read(rs2) {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::Bgeu { rs1, rs2, imm } => {
-                if state.regs.read(rs1) >= state.regs.read(rs2) {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1) >= regs.read(rs2) {
+                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
 
             Self::Lui { rd, imm } => {
-                state.regs.write(rd, i64::from(imm).cast_unsigned());
+                regs.write(rd, i64::from(imm).cast_unsigned());
             }
 
             Self::Auipc { rd, imm } => {
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                state
-                    .regs
-                    .write(rd, old_pc.wrapping_add(i64::from(imm).cast_unsigned()));
+                let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                regs.write(rd, old_pc.wrapping_add(i64::from(imm).cast_unsigned()));
             }
 
             Self::Jal { rd, imm } => {
-                let pc = state.instruction_fetcher.get_pc();
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
-                state.regs.write(rd, pc);
-                return state
-                    .instruction_fetcher
-                    .set_pc(
-                        &state.memory,
-                        old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                    )
+                let pc = program_counter.get_pc();
+                let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
+                regs.write(rd, pc);
+                return program_counter
+                    .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                     .map_err(ExecutionError::from);
             }
 
             Self::Fence { pred, succ } => {
-                state.system_instruction_handler.handle_fence(pred, succ);
+                system_instruction_handler.handle_fence(pred, succ);
             }
             Self::FenceTso => {
-                state.system_instruction_handler.handle_fence_tso();
+                system_instruction_handler.handle_fence_tso();
             }
 
             Self::Ecall => {
-                return state.system_instruction_handler.handle_ecall(
-                    &mut state.regs,
-                    &mut state.memory,
-                    &mut state.instruction_fetcher,
-                );
+                return system_instruction_handler.handle_ecall(regs, memory, program_counter);
             }
             Self::Ebreak => {
-                state.system_instruction_handler.handle_ebreak(
-                    &mut state.regs,
-                    &mut state.memory,
-                    state.instruction_fetcher.get_pc(),
-                );
+                system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
             }
 
             Self::Unimp => {
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u32>() as u8);
+                let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 return Err(ExecutionError::IllegalInstruction { address: old_pc });
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
@@ -6,24 +6,26 @@ pub mod zbc;
 pub mod zbs;
 
 use crate::rv64::b::zbb::rv64_zbb_helpers;
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64BInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64BInstruction<Reg>
 where
     Reg: Register<Type = u64>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
@@ -3,17 +3,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZbaInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZbaInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -21,45 +19,49 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::AddUw { rd, rs1, rs2 } => {
-                let rs1_val = (state.regs.read(rs1) as u32) as u64;
-                let value = rs1_val.wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let rs1_val = (regs.read(rs1) as u32) as u64;
+                let value = rs1_val.wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sh1add { rd, rs1, rs2 } => {
-                let value = (state.regs.read(rs1) << 1).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = (regs.read(rs1) << 1).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sh1addUw { rd, rs1, rs2 } => {
-                let rs1_val = (state.regs.read(rs1) as u32) as u64;
-                let value = (rs1_val << 1).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let rs1_val = (regs.read(rs1) as u32) as u64;
+                let value = (rs1_val << 1).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sh2add { rd, rs1, rs2 } => {
-                let value = (state.regs.read(rs1) << 2).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = (regs.read(rs1) << 2).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sh2addUw { rd, rs1, rs2 } => {
-                let rs1_val = (state.regs.read(rs1) as u32) as u64;
-                let value = (rs1_val << 2).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let rs1_val = (regs.read(rs1) as u32) as u64;
+                let value = (rs1_val << 2).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sh3add { rd, rs1, rs2 } => {
-                let value = (state.regs.read(rs1) << 3).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = (regs.read(rs1) << 3).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sh3addUw { rd, rs1, rs2 } => {
-                let rs1_val = (state.regs.read(rs1) as u32) as u64;
-                let value = (rs1_val << 3).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let rs1_val = (regs.read(rs1) as u32) as u64;
+                let value = (rs1_val << 3).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::SlliUw { rd, rs1, shamt } => {
-                let rs1_val = (state.regs.read(rs1) as u32) as u64;
+                let rs1_val = (regs.read(rs1) as u32) as u64;
                 let value = rs1_val << (shamt & 0x3f);
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
@@ -4,17 +4,15 @@ pub mod rv64_zbb_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZbbInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZbbInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -22,125 +20,121 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Andn { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) & !state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) & !regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::Orn { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1) | !state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rs1) | !regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::Xnor { rd, rs1, rs2 } => {
-                let value = !(state.regs.read(rs1) ^ state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = !(regs.read(rs1) ^ regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Clz { rd, rs1 } => {
-                let value = u64::from(state.regs.read(rs1).leading_zeros());
-                state.regs.write(rd, value);
+                let value = u64::from(regs.read(rs1).leading_zeros());
+                regs.write(rd, value);
             }
             Self::Clzw { rd, rs1 } => {
-                let value = u64::from((state.regs.read(rs1) as u32).leading_zeros());
-                state.regs.write(rd, value);
+                let value = u64::from((regs.read(rs1) as u32).leading_zeros());
+                regs.write(rd, value);
             }
             Self::Ctz { rd, rs1 } => {
-                let value = u64::from(state.regs.read(rs1).trailing_zeros());
-                state.regs.write(rd, value);
+                let value = u64::from(regs.read(rs1).trailing_zeros());
+                regs.write(rd, value);
             }
             Self::Ctzw { rd, rs1 } => {
-                let value = u64::from((state.regs.read(rs1) as u32).trailing_zeros());
-                state.regs.write(rd, value);
+                let value = u64::from((regs.read(rs1) as u32).trailing_zeros());
+                regs.write(rd, value);
             }
             Self::Cpop { rd, rs1 } => {
-                let value = u64::from(state.regs.read(rs1).count_ones());
-                state.regs.write(rd, value);
+                let value = u64::from(regs.read(rs1).count_ones());
+                regs.write(rd, value);
             }
             Self::Cpopw { rd, rs1 } => {
-                let value = u64::from((state.regs.read(rs1) as u32).count_ones());
-                state.regs.write(rd, value);
+                let value = u64::from((regs.read(rs1) as u32).count_ones());
+                regs.write(rd, value);
             }
             Self::Max { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1).cast_signed();
-                let b = state.regs.read(rs2).cast_signed();
+                let a = regs.read(rs1).cast_signed();
+                let b = regs.read(rs2).cast_signed();
                 let value = a.max(b).cast_unsigned();
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Maxu { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).max(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).max(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Min { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1).cast_signed();
-                let b = state.regs.read(rs2).cast_signed();
+                let a = regs.read(rs1).cast_signed();
+                let b = regs.read(rs2).cast_signed();
                 let value = a.min(b).cast_unsigned();
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Minu { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).min(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).min(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Sextb { rd, rs1 } => {
-                let value = i64::from(state.regs.read(rs1) as i8).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = i64::from(regs.read(rs1) as i8).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Sexth { rd, rs1 } => {
-                let value = i64::from(state.regs.read(rs1) as i16).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = i64::from(regs.read(rs1) as i16).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::Zexth { rd, rs1 } => {
-                let value = u64::from(state.regs.read(rs1) as u16);
-                state.regs.write(rd, value);
+                let value = u64::from(regs.read(rs1) as u16);
+                regs.write(rd, value);
             }
             Self::Rol { rd, rs1, rs2 } => {
-                let shamt = (state.regs.read(rs2) & 0x3f) as u32;
-                let value = state.regs.read(rs1).rotate_left(shamt);
-                state.regs.write(rd, value);
+                let shamt = (regs.read(rs2) & 0x3f) as u32;
+                let value = regs.read(rs1).rotate_left(shamt);
+                regs.write(rd, value);
             }
             Self::Rolw { rd, rs1, rs2 } => {
-                let shamt = (state.regs.read(rs2) & 0x1f) as u32;
-                let value = i64::from(
-                    (state.regs.read(rs1) as u32)
-                        .rotate_left(shamt)
-                        .cast_signed(),
-                );
-                state.regs.write(rd, value.cast_unsigned());
+                let shamt = (regs.read(rs2) & 0x1f) as u32;
+                let value = i64::from((regs.read(rs1) as u32).rotate_left(shamt).cast_signed());
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Ror { rd, rs1, rs2 } => {
-                let shamt = (state.regs.read(rs2) & 0x3f) as u32;
-                let value = state.regs.read(rs1).rotate_right(shamt);
-                state.regs.write(rd, value);
+                let shamt = (regs.read(rs2) & 0x3f) as u32;
+                let value = regs.read(rs1).rotate_right(shamt);
+                regs.write(rd, value);
             }
             Self::Rori { rd, rs1, shamt } => {
-                let value = state.regs.read(rs1).rotate_right(u32::from(shamt & 0x3f));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).rotate_right(u32::from(shamt & 0x3f));
+                regs.write(rd, value);
             }
             Self::Roriw { rd, rs1, shamt } => {
                 let value = i64::from(
-                    (state.regs.read(rs1) as u32)
+                    (regs.read(rs1) as u32)
                         .rotate_right((shamt & 0x1f) as u32)
                         .cast_signed(),
                 );
-                state.regs.write(rd, value.cast_unsigned());
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Rorw { rd, rs1, rs2 } => {
-                let shamt = (state.regs.read(rs2) & 0x1f) as u32;
-                let value = i64::from(
-                    (state.regs.read(rs1) as u32)
-                        .rotate_right(shamt)
-                        .cast_signed(),
-                );
-                state.regs.write(rd, value.cast_unsigned());
+                let shamt = (regs.read(rs2) & 0x1f) as u32;
+                let value = i64::from((regs.read(rs1) as u32).rotate_right(shamt).cast_signed());
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Orcb { rd, rs1 } => {
-                let src = state.regs.read(rs1);
+                let src = regs.read(rs1);
 
-                state.regs.write(rd, rv64_zbb_helpers::orc_b(src));
+                regs.write(rd, rv64_zbb_helpers::orc_b(src));
             }
             Self::Rev8 { rd, rs1 } => {
-                let value = state.regs.read(rs1).swap_bytes();
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).swap_bytes();
+                regs.write(rd, value);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
@@ -4,17 +4,15 @@ pub mod rv64_zbc_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZbcInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZbcInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -22,26 +20,30 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Clmul { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1);
-                let b = state.regs.read(rs2);
+                let a = regs.read(rs1);
+                let b = regs.read(rs2);
 
-                state.regs.write(rd, rv64_zbc_helpers::clmul(a, b));
+                regs.write(rd, rv64_zbc_helpers::clmul(a, b));
             }
             Self::Clmulh { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1);
-                let b = state.regs.read(rs2);
+                let a = regs.read(rs1);
+                let b = regs.read(rs2);
 
-                state.regs.write(rd, rv64_zbc_helpers::clmulh(a, b));
+                regs.write(rd, rv64_zbc_helpers::clmulh(a, b));
             }
             Self::Clmulr { rd, rs1, rs2 } => {
-                let a = state.regs.read(rs1);
-                let b = state.regs.read(rs2);
+                let a = regs.read(rs1);
+                let b = regs.read(rs2);
 
-                state.regs.write(rd, rv64_zbc_helpers::clmulr(a, b));
+                regs.write(rd, rv64_zbc_helpers::clmulr(a, b));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
@@ -3,17 +3,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZbsInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZbsInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -21,49 +19,53 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Bset { rd, rs1, rs2 } => {
                 // Only the bottom 6 bits for RV64
-                let index = state.regs.read(rs2) & 0x3f;
-                let result = state.regs.read(rs1) | (1u64 << index);
-                state.regs.write(rd, result);
+                let index = regs.read(rs2) & 0x3f;
+                let result = regs.read(rs1) | (1u64 << index);
+                regs.write(rd, result);
             }
             Self::Bseti { rd, rs1, shamt } => {
                 let index = shamt;
-                let result = state.regs.read(rs1) | (1u64 << index);
-                state.regs.write(rd, result);
+                let result = regs.read(rs1) | (1u64 << index);
+                regs.write(rd, result);
             }
             Self::Bclr { rd, rs1, rs2 } => {
-                let index = state.regs.read(rs2) & 0x3f;
-                let result = state.regs.read(rs1) & !(1u64 << index);
-                state.regs.write(rd, result);
+                let index = regs.read(rs2) & 0x3f;
+                let result = regs.read(rs1) & !(1u64 << index);
+                regs.write(rd, result);
             }
             Self::Bclri { rd, rs1, shamt } => {
                 let index = shamt;
-                let result = state.regs.read(rs1) & !(1u64 << index);
-                state.regs.write(rd, result);
+                let result = regs.read(rs1) & !(1u64 << index);
+                regs.write(rd, result);
             }
             Self::Binv { rd, rs1, rs2 } => {
-                let index = state.regs.read(rs2) & 0x3f;
-                let result = state.regs.read(rs1) ^ (1u64 << index);
-                state.regs.write(rd, result);
+                let index = regs.read(rs2) & 0x3f;
+                let result = regs.read(rs1) ^ (1u64 << index);
+                regs.write(rd, result);
             }
             Self::Binvi { rd, rs1, shamt } => {
                 let index = shamt;
-                let result = state.regs.read(rs1) ^ (1u64 << index);
-                state.regs.write(rd, result);
+                let result = regs.read(rs1) ^ (1u64 << index);
+                regs.write(rd, result);
             }
             Self::Bext { rd, rs1, rs2 } => {
-                let index = state.regs.read(rs2) & 0x3f;
-                let result = (state.regs.read(rs1) >> index) & 1;
-                state.regs.write(rd, result);
+                let index = regs.read(rs2) & 0x3f;
+                let result = (regs.read(rs1) >> index) & 1;
+                regs.write(rd, result);
             }
             Self::Bexti { rd, rs1, shamt } => {
                 let index = shamt;
-                let result = (state.regs.read(rs1) >> index) & 1;
-                state.regs.write(rd, result);
+                let result = (regs.read(rs1) >> index) & 1;
+                regs.write(rd, result);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -4,8 +4,8 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -13,10 +13,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZcaInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZcaInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -27,185 +25,167 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // Quadrant 00
             Self::CAddi4spn { rd, nzuimm } => {
-                let sp_val = state.regs.read(Reg::SP);
-                state.regs.write(rd, sp_val.wrapping_add(u64::from(nzuimm)));
+                let sp_val = regs.read(Reg::SP);
+                regs.write(rd, sp_val.wrapping_add(u64::from(nzuimm)));
             }
             Self::CLw { rd, rs1, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                let value = i64::from(state.memory.read::<i32>(addr)?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                let value = i64::from(memory.read::<i32>(addr)?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CLd { rd, rs1, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                let value = state.memory.read::<u64>(addr)?;
-                state.regs.write(rd, value);
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                let value = memory.read::<u64>(addr)?;
+                regs.write(rd, value);
             }
             Self::CSw { rs1, rs2, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                state.memory.write(addr, state.regs.read(rs2) as u32)?;
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                memory.write(addr, regs.read(rs2) as u32)?;
             }
             Self::CSd { rs1, rs2, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                state.memory.write(addr, state.regs.read(rs2))?;
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                memory.write(addr, regs.read(rs2))?;
             }
 
             // Quadrant 01
             Self::CNop => {}
             Self::CAddi { rd, nzimm } => {
-                let value = state
-                    .regs
-                    .read(rd)
-                    .wrapping_add(i64::from(nzimm).cast_unsigned());
-                state.regs.write(rd, value);
+                let value = regs.read(rd).wrapping_add(i64::from(nzimm).cast_unsigned());
+                regs.write(rd, value);
             }
             Self::CAddiw { rd, imm } => {
-                let sum = (state.regs.read(rd) as i32).wrapping_add(i32::from(imm));
-                state.regs.write(rd, i64::from(sum).cast_unsigned());
+                let sum = (regs.read(rd) as i32).wrapping_add(i32::from(imm));
+                regs.write(rd, i64::from(sum).cast_unsigned());
             }
             Self::CLi { rd, imm } => {
-                state.regs.write(rd, i64::from(imm).cast_unsigned());
+                regs.write(rd, i64::from(imm).cast_unsigned());
             }
             Self::CAddi16sp { nzimm } => {
-                let value = state
-                    .regs
+                let value = regs
                     .read(Reg::SP)
                     .wrapping_add(i64::from(nzimm).cast_unsigned());
-                state.regs.write(Reg::SP, value);
+                regs.write(Reg::SP, value);
             }
             Self::CLui { rd, nzimm } => {
-                state.regs.write(rd, i64::from(nzimm).cast_unsigned());
+                regs.write(rd, i64::from(nzimm).cast_unsigned());
             }
             Self::CSrli { rd, shamt } => {
-                let value = state.regs.read(rd) >> shamt;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) >> shamt;
+                regs.write(rd, value);
             }
             Self::CSrai { rd, shamt } => {
-                let value = state.regs.read(rd).cast_signed() >> shamt;
-                state.regs.write(rd, value.cast_unsigned());
+                let value = regs.read(rd).cast_signed() >> shamt;
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CAndi { rd, imm } => {
-                let value = state.regs.read(rd) & i64::from(imm).cast_unsigned();
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & i64::from(imm).cast_unsigned();
+                regs.write(rd, value);
             }
             Self::CSub { rd, rs2 } => {
-                let value = state.regs.read(rd).wrapping_sub(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rd).wrapping_sub(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::CXor { rd, rs2 } => {
-                let value = state.regs.read(rd) ^ state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rd) ^ regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::COr { rd, rs2 } => {
-                let value = state.regs.read(rd) | state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rd) | regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::CAnd { rd, rs2 } => {
-                let value = state.regs.read(rd) & state.regs.read(rs2);
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & regs.read(rs2);
+                regs.write(rd, value);
             }
             Self::CSubw { rd, rs2 } => {
-                let diff = (state.regs.read(rd) as i32).wrapping_sub(state.regs.read(rs2) as i32);
-                state.regs.write(rd, i64::from(diff).cast_unsigned());
+                let diff = (regs.read(rd) as i32).wrapping_sub(regs.read(rs2) as i32);
+                regs.write(rd, i64::from(diff).cast_unsigned());
             }
             Self::CAddw { rd, rs2 } => {
-                let sum = (state.regs.read(rd) as i32).wrapping_add(state.regs.read(rs2) as i32);
-                state.regs.write(rd, i64::from(sum).cast_unsigned());
+                let sum = (regs.read(rd) as i32).wrapping_add(regs.read(rs2) as i32);
+                regs.write(rd, i64::from(sum).cast_unsigned());
             }
             Self::CJ { imm } => {
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
-                return state
-                    .instruction_fetcher
-                    .set_pc(
-                        &state.memory,
-                        old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                    )
+                let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
+                return program_counter
+                    .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                     .map_err(ExecutionError::from);
             }
             Self::CBeqz { rs1, imm } => {
-                if state.regs.read(rs1) == 0 {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1) == 0 {
+                    let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
             Self::CBnez { rs1, imm } => {
-                if state.regs.read(rs1) != 0 {
-                    let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
-                    return state
-                        .instruction_fetcher
-                        .set_pc(
-                            &state.memory,
-                            old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                        )
+                if regs.read(rs1) != 0 {
+                    let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
+                    return program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
 
             // Quadrant 10
             Self::CSlli { rd, shamt } => {
-                let value = state.regs.read(rd) << shamt;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) << shamt;
+                regs.write(rd, value);
             }
             Self::CLwsp { rd, uimm } => {
-                let addr = state.regs.read(Reg::SP).wrapping_add(u64::from(uimm));
-                let value = i64::from(state.memory.read::<i32>(addr)?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
+                let value = i64::from(memory.read::<i32>(addr)?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CLdsp { rd, uimm } => {
-                let addr = state.regs.read(Reg::SP).wrapping_add(u64::from(uimm));
-                let value = state.memory.read::<u64>(addr)?;
-                state.regs.write(rd, value);
+                let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
+                let value = memory.read::<u64>(addr)?;
+                regs.write(rd, value);
             }
             Self::CJr { rs1 } => {
-                let target = state.regs.read(rs1) & !1;
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                let target = regs.read(rs1) & !1;
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
             Self::CMv { rd, rs2 } => {
-                state.regs.write(rd, state.regs.read(rs2));
+                regs.write(rd, regs.read(rs2));
             }
             Self::CEbreak => {
-                state.system_instruction_handler.handle_ebreak(
-                    &mut state.regs,
-                    &mut state.memory,
-                    state.instruction_fetcher.get_pc(),
-                );
+                system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
             }
             Self::CJalr { rs1 } => {
-                let target = state.regs.read(rs1) & !1;
-                let return_addr = state.instruction_fetcher.get_pc();
-                state.regs.write(Reg::RA, return_addr);
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                let target = regs.read(rs1) & !1;
+                let return_addr = program_counter.get_pc();
+                regs.write(Reg::RA, return_addr);
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
             Self::CAdd { rd, rs2 } => {
-                let value = state.regs.read(rd).wrapping_add(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rd).wrapping_add(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::CSwsp { rs2, uimm } => {
-                let addr = state.regs.read(Reg::SP).wrapping_add(u64::from(uimm));
-                state.memory.write(addr, state.regs.read(rs2) as u32)?;
+                let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
+                memory.write(addr, regs.read(rs2) as u32)?;
             }
             Self::CSdsp { rs2, uimm } => {
-                let addr = state.regs.read(Reg::SP).wrapping_add(u64::from(uimm));
-                state.memory.write(addr, state.regs.read(rs2))?;
+                let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
+                memory.write(addr, regs.read(rs2))?;
             }
             Self::CUnimp => {
-                let old_pc = state.instruction_fetcher.old_pc(size_of::<u16>() as u8);
+                let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
                 return Err(ExecutionError::IllegalInstruction { address: old_pc });
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
@@ -4,17 +4,15 @@
 mod tests;
 pub mod zmmul;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64MInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64MInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -22,38 +20,40 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Mul { rd, rs1, rs2 } => {
-                let value = state.regs.read(rs1).wrapping_mul(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rs1).wrapping_mul(regs.read(rs2));
+                regs.write(rd, value);
             }
             Self::Mulh { rd, rs1, rs2 } => {
                 // Signed × signed: widen to i128, take upper 64 bits
-                let (_lo, prod) = state
-                    .regs
+                let (_lo, prod) = regs
                     .read(rs1)
                     .cast_signed()
-                    .widening_mul(state.regs.read(rs2).cast_signed());
-                state.regs.write(rd, prod.cast_unsigned());
+                    .widening_mul(regs.read(rs2).cast_signed());
+                regs.write(rd, prod.cast_unsigned());
             }
             Self::Mulhsu { rd, rs1, rs2 } => {
                 // Signed × unsigned: widen to i128, take upper 64 bits
-                let prod = i128::from(state.regs.read(rs1).cast_signed())
-                    * i128::from(state.regs.read(rs2));
+                let prod = i128::from(regs.read(rs1).cast_signed()) * i128::from(regs.read(rs2));
                 let value = prod >> 64;
-                state.regs.write(rd, value.cast_unsigned() as u64);
+                regs.write(rd, value.cast_unsigned() as u64);
             }
             Self::Mulhu { rd, rs1, rs2 } => {
                 // Unsigned × unsigned: widen to u128, take upper 64 bits
-                let prod = u128::from(state.regs.read(rs1)) * u128::from(state.regs.read(rs2));
+                let prod = u128::from(regs.read(rs1)) * u128::from(regs.read(rs2));
                 let value = prod >> 64;
-                state.regs.write(rd, value as u64);
+                regs.write(rd, value as u64);
             }
             Self::Div { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1).cast_signed();
-                let divisor = state.regs.read(rs2).cast_signed();
+                let dividend = regs.read(rs1).cast_signed();
+                let divisor = regs.read(rs2).cast_signed();
                 let value = if divisor == 0 {
                     -1i64
                 } else if dividend == i64::MIN && divisor == -1 {
@@ -61,17 +61,17 @@ where
                 } else {
                     dividend / divisor
                 };
-                state.regs.write(rd, value.cast_unsigned());
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Divu { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1);
-                let divisor = state.regs.read(rs2);
+                let dividend = regs.read(rs1);
+                let divisor = regs.read(rs2);
                 let value = dividend.checked_div(divisor).unwrap_or(u64::MAX);
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Rem { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1).cast_signed();
-                let divisor = state.regs.read(rs2).cast_signed();
+                let dividend = regs.read(rs1).cast_signed();
+                let divisor = regs.read(rs2).cast_signed();
                 let value = if divisor == 0 {
                     dividend
                 } else if dividend == i64::MIN && divisor == -1 {
@@ -79,27 +79,27 @@ where
                 } else {
                     dividend % divisor
                 };
-                state.regs.write(rd, value.cast_unsigned());
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Remu { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1);
-                let divisor = state.regs.read(rs2);
+                let dividend = regs.read(rs1);
+                let divisor = regs.read(rs2);
                 let value = if divisor == 0 {
                     dividend
                 } else {
                     dividend % divisor
                 };
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
 
             // RV64 R-type W
             Self::Mulw { rd, rs1, rs2 } => {
-                let prod = (state.regs.read(rs1) as i32).wrapping_mul(state.regs.read(rs2) as i32);
-                state.regs.write(rd, (prod as i64).cast_unsigned());
+                let prod = (regs.read(rs1) as i32).wrapping_mul(regs.read(rs2) as i32);
+                regs.write(rd, (prod as i64).cast_unsigned());
             }
             Self::Divw { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1) as i32;
-                let divisor = state.regs.read(rs2) as i32;
+                let dividend = regs.read(rs1) as i32;
+                let divisor = regs.read(rs2) as i32;
                 let value = if divisor == 0 {
                     -1i64
                 } else if dividend == i32::MIN && divisor == -1 {
@@ -107,19 +107,19 @@ where
                 } else {
                     i64::from(dividend / divisor)
                 };
-                state.regs.write(rd, value.cast_unsigned());
+                regs.write(rd, value.cast_unsigned());
             }
             Self::Divuw { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1) as u32;
-                let divisor = state.regs.read(rs2) as u32;
+                let dividend = regs.read(rs1) as u32;
+                let divisor = regs.read(rs2) as u32;
                 let value = dividend.checked_div(divisor).map_or(u64::MAX, |value| {
                     i64::from(value.cast_signed()).cast_unsigned()
                 });
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Remw { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1) as i32;
-                let divisor = state.regs.read(rs2) as i32;
+                let dividend = regs.read(rs1) as i32;
+                let divisor = regs.read(rs2) as i32;
                 let value = if divisor == 0 {
                     (dividend as i64).cast_unsigned()
                 } else if dividend == i32::MIN && divisor == -1 {
@@ -127,17 +127,17 @@ where
                 } else {
                     ((dividend % divisor) as i64).cast_unsigned()
                 };
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Remuw { rd, rs1, rs2 } => {
-                let dividend = state.regs.read(rs1) as u32;
-                let divisor = state.regs.read(rs2) as u32;
+                let dividend = regs.read(rs1) as u32;
+                let divisor = regs.read(rs2) as u32;
                 let value = if divisor == 0 {
                     dividend.cast_signed() as i64
                 } else {
                     (dividend % divisor).cast_signed() as i64
                 };
-                state.regs.write(rd, value.cast_unsigned());
+                regs.write(rd, value.cast_unsigned());
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
@@ -1,23 +1,25 @@
 //! RV64 Zmmul extension (multiplication subset of M extension)
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZmmulInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZmmulInstruction<Reg>
 where
     Reg: Register<Type = u64>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -1,19 +1,18 @@
 extern crate alloc;
 
-use crate::basic::BasicRegisters;
+use crate::basic::{BasicInterpreterState, BasicRegisters};
 use crate::v::vector_registers::{
     VectorRegisterFile, VectorRegisters, VectorRegistersBase, VectorRegistersExt,
 };
 use crate::{
-    Address, BasicInt, CsrError, Csrs, CustomErrorPlaceholder, ExecutableInstruction,
-    ExecutionError, FetchInstructionResult, InstructionFetcher, InterpreterState, ProgramCounter,
-    ProgramCounterError, RegisterFile, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError,
+    FetchInstructionResult, InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
+    SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::collections::BTreeMap;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 use core::ops::ControlFlow;
 
 pub(crate) const TEST_BASE_ADDR: u64 = 0x1000;
@@ -460,7 +459,7 @@ impl ExtState {
     }
 }
 
-pub(crate) type TestInterpreterState<Instruction> = InterpreterState<
+pub(crate) type TestInterpreterState<Instruction> = BasicInterpreterState<
     BasicRegisters<Reg<u64>>,
     ExtState,
     TestMemory,
@@ -475,7 +474,7 @@ where
     I: Instruction<Reg = Reg<u64>>,
     Instructions: IntoIterator<Item = I>,
 {
-    InterpreterState {
+    BasicInterpreterState {
         regs: BasicRegisters::default(),
         ext_state: ExtState::default(),
         memory: TestMemory::new(8192, TEST_BASE_ADDR),
@@ -486,7 +485,6 @@ where
             TEST_BASE_ADDR,
         ),
         system_instruction_handler: TestInstructionHandler,
-        custom_error: PhantomData,
     }
 }
 
@@ -495,7 +493,13 @@ pub(crate) fn execute<I>(
 ) -> Result<(), ExecutionError<Address<I>>>
 where
     I: Instruction<Reg = Reg<u64>>
-        + ExecutableInstruction<TestInterpreterState<I>, CustomErrorPlaceholder>,
+        + ExecutableInstruction<
+            BasicRegisters<Reg<u64>>,
+            ExtState,
+            TestMemory,
+            TestInstructionFetcher<I>,
+            TestInstructionHandler,
+        >,
 {
     loop {
         let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory)? {
@@ -508,7 +512,13 @@ where
             }
         };
 
-        match instruction.execute(state)? {
+        match instruction.execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )? {
             ControlFlow::Continue(()) => {
                 continue;
             }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -4,8 +4,8 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -13,10 +13,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZcbInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZcbInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -27,59 +25,63 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::CLbu { rd, rs1, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                let value = state.memory.read::<u8>(addr)?;
-                state.regs.write(rd, u64::from(value));
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                let value = memory.read::<u8>(addr)?;
+                regs.write(rd, u64::from(value));
             }
             Self::CLh { rd, rs1, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                let value = i64::from(state.memory.read::<i16>(addr)?);
-                state.regs.write(rd, value.cast_unsigned());
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                let value = i64::from(memory.read::<i16>(addr)?);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CLhu { rd, rs1, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                let value = state.memory.read::<u16>(addr)?;
-                state.regs.write(rd, u64::from(value));
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                let value = memory.read::<u16>(addr)?;
+                regs.write(rd, u64::from(value));
             }
             Self::CSb { rs1, rs2, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                state.memory.write(addr, state.regs.read(rs2) as u8)?;
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                memory.write(addr, regs.read(rs2) as u8)?;
             }
             Self::CSh { rs1, rs2, uimm } => {
-                let addr = state.regs.read(rs1).wrapping_add(u64::from(uimm));
-                state.memory.write(addr, state.regs.read(rs2) as u16)?;
+                let addr = regs.read(rs1).wrapping_add(u64::from(uimm));
+                memory.write(addr, regs.read(rs2) as u16)?;
             }
             Self::CZextB { rd } => {
-                let value = state.regs.read(rd) & 0xff;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & 0xff;
+                regs.write(rd, value);
             }
             Self::CSextB { rd } => {
-                let value = i64::from(state.regs.read(rd) as i8);
-                state.regs.write(rd, value.cast_unsigned());
+                let value = i64::from(regs.read(rd) as i8);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CZextH { rd } => {
-                let value = state.regs.read(rd) & 0xffff;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & 0xffff;
+                regs.write(rd, value);
             }
             Self::CSextH { rd } => {
-                let value = i64::from(state.regs.read(rd) as i16);
-                state.regs.write(rd, value.cast_unsigned());
+                let value = i64::from(regs.read(rd) as i16);
+                regs.write(rd, value.cast_unsigned());
             }
             Self::CZextW { rd } => {
-                let value = state.regs.read(rd) & 0xffff_ffff;
-                state.regs.write(rd, value);
+                let value = regs.read(rd) & 0xffff_ffff;
+                regs.write(rd, value);
             }
             Self::CNot { rd } => {
-                let value = !state.regs.read(rd);
-                state.regs.write(rd, value);
+                let value = !regs.read(rd);
+                regs.write(rd, value);
             }
             Self::CMul { rd, rs2 } => {
-                let value = state.regs.read(rd).wrapping_mul(state.regs.read(rs2));
-                state.regs.write(rd, value);
+                let value = regs.read(rd).wrapping_mul(regs.read(rs2));
+                regs.write(rd, value);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -5,8 +5,8 @@ pub mod rv64_zcmp_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -14,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZcmpInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZcmpInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -28,48 +26,50 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::CmPush { urlist, stack_adj } => {
-                rv64_zcmp_helpers::do_push(state, urlist, stack_adj)?;
+                rv64_zcmp_helpers::do_push(regs, memory, urlist, stack_adj)?;
             }
             Self::CmPop { urlist, stack_adj } => {
-                rv64_zcmp_helpers::do_pop(state, urlist, stack_adj)?;
+                rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
             }
             Self::CmPopretz { urlist, stack_adj } => {
-                let ra_val = rv64_zcmp_helpers::do_pop(state, urlist, stack_adj)?;
+                let ra_val = rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
                 // Zero a0 before returning
-                state.regs.write(Reg::A0, 0);
+                regs.write(Reg::A0, 0);
                 // Jump to ra with LSB cleared (RISC-V mode bit)
                 let target = ra_val & !1;
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
             Self::CmPopret { urlist, stack_adj } => {
-                let ra_val = rv64_zcmp_helpers::do_pop(state, urlist, stack_adj)?;
+                let ra_val = rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
                 // Jump to ra with LSB cleared (RISC-V mode bit)
                 let target = ra_val & !1;
-                return state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, target)
+                return program_counter
+                    .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
             Self::CmMva01s { r1s, r2s } => {
                 // Read both sources before any write to avoid aliasing
-                let v1 = state.regs.read(r1s);
-                let v2 = state.regs.read(r2s);
-                state.regs.write(Reg::A0, v1);
-                state.regs.write(Reg::A1, v2);
+                let v1 = regs.read(r1s);
+                let v2 = regs.read(r2s);
+                regs.write(Reg::A0, v1);
+                regs.write(Reg::A1, v2);
             }
             Self::CmMvsa01 { r1s, r2s } => {
                 // Read both sources before any write to avoid aliasing
-                let a0_val = state.regs.read(Reg::A0);
-                let a1_val = state.regs.read(Reg::A1);
-                state.regs.write(r1s, a0_val);
-                state.regs.write(r2s, a1_val);
+                let a0_val = regs.read(Reg::A0);
+                let a1_val = regs.read(Reg::A1);
+                regs.write(r1s, a0_val);
+                regs.write(r2s, a1_val);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
@@ -1,16 +1,14 @@
 //! Opaque helpers for Zcmp extension
 
-use crate::{
-    ExecutionError, InterpreterState, ProgramCounter, RegisterFile, SystemInstructionHandler,
-    VirtualMemory,
-};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
 
 /// Execute CM.PUSH: store registers below sp, then decrement sp
 #[inline(always)]
 #[doc(hidden)]
-pub fn do_push<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+pub fn do_push<Reg, Regs, Memory, CustomError>(
+    regs: &mut Regs,
+    memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u32,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
@@ -18,19 +16,15 @@ where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
 {
-    let sp = state.regs.read(Reg::SP);
+    let sp = regs.read(Reg::SP);
     // Store from sp-8 downward, highest-priority register first
     let mut store_addr = sp.wrapping_sub(size_of::<Reg::Type>() as u64);
     for reg in urlist.reg_list() {
-        state.memory.write(store_addr, state.regs.read(reg))?;
+        memory.write(store_addr, regs.read(reg))?;
         store_addr = store_addr.wrapping_sub(size_of::<Reg::Type>() as u64);
     }
-    state
-        .regs
-        .write(Reg::SP, sp.wrapping_sub(u64::from(stack_adj)));
+    regs.write(Reg::SP, sp.wrapping_sub(u64::from(stack_adj)));
     Ok(())
 }
 
@@ -38,8 +32,9 @@ where
 /// Returns the value of ra (x1) for use with popret/popretz.
 #[inline(always)]
 #[doc(hidden)]
-pub fn do_pop<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+pub fn do_pop<Reg, Regs, Memory, CustomError>(
+    regs: &mut Regs,
+    memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u32,
 ) -> Result<u64, ExecutionError<Reg::Type, CustomError>>
@@ -47,18 +42,16 @@ where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
 {
-    let sp = state.regs.read(Reg::SP);
+    let sp = regs.read(Reg::SP);
     let new_sp = sp.wrapping_add(u64::from(stack_adj));
     // Restore from [new_sp-8, new_sp-16, ...], matching push order
     let mut load_addr = new_sp.wrapping_sub(size_of::<Reg::Type>() as u64);
     for reg in urlist.reg_list() {
-        let value = state.memory.read::<u64>(load_addr)?;
-        state.regs.write(reg, value);
+        let value = memory.read::<u64>(load_addr)?;
+        regs.write(reg, value);
         load_addr = load_addr.wrapping_sub(size_of::<Reg::Type>() as u64);
     }
-    state.regs.write(Reg::SP, new_sp);
-    Ok(state.regs.read(Reg::RA))
+    regs.write(Reg::SP, new_sp);
+    Ok(regs.read(Reg::RA))
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
@@ -3,17 +3,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZbkbInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZbkbInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -21,37 +19,41 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Pack { rd, rs1, rs2 } => {
                 // Pack lower 32 bits of rs1 into lower 32 bits of rd,
                 // lower 32 bits of rs2 into upper 32 bits of rd.
-                let lo = state.regs.read(rs1) & 0x0000_0000_FFFF_FFFFu64;
-                let hi = (state.regs.read(rs2) & 0x0000_0000_FFFF_FFFFu64) << 32;
-                state.regs.write(rd, lo | hi);
+                let lo = regs.read(rs1) & 0x0000_0000_FFFF_FFFFu64;
+                let hi = (regs.read(rs2) & 0x0000_0000_FFFF_FFFFu64) << 32;
+                regs.write(rd, lo | hi);
             }
             Self::Packh { rd, rs1, rs2 } => {
                 // Pack low byte of rs1 into bits [7:0], low byte of rs2 into bits [15:8].
                 // Upper bits of rd are zeroed.
-                let lo = state.regs.read(rs1) & 0xFF;
-                let hi = (state.regs.read(rs2) & 0xFF) << 8;
-                state.regs.write(rd, lo | hi);
+                let lo = regs.read(rs1) & 0xFF;
+                let hi = (regs.read(rs2) & 0xFF) << 8;
+                regs.write(rd, lo | hi);
             }
             Self::Packw { rd, rs1, rs2 } => {
                 // Pack low 16 bits of rs1 into bits [15:0] of the 32-bit result,
                 // low 16 bits of rs2 into bits [31:16], then sign-extend to 64 bits.
-                let lo = state.regs.read(rs1) & 0xFFFF;
-                let hi = (state.regs.read(rs2) & 0xFFFF) << 16;
+                let lo = regs.read(rs1) & 0xFFFF;
+                let hi = (regs.read(rs2) & 0xFFFF) << 16;
                 let word = (lo | hi) as u32;
                 let value = i64::from(word.cast_signed()).cast_unsigned();
-                state.regs.write(rd, value);
+                regs.write(rd, value);
             }
             Self::Brev8 { rd, rs1 } => {
                 // Reverse bits within each byte of rs1
-                let src = state.regs.read(rs1);
+                let src = regs.read(rs1);
                 let bytes = src.to_le_bytes().map(u8::reverse_bits);
-                state.regs.write(rd, u64::from_le_bytes(bytes));
+                regs.write(rd, u64::from_le_bytes(bytes));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
@@ -1,24 +1,26 @@
 //! RV64 Zbkc extension (subset of Zbc extension)
 
 use crate::rv64::b::zbc::rv64_zbc_helpers;
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZbkcInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZbkcInstruction<Reg>
 where
     Reg: Register<Type = u64>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
@@ -4,17 +4,15 @@ pub mod rv64_zbkx_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZbkxInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZbkxInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -22,24 +20,24 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Xperm4 { rd, rs1, rs2 } => {
-                let rs1_value = state.regs.read(rs1);
-                let rs2_value = state.regs.read(rs2);
+                let rs1_value = regs.read(rs1);
+                let rs2_value = regs.read(rs2);
 
-                state
-                    .regs
-                    .write(rd, rv64_zbkx_helpers::xperm4(rs1_value, rs2_value));
+                regs.write(rd, rv64_zbkx_helpers::xperm4(rs1_value, rs2_value));
             }
             Self::Xperm8 { rd, rs1, rs2 } => {
-                let rs1_value = state.regs.read(rs1);
-                let rs2_value = state.regs.read(rs2);
+                let rs1_value = regs.read(rs1);
+                let rs2_value = regs.read(rs2);
 
-                state
-                    .regs
-                    .write(rd, rv64_zbkx_helpers::xperm8(rs1_value, rs2_value));
+                regs.write(rd, rv64_zbkx_helpers::xperm8(rs1_value, rs2_value));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
@@ -9,24 +9,26 @@ use crate::rv64::zk::zbkx::rv64_zbkx_helpers;
 use crate::rv64::zk::zkn::zknd::rv64_zknd_helpers;
 use crate::rv64::zk::zkn::zkne::rv64_zkne_helpers;
 use crate::rv64::zk::zkn::zknh::rv64_zknh_helpers;
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZknInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZknInstruction<Reg>
 where
     Reg: Register<Type = u64>,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
@@ -4,17 +4,15 @@ pub mod rv64_zknd_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZkndInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZkndInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -22,31 +20,35 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Aes64Ds { rd, rs1, rs2 } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state.regs.write(rd, rv64_zknd_helpers::aes64ds(v1, v2));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv64_zknd_helpers::aes64ds(v1, v2));
             }
             Self::Aes64Dsm { rd, rs1, rs2 } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state.regs.write(rd, rv64_zknd_helpers::aes64dsm(v1, v2));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv64_zknd_helpers::aes64dsm(v1, v2));
             }
             Self::Aes64Im { rd, rs1 } => {
-                let v1 = state.regs.read(rs1);
-                state.regs.write(rd, rv64_zknd_helpers::aes64im(v1));
+                let v1 = regs.read(rs1);
+                regs.write(rd, rv64_zknd_helpers::aes64im(v1));
             }
             Self::Aes64Ks1i { rd, rs1, rnum } => {
-                let v1 = state.regs.read(rs1);
-                state.regs.write(rd, rv64_zknd_helpers::aes64ks1i(v1, rnum));
+                let v1 = regs.read(rs1);
+                regs.write(rd, rv64_zknd_helpers::aes64ks1i(v1, rnum));
             }
             Self::Aes64Ks2 { rd, rs1, rs2 } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state.regs.write(rd, rv64_zknd_helpers::aes64ks2(v1, v2));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv64_zknd_helpers::aes64ks2(v1, v2));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
@@ -5,17 +5,15 @@ pub mod rv64_zkne_helpers;
 mod tests;
 
 use crate::rv64::zk::zkn::zknd::rv64_zknd_helpers;
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZkneInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZkneInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -23,18 +21,22 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Aes64Es { rd, rs1, rs2 } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state.regs.write(rd, rv64_zkne_helpers::aes64es(v1, v2));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv64_zkne_helpers::aes64es(v1, v2));
             }
             Self::Aes64Esm { rd, rs1, rs2 } => {
-                let v1 = state.regs.read(rs1);
-                let v2 = state.regs.read(rs2);
-                state.regs.write(rd, rv64_zkne_helpers::aes64esm(v1, v2));
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
+                regs.write(rd, rv64_zkne_helpers::aes64esm(v1, v2));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
@@ -4,17 +4,15 @@ pub mod rv64_zknh_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Rv64ZknhInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZknhInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -22,64 +20,60 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Sha256Sig0 { rd, rs1 } => {
-                let x = state.regs.read(rs1) as u32;
+                let x = regs.read(rs1) as u32;
 
                 let res32 = rv64_zknh_helpers::sha256sig0(x);
 
-                state
-                    .regs
-                    .write(rd, i64::from(res32.cast_signed()).cast_unsigned());
+                regs.write(rd, i64::from(res32.cast_signed()).cast_unsigned());
             }
             Self::Sha256Sig1 { rd, rs1 } => {
-                let x = state.regs.read(rs1) as u32;
+                let x = regs.read(rs1) as u32;
 
                 let res32 = rv64_zknh_helpers::sha256sig1(x);
 
-                state
-                    .regs
-                    .write(rd, i64::from(res32.cast_signed()).cast_unsigned());
+                regs.write(rd, i64::from(res32.cast_signed()).cast_unsigned());
             }
             Self::Sha256Sum0 { rd, rs1 } => {
-                let x = state.regs.read(rs1) as u32;
+                let x = regs.read(rs1) as u32;
 
                 let res32 = rv64_zknh_helpers::sha256sum0(x);
 
-                state
-                    .regs
-                    .write(rd, i64::from(res32.cast_signed()).cast_unsigned());
+                regs.write(rd, i64::from(res32.cast_signed()).cast_unsigned());
             }
             Self::Sha256Sum1 { rd, rs1 } => {
-                let x = state.regs.read(rs1) as u32;
+                let x = regs.read(rs1) as u32;
 
                 let res32 = rv64_zknh_helpers::sha256sum1(x);
 
-                state
-                    .regs
-                    .write(rd, i64::from(res32.cast_signed()).cast_unsigned());
+                regs.write(rd, i64::from(res32.cast_signed()).cast_unsigned());
             }
             Self::Sha512Sig0 { rd, rs1 } => {
-                let x = state.regs.read(rs1);
+                let x = regs.read(rs1);
 
-                state.regs.write(rd, rv64_zknh_helpers::sha512sig0(x));
+                regs.write(rd, rv64_zknh_helpers::sha512sig0(x));
             }
             Self::Sha512Sig1 { rd, rs1 } => {
-                let x = state.regs.read(rs1);
+                let x = regs.read(rs1);
 
-                state.regs.write(rd, rv64_zknh_helpers::sha512sig1(x));
+                regs.write(rd, rv64_zknh_helpers::sha512sig1(x));
             }
             Self::Sha512Sum0 { rd, rs1 } => {
-                let x = state.regs.read(rs1);
+                let x = regs.read(rs1);
 
-                state.regs.write(rd, rv64_zknh_helpers::sha512sum0(x));
+                regs.write(rd, rv64_zknh_helpers::sha512sum0(x));
             }
             Self::Sha512Sum1 { rd, rs1 } => {
-                let x = state.regs.read(rs1);
+                let x = regs.read(rs1);
 
-                state.regs.write(rd, rv64_zknh_helpers::sha512sum1(x));
+                regs.write(rd, rv64_zknh_helpers::sha512sum1(x));
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x.rs
@@ -25,8 +25,8 @@ use crate::v::zve64x::store::zve64x_store_helpers;
 use crate::v::zve64x::widen_narrow::zve64x_widen_narrow_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
-    CsrError, Csrs, ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter,
-    RegisterFile, VirtualMemory,
+    CsrError, Csrs, ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -35,17 +35,19 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xInstruction<Reg>
 where
     Reg: Register,
 {
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Ok(ControlFlow::Continue(()))
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith.rs
@@ -6,10 +6,7 @@ pub mod zve64x_arith_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -17,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xArithInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xArithInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -35,51 +30,54 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // vadd
             Self::VaddVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above; `vl <= VLMAX = group_regs * VLENB / sew_bytes`;
                 // masked vd != v0 checked above.
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -92,43 +90,40 @@ where
                 }
             }
             Self::VaddVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above; scalar source has no register constraints
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -141,44 +136,41 @@ where
                 }
             }
             Self::VaddVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Sign-extend imm to u64 so wrapping_add works correctly for all SEW
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -192,45 +184,44 @@ where
             }
             // vsub / vrsub
             Self::VsubVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -243,43 +234,40 @@ where
                 }
             }
             Self::VsubVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -292,44 +280,41 @@ where
                 }
             }
             Self::VrsubVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // vrsub: result = src - vs2[i]
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -342,43 +327,40 @@ where
                 }
             }
             Self::VrsubVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -392,45 +374,44 @@ where
             }
             // vand
             Self::VandVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -443,43 +424,40 @@ where
                 }
             }
             Self::VandVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -492,43 +470,40 @@ where
                 }
             }
             Self::VandVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -542,45 +517,44 @@ where
             }
             // vor
             Self::VorVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -593,43 +567,40 @@ where
                 }
             }
             Self::VorVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -642,43 +613,40 @@ where
                 }
             }
             Self::VorVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -692,45 +660,44 @@ where
             }
             // vxor
             Self::VxorVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -743,43 +710,40 @@ where
                 }
             }
             Self::VxorVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -792,43 +756,40 @@ where
                 }
             }
             Self::VxorVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -842,45 +803,44 @@ where
             }
             // vsll
             Self::VsllVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -894,43 +854,40 @@ where
                 }
             }
             Self::VsllVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -943,44 +900,41 @@ where
                 }
             }
             Self::VsllVi { vd, vs2, uimm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Immediate is already unsigned 5-bit; mask to log2(SEW) here too
                 let shamt = u64::from(uimm) & u64::from(sew.bits() - 1);
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(shamt),
@@ -994,45 +948,44 @@ where
             }
             // vsrl
             Self::VsrlVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1050,43 +1003,40 @@ where
                 }
             }
             Self::VsrlVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1103,43 +1053,40 @@ where
                 }
             }
             Self::VsrlVi { vd, vs2, uimm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let shamt = u64::from(uimm) & u64::from(sew.bits() - 1);
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(shamt),
@@ -1153,45 +1100,44 @@ where
             }
             // vsra
             Self::VsraVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1208,43 +1154,40 @@ where
                 }
             }
             Self::VsraVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1261,43 +1204,40 @@ where
                 }
             }
             Self::VsraVi { vd, vs2, uimm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let shamt = u64::from(uimm) & u64::from(sew.bits() - 1);
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(shamt),
@@ -1314,45 +1254,44 @@ where
             }
             // vminu / vmin
             Self::VminuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1368,43 +1307,40 @@ where
                 }
             }
             Self::VminuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1420,45 +1356,44 @@ where
                 }
             }
             Self::VminVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1479,43 +1414,40 @@ where
                 }
             }
             Self::VminVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1537,45 +1469,44 @@ where
             }
             // vmaxu / vmax
             Self::VmaxuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1591,43 +1522,40 @@ where
                 }
             }
             Self::VmaxuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1643,45 +1571,44 @@ where
                 }
             }
             Self::VmaxVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1702,43 +1629,40 @@ where
                 }
             }
             Self::VmaxVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1760,43 +1684,48 @@ where
             }
             // vmseq
             Self::VmseqVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs1, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: `vs2` and `vs1` alignment checked; `vd` is a single mask register,
                 // no alignment constraint; `vl <= VLMAX <= VLEN` so all element indices fit
                 // within the mask register. Mask-dest overlap rule (§11.8) checked above.
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1812,36 +1741,36 @@ where
                 }
             }
             Self::VmseqVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1857,36 +1786,36 @@ where
                 }
             }
             Self::VmseqVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1903,41 +1832,46 @@ where
             }
             // vmsne
             Self::VmsneVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs1, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1953,36 +1887,36 @@ where
                 }
             }
             Self::VmsneVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -1998,36 +1932,36 @@ where
                 }
             }
             Self::VmsneVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2044,41 +1978,46 @@ where
             }
             // vmsltu (unsigned <)
             Self::VmsltuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs1, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -2094,36 +2033,36 @@ where
                 }
             }
             Self::VmsltuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2140,41 +2079,46 @@ where
             }
             // vmslt (signed <)
             Self::VmsltVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs1, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -2190,36 +2134,36 @@ where
                 }
             }
             Self::VmsltVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2236,41 +2180,46 @@ where
             }
             // vmsleu (unsigned <=)
             Self::VmsleuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs1, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -2286,36 +2235,36 @@ where
                 }
             }
             Self::VmsleuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2331,31 +2280,31 @@ where
                 }
             }
             Self::VmsleuVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Per spec §12.8: for vmsleu.vi, the immediate is sign-extended to XLEN
                 // then the comparison is unsigned. A negative i8 immediate sign-extends to
                 // a large u64 (e.g. -1 -> 0xFFFF...FF). Both operands are masked to SEW
@@ -2367,7 +2316,7 @@ where
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2384,41 +2333,46 @@ where
             }
             // vmsle (signed <=)
             Self::VmsleVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs1, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Vreg(vs1.bits()),
@@ -2434,36 +2388,36 @@ where
                 }
             }
             Self::VmsleVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2479,36 +2433,36 @@ where
                 }
             }
             Self::VmsleVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2525,36 +2479,36 @@ where
             }
             // vmsgtu (unsigned >): no vv form; vx and vi only
             Self::VmsgtuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2570,36 +2524,36 @@ where
                 }
             }
             Self::VmsgtuVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2616,36 +2570,36 @@ where
             }
             // vmsgt (signed >): no vv form; vx and vi only
             Self::VmsgtVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),
@@ -2661,36 +2615,36 @@ where
                 }
             }
             Self::VmsgtVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_arith_helpers::OpSrc::Scalar(scalar),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
@@ -28,7 +28,15 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xArithInstruction<Reg<u64>>>,
     instr: Zve64xArithInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 /// Write bytes into a vector register

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/zve64x_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/zve64x_arith_helpers.rs
@@ -3,15 +3,15 @@
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, InterpreterState, ProgramCounter, VirtualMemory};
+use crate::{ExecutionError, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
 /// Check that `vreg` (`vd`/`vs`) is aligned to `group_regs` and fits within `[0, 32)`
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_vreg_group_alignment<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_vreg_group_alignment<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vreg: VReg,
     group_regs: u8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
@@ -22,7 +22,7 @@ where
     let vreg_idx = vreg.bits();
     if !vreg_idx.is_multiple_of(group_regs) || vreg_idx + group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -35,8 +35,8 @@ where
 /// the encoding is reserved and raises an illegal instruction.
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_mask_dest_no_overlap<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_mask_dest_no_overlap<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vd: VReg,
     src_base: VReg,
     group_regs: u8,
@@ -50,7 +50,7 @@ where
         let src = src_base.bits();
         if vd_idx >= src && vd_idx < src + group_regs {
             return Err(ExecutionError::IllegalInstruction {
-                address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+                address: program_counter.old_pc(INSTRUCTION_SIZE),
             });
         }
     }
@@ -169,8 +169,8 @@ pub enum OpSrc {
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -185,13 +185,11 @@ pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, Vsew) -> u64,
 {
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
 
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
@@ -203,15 +201,12 @@ pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
 
         // SAFETY: `vs2_base % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`,
         // so `vs2_base + i / elems_per_reg < vs2_base + group_regs <= 32`
-        let a =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
 
         let b = match &src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe {
-                    read_element_u64(state.ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
-                }
+                unsafe { read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew) }
             }
             OpSrc::Scalar(val) => *val,
         };
@@ -221,12 +216,12 @@ pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
         // SAFETY: `vd_base % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`,
         // so `vd_base + i / elems_per_reg < vd_base + group_regs <= 32`
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
 
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a single-width element-wise integer compare over `vstart..vl`, writing one result
@@ -245,8 +240,8 @@ pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_compare_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -261,13 +256,11 @@ pub unsafe fn execute_compare_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, Vsew) -> bool,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
 
     let vs2_base = vs2.bits();
 
@@ -279,15 +272,12 @@ pub unsafe fn execute_compare_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
         }
 
         // SAFETY: same argument as in `execute_arith_op`
-        let a =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
 
         let b = match &src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe {
-                    read_element_u64(state.ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
-                }
+                unsafe { read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew) }
             }
             OpSrc::Scalar(val) => *val,
         };
@@ -296,12 +286,12 @@ pub unsafe fn execute_compare_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
 
         // SAFETY: `i < vl <= VLMAX <= VLEN`, so `i / 8 < VLEN / 8 = VLENB`
         unsafe {
-            write_mask_bit(state.ext_state.write_vreg(), vd, i, result);
+            write_mask_bit(ext_state.write_vreg(), vd, i, result);
         }
     }
 
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Sign-extend the low `sew.bits()` of `val` to a full `i64`

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/config.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/config.rs
@@ -5,10 +5,7 @@ mod tests;
 pub mod zve64x_config_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
-use crate::{
-    CsrError, Csrs, ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter,
-    RegisterFile,
-};
+use crate::{CsrError, Csrs, ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -16,10 +13,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xConfigInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xConfigInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -117,18 +112,43 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Vsetvli { rd, rs1, vtypei } => {
-                zve64x_config_helpers::apply_vsetvl(state, rd, rs1, Reg::Type::from(vtypei))?;
+                zve64x_config_helpers::apply_vsetvl(
+                    regs,
+                    ext_state,
+                    program_counter,
+                    rd,
+                    rs1,
+                    Reg::Type::from(vtypei),
+                )?;
             }
             Self::Vsetivli { rd, uimm, vtypei } => {
-                zve64x_config_helpers::apply_vsetivli(state, rd, uimm, vtypei)?;
+                zve64x_config_helpers::apply_vsetivli(
+                    regs,
+                    ext_state,
+                    program_counter,
+                    rd,
+                    uimm,
+                    vtypei,
+                )?;
             }
             Self::Vsetvl { rd, rs1, rs2 } => {
-                let vtype_raw = state.regs.read(rs2);
-                zve64x_config_helpers::apply_vsetvl(state, rd, rs1, vtype_raw)?;
+                let vtype_raw = regs.read(rs2);
+                zve64x_config_helpers::apply_vsetvl(
+                    regs,
+                    ext_state,
+                    program_counter,
+                    rd,
+                    rs1,
+                    vtype_raw,
+                )?;
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/tests.rs
@@ -1,4 +1,7 @@
-use crate::rv64::test_utils::{ExtState, TestInterpreterState, execute, initialize_state};
+use crate::basic::BasicRegisters;
+use crate::rv64::test_utils::{
+    ExtState, TestInstructionFetcher, TestInstructionHandler, TestMemory, execute, initialize_state,
+};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersBase, VectorRegistersExt};
 use crate::{Csrs, ExecutableInstruction, RegisterFile};
 use ab_riscv_primitives::prelude::*;
@@ -716,8 +719,11 @@ fn prepare_csr_read_passes_through_vector_csrs() {
     state.ext_state.init_vector_csrs();
 
     let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_read(&state.ext_state, VCsr::Vstart as u16, 42, &mut output);
     assert!(result.unwrap());
     assert_eq!(output, 42);
@@ -730,8 +736,11 @@ fn prepare_csr_read_ignores_non_vector_csrs() {
     state.ext_state.init_vector_csrs();
 
     let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_read(&state.ext_state, 0x300, 42, &mut output);
     // Returns Ok(false) meaning "not handled by this extension"
     assert!(!result.unwrap());
@@ -754,8 +763,11 @@ fn prepare_csr_read_works_for_all_vector_csrs() {
     for csr_index in csr_indices {
         let mut output = 0u64;
         let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            TestInterpreterState<Zve64xConfigInstruction<_>>,
-            _,
+            BasicRegisters<Reg<u64>>,
+            ExtState,
+            TestMemory,
+            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+            TestInstructionHandler,
         >>::prepare_csr_read(&state.ext_state, csr_index, 0xFF, &mut output);
         assert!(result.unwrap(), "CSR {csr_index:#x} should be handled");
         assert_eq!(output, 0xFF, "CSR {csr_index:#x} should pass through");
@@ -769,8 +781,11 @@ fn prepare_csr_write_rejects_read_only_vl() {
     state.ext_state.init_vector_csrs();
 
     let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vl as u16, 42, &mut output);
     assert!(result.is_err());
 }
@@ -783,8 +798,11 @@ fn prepare_csr_write_rejects_read_only_vtype() {
 
     let result =
         <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            TestInterpreterState<Zve64xConfigInstruction<_>>,
-            _,
+            BasicRegisters<Reg<u64>>,
+            ExtState,
+            TestMemory,
+            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+            TestInstructionHandler,
         >>::prepare_csr_write(&mut state.ext_state, VCsr::Vtype as u16, 42, &mut output);
     assert!(result.is_err());
 }
@@ -797,8 +815,11 @@ fn prepare_csr_write_rejects_read_only_vlenb() {
 
     let result =
         <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            TestInterpreterState<Zve64xConfigInstruction<_>>,
-            _,
+            BasicRegisters<Reg<u64>>,
+            ExtState,
+            TestMemory,
+            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+            TestInstructionHandler,
         >>::prepare_csr_write(&mut state.ext_state, VCsr::Vlenb as u16, 42, &mut output);
     assert!(result.is_err());
 }
@@ -811,8 +832,11 @@ fn prepare_csr_write_vxsat_masks_to_1_bit() {
 
     let result =
         <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            TestInterpreterState<Zve64xConfigInstruction<_>>,
-            _,
+            BasicRegisters<Reg<u64>>,
+            ExtState,
+            TestMemory,
+            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+            TestInstructionHandler,
         >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxsat as u16, 0xFF, &mut output);
     assert!(result.unwrap());
     assert_eq!(output, 1);
@@ -826,8 +850,11 @@ fn prepare_csr_write_vxrm_masks_to_2_bits() {
 
     let result =
         <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            TestInterpreterState<Zve64xConfigInstruction<_>>,
-            _,
+            BasicRegisters<Reg<u64>>,
+            ExtState,
+            TestMemory,
+            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+            TestInstructionHandler,
         >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxrm as u16, 0xFF, &mut output);
     assert!(result.unwrap());
     assert_eq!(output, 0b11);
@@ -841,8 +868,11 @@ fn prepare_csr_write_vcsr_masks_to_3_bits() {
 
     let result =
         <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            TestInterpreterState<Zve64xConfigInstruction<_>>,
-            _,
+            BasicRegisters<Reg<u64>>,
+            ExtState,
+            TestMemory,
+            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+            TestInstructionHandler,
         >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0xFFFF, &mut output);
     assert!(result.unwrap());
     assert_eq!(output, 0b111);
@@ -855,8 +885,11 @@ fn prepare_csr_write_vstart_passes_full_value() {
     state.ext_state.init_vector_csrs();
 
     let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(
         &mut state.ext_state,
         VCsr::Vstart as u16,
@@ -874,8 +907,11 @@ fn prepare_csr_write_ignores_non_vector_csrs() {
     state.ext_state.init_vector_csrs();
 
     let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, 0x300, 42, &mut output);
     assert!(!result.unwrap());
 }
@@ -1271,8 +1307,11 @@ fn prepare_csr_write_vxsat_mirrors_into_vcsr() {
 
     let mut output = 0u64;
     let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxsat as u16, 1, &mut output);
     assert!(result.unwrap());
     assert_eq!(output, 1);
@@ -1291,8 +1330,11 @@ fn prepare_csr_write_vxsat_clear_mirrors_into_vcsr() {
 
     let mut output = 0u64;
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxsat as u16, 0, &mut output)
     .unwrap();
 
@@ -1310,8 +1352,11 @@ fn prepare_csr_write_vxrm_mirrors_into_vcsr() {
 
     let mut output = 0u64;
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxrm as u16, 0b11, &mut output)
     .unwrap();
     assert_eq!(output, 0b11);
@@ -1330,8 +1375,11 @@ fn prepare_csr_write_vxrm_clear_mirrors_into_vcsr() {
 
     let mut output = 0u64;
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxrm as u16, 0b00, &mut output)
     .unwrap();
 
@@ -1351,8 +1399,11 @@ fn prepare_csr_write_vcsr_mirrors_into_vxsat_and_vxrm() {
     let mut output = 0u64;
     // Write vcsr = 0b101 (vxrm=0b10, vxsat=1)
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0b101, &mut output)
     .unwrap();
     assert_eq!(output, 0b101);
@@ -1374,8 +1425,11 @@ fn prepare_csr_write_vcsr_zero_clears_vxsat_and_vxrm() {
 
     let mut output = 0u64;
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0, &mut output)
     .unwrap();
 
@@ -1394,8 +1448,11 @@ fn prepare_csr_write_vcsr_masks_then_mirrors() {
     let mut output = 0u64;
     // Write 0xFF to vcsr; should mask to 0b111, then mirror
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0xFF, &mut output)
     .unwrap();
     assert_eq!(output, 0b111);
@@ -1416,8 +1473,11 @@ fn mirroring_roundtrip_vxsat_to_vcsr_and_back() {
 
     // Write vxrm=0b10 via vcsr
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0b100, &mut output)
     .unwrap();
     // Now write the masked vcsr value to the CSR storage itself
@@ -1428,8 +1488,11 @@ fn mirroring_roundtrip_vxsat_to_vcsr_and_back() {
 
     // Write vxsat=1 directly
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxsat as u16, 1, &mut output)
     .unwrap();
     state
@@ -1464,8 +1527,11 @@ fn prepare_csr_read_vcsr_reflects_separate_csr_values() {
     let mut output = 0u64;
     let raw = state.ext_state.read_csr(VCsr::Vcsr as u16).unwrap();
     <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        TestInterpreterState<Zve64xConfigInstruction<_>>,
-        _,
+        BasicRegisters<Reg<u64>>,
+        ExtState,
+        TestMemory,
+        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
+        TestInstructionHandler,
     >>::prepare_csr_read(&state.ext_state, VCsr::Vcsr as u16, raw, &mut output)
     .unwrap();
     assert_eq!(output, 0b101);

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/zve64x_config_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/zve64x_config_helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, InterpreterState, ProgramCounter, RegisterFile};
+use crate::{ExecutionError, ProgramCounter, RegisterFile};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
@@ -11,8 +11,10 @@ use core::fmt;
 /// Both share identical `AVL` resolution; they differ only in how the `vtype` value is obtained
 /// (immediate for `vsetvli`, register for `vsetvl`).
 #[doc(hidden)]
-pub fn apply_vsetvl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+pub fn apply_vsetvl<Reg, Regs, ExtState, Memory, PC, CustomError>(
+    regs: &mut Regs,
+    ext_state: &mut ExtState,
+    program_counter: &PC,
     rd: Reg,
     rs1: Reg,
     vtype_raw: Reg::Type,
@@ -27,33 +29,33 @@ where
     CustomError: fmt::Debug,
 {
     // Check whether vector instructions are enabled
-    if !state.ext_state.vector_instructions_allowed() {
+    if !ext_state.vector_instructions_allowed() {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
 
     let new_vtype = if let Some(new_vtype) = Vtype::from_raw::<Reg>(vtype_raw) {
         new_vtype
     } else {
-        state.ext_state.set_vtype(None);
-        state.ext_state.set_vl(0);
-        state.regs.write(rd, Reg::Type::from(0u8));
-        state.ext_state.mark_vs_dirty();
-        state.ext_state.reset_vstart();
+        ext_state.set_vtype(None);
+        ext_state.set_vl(0);
+        regs.write(rd, Reg::Type::from(0u8));
+        ext_state.mark_vs_dirty();
+        ext_state.reset_vstart();
 
         return Ok(());
     };
 
-    let vlmax = state.ext_state.vlmax_for_vtype(new_vtype);
+    let vlmax = ext_state.vlmax_for_vtype(new_vtype);
 
     let rs1_is_zero = rs1 == Reg::ZERO;
     let rd_is_zero = rd == Reg::ZERO;
 
     let new_vl = if !rs1_is_zero {
         // Truncate to `u32`: `VLMAX` fits in `u32` (max 65536)
-        let avl = state.regs.read(rs1).as_u64() as u32;
-        state.ext_state.compute_vl(avl, vlmax)
+        let avl = regs.read(rs1).as_u64() as u32;
+        ext_state.compute_vl(avl, vlmax)
     } else if !rd_is_zero {
         //` rs1=x0, rd!=x0`: `AVL = max`, `result` is `VLMAX`
         vlmax
@@ -61,28 +63,27 @@ where
         // `rs1=x0, rd=x0`: use current `vl` as `AVL`, keep `vl` unchanged if `VLMAX` stays the
         // same. If `VLMAX` changes, this is reserved, and we set `vill` (conservative choice per
         // spec).
-        let current_vl = state.ext_state.vl();
-        let old_vtype = state.ext_state.vtype();
-        let old_vlmax =
-            old_vtype.map_or_default(|old_vtype| state.ext_state.vlmax_for_vtype(old_vtype));
+        let current_vl = ext_state.vl();
+        let old_vtype = ext_state.vtype();
+        let old_vlmax = old_vtype.map_or_default(|old_vtype| ext_state.vlmax_for_vtype(old_vtype));
 
         if vlmax != old_vlmax {
-            state.ext_state.set_vtype(None);
-            state.ext_state.set_vl(0);
-            state.ext_state.mark_vs_dirty();
-            state.ext_state.reset_vstart();
+            ext_state.set_vtype(None);
+            ext_state.set_vl(0);
+            ext_state.mark_vs_dirty();
+            ext_state.reset_vstart();
 
             return Ok(());
         }
 
-        state.ext_state.compute_vl(current_vl, vlmax)
+        ext_state.compute_vl(current_vl, vlmax)
     };
 
-    state.ext_state.set_vtype(Some(new_vtype));
-    state.ext_state.set_vl(new_vl);
-    state.regs.write(rd, Reg::Type::from(new_vl));
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.set_vtype(Some(new_vtype));
+    ext_state.set_vl(new_vl);
+    regs.write(rd, Reg::Type::from(new_vl));
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 
     Ok(())
 }
@@ -92,8 +93,10 @@ where
 /// `AVL` comes from 5-bit zero-extended immediate (0..31). No `rs1=x0/rd=x0` special casing
 /// applies to this variant.
 #[doc(hidden)]
-pub fn apply_vsetivli<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+pub fn apply_vsetivli<Reg, Regs, ExtState, Memory, PC, CustomError>(
+    regs: &mut Regs,
+    ext_state: &mut ExtState,
+    program_counter: &PC,
     rd: Reg,
     uimm: u8,
     vtypei: u16,
@@ -108,29 +111,29 @@ where
     CustomError: fmt::Debug,
 {
     // Check whether vector instructions are enabled
-    if !state.ext_state.vector_instructions_allowed() {
+    if !ext_state.vector_instructions_allowed() {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
 
     let vtype_raw = Reg::Type::from(vtypei);
 
     if let Some(new_vtype) = Vtype::from_raw::<Reg>(vtype_raw) {
-        let vlmax = state.ext_state.vlmax_for_vtype(new_vtype);
+        let vlmax = ext_state.vlmax_for_vtype(new_vtype);
         let avl = u32::from(uimm);
-        let new_vl = state.ext_state.compute_vl(avl, vlmax);
+        let new_vl = ext_state.compute_vl(avl, vlmax);
 
-        state.ext_state.set_vtype(Some(new_vtype));
-        state.ext_state.set_vl(new_vl);
-        state.regs.write(rd, Reg::Type::from(new_vl));
+        ext_state.set_vtype(Some(new_vtype));
+        ext_state.set_vl(new_vl);
+        regs.write(rd, Reg::Type::from(new_vl));
     } else {
-        state.ext_state.set_vtype(None);
-        state.ext_state.set_vl(0);
-        state.regs.write(rd, Reg::Type::from(0u8));
+        ext_state.set_vtype(None);
+        ext_state.set_vl(0);
+        regs.write(rd, Reg::Type::from(0u8));
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 
     Ok(())
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
@@ -6,10 +6,7 @@ pub mod zve64x_fixed_point_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -17,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xFixedPointInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xFixedPointInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -35,50 +30,53 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // vsaddu.vv / vsaddu.vx / vsaddu.vi - saturating unsigned add
             Self::VsadduVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -93,43 +91,40 @@ where
                 }
             }
             Self::VsadduVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -144,45 +139,42 @@ where
                 }
             }
             Self::VsadduVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Per v-spec §12.1 / §11.1: the 5-bit immediate is sign-extended to SEW,
                 // then interpreted as an unsigned SEW-wide value for the saturating add.
                 // Sign-extend i8 -> i64 -> bit-cast to u64; sat_addu masks to SEW internally.
                 let scalar = i64::from(imm).cast_unsigned();
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -198,45 +190,44 @@ where
             }
             // vsadd.vv / vsadd.vx / vsadd.vi - saturating signed add
             Self::VsaddVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -251,43 +242,40 @@ where
                 }
             }
             Self::VsaddVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -302,44 +290,41 @@ where
                 }
             }
             Self::VsaddVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Sign-extend 5-bit immediate for signed sat add
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -355,45 +340,44 @@ where
             }
             // vssubu.vv / vssubu.vx - saturating unsigned subtract
             Self::VssubuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -408,43 +392,40 @@ where
                 }
             }
             Self::VssubuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -460,45 +441,44 @@ where
             }
             // vssub.vv / vssub.vx - saturating signed subtract
             Self::VssubVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -513,43 +493,40 @@ where
                 }
             }
             Self::VssubVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -565,45 +542,44 @@ where
             }
             // vaaddu.vv / vaaddu.vx - averaging unsigned add
             Self::VaadduVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -618,43 +594,40 @@ where
                 }
             }
             Self::VaadduVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -670,45 +643,44 @@ where
             }
             // vaadd.vv / vaadd.vx - averaging signed add
             Self::VaaddVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -723,43 +695,40 @@ where
                 }
             }
             Self::VaaddVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -775,45 +744,44 @@ where
             }
             // vasubu.vv / vasubu.vx - averaging unsigned subtract
             Self::VasubuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -828,43 +796,40 @@ where
                 }
             }
             Self::VasubuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -880,45 +845,44 @@ where
             }
             // vasub.vv / vasub.vx - averaging signed subtract
             Self::VasubVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -933,43 +897,40 @@ where
                 }
             }
             Self::VasubVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -985,45 +946,44 @@ where
             }
             // vsmul.vv / vsmul.vx - fractional multiply with rounding and saturation
             Self::VsmulVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1038,43 +998,40 @@ where
                 }
             }
             Self::VsmulVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -1090,45 +1047,44 @@ where
             }
             // vssrl.vv / vssrl.vx / vssrl.vi - scaling shift right logical
             Self::VssrlVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1147,43 +1103,40 @@ where
                 }
             }
             Self::VssrlVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -1201,44 +1154,41 @@ where
                 }
             }
             Self::VssrlVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Immediate is unsigned 5-bit; mask to log2(SEW) here too
                 let shamt = (u64::from(imm) & u64::from(sew.bits() - 1)) as u32;
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(u64::from(shamt)),
@@ -1257,45 +1207,44 @@ where
             }
             // vssra.vv / vssra.vx / vssra.vi - scaling shift right arithmetic
             Self::VssraVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1312,43 +1261,40 @@ where
                 }
             }
             Self::VssraVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -1365,43 +1311,40 @@ where
                 }
             }
             Self::VssraVi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let shamt = (u64::from(imm) & u64::from(sew.bits() - 1)) as u32;
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(u64::from(shamt)),
@@ -1419,51 +1362,51 @@ where
             }
             // vnclipu.wv / vnclipu.wx / vnclipu.wi - narrowing unsigned clip
             Self::VnclipuWv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // Destination SEW must be <= 32 so that 2*SEW fits in 64 bits
                 let sew = vtype.vsew();
-                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _, _, _, _>(
-                    state, sew,
+                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
+                    program_counter,
+                    sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 // vs2 holds 2*SEW elements; its register group is double-width
-                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 // vs1 is a normal SEW-wide source for the shift amount
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: sew <= 32 checked; alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_narrowing_clip_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1478,46 +1421,44 @@ where
                 }
             }
             Self::VnclipuWx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
-                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _, _, _, _>(
-                    state, sew,
+                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
+                    program_counter,
+                    sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: sew <= 32 checked; alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_narrowing_clip_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -1532,45 +1473,43 @@ where
                 }
             }
             Self::VnclipuWi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
-                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _, _, _, _>(
-                    state, sew,
+                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
+                    program_counter,
+                    sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: sew <= 32 checked; alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_narrowing_clip_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         // Immediate is the shift amount directly; masking done inside the helper
@@ -1587,48 +1526,48 @@ where
             }
             // vnclip.wv / vnclip.wx / vnclip.wi - narrowing signed clip
             Self::VnclipWv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
-                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _, _, _, _>(
-                    state, sew,
+                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
+                    program_counter,
+                    sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: sew <= 32 checked; alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_narrowing_clip_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1643,46 +1582,44 @@ where
                 }
             }
             Self::VnclipWx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
-                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _, _, _, _>(
-                    state, sew,
+                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
+                    program_counter,
+                    sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: sew <= 32 checked; alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_narrowing_clip_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(scalar),
@@ -1697,45 +1634,43 @@ where
                 }
             }
             Self::VnclipWi { vd, vs2, imm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
-                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _, _, _, _>(
-                    state, sew,
+                zve64x_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
+                    program_counter,
+                    sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: sew <= 32 checked; alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_narrowing_clip_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_fixed_point_helpers::OpSrc::Scalar(u64::from(imm)),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
@@ -37,7 +37,15 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xFixedPointInstruction<Reg<u64>>>,
     instr: Zve64xFixedPointInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 fn write_elem(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
@@ -9,7 +9,7 @@ use crate::v::zve64x::arith::zve64x_arith_helpers::{
 };
 use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, InterpreterState, ProgramCounter, VirtualMemory};
+use crate::{ExecutionError, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
@@ -434,8 +434,8 @@ pub unsafe fn read_wide_element_u64<const VLENB: usize>(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_fixed_point_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -450,15 +450,13 @@ pub unsafe fn execute_fixed_point_op<Reg, Regs, ExtState, Memory, PC, IH, Custom
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     // op: (vs2_elem, src_elem, sew, vxrm) -> result
     F: Fn(u64, u64, Vsew, Vxrm, &mut bool) -> u64,
 {
-    let vxrm = state.ext_state.vxrm();
+    let vxrm = ext_state.vxrm();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     let mut any_sat = false;
@@ -467,29 +465,26 @@ pub unsafe fn execute_fixed_point_op<Reg, Regs, ExtState, Memory, PC, IH, Custom
             continue;
         }
         // SAFETY: alignment and bounds checked by caller
-        let a =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
         let b = match &src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe {
-                    read_element_u64(state.ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
-                }
+                unsafe { read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew) }
             }
             OpSrc::Scalar(val) => *val,
         };
         let result = op(a, b, sew, vxrm, &mut any_sat);
         // SAFETY: alignment and bounds checked by caller
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
     if any_sat {
         // vxsat is sticky: OR in the new saturation flag
-        state.ext_state.set_vxsat(true);
+        ext_state.set_vxsat(true);
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a narrowing fixed-point clip operation.
@@ -509,8 +504,8 @@ pub unsafe fn execute_fixed_point_op<Reg, Regs, ExtState, Memory, PC, IH, Custom
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_narrowing_clip_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -525,15 +520,13 @@ pub unsafe fn execute_narrowing_clip_op<Reg, Regs, ExtState, Memory, PC, IH, Cus
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     // op: (vs2_wide_elem, shamt, sew, vxrm, vxsat) -> result
     F: Fn(u64, u32, Vsew, Vxrm, &mut bool) -> u64,
 {
-    let vxrm = state.ext_state.vxrm();
+    let vxrm = ext_state.vxrm();
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     let mut any_sat = false;
@@ -545,14 +538,13 @@ pub unsafe fn execute_narrowing_clip_op<Reg, Regs, ExtState, Memory, PC, IH, Cus
         }
         // Read 2*SEW-wide source element
         // SAFETY: `vs2` double-width alignment checked by caller
-        let wide_a = unsafe {
-            read_wide_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew)
-        };
+        let wide_a =
+            unsafe { read_wide_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
         let shamt = match &src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: vs1 SEW-wide alignment checked by caller
                 let raw = unsafe {
-                    read_element_u64(state.ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
+                    read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
                 };
                 (raw & shamt_mask) as u32
             }
@@ -561,14 +553,14 @@ pub unsafe fn execute_narrowing_clip_op<Reg, Regs, ExtState, Memory, PC, IH, Cus
         let result = op(wide_a, shamt, sew, vxrm, &mut any_sat);
         // SAFETY: `vd` alignment checked by caller
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
     if any_sat {
-        state.ext_state.set_vxsat(true);
+        ext_state.set_vxsat(true);
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Verify that the destination SEW is valid for narrowing (must be at most 32 in Zve64x).
@@ -576,8 +568,8 @@ pub unsafe fn execute_narrowing_clip_op<Reg, Regs, ExtState, Memory, PC, IH, Cus
 /// Returns `Err(IllegalInstruction)` when `sew.bits() > 32`.
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_narrowing_sew<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_narrowing_sew<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     sew: Vsew,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -586,7 +578,7 @@ where
 {
     if sew.bits() > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -595,8 +587,8 @@ where
 /// Check that `vs2` for a narrowing instruction is aligned to `2 * group_regs` and fits in [0,32).
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_vs2_narrowing_alignment<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_vs2_narrowing_alignment<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vs2: VReg,
     group_regs: u8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
@@ -608,14 +600,14 @@ where
     // LMUL=8 with a narrowing instruction is reserved.
     if group_regs > 4 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     let double_group = group_regs * 2;
     let vs2_idx = vs2.bits();
     if !vs2_idx.is_multiple_of(double_group) || vs2_idx + double_group > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -6,10 +6,7 @@ pub mod zve64x_load_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -17,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xLoadInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xLoadInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -35,7 +30,11 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // Whole-register load: loads `nreg` consecutive registers starting at `vd` directly
@@ -46,33 +45,26 @@ where
                 nreg,
                 eew: _,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if u32::from(vd.bits()) % u32::from(nreg) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let base = state.regs.read(rs1).as_u64();
+                let base = regs.read(rs1).as_u64();
                 let vlenb = u64::from(ExtState::VLENB);
                 for reg_off in 0..u64::from(nreg) {
                     let reg_idx = u64::from(vd.bits()) + reg_off;
-                    let bytes = match state
-                        .memory
-                        .read_slice(base + reg_off * vlenb, ExtState::VLENB)
-                    {
+                    let bytes = match memory.read_slice(base + reg_off * vlenb, ExtState::VLENB) {
                         Ok(bytes) => bytes,
                         Err(error) => {
                             if reg_off > 0 {
-                                state.ext_state.mark_vs_dirty();
-                                state.ext_state.reset_vstart();
+                                ext_state.mark_vs_dirty();
+                                ext_state.reset_vstart();
                             }
                             Err(ExecutionError::MemoryAccess(error))?
                         }
@@ -81,48 +73,40 @@ where
                     // and vd is nreg-aligned (checked above), so vd.bits() + nreg - 1 <= 31.
                     // `read_slice` returns a slice of exactly `ExtState::VLENB` bytes on success,
                     // matching `dst`'s length, so `copy_from_slice` cannot panic.
-                    let dst = unsafe {
-                        state
-                            .ext_state
-                            .write_vreg()
-                            .get_unchecked_mut(reg_idx as usize)
-                    };
+                    let dst = unsafe { ext_state.write_vreg().get_unchecked_mut(reg_idx as usize) };
                     dst.copy_from_slice(bytes);
                 }
-                state.ext_state.mark_vs_dirty();
-                state.ext_state.reset_vstart();
+                ext_state.mark_vs_dirty();
+                ext_state.reset_vstart();
             }
 
             // Mask load: loads ceil(vl / 8) bytes from base into vd with no masking applied.
             // Does not require a valid vtype: when vill is set vl is 0, so zero bytes are read.
             Self::Vlm { vd, rs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 let byte_count = vl.div_ceil(u8::BITS);
                 if byte_count > 0 {
-                    let base = state.regs.read(rs1).as_u64();
-                    let bytes = state.memory.read_slice(base, byte_count)?;
+                    let base = regs.read(rs1).as_u64();
+                    let bytes = memory.read_slice(base, byte_count)?;
                     // SAFETY: `vd.bits() < 32` is guaranteed by the `VReg` type.
                     // `bytes.len() == byte_count = vl.div_ceil(8) <= VLEN / 8 = VLENB` because
                     // `vl <= VLMAX <= VLEN`, so `..bytes.len()` is in bounds within the
                     // `VLENB`-byte destination register.
                     unsafe {
-                        state
-                            .ext_state
+                        ext_state
                             .write_vreg()
                             .get_unchecked_mut(usize::from(vd.bits()))
                             .get_unchecked_mut(..bytes.len())
                             .copy_from_slice(bytes);
                     }
                 }
-                state.ext_state.mark_vs_dirty();
-                state.ext_state.reset_vstart();
+                ext_state.mark_vs_dirty();
+                ext_state.reset_vstart();
             }
 
             // Unit-stride load.
@@ -131,37 +115,30 @@ where
             // gives `group_regs` such that `VLMAX = group_regs * VLENB / eew.bytes()` matches
             // the architectural `vl`.
             Self::Vle { vd, rs1, vm, eew } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && zve64x_load_helpers::groups_overlap(vd, group_regs, VReg::V0, 1) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY:
@@ -175,12 +152,13 @@ where
                 // - mask overlap: checked above via `groups_overlap`
                 unsafe {
                     zve64x_load_helpers::execute_unit_stride_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         eew,
                         group_regs,
                         1,
@@ -191,48 +169,42 @@ where
 
             // Fault-only-first unit-stride load. Preconditions identical to `Vle`.
             Self::Vleff { vd, rs1, vm, eew } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && zve64x_load_helpers::groups_overlap(vd, group_regs, VReg::V0, 1) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY: preconditions identical to `Vle`; see that arm for the full argument.
                 unsafe {
                     zve64x_load_helpers::execute_unit_stride_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         eew,
                         group_regs,
                         1,
@@ -249,41 +221,34 @@ where
                 vm,
                 eew,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && zve64x_load_helpers::groups_overlap(vd, group_regs, VReg::V0, 1) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // rs2 holds a signed stride; reinterpret the register value as signed.
-                let stride = state.regs.read(rs2).as_u64().cast_signed();
+                let stride = regs.read(rs2).as_u64().cast_signed();
                 // SAFETY:
                 // - alignment and nf=1 bounds: `check_register_group_alignment` verified `vd %
                 //   group_regs == 0` and `vd + group_regs <= 32`
@@ -292,12 +257,13 @@ where
                 // - mask overlap: checked above via `groups_overlap`
                 unsafe {
                     zve64x_load_helpers::execute_strided_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         stride,
                         eew,
                         group_regs,
@@ -315,52 +281,41 @@ where
                 vm,
                 eew: index_eew,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let data_group_regs = vtype.vlmul().register_count();
                 let index_group_regs = vtype
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     data_group_regs,
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     index_group_regs,
                 )?;
                 if zve64x_load_helpers::groups_overlap(vd, data_group_regs, vs2, index_group_regs) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vm && zve64x_load_helpers::groups_overlap(vd, data_group_regs, VReg::V0, 1) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY:
@@ -374,13 +329,14 @@ where
                 // - mask overlap: checked above via `groups_overlap`
                 unsafe {
                     zve64x_load_helpers::execute_indexed_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vs2,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         vtype.vsew().as_eew(),
                         index_eew,
                         data_group_regs,
@@ -398,65 +354,55 @@ where
                 vm,
                 eew: index_eew,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let data_group_regs = vtype.vlmul().register_count();
                 let index_group_regs = vtype
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     data_group_regs,
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     index_group_regs,
                 )?;
                 if zve64x_load_helpers::groups_overlap(vd, data_group_regs, vs2, index_group_regs) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vm && zve64x_load_helpers::groups_overlap(vd, data_group_regs, VReg::V0, 1) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY: preconditions identical to `Vluxei`; see that arm for the full
                 // argument.
                 unsafe {
                     zve64x_load_helpers::execute_indexed_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vs2,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         vtype.vsew().as_eew(),
                         index_eew,
                         data_group_regs,
@@ -473,37 +419,32 @@ where
                 eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _, _, _, _>(
-                    state, vd, vm, group_regs, nf,
+                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vm,
+                    group_regs,
+                    nf,
                 )?;
                 if nf > zve64x_load_helpers::MAX_NF {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY:
@@ -516,12 +457,13 @@ where
                 //   when `vm=false`, ensuring no field group contains v0
                 unsafe {
                     zve64x_load_helpers::execute_unit_stride_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         eew,
                         group_regs,
                         nf,
@@ -538,48 +480,44 @@ where
                 eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _, _, _, _>(
-                    state, vd, vm, group_regs, nf,
+                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vm,
+                    group_regs,
+                    nf,
                 )?;
                 if nf > zve64x_load_helpers::MAX_NF {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY: preconditions identical to `Vlseg`; see that arm for the full argument.
                 unsafe {
                     zve64x_load_helpers::execute_unit_stride_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         eew,
                         group_regs,
                         nf,
@@ -597,33 +535,30 @@ where
                 eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _, _, _, _>(
-                    state, vd, vm, group_regs, nf,
+                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vm,
+                    group_regs,
+                    nf,
                 )?;
-                let stride = state.regs.read(rs2).as_u64().cast_signed();
+                let stride = regs.read(rs2).as_u64().cast_signed();
                 // SAFETY:
                 // - alignment and nf-group bounds: `validate_segment_registers` verified `vd %
                 //   group_regs == 0` and `vd + nf * group_regs <= 32`
@@ -633,12 +568,13 @@ where
                 //   `vm=false`
                 unsafe {
                     zve64x_load_helpers::execute_strided_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         stride,
                         eew,
                         group_regs,
@@ -656,42 +592,35 @@ where
                 eew: index_eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let data_group_regs = vtype.vlmul().register_count();
                 let index_group_regs = vtype
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // `validate_segment_registers` is called before the per-field overlap loop so
                 // that `vd.bits() + f * data_group_regs < 32` is established for all `f < nf`,
                 // which is required by the `VReg::from_bits` call inside the loop.
-                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vm,
                     data_group_regs,
                     nf,
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     index_group_regs,
                 )?;
@@ -710,9 +639,7 @@ where
                         index_group_regs,
                     ) {
                         Err(ExecutionError::IllegalInstruction {
-                            address: state
-                                .instruction_fetcher
-                                .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                            address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                         })?;
                     }
                 }
@@ -731,13 +658,14 @@ where
                 //   `vd` which is nonzero
                 unsafe {
                     zve64x_load_helpers::execute_indexed_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vs2,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         vtype.vsew().as_eew(),
                         index_eew,
                         data_group_regs,
@@ -756,39 +684,32 @@ where
                 eew: index_eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let data_group_regs = vtype.vlmul().register_count();
                 let index_group_regs = vtype
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vm,
                     data_group_regs,
                     nf,
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     index_group_regs,
                 )?;
@@ -807,9 +728,7 @@ where
                         index_group_regs,
                     ) {
                         Err(ExecutionError::IllegalInstruction {
-                            address: state
-                                .instruction_fetcher
-                                .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                            address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                         })?;
                     }
                 }
@@ -817,13 +736,14 @@ where
                 // argument
                 unsafe {
                     zve64x_load_helpers::execute_indexed_load(
-                        state,
+                        ext_state,
+                        memory,
                         vd,
                         vs2,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         vtype.vsew().as_eew(),
                         index_eew,
                         data_group_regs,

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
@@ -73,7 +73,15 @@ fn exec_one(
     state: &mut TestInterpreterState<Zve64xLoadInstruction<Reg<u64>>>,
     instr: Zve64xLoadInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 // `Vlr` tests

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, InterpreterState, ProgramCounter, VirtualMemory, VirtualMemoryError};
+use crate::{ExecutionError, ProgramCounter, VirtualMemory, VirtualMemoryError};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
@@ -67,8 +67,8 @@ pub fn groups_overlap(a: VReg, a_regs: u8, b: VReg, b_regs: u8) -> bool {
 /// Per spec, the base register of every register group must be a multiple of the group size.
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_register_group_alignment<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_register_group_alignment<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vd: VReg,
     group_regs: u8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
@@ -79,7 +79,7 @@ where
     let vd = vd.bits();
     if !vd.is_multiple_of(group_regs) || vd + group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -92,8 +92,8 @@ where
 /// On `Ok`, `vd.bits() + nf * group_regs <= 32` is guaranteed.
 #[inline(always)]
 #[doc(hidden)]
-pub fn validate_segment_registers<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn validate_segment_registers<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vd: VReg,
     vm: bool,
     group_regs: u8,
@@ -108,7 +108,7 @@ where
     let vd_idx = u32::from(vd.bits());
     if vd_idx % group_regs != 0 || vd_idx + nf * group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     // When masked, no field group may contain v0 (index 0). Since groups are laid out
@@ -116,7 +116,7 @@ where
     // v0, which happens exactly when vd == 0.
     if !vm && vd_idx == 0 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -223,8 +223,9 @@ fn read_mem_element(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_unit_stride_load<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_unit_stride_load<Reg, ExtState, Memory, CustomError>(
+    ext_state: &mut ExtState,
+    memory: &Memory,
     vd: VReg,
     vm: bool,
     vl: u32,
@@ -242,14 +243,13 @@ where
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let elem_bytes = eew.bytes();
     let segment_stride = u64::from(nf) * u64::from(elem_bytes);
 
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
 
     for i in vstart..vl {
         if !vm && !mask_bit(&mask_buf, i) {
@@ -269,7 +269,7 @@ where
 
         for f in 0..nf {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
-            match read_mem_element(&state.memory, addr, eew) {
+            match read_mem_element(memory, addr, eew) {
                 Ok(data) => {
                     // SAFETY: `f < nf` and the precondition on this function requires
                     // `nf <= MAX_NF` (the V spec encodes nf in 3 bits giving 1..=8 =
@@ -282,16 +282,16 @@ where
                 }
                 Err(mem_err) => {
                     if fault_only_first && i > 0 {
-                        state.ext_state.set_vl(i);
-                        state.ext_state.mark_vs_dirty();
-                        state.ext_state.reset_vstart();
+                        ext_state.set_vl(i);
+                        ext_state.mark_vs_dirty();
+                        ext_state.reset_vstart();
                         return Ok(());
                     }
                     if i > vstart {
                         // Elements [vstart, i) were committed; VS is now dirty.
-                        state.ext_state.mark_vs_dirty();
+                        ext_state.mark_vs_dirty();
                         // vstart records the faulting element for restartability.
-                        state.ext_state.set_vstart(i as u16);
+                        ext_state.set_vstart(i as u16);
                     }
                     return Err(ExecutionError::MemoryAccess(mem_err));
                 }
@@ -319,7 +319,7 @@ where
             // above), so `f as usize < MAX_NF = field_buf.len()`.
             unsafe {
                 write_group_element(
-                    state.ext_state.write_vreg(),
+                    ext_state.write_vreg(),
                     field_base_reg,
                     i,
                     eew,
@@ -329,8 +329,8 @@ where
         }
     }
 
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
     Ok(())
 }
 
@@ -347,8 +347,9 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_strided_load<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_strided_load<Reg, ExtState, Memory, CustomError>(
+    ext_state: &mut ExtState,
+    memory: &Memory,
     vd: VReg,
     vm: bool,
     vl: u32,
@@ -366,13 +367,12 @@ where
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let elem_bytes = eew.bytes();
 
     // SAFETY: `vl <= VLMAX <= VLEN` (precondition), so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
 
     for i in vstart..vl {
         if !vm && !mask_bit(&mask_buf, i) {
@@ -383,12 +383,12 @@ where
 
         for f in 0..nf {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
-            let data = match read_mem_element(&state.memory, addr, eew) {
+            let data = match read_mem_element(memory, addr, eew) {
                 Ok(data) => data,
                 Err(mem_err) => {
                     if f > 0 || i > vstart {
-                        state.ext_state.mark_vs_dirty();
-                        state.ext_state.set_vstart(i as u16);
+                        ext_state.mark_vs_dirty();
+                        ext_state.set_vstart(i as u16);
                     }
                     return Err(ExecutionError::MemoryAccess(mem_err));
                 }
@@ -407,13 +407,13 @@ where
             //
             // Therefore, `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
             unsafe {
-                write_group_element(state.ext_state.write_vreg(), field_base_reg, i, eew, data);
+                write_group_element(ext_state.write_vreg(), field_base_reg, i, eew, data);
             }
         }
     }
 
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
     Ok(())
 }
 
@@ -435,8 +435,9 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_indexed_load<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_indexed_load<Reg, ExtState, Memory, CustomError>(
+    ext_state: &mut ExtState,
+    memory: &Memory,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -455,13 +456,12 @@ where
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let index_base_reg = usize::from(vs2.bits());
 
     // SAFETY: `vl <= VLMAX <= VLEN` (precondition), so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
 
     for i in vstart..vl {
         if !vm && !mask_bit(&mask_buf, i) {
@@ -475,21 +475,20 @@ where
         // `EMUL_index * (VLENB / index_eew.bytes()) = VLMAX`. Since `i < vl <= VLMAX`,
         // `i / (VLENB / index_eew.bytes()) < EMUL_index`, and therefore
         // `index_base_reg + i / (VLENB / index_eew.bytes()) < index_base_reg + EMUL_index <= 32`.
-        let index_buf = unsafe {
-            read_group_element(state.ext_state.read_vreg(), index_base_reg, i, index_eew)
-        };
+        let index_buf =
+            unsafe { read_group_element(ext_state.read_vreg(), index_base_reg, i, index_eew) };
         let offset = u64::from_le_bytes(index_buf);
         let elem_addr = base.wrapping_add(offset);
 
         let data_elem_bytes = data_eew.bytes();
         for f in 0..nf {
             let addr = elem_addr.wrapping_add(u64::from(f) * u64::from(data_elem_bytes));
-            let data = match read_mem_element(&state.memory, addr, data_eew) {
+            let data = match read_mem_element(memory, addr, data_eew) {
                 Ok(data) => data,
                 Err(mem_err) => {
                     if f > 0 || i > vstart {
-                        state.ext_state.mark_vs_dirty();
-                        state.ext_state.set_vstart(i as u16);
+                        ext_state.mark_vs_dirty();
+                        ext_state.set_vstart(i as u16);
                     }
                     return Err(ExecutionError::MemoryAccess(mem_err));
                 }
@@ -509,18 +508,12 @@ where
             // Therefore,
             // `field_base_reg + i / data_elems_per_reg < field_base_reg + data_group_regs <= 32`.
             unsafe {
-                write_group_element(
-                    state.ext_state.write_vreg(),
-                    field_base_reg,
-                    i,
-                    data_eew,
-                    data,
-                );
+                write_group_element(ext_state.write_vreg(), field_base_reg, i, data_eew, data);
             }
         }
     }
 
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
     Ok(())
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
@@ -6,10 +6,7 @@ pub mod zve64x_mask_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -17,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xMaskInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xMaskInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -35,7 +30,11 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // Mask-register logical instructions (§16.1).
@@ -43,375 +42,330 @@ where
             // vtype to be valid (vill=0). Any vector instruction must be rejected when vill is
             // set, regardless of whether it uses SEW or vl.
             Self::Vmandn { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // SAFETY: all VReg values are valid indices < 32; snapshot-before-write
                 // inside the helper means vd may overlap vs2 or vs1 safely.
                 unsafe {
-                    zve64x_mask_helpers::execute_mask_logical_op(state, vd, vs2, vs1, |a, b| {
-                        a & !b
-                    });
+                    zve64x_mask_helpers::execute_mask_logical_op(
+                        ext_state,
+                        vd,
+                        vs2,
+                        vs1,
+                        |a, b| a & !b,
+                    );
                 }
             }
             Self::Vmand { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // SAFETY: see `Vmandn`
                 unsafe {
-                    zve64x_mask_helpers::execute_mask_logical_op(state, vd, vs2, vs1, |a, b| a & b);
+                    zve64x_mask_helpers::execute_mask_logical_op(
+                        ext_state,
+                        vd,
+                        vs2,
+                        vs1,
+                        |a, b| a & b,
+                    );
                 }
             }
             Self::Vmor { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // SAFETY: see `Vmandn`
                 unsafe {
-                    zve64x_mask_helpers::execute_mask_logical_op(state, vd, vs2, vs1, |a, b| a | b);
+                    zve64x_mask_helpers::execute_mask_logical_op(
+                        ext_state,
+                        vd,
+                        vs2,
+                        vs1,
+                        |a, b| a | b,
+                    );
                 }
             }
             Self::Vmxor { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // SAFETY: see `Vmandn`
                 unsafe {
-                    zve64x_mask_helpers::execute_mask_logical_op(state, vd, vs2, vs1, |a, b| a ^ b);
+                    zve64x_mask_helpers::execute_mask_logical_op(
+                        ext_state,
+                        vd,
+                        vs2,
+                        vs1,
+                        |a, b| a ^ b,
+                    );
                 }
             }
             Self::Vmorn { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // SAFETY: see `Vmandn`
                 unsafe {
-                    zve64x_mask_helpers::execute_mask_logical_op(state, vd, vs2, vs1, |a, b| {
-                        a | !b
-                    });
+                    zve64x_mask_helpers::execute_mask_logical_op(
+                        ext_state,
+                        vd,
+                        vs2,
+                        vs1,
+                        |a, b| a | !b,
+                    );
                 }
             }
             Self::Vmnand { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // SAFETY: see `Vmandn`
                 unsafe {
-                    zve64x_mask_helpers::execute_mask_logical_op(state, vd, vs2, vs1, |a, b| {
-                        !(a & b)
-                    });
+                    zve64x_mask_helpers::execute_mask_logical_op(
+                        ext_state,
+                        vd,
+                        vs2,
+                        vs1,
+                        |a, b| !(a & b),
+                    );
                 }
             }
             Self::Vmnor { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // SAFETY: see `Vmandn`
                 unsafe {
-                    zve64x_mask_helpers::execute_mask_logical_op(state, vd, vs2, vs1, |a, b| {
-                        !(a | b)
-                    });
+                    zve64x_mask_helpers::execute_mask_logical_op(
+                        ext_state,
+                        vd,
+                        vs2,
+                        vs1,
+                        |a, b| !(a | b),
+                    );
                 }
             }
             Self::Vmxnor { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // SAFETY: see `Vmandn`
                 unsafe {
-                    zve64x_mask_helpers::execute_mask_logical_op(state, vd, vs2, vs1, |a, b| {
-                        !(a ^ b)
-                    });
+                    zve64x_mask_helpers::execute_mask_logical_op(
+                        ext_state,
+                        vd,
+                        vs2,
+                        vs1,
+                        |a, b| !(a ^ b),
+                    );
                 }
             }
             // vcpop.m (§16.2): count set bits in vs2 over active elements, write to GPR rd.
             Self::Vcpop { rd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // vcpop/vfirst require a valid vtype to know vl, but do not use SEW.
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`; `vstart <= vl`
                 // by spec invariant.
                 unsafe {
-                    zve64x_mask_helpers::execute_vcpop(state, rd, vs2, vm, vl, vstart);
+                    zve64x_mask_helpers::execute_vcpop(regs, ext_state, rd, vs2, vm, vl, vstart);
                 }
             }
             // vfirst.m (§16.3): find lowest-numbered active set bit in vs2, write index to rd.
             Self::Vfirst { rd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: same as `Vcpop`
                 unsafe {
-                    zve64x_mask_helpers::execute_vfirst(state, rd, vs2, vm, vl, vstart);
+                    zve64x_mask_helpers::execute_vfirst(regs, ext_state, rd, vs2, vm, vl, vstart);
                 }
             }
             // vmsbf.m (§16.4): set-before-first mask bit.
             // Constraints: vd != vs2 (overlap illegal), vm=false implies vd != v0.
             Self::Vmsbf { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // Spec §16.4: vmsbf/vmsif/vmsof with vstart != 0 raise an illegal instruction
                 // exception.
-                if state.ext_state.vstart() != 0 {
+                if ext_state.vstart() != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // Per spec §16.4: vd must not overlap vs2
                 if vd.bits() == vs2.bits() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: `vd != vs2` checked above; `vd != v0` when masked checked above;
                 // `vstart == 0` checked above; `vl <= VLEN` so `vl.div_ceil(8) <= VLENB`.
                 unsafe {
-                    zve64x_mask_helpers::execute_vmsbf(state, vd, vs2, vm, vl);
+                    zve64x_mask_helpers::execute_vmsbf(ext_state, vd, vs2, vm, vl);
                 }
             }
             // vmsof.m (§16.5): set-only-first mask bit.
             // Same overlap constraints as vmsbf.
             Self::Vmsof { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // Spec §16.4: vmsbf/vmsif/vmsof with vstart != 0 raise an illegal instruction
                 // exception.
-                if state.ext_state.vstart() != 0 {
+                if ext_state.vstart() != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if vd.bits() == vs2.bits() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vmsbf`
                 unsafe {
-                    zve64x_mask_helpers::execute_vmsof(state, vd, vs2, vm, vl);
+                    zve64x_mask_helpers::execute_vmsof(ext_state, vd, vs2, vm, vl);
                 }
             }
             // vmsif.m (§16.6): set-including-first mask bit.
             // Same overlap constraints as vmsbf.
             Self::Vmsif { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                state
-                    .ext_state
+                ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // Spec §16.4: vmsbf/vmsif/vmsof with vstart != 0 raise an illegal instruction
                 // exception.
-                if state.ext_state.vstart() != 0 {
+                if ext_state.vstart() != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if vd.bits() == vs2.bits() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vmsbf`
                 unsafe {
-                    zve64x_mask_helpers::execute_vmsif(state, vd, vs2, vm, vl);
+                    zve64x_mask_helpers::execute_vmsif(ext_state, vd, vs2, vm, vl);
                 }
             }
             // viota.m (§16.8): write prefix popcount of vs2 bits as SEW-wide elements into vd.
@@ -419,36 +373,27 @@ where
             // vstart must be zero (mandatory trap per spec §16.8); SEW must be wide enough
             // to represent VLMAX-1.
             Self::Viota { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // Spec §16.8: viota.m with vstart != 0 raises an illegal instruction exception.
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
                 let vd_idx = vd.bits();
                 if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // vd must not overlap vs2; vs2 is always a single mask register (group size 1).
@@ -456,16 +401,12 @@ where
                 let vs2_start = u32::from(vs2.bits());
                 if vd_start < vs2_start + 1 && vs2_start < vd_start + u32::from(group_regs) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
@@ -473,61 +414,50 @@ where
                 let vlmax = vtype.vlmul().vlmax(ExtState::VLEN, sew_bits);
                 if u64::from(vlmax).unbounded_shr(sew_bits) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: vd alignment checked above; vd group does not overlap vs2 checked above;
                 // `vm=false` implies `vd != v0` checked above; vstart == 0 checked above;
                 // SEW wide enough to hold VLMAX-1 checked above;
                 // `vl <= VLMAX = group_regs * VLENB / sew_bytes`, all element indices valid.
                 unsafe {
-                    zve64x_mask_helpers::execute_viota(state, vd, vs2, vm, vl, sew);
+                    zve64x_mask_helpers::execute_viota(ext_state, vd, vs2, vm, vl, sew);
                 }
             }
             // vid.v (§16.9): write element index i as SEW-wide integer into vd[i].
             // Constraints: vm=false implies vd != v0; vd alignment per LMUL.
             Self::Vid { vd, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
                 let vd_idx = vd.bits();
                 if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: vd alignment checked above; `vm=false` implies `vd != v0` checked above;
                 // `vl <= VLMAX = group_regs * VLENB / sew_bytes`, all element indices valid.
                 unsafe {
-                    zve64x_mask_helpers::execute_vid(state, vd, vm, vl, vstart, sew);
+                    zve64x_mask_helpers::execute_vid(ext_state, vd, vm, vl, vstart, sew);
                 }
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
@@ -33,7 +33,15 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xMaskInstruction<Reg<u64>>>,
     instr: Zve64xMaskInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 fn get_vreg(state: &TestInterpreterState<Zve64xMaskInstruction<Reg<u64>>>, reg: VReg) -> [u8; 16] {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
@@ -1,9 +1,9 @@
 //! Opaque helpers for Zve64x extension
 
+use crate::RegisterFile;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::arith::zve64x_arith_helpers::{write_element_u64, write_mask_bit};
 use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
-use crate::{InterpreterState, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
@@ -17,8 +17,8 @@ use core::fmt;
 /// The operation snaps both sources before writing, so `vd` may safely overlap either source.
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_mask_logical_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vs1: VReg,
@@ -29,30 +29,17 @@ pub unsafe fn execute_mask_logical_op<Reg, Regs, ExtState, Memory, PC, IH, Custo
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u8, u8) -> u8,
 {
     // Snapshot both sources before writing to handle vd overlapping vs2 or vs1
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        state
-            .ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.bits()))
-    };
+    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     // SAFETY: `vs1.bits() < 32`; `VReg` values are always in `0..32`
-    let vs1_snap = *unsafe {
-        state
-            .ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs1.bits()))
-    };
+    let vs1_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs1.bits())) };
     // SAFETY: `vd.bits() < 32`; `VReg` values are always in `0..32`
     let vd_reg = unsafe {
-        state
-            .ext_state
+        ext_state
             .write_vreg()
             .get_unchecked_mut(usize::from(vd.bits()))
     };
@@ -67,8 +54,8 @@ pub unsafe fn execute_mask_logical_op<Reg, Regs, ExtState, Memory, PC, IH, Custo
         // `vd_reg` points to a `[u8; VLENB]` register row
         *unsafe { vd_reg.get_unchecked_mut(byte_i) } = op(a, b);
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute `vcpop.m`: count set bits in vs2 for active elements `0..vl`, write result to `rd`.
@@ -81,8 +68,9 @@ pub unsafe fn execute_mask_logical_op<Reg, Regs, ExtState, Memory, PC, IH, Custo
 /// - `vstart <= vl`
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_vcpop<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_vcpop<Reg, Regs, ExtState, CustomError>(
+    regs: &mut Regs,
+    ext_state: &mut ExtState,
     rd: Reg,
     vs2: VReg,
     vm: bool,
@@ -95,19 +83,12 @@ pub unsafe fn execute_vcpop<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2` is a valid VReg index (< 32)
-    let vs2_reg = *unsafe {
-        state
-            .ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.bits()))
-    };
+    let vs2_reg = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     let mut count = 0u32;
     for i in vstart..vl {
         if !mask_bit(&mask_buf, i) {
@@ -117,9 +98,9 @@ pub unsafe fn execute_vcpop<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
             count += 1;
         }
     }
-    state.regs.write(rd, Reg::Type::from(count));
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    regs.write(rd, Reg::Type::from(count));
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute `vfirst.m`: find the index of the first set bit in vs2 for active elements `0..vl`,
@@ -133,8 +114,9 @@ pub unsafe fn execute_vcpop<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
 /// - `vstart <= vl`
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_vfirst<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_vfirst<Reg, Regs, ExtState, CustomError>(
+    regs: &mut Regs,
+    ext_state: &mut ExtState,
     rd: Reg,
     vs2: VReg,
     vm: bool,
@@ -147,19 +129,12 @@ pub unsafe fn execute_vfirst<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2` is a valid VReg index (< 32)
-    let vs2_reg = *unsafe {
-        state
-            .ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.bits()))
-    };
+    let vs2_reg = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     // -1 encoded as all-ones for the register width; `Into<u64>` on XLEN-wide type then back
     let not_found = u64::MAX;
     let mut result = not_found;
@@ -182,9 +157,9 @@ pub unsafe fn execute_vfirst<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     } else {
         Reg::Type::from(result as u32)
     };
-    state.regs.write(rd, reg_value);
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    regs.write(rd, reg_value);
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute `vmsbf.m`: set all mask bits before (not including) the first set bit of vs2.
@@ -201,8 +176,8 @@ pub unsafe fn execute_vfirst<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
 /// - `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_vmsbf<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -213,19 +188,12 @@ pub unsafe fn execute_vmsbf<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        state
-            .ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.bits()))
-    };
+    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     let mut found_first = false;
     for i in 0..vl {
         // Inactive elements: undisturbed
@@ -239,9 +207,9 @@ pub unsafe fn execute_vmsbf<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
             found_first = true;
         }
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
-        unsafe { write_mask_bit(state.ext_state.write_vreg(), vd, i, result) };
+        unsafe { write_mask_bit(ext_state.write_vreg(), vd, i, result) };
     }
-    state.ext_state.mark_vs_dirty();
+    ext_state.mark_vs_dirty();
     // vstart is already zero, doesn't need to be reset
 }
 
@@ -254,8 +222,8 @@ pub unsafe fn execute_vmsbf<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
 /// Same as [`execute_vmsbf`].
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_vmsof<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -266,19 +234,12 @@ pub unsafe fn execute_vmsof<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        state
-            .ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.bits()))
-    };
+    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     let mut found_first = false;
     for i in 0..vl {
         if !mask_bit(&mask_buf, i) {
@@ -291,9 +252,9 @@ pub unsafe fn execute_vmsof<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
             found_first = true;
         }
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
-        unsafe { write_mask_bit(state.ext_state.write_vreg(), vd, i, result) };
+        unsafe { write_mask_bit(ext_state.write_vreg(), vd, i, result) };
     }
-    state.ext_state.mark_vs_dirty();
+    ext_state.mark_vs_dirty();
     // vstart is already zero, doesn't need to be reset
 }
 
@@ -307,8 +268,8 @@ pub unsafe fn execute_vmsof<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
 /// Same as [`execute_vmsbf`].
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_vmsif<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -319,19 +280,12 @@ pub unsafe fn execute_vmsif<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        state
-            .ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.bits()))
-    };
+    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     let mut found_first = false;
     for i in 0..vl {
         if !mask_bit(&mask_buf, i) {
@@ -344,9 +298,9 @@ pub unsafe fn execute_vmsif<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
             found_first = true;
         }
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
-        unsafe { write_mask_bit(state.ext_state.write_vreg(), vd, i, result) };
+        unsafe { write_mask_bit(ext_state.write_vreg(), vd, i, result) };
     }
-    state.ext_state.mark_vs_dirty();
+    ext_state.mark_vs_dirty();
     // vstart is already zero, doesn't need to be reset
 }
 
@@ -367,8 +321,8 @@ pub unsafe fn execute_vmsif<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
 /// - `vl <= VLMAX`; `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_viota<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -380,19 +334,12 @@ pub unsafe fn execute_viota<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        state
-            .ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.bits()))
-    };
+    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     // Per spec §16.8: inactive vs2 elements are treated as zero for the prefix sum.
     // The prefix count advances only when the execution mask is active AND the
     // corresponding vs2 bit is set.
@@ -403,20 +350,14 @@ pub unsafe fn execute_viota<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
         }
         // SAFETY: `vd + i / elems_per_reg < 32` by caller's alignment + vl preconditions
         unsafe {
-            write_element_u64(
-                state.ext_state.write_vreg(),
-                vd.bits(),
-                i,
-                sew,
-                prefix_count,
-            );
+            write_element_u64(ext_state.write_vreg(), vd.bits(), i, sew, prefix_count);
         }
         if mask_bit(&vs2_snap, i) {
             prefix_count += 1;
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute `vid.v`: write the element index `i` as a SEW-wide integer into `vd[i]` for each
@@ -431,8 +372,8 @@ pub unsafe fn execute_viota<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
 /// - `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_vid<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_vid<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vm: bool,
     vl: u32,
@@ -444,27 +385,19 @@ pub unsafe fn execute_vid<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     for i in vstart..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: `vd + i / elems_per_reg < 32` by caller's alignment + vl preconditions
         unsafe {
-            write_element_u64(
-                state.ext_state.write_vreg(),
-                vd.bits(),
-                i,
-                sew,
-                u64::from(i),
-            );
+            write_element_u64(ext_state.write_vreg(), vd.bits(), i, sew, u64::from(i));
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
@@ -6,10 +6,7 @@ pub mod zve64x_muldiv_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -17,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xMulDivInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xMulDivInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -35,50 +30,53 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // vmul.vv / vmul.vx - signed multiply, low half
             Self::VmulVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -91,43 +89,40 @@ where
                 }
             }
             Self::VmulVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -141,53 +136,50 @@ where
             }
             // vmulh.vv / vmulh.vx - signed×signed multiply, high half; illegal for SEW=64
             Self::VmulhVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // vmulh is not supported for SEW=64 in Zve64x (would need 128-bit result)
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -200,50 +192,45 @@ where
                 }
             }
             Self::VmulhVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -257,52 +244,49 @@ where
             }
             // vmulhu.vv / vmulhu.vx - unsigned×unsigned multiply, high half; illegal for SEW=64
             Self::VmulhuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -315,50 +299,45 @@ where
                 }
             }
             Self::VmulhuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -372,52 +351,49 @@ where
             }
             // vmulhsu.vv / vmulhsu.vx - signed×unsigned multiply, high half; illegal for SEW=64
             Self::VmulhsuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -431,51 +407,46 @@ where
                 }
             }
             Self::VmulhsuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // scalar from rs1 is the unsigned operand; vs2 elements are signed
-                let scalar = state.regs.read(rs1).as_u64();
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -490,45 +461,44 @@ where
             }
             // vdivu.vv / vdivu.vx - unsigned divide
             Self::VdivuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -547,43 +517,40 @@ where
                 }
             }
             Self::VdivuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -602,45 +569,44 @@ where
             }
             // vdiv.vv / vdiv.vx - signed divide
             Self::VdivVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -653,43 +619,40 @@ where
                 }
             }
             Self::VdivVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -703,45 +666,44 @@ where
             }
             // vremu.vv / vremu.vx - unsigned remainder
             Self::VremuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -764,43 +726,40 @@ where
                 }
             }
             Self::VremuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -823,45 +782,44 @@ where
             }
             // vrem.vv / vrem.vx - signed remainder
             Self::VremVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -874,43 +832,40 @@ where
                 }
             }
             Self::VremVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -924,27 +879,20 @@ where
             }
             // vwmulu.vv / vwmulu.vx - unsigned widening multiply; illegal for SEW=64
             Self::VwmuluVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // Widening produces 2*SEW result; SEW=64 would require 128-bit output
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -953,50 +901,50 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // vd and vs2/vs1 must not overlap
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1012,26 +960,19 @@ where
                 }
             }
             Self::VwmuluVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1039,40 +980,38 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -1089,26 +1028,19 @@ where
             }
             // vwmulsu.vv / vwmulsu.vx - signed×unsigned widening multiply; illegal for SEW=64
             Self::VwmulsuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1116,49 +1048,49 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1176,26 +1108,19 @@ where
                 }
             }
             Self::VwmulsuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1203,41 +1128,39 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // scalar from rs1 is the unsigned operand; vs2 elements are signed
-                let scalar = state.regs.read(rs1).as_u64();
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -1255,26 +1178,19 @@ where
             }
             // vwmul.vv / vwmul.vx - signed widening multiply; illegal for SEW=64
             Self::VwmulVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1282,49 +1198,49 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1342,26 +1258,19 @@ where
                 }
             }
             Self::VwmulVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1369,41 +1278,39 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // scalar from rs1 is sign-extended to XLEN; treat as signed SEW-wide
-                let scalar = state.regs.read(rs1).as_u64();
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_muldiv_helpers::OpSrc::Scalar(scalar),
@@ -1421,45 +1328,44 @@ where
             }
             // vmacc.vv / vmacc.vx - vd = vd + vs1 * vs2
             Self::VmaccVv { vd, vs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_op(
-                        state,
+                        ext_state,
                         vd,
                         vs1.bits(),
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1473,43 +1379,40 @@ where
                 }
             }
             Self::VmaccVx { vd, rs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_scalar_op(
-                        state,
+                        ext_state,
                         vd,
                         scalar,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1523,45 +1426,44 @@ where
             }
             // vnmsac.vv / vnmsac.vx - vd = vd - vs1 * vs2
             Self::VnmsacVv { vd, vs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_op(
-                        state,
+                        ext_state,
                         vd,
                         vs1.bits(),
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1575,43 +1477,40 @@ where
                 }
             }
             Self::VnmsacVx { vd, rs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_scalar_op(
-                        state,
+                        ext_state,
                         vd,
                         scalar,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1625,45 +1524,44 @@ where
             }
             // vmadd.vv / vmadd.vx - vd = vs1 * vd + vs2
             Self::VmaddVv { vd, vs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_op(
-                        state,
+                        ext_state,
                         vd,
                         vs1.bits(),
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1677,43 +1575,40 @@ where
                 }
             }
             Self::VmaddVx { vd, rs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_scalar_op(
-                        state,
+                        ext_state,
                         vd,
                         scalar,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1728,45 +1623,44 @@ where
             }
             // vnmsub.vv / vnmsub.vx - vd = -(vs1 * vd) + vs2
             Self::VnmsubVv { vd, vs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_op(
-                        state,
+                        ext_state,
                         vd,
                         vs1.bits(),
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1780,43 +1674,40 @@ where
                 }
             }
             Self::VnmsubVx { vd, rs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_scalar_op(
-                        state,
+                        ext_state,
                         vd,
                         scalar,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1831,26 +1722,19 @@ where
             }
             // vwmaccu.vv / vwmaccu.vx - unsigned widening multiply-add; illegal for SEW=64
             Self::VwmaccuVv { vd, vs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1858,50 +1742,50 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
                 // vd holds the 2*SEW accumulator
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_muladd_op(
-                        state,
+                        ext_state,
                         vd,
                         vs1.bits(),
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1918,26 +1802,19 @@ where
                 }
             }
             Self::VwmaccuVx { vd, rs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1945,40 +1822,38 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_muladd_scalar_op(
-                        state,
+                        ext_state,
                         vd,
                         scalar,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -1995,26 +1870,19 @@ where
             }
             // vwmacc.vv / vwmacc.vx - signed widening multiply-add; illegal for SEW=64
             Self::VwmaccVv { vd, vs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2022,49 +1890,49 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_muladd_op(
-                        state,
+                        ext_state,
                         vd,
                         vs1.bits(),
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -2082,26 +1950,19 @@ where
                 }
             }
             Self::VwmaccVx { vd, rs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2109,40 +1970,38 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_muladd_scalar_op(
-                        state,
+                        ext_state,
                         vd,
                         scalar,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -2160,26 +2019,19 @@ where
             }
             // vwmaccsu.vv / vwmaccsu.vx - signed×unsigned widening multiply-add; illegal for SEW=64
             Self::VwmaccsuVv { vd, vs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2187,49 +2039,49 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_muladd_op(
-                        state,
+                        ext_state,
                         vd,
                         vs1.bits(),
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -2247,26 +2099,19 @@ where
                 }
             }
             Self::VwmaccsuVx { vd, rs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2274,41 +2119,39 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // scalar (rs1) is the signed operand; vs2 elements are unsigned
-                let scalar = state.regs.read(rs1).as_u64();
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_muladd_scalar_op(
-                        state,
+                        ext_state,
                         vd,
                         scalar,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),
@@ -2329,26 +2172,19 @@ where
             }
             // vwmaccus.vx - unsigned×signed widening multiply-add (vx only); illegal for SEW=64
             Self::VwmaccusVx { vd, rs1, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 if u32::from(vtype.vsew().bits()) == u64::BITS {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2356,41 +2192,39 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: state
-                        .instruction_fetcher
-                        .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                 })?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // scalar (rs1) is the unsigned operand; vs2 elements are signed
-                let scalar = state.regs.read(rs1).as_u64();
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and overlap checked above; SEW < 64 checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_widening_muladd_scalar_op(
-                        state,
+                        ext_state,
                         vd,
                         scalar,
                         zve64x_muldiv_helpers::OpSrc::Vreg(vs2.bits()),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
@@ -36,7 +36,15 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xMulDivInstruction<Reg<u64>>>,
     instr: Zve64xMulDivInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 fn read_elem(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
@@ -8,7 +8,7 @@ use crate::v::zve64x::arith::zve64x_arith_helpers::{read_element_u64, write_elem
 use crate::v::zve64x::fixed_point::zve64x_fixed_point_helpers::read_wide_element_u64;
 use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, InterpreterState, ProgramCounter, VirtualMemory};
+use crate::{ExecutionError, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
@@ -49,8 +49,8 @@ pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<u8> {
 /// The spec prohibits any overlap between them.
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_no_widening_overlap<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_no_widening_overlap<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vd: VReg,
     vs: VReg,
     dest_group_regs: u8,
@@ -67,7 +67,7 @@ where
     // Overlap when the intervals intersect
     if vs_start < vd_end && vd_start < vs_end {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -111,8 +111,8 @@ unsafe fn write_wide_element_u64<const VLENB: usize>(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -127,13 +127,11 @@ pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, Vsew) -> u64,
 {
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     for i in vstart..vl {
@@ -141,23 +139,22 @@ pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let a =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
         let b = match &src {
             // SAFETY: register bounds verified by caller
             OpSrc::Vreg(vs1_base) => unsafe {
-                read_element_u64(state.ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
+                read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
             },
             OpSrc::Scalar(val) => *val,
         };
         let result = op(a, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a single-width widening operation over `vstart..vl`.
@@ -174,8 +171,8 @@ pub unsafe fn execute_arith_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_widening_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -190,13 +187,11 @@ pub unsafe fn execute_widening_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, Vsew) -> u64,
 {
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     for i in vstart..vl {
@@ -204,12 +199,11 @@ pub unsafe fn execute_widening_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let a =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
         let b = match &src {
             // SAFETY: register bounds verified by caller
             OpSrc::Vreg(vs1_base) => unsafe {
-                read_element_u64(state.ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
+                read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew)
             },
             OpSrc::Scalar(val) => *val,
         };
@@ -218,11 +212,11 @@ pub unsafe fn execute_widening_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
         // `vl <= src_group_regs * VLENB / sew_bytes` and dest stores at 2*SEW width so
         // `i < dest_group_regs * VLENB / (2*sew_bytes)`
         unsafe {
-            write_wide_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_wide_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a single-width multiply-add where the first multiplier is a vector register group.
@@ -237,8 +231,8 @@ pub unsafe fn execute_widening_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_muladd_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     a_reg: u8,
     src: OpSrc,
@@ -253,39 +247,35 @@ pub unsafe fn execute_muladd_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     for i in vstart..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let acc =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vd_base), i, sew) };
+        let acc = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vd_base), i, sew) };
         // SAFETY: register bounds verified by caller
-        let a =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(a_reg), i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(a_reg), i, sew) };
         let b = match &src {
             // SAFETY: register bounds verified by caller
             OpSrc::Vreg(b_reg) => unsafe {
-                read_element_u64(state.ext_state.read_vreg(), usize::from(*b_reg), i, sew)
+                read_element_u64(ext_state.read_vreg(), usize::from(*b_reg), i, sew)
             },
             OpSrc::Scalar(val) => *val,
         };
         let result = op(acc, a, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a single-width multiply-add where the first multiplier is a scalar.
@@ -297,8 +287,8 @@ pub unsafe fn execute_muladd_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_muladd_scalar_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     scalar: u64,
     src: OpSrc,
@@ -313,36 +303,33 @@ pub unsafe fn execute_muladd_scalar_op<Reg, Regs, ExtState, Memory, PC, IH, Cust
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     for i in vstart..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let acc =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vd_base), i, sew) };
+        let acc = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vd_base), i, sew) };
         let b = match &src {
             // SAFETY: register bounds verified by caller
             OpSrc::Vreg(b_reg) => unsafe {
-                read_element_u64(state.ext_state.read_vreg(), usize::from(*b_reg), i, sew)
+                read_element_u64(ext_state.read_vreg(), usize::from(*b_reg), i, sew)
             },
             OpSrc::Scalar(val) => *val,
         };
         let result = op(acc, scalar, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a widening multiply-add where the first multiplier is a vector register group.
@@ -360,8 +347,8 @@ pub unsafe fn execute_muladd_scalar_op<Reg, Regs, ExtState, Memory, PC, IH, Cust
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_widening_muladd_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     a_reg: u8,
     src: OpSrc,
@@ -376,13 +363,11 @@ pub unsafe fn execute_widening_muladd_op<Reg, Regs, ExtState, Memory, PC, IH, Cu
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     for i in vstart..vl {
         if !mask_bit(&mask_buf, i) {
@@ -391,27 +376,25 @@ pub unsafe fn execute_widening_muladd_op<Reg, Regs, ExtState, Memory, PC, IH, Cu
         // Read the existing 2*SEW accumulator from vd
         // SAFETY: vd has dest_group_regs registers; element `i` fits within them (see
         // `execute_widening_op` for the bound argument)
-        let acc = unsafe {
-            read_wide_element_u64(state.ext_state.read_vreg(), usize::from(vd_base), i, sew)
-        };
+        let acc =
+            unsafe { read_wide_element_u64(ext_state.read_vreg(), usize::from(vd_base), i, sew) };
         // SAFETY: register bounds verified by caller
-        let a =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(a_reg), i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(a_reg), i, sew) };
         let b = match &src {
             // SAFETY: register bounds verified by caller
             OpSrc::Vreg(b_reg) => unsafe {
-                read_element_u64(state.ext_state.read_vreg(), usize::from(*b_reg), i, sew)
+                read_element_u64(ext_state.read_vreg(), usize::from(*b_reg), i, sew)
             },
             OpSrc::Scalar(val) => *val,
         };
         let result = op(acc, a, b, sew);
         // SAFETY: same as acc read above
         unsafe {
-            write_wide_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_wide_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a widening multiply-add where the first multiplier is a scalar.
@@ -423,17 +406,8 @@ pub unsafe fn execute_widening_muladd_op<Reg, Regs, ExtState, Memory, PC, IH, Cu
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_widening_muladd_scalar_op<
-    Reg,
-    Regs,
-    ExtState,
-    Memory,
-    PC,
-    IH,
-    CustomError,
-    F,
->(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     scalar: u64,
     src: OpSrc,
@@ -448,13 +422,11 @@ pub unsafe fn execute_widening_muladd_scalar_op<
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     for i in vstart..vl {
         if !mask_bit(&mask_buf, i) {
@@ -462,24 +434,23 @@ pub unsafe fn execute_widening_muladd_scalar_op<
         }
         // SAFETY: vd has dest_group_regs registers; element `i` fits within them (see
         // `execute_widening_op` for the bound argument)
-        let acc = unsafe {
-            read_wide_element_u64(state.ext_state.read_vreg(), usize::from(vd_base), i, sew)
-        };
+        let acc =
+            unsafe { read_wide_element_u64(ext_state.read_vreg(), usize::from(vd_base), i, sew) };
         let b = match &src {
             // SAFETY: register bounds verified by caller
             OpSrc::Vreg(b_reg) => unsafe {
-                read_element_u64(state.ext_state.read_vreg(), usize::from(*b_reg), i, sew)
+                read_element_u64(ext_state.read_vreg(), usize::from(*b_reg), i, sew)
             },
             OpSrc::Scalar(val) => *val,
         };
         let result = op(acc, scalar, b, sew);
         // SAFETY: same as acc read above
         unsafe {
-            write_wide_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, result);
+            write_wide_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Signed × signed high half.

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
@@ -6,10 +6,7 @@ pub mod zve64x_perm_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -17,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xPermInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xPermInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -35,7 +30,11 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // vmv.x.s rd, vs2
@@ -44,74 +43,60 @@ where
             // Does not use vl or masking; always reads element 0.
             // Resets vstart per spec §6.3.
             Self::VmvXS { rd, vs2 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 // SAFETY: element 0 is always within register v(vs2_base), byte offset 0;
                 // VLENB >= sew.bytes() for all legal vtype configurations.
                 let raw = unsafe {
-                    zve64x_perm_helpers::read_element_0_u64(
-                        state.ext_state.read_vreg(),
-                        vs2.bits(),
-                        sew,
-                    )
+                    zve64x_perm_helpers::read_element_0_u64(ext_state.read_vreg(), vs2.bits(), sew)
                 };
                 let sign_extended = zve64x_perm_helpers::sign_extend_to_reg::<Reg>(raw, sew);
-                state.regs.write(rd, sign_extended);
-                state.ext_state.mark_vs_dirty();
-                state.ext_state.reset_vstart();
+                regs.write(rd, sign_extended);
+                ext_state.mark_vs_dirty();
+                ext_state.reset_vstart();
             }
             // vmv.s.x vd, rs1
             // Copies scalar GPR rs1 (zero-extended / truncated to SEW) into element 0 of vd.
             // When vl == 0, the write is suppressed but vstart is still reset.
             // Resets vstart per spec §6.3.
             Self::VmvSX { vd, rs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Per spec §16.1: update only when vstart < vl.
                 if vstart < vl {
-                    let scalar = state.regs.read(rs1).as_u64();
+                    let scalar = regs.read(rs1).as_u64();
                     // SAFETY: element 0 always fits.
                     unsafe {
                         zve64x_perm_helpers::write_element_0_u64(
-                            state.ext_state.write_vreg(),
+                            ext_state.write_vreg(),
                             vd.bits(),
                             sew,
                             scalar,
                         );
                     }
                 }
-                state.ext_state.mark_vs_dirty();
-                state.ext_state.reset_vstart();
+                ext_state.mark_vs_dirty();
+                ext_state.reset_vstart();
             }
             // vslideup.vx vd, vs2, rs1, vm
             // Slides elements of vs2 up by the scalar offset in rs1.
@@ -119,93 +104,93 @@ where
             // Elements vd[i] for offset <= i < vl get vs2[i - offset].
             // Per spec §16.3.1: vd must not overlap vs2.
             Self::VslideupVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 // vd must not overlap vs2
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let offset = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let offset = regs.read(rs1).as_u64();
                 // SAFETY: alignment and no-overlap verified above; vl <= VLMAX.
                 unsafe {
                     zve64x_perm_helpers::execute_slideup(
-                        state, vd, vs2, vm, vl, vstart, sew, offset,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, offset,
                     );
                 }
             }
             // vslideup.vi vd, vs2, uimm, vm
             // Same as vslideup.vx but offset is a 5-bit unsigned immediate.
             Self::VslideupVi { vd, vs2, uimm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let offset = u64::from(uimm);
                 // SAFETY: same as VslideupVx.
                 unsafe {
                     zve64x_perm_helpers::execute_slideup(
-                        state, vd, vs2, vm, vl, vstart, sew, offset,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, offset,
                     );
                 }
             }
@@ -213,88 +198,82 @@ where
             // Element vd[i] = vs2[i + offset] if i + offset < VLMAX, else 0.
             // vd may overlap vs2 for slidedown.
             Self::VslidedownVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let vlmax = state.ext_state.vlmax_for_vtype(vtype);
-                let offset = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let vlmax = ext_state.vlmax_for_vtype(vtype);
+                let offset = regs.read(rs1).as_u64();
                 // SAFETY: alignment verified above; vl <= VLMAX; offset clamped in helper.
                 unsafe {
                     zve64x_perm_helpers::execute_slidedown(
-                        state, vd, vs2, vm, vl, vstart, sew, vlmax, offset,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, vlmax, offset,
                     );
                 }
             }
             // vslidedown.vi vd, vs2, uimm, vm
             // Same as vslidedown.vx but offset is a 5-bit unsigned immediate.
             Self::VslidedownVi { vd, vs2, uimm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let vlmax = state.ext_state.vlmax_for_vtype(vtype);
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let vlmax = ext_state.vlmax_for_vtype(vtype);
                 let offset = u64::from(uimm);
                 // SAFETY: same as VslidedownVx.
                 unsafe {
                     zve64x_perm_helpers::execute_slidedown(
-                        state, vd, vs2, vm, vl, vstart, sew, vlmax, offset,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, vlmax, offset,
                     );
                 }
             }
@@ -303,46 +282,46 @@ where
             // Elements vd[i] for 1 <= i < vl get vs2[i - 1].
             // vd must not overlap vs2.
             Self::Vslide1upVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and no-overlap verified; vl <= VLMAX.
                 unsafe {
                     zve64x_perm_helpers::execute_slide1up(
-                        state, vd, vs2, vm, vl, vstart, sew, scalar,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, scalar,
                     );
                 }
             }
@@ -351,43 +330,40 @@ where
             // Element vd[vl - 1] gets the scalar value rs1.
             // vd may overlap vs2 for slide1down.
             Self::Vslide1downVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment verified; vl <= VLMAX; overlap permitted by spec.
                 unsafe {
                     zve64x_perm_helpers::execute_slide1down(
-                        state, vd, vs2, vm, vl, vstart, sew, scalar,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, scalar,
                     );
                 }
             }
@@ -395,52 +371,57 @@ where
             // vd[i] = (vs1[i] < VLMAX) ? vs2[vs1[i]] : 0
             // vd must not overlap vs1 or vs2.
             Self::VrgatherVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs1, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let vlmax = state.ext_state.vlmax_for_vtype(vtype);
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let vlmax = ext_state.vlmax_for_vtype(vtype);
                 // SAFETY: all alignment and overlap constraints verified above; vl <= VLMAX.
                 unsafe {
                     zve64x_perm_helpers::execute_rgather_vv(
-                        state, vd, vs2, vs1, vm, vl, vstart, sew, vlmax,
+                        ext_state, vd, vs2, vs1, vm, vl, vstart, sew, vlmax,
                     );
                 }
             }
@@ -448,94 +429,94 @@ where
             // All active elements of vd get vs2[rs1] if rs1 < VLMAX, else 0.
             // vd must not overlap vs2.
             Self::VrgatherVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let vlmax = state.ext_state.vlmax_for_vtype(vtype);
-                let index = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let vlmax = ext_state.vlmax_for_vtype(vtype);
+                let index = regs.read(rs1).as_u64();
                 // SAFETY: alignment and no-overlap verified; vl <= VLMAX.
                 unsafe {
                     zve64x_perm_helpers::execute_rgather_scalar(
-                        state, vd, vs2, vm, vl, vstart, sew, vlmax, index,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, vlmax, index,
                     );
                 }
             }
             // vrgather.vi vd, vs2, uimm, vm
             // Same as vrgather.vx but index is a 5-bit unsigned immediate.
             Self::VrgatherVi { vd, vs2, uimm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let vlmax = state.ext_state.vlmax_for_vtype(vtype);
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let vlmax = ext_state.vlmax_for_vtype(vtype);
                 let index = u64::from(uimm);
                 // SAFETY: same as VrgatherVx.
                 unsafe {
                     zve64x_perm_helpers::execute_rgather_scalar(
-                        state, vd, vs2, vm, vl, vstart, sew, vlmax, index,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, vlmax, index,
                     );
                 }
             }
@@ -544,27 +525,26 @@ where
             // EMUL_vs1 = (16 / SEW) * LMUL; must be in [1/8, 8] else illegal.
             // vd must not overlap vs1 or vs2.
             Self::Vrgatherei16Vv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 // Compute EMUL for vs1 index register (EEW=16).
                 let index_group_regs = vtype
@@ -574,22 +554,23 @@ where
                         vtype.vsew(),
                     )
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs1,
                     index_group_regs,
                 )?;
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 // vd and vs1 have different group sizes (group_regs vs index_group_regs),
                 // so the symmetric helper would use the wrong size for one of the intervals.
-                zve64x_perm_helpers::check_no_overlap_asymmetric::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_perm_helpers::check_no_overlap_asymmetric::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     group_regs,
                     vs1,
@@ -597,20 +578,18 @@ where
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let vlmax = state.ext_state.vlmax_for_vtype(vtype);
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let vlmax = ext_state.vlmax_for_vtype(vtype);
                 // SAFETY: all alignment and overlap constraints verified; vl <= VLMAX;
                 // vs1 uses EEW=16 with computed index_group_regs.
                 unsafe {
                     zve64x_perm_helpers::execute_rgatherei16(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -630,90 +609,92 @@ where
             //   vd[i] = v0[i] ? vs1[i] : vs2[i]
             //   vd must not overlap v0 (mask source).
             Self::VmergeVvm { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm {
                     // vmerge: vs2 is read, vd must not overlap v0
-                    zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                        state, vs2, group_regs,
+                    zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                        program_counter,
+                        vs2,
+                        group_regs,
                     )?;
-                    zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                        state,
+                    zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                        program_counter,
                         vd,
                         VReg::V0,
                         group_regs,
                     )?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment and overlap verified above; vl <= VLMAX.
                 unsafe {
-                    zve64x_perm_helpers::execute_merge_vv(state, vd, vs2, vs1, vm, vl, vstart, sew);
+                    zve64x_perm_helpers::execute_merge_vv(
+                        ext_state, vd, vs2, vs1, vm, vl, vstart, sew,
+                    );
                 }
             }
             // vmerge.vxm / vmv.v.x
             // When vm=true: vmv.v.x vd, rs1 - broadcast scalar to all active elements.
             // When vm=false: vmerge.vxm - vd[i] = v0[i] ? rs1 : vs2[i]
             Self::VmergeVxm { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm {
-                    zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                        state, vs2, group_regs,
+                    zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                        program_counter,
+                        vs2,
+                        group_regs,
                     )?;
-                    zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                        state,
+                    zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                        program_counter,
                         vd,
                         VReg::V0,
                         group_regs,
                     )?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment and overlap verified above; vl <= VLMAX.
                 unsafe {
                     zve64x_perm_helpers::execute_merge_scalar(
-                        state, vd, vs2, vm, vl, vstart, sew, scalar,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, scalar,
                     );
                 }
             }
@@ -721,45 +702,44 @@ where
             // When vm=true: vmv.v.i vd, simm5 - broadcast sign-extended immediate.
             // When vm=false: vmerge.vim - vd[i] = v0[i] ? simm5 : vs2[i]
             Self::VmergeVim { vd, vs2, simm5, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm {
-                    zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                        state, vs2, group_regs,
+                    zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                        program_counter,
+                        vs2,
+                        group_regs,
                     )?;
-                    zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                        state,
+                    zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                        program_counter,
                         vd,
                         VReg::V0,
                         group_regs,
                     )?;
                 }
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Sign-extend imm to u64 so the low sew_bytes are correct for all SEW.
                 let scalar = i64::from(simm5).cast_unsigned();
                 // SAFETY: alignment and overlap verified above; vl <= VLMAX.
                 unsafe {
                     zve64x_perm_helpers::execute_merge_scalar(
-                        state, vd, vs2, vm, vl, vstart, sew, scalar,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, scalar,
                     );
                 }
             }
@@ -768,159 +748,145 @@ where
             // Always unmasked (vm=1 in encoding); vs1 is the explicit mask operand.
             // vd must not overlap vs1 or vs2.
             Self::VcompressVm { vd, vs2, vs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // Spec §16.5: vstart must be zero.
-                if state.ext_state.vstart() != 0 {
+                if ext_state.vstart() != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 // vs1 is always a single mask register (no LMUL grouping)
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(
-                    state, vd, vs2, group_regs,
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
                 )?;
                 // vs1 is a mask register; check it doesn't overlap vd
-                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _, _, _, _>(state, vd, vs1, 1)?;
+                zve64x_perm_helpers::check_no_overlap::<Reg, _, _, _>(program_counter, vd, vs1, 1)?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 unsafe {
-                    zve64x_perm_helpers::execute_compress(state, vd, vs2, vs1, vl, sew);
+                    zve64x_perm_helpers::execute_compress(ext_state, vd, vs2, vs1, vl, sew);
                 }
             }
             // vmv1r.v vd, vs2
             // Whole register move: copies 1 register.
             // No masking, no vtype/vl dependency.
             Self::Vmv1rV { vd, vs2 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY: both vd.bits() and vs2.bits() are always in [0, 32) by VReg invariant;
                 // copying 1 register always fits.
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
-                        state.ext_state.write_vreg(),
+                        ext_state.write_vreg(),
                         vd.bits(),
                         vs2.bits(),
                         1,
                     );
                 }
-                state.ext_state.mark_vs_dirty();
-                state.ext_state.reset_vstart();
+                ext_state.mark_vs_dirty();
+                ext_state.reset_vstart();
             }
             // vmv2r.v vd, vs2
             // Whole register move: copies 2 registers.
             // vd and vs2 must be aligned to 2 (checked here per spec §17.6).
             Self::Vmv2rV { vd, vs2 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vd.bits().is_multiple_of(2) || !vs2.bits().is_multiple_of(2) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY: alignment verified; 2 registers from aligned base always stay in [0, 32).
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
-                        state.ext_state.write_vreg(),
+                        ext_state.write_vreg(),
                         vd.bits(),
                         vs2.bits(),
                         2,
                     );
                 }
-                state.ext_state.mark_vs_dirty();
-                state.ext_state.reset_vstart();
+                ext_state.mark_vs_dirty();
+                ext_state.reset_vstart();
             }
             // vmv4r.v vd, vs2
             // Whole register move: copies 4 registers.
             Self::Vmv4rV { vd, vs2 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vd.bits().is_multiple_of(4) || !vs2.bits().is_multiple_of(4) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY: alignment verified; 4 registers from aligned base always stay in [0, 32).
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
-                        state.ext_state.write_vreg(),
+                        ext_state.write_vreg(),
                         vd.bits(),
                         vs2.bits(),
                         4,
                     );
                 }
-                state.ext_state.mark_vs_dirty();
-                state.ext_state.reset_vstart();
+                ext_state.mark_vs_dirty();
+                ext_state.reset_vstart();
             }
             // vmv8r.v vd, vs2
             // Whole register move: copies 8 registers.
             Self::Vmv8rV { vd, vs2 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if !vd.bits().is_multiple_of(8) || !vs2.bits().is_multiple_of(8) {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // SAFETY: alignment verified; 8 registers from aligned base always stay in [0, 32).
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
-                        state.ext_state.write_vreg(),
+                        ext_state.write_vreg(),
                         vd.bits(),
                         vs2.bits(),
                         8,
                     );
                 }
-                state.ext_state.mark_vs_dirty();
-                state.ext_state.reset_vstart();
+                ext_state.mark_vs_dirty();
+                ext_state.reset_vstart();
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
@@ -38,7 +38,15 @@ fn exec(
     state: &mut crate::rv64::test_utils::TestInterpreterState<ZVPerm>,
     instr: ZVPerm,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 fn read_elem(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/zve64x_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/zve64x_perm_helpers.rs
@@ -5,7 +5,7 @@ pub use crate::v::zve64x::arith::zve64x_arith_helpers::check_vreg_group_alignmen
 use crate::v::zve64x::arith::zve64x_arith_helpers::{read_element_u64, write_element_u64};
 use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, InterpreterState, ProgramCounter, VirtualMemory};
+use crate::{ExecutionError, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
@@ -15,8 +15,8 @@ use core::fmt;
 /// [`check_no_overlap_asymmetric`].
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_no_overlap<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_no_overlap<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     a: VReg,
     b: VReg,
     count: u8,
@@ -33,7 +33,7 @@ where
     // (e.g., b_start=30 + count=8 = 38, which overflows u8).
     if a_start < b_start + count && b_start < a_start + count {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -46,8 +46,8 @@ where
 /// uses EEW=16-derived `index_group_regs`.
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_no_overlap_asymmetric<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_no_overlap_asymmetric<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     a: VReg,
     a_count: u8,
     b: VReg,
@@ -65,7 +65,7 @@ where
     // each starts before the other ends.
     if a_start < b_start + b_count && b_start < a_start + a_count {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -159,8 +159,8 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_slideup<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -174,12 +174,10 @@ pub unsafe fn execute_slideup<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     // Per spec §16.3.1: elements 0..offset are never written (vd keeps its value).
@@ -193,7 +191,7 @@ pub unsafe fn execute_slideup<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
         // SAFETY: src_idx < vl <= group_regs * elems_per_reg, so source element is in range
         let val = unsafe {
             read_element_u64(
-                state.ext_state.read_vreg(),
+                ext_state.read_vreg(),
                 usize::from(vs2_base),
                 src_idx as u32,
                 sew,
@@ -201,11 +199,11 @@ pub unsafe fn execute_slideup<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg, so dest element is in range
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a vslidedown operation.
@@ -219,8 +217,8 @@ pub unsafe fn execute_slideup<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_slidedown<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -235,12 +233,10 @@ pub unsafe fn execute_slidedown<Reg, Regs, ExtState, Memory, PC, IH, CustomError
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     for i in vstart..vl {
@@ -255,7 +251,7 @@ pub unsafe fn execute_slidedown<Reg, Regs, ExtState, Memory, PC, IH, CustomError
             // SAFETY: src_idx < vlmax <= group_regs * elems_per_reg, so element is in range
             unsafe {
                 read_element_u64(
-                    state.ext_state.read_vreg(),
+                    ext_state.read_vreg(),
                     usize::from(vs2_base),
                     src_idx as u32,
                     sew,
@@ -266,11 +262,11 @@ pub unsafe fn execute_slidedown<Reg, Regs, ExtState, Memory, PC, IH, CustomError
         };
         // SAFETY: i < vl <= vlmax <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a vslide1up operation.
@@ -286,8 +282,8 @@ pub unsafe fn execute_slidedown<Reg, Regs, ExtState, Memory, PC, IH, CustomError
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_slide1up<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -301,12 +297,10 @@ pub unsafe fn execute_slide1up<Reg, Regs, ExtState, Memory, PC, IH, CustomError>
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     for i in vstart..vl {
@@ -317,22 +311,15 @@ pub unsafe fn execute_slide1up<Reg, Regs, ExtState, Memory, PC, IH, CustomError>
             scalar
         } else {
             // SAFETY: i - 1 < vl <= group_regs * elems_per_reg
-            unsafe {
-                read_element_u64(
-                    state.ext_state.read_vreg(),
-                    usize::from(vs2_base),
-                    i - 1,
-                    sew,
-                )
-            }
+            unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i - 1, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a vslide1down operation.
@@ -352,8 +339,8 @@ pub unsafe fn execute_slide1up<Reg, Regs, ExtState, Memory, PC, IH, CustomError>
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_slide1down<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -367,12 +354,10 @@ pub unsafe fn execute_slide1down<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     for i in vstart..vl {
@@ -381,24 +366,17 @@ pub unsafe fn execute_slide1down<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
         }
         let val = if i + 1 < vl {
             // SAFETY: i + 1 < vl <= group_regs * elems_per_reg
-            unsafe {
-                read_element_u64(
-                    state.ext_state.read_vreg(),
-                    usize::from(vs2_base),
-                    i + 1,
-                    sew,
-                )
-            }
+            unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i + 1, sew) }
         } else {
             scalar
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute vrgather.vv: `vd[i] = (vs1[i] < vlmax) ? vs2[vs1[i]] : 0`.
@@ -410,8 +388,8 @@ pub unsafe fn execute_slide1down<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_rgather_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vs1: VReg,
@@ -426,12 +404,10 @@ pub unsafe fn execute_rgather_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     let vs1_base = vs1.bits();
@@ -441,12 +417,12 @@ pub unsafe fn execute_rgather_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg for vs1
         let index =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs1_base), i, sew) };
+            unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs1_base), i, sew) };
         let val = if index < u64::from(vlmax) {
             // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
             unsafe {
                 read_element_u64(
-                    state.ext_state.read_vreg(),
+                    ext_state.read_vreg(),
                     usize::from(vs2_base),
                     index as u32,
                     sew,
@@ -457,11 +433,11 @@ pub unsafe fn execute_rgather_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute vrgather.vx / vrgather.vi: all active elements get `vs2[index]` or `0`.
@@ -473,8 +449,8 @@ pub unsafe fn execute_rgather_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_rgather_scalar<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -489,12 +465,10 @@ pub unsafe fn execute_rgather_scalar<Reg, Regs, ExtState, Memory, PC, IH, Custom
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     // Pre-compute the gathered value; it's the same for all elements.
@@ -502,7 +476,7 @@ pub unsafe fn execute_rgather_scalar<Reg, Regs, ExtState, Memory, PC, IH, Custom
         // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
         unsafe {
             read_element_u64(
-                state.ext_state.read_vreg(),
+                ext_state.read_vreg(),
                 usize::from(vs2_base),
                 index as u32,
                 sew,
@@ -517,11 +491,11 @@ pub unsafe fn execute_rgather_scalar<Reg, Regs, ExtState, Memory, PC, IH, Custom
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute vrgatherei16.vv: `vd[i] = (vs1_16[i] < vlmax) ? vs2[vs1_16[i]] : 0`.
@@ -537,8 +511,8 @@ pub unsafe fn execute_rgather_scalar<Reg, Regs, ExtState, Memory, PC, IH, Custom
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_rgatherei16<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vs1: VReg,
@@ -554,8 +528,6 @@ pub unsafe fn execute_rgatherei16<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // Maximum number of EEW=16 elements the index register group can hold.
@@ -568,7 +540,7 @@ pub unsafe fn execute_rgatherei16<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
         "vl={vl} exceeds vlmax={vlmax} or index_capacity={index_capacity}"
     );
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     let vs1_base = vs1.bits();
@@ -579,19 +551,13 @@ pub unsafe fn execute_rgatherei16<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
         // Read 16-bit index from vs1; EEW=16 always.
         // SAFETY: i < vl <= index_capacity = index_group_regs * (VLENB/2), so element i
         // fits within the index register group.
-        let index = unsafe {
-            read_element_u64(
-                state.ext_state.read_vreg(),
-                usize::from(vs1_base),
-                i,
-                Vsew::E16,
-            )
-        };
+        let index =
+            unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs1_base), i, Vsew::E16) };
         let val = if index < u64::from(vlmax) {
             // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
             unsafe {
                 read_element_u64(
-                    state.ext_state.read_vreg(),
+                    ext_state.read_vreg(),
                     usize::from(vs2_base),
                     index as u32,
                     sew,
@@ -602,11 +568,11 @@ pub unsafe fn execute_rgatherei16<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute vmerge.vvm / vmv.v.v.
@@ -622,8 +588,8 @@ pub unsafe fn execute_rgatherei16<Reg, Regs, ExtState, Memory, PC, IH, CustomErr
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_merge_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vs1: VReg,
@@ -637,13 +603,11 @@ pub unsafe fn execute_merge_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomError>
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
     // For vmv.v.v (vm=true) the mask is all-ones so snapshot_mask is still valid.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs1_base = vs1.bits();
     let vs2_base = vs2.bits();
@@ -651,17 +615,17 @@ pub unsafe fn execute_merge_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomError>
         let mask_set = mask_bit(&mask_buf, i);
         let val = if mask_set {
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs1
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs1_base), i, sew) }
+            unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs1_base), i, sew) }
         } else {
             // mask_set=false only reachable when vm=false (vmerge path).
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew) }
+            unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
-        unsafe { write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val) };
+        unsafe { write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val) };
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute vmerge.vxm / vmerge.vim / vmv.v.x / vmv.v.i.
@@ -677,8 +641,8 @@ pub unsafe fn execute_merge_vv<Reg, Regs, ExtState, Memory, PC, IH, CustomError>
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_merge_scalar<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -692,12 +656,10 @@ pub unsafe fn execute_merge_scalar<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     for i in vstart..vl {
@@ -705,13 +667,13 @@ pub unsafe fn execute_merge_scalar<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
             scalar
         } else {
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew) }
+            unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
-        unsafe { write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew, val) };
+        unsafe { write_element_u64(ext_state.write_vreg(), vd_base, i, sew, val) };
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute vcompress.vm: pack active elements of vs2 (under vs1 mask) sequentially into vd.
@@ -726,8 +688,8 @@ pub unsafe fn execute_merge_scalar<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
 /// - `vl <= VLMAX`.
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn execute_compress<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vs1: VReg,
@@ -739,15 +701,13 @@ pub unsafe fn execute_compress<Reg, Regs, ExtState, Memory, PC, IH, CustomError>
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
     let vs1_base = vs1.bits();
     let mask_bytes = vl.div_ceil(u8::BITS) as usize;
-    let vreg = state.ext_state.read_vreg();
+    let vreg = ext_state.read_vreg();
     let mut vs1_buf = [0u8; { ExtState::VLENB as usize }];
     // SAFETY: mask_bytes <= VLENB since vl <= VLEN; vs1_base < 32
     unsafe {
@@ -762,16 +722,15 @@ pub unsafe fn execute_compress<Reg, Regs, ExtState, Memory, PC, IH, CustomError>
             continue;
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg
-        let val =
-            unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let val = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
         // SAFETY: out_idx <= popcount(vs1[0..vl)) <= vl
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, out_idx, sew, val);
+            write_element_u64(ext_state.write_vreg(), vd_base, out_idx, sew, val);
         }
         out_idx += 1;
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Copy `count` whole vector registers from `src_base` to `dst_base`.

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction.rs
@@ -7,10 +7,7 @@ pub mod zve64x_reduction_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::arith::zve64x_arith_helpers;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -18,10 +15,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xReductionInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xReductionInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -36,44 +31,43 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        _regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             Self::Vredsum { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // Spec §14: reductions with vstart > 0 are reserved; raise illegal instruction
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: `vs2` alignment checked; `vstart == 0` checked;
                 // `vs1` and `vd` are single-register scalar operands
                 unsafe {
                     zve64x_reduction_helpers::execute_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -85,38 +79,33 @@ where
                 }
             }
             Self::Vredand { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vredsum`
                 unsafe {
                     zve64x_reduction_helpers::execute_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -128,38 +117,33 @@ where
                 }
             }
             Self::Vredor { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vredsum`
                 unsafe {
                     zve64x_reduction_helpers::execute_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -171,38 +155,33 @@ where
                 }
             }
             Self::Vredxor { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vredsum`
                 unsafe {
                     zve64x_reduction_helpers::execute_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -214,38 +193,33 @@ where
                 }
             }
             Self::Vredminu { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vredsum`
                 unsafe {
                     zve64x_reduction_helpers::execute_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -260,38 +234,33 @@ where
                 }
             }
             Self::Vredmin { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vredsum`
                 unsafe {
                     zve64x_reduction_helpers::execute_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -311,38 +280,33 @@ where
                 }
             }
             Self::Vredmaxu { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vredsum`
                 unsafe {
                     zve64x_reduction_helpers::execute_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -357,38 +321,33 @@ where
                 }
             }
             Self::Vredmax { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vredsum`
                 unsafe {
                     zve64x_reduction_helpers::execute_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -408,47 +367,40 @@ where
                 }
             }
             Self::Vwredsumu { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 // Widening: 2*SEW must fit in ELEN
                 if u32::from(vtype.vsew().bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: `vs2` alignment checked; widening SEW constraint checked above;
                 // `vstart == 0` checked; `vd` and `vs1` are single-register 2*SEW scalar operands
                 unsafe {
                     zve64x_reduction_helpers::execute_widening_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,
@@ -462,45 +414,38 @@ where
                 }
             }
             Self::Vwredsum { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                if u32::from(state.ext_state.vstart()) != 0 {
+                if u32::from(ext_state.vstart()) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if u32::from(vtype.vsew().bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 // SAFETY: see `Vwredsumu`
                 unsafe {
                     zve64x_reduction_helpers::execute_widening_reduce_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         vs1,

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
@@ -25,7 +25,15 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xReductionInstruction<Reg<u64>>>,
     instr: Zve64xReductionInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 fn read_elem(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/zve64x_reduction_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/zve64x_reduction_helpers.rs
@@ -4,7 +4,6 @@ use crate::v::zve64x::arith::zve64x_arith_helpers::{
     read_element_u64, sign_extend, write_element_u64,
 };
 use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
-use crate::{InterpreterState, ProgramCounter, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
@@ -18,8 +17,8 @@ use core::fmt;
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vs1: VReg,
@@ -33,8 +32,6 @@ pub unsafe fn execute_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, Vsew) -> u64,
 {
@@ -42,14 +39,13 @@ pub unsafe fn execute_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError
     // vl == 0 (since caller has verified vstart == 0). In that case we must not write vd and
     // must not mark vs dirty.
     if vl == 0 {
-        state.ext_state.reset_vstart();
+        ext_state.reset_vstart();
         return;
     }
     // SAFETY: element 0 always fits within register vs1
-    let init =
-        unsafe { read_element_u64(state.ext_state.read_vreg(), usize::from(vs1.bits()), 0, sew) };
+    let init = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs1.bits()), 0, sew) };
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vs2_base = usize::from(vs2.bits());
     let mut acc = init;
     for i in 0..vl {
@@ -57,15 +53,15 @@ pub unsafe fn execute_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError
             continue;
         }
         // SAFETY: `vs2_base % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`
-        let elem = unsafe { read_element_u64(state.ext_state.read_vreg(), vs2_base, i, sew) };
+        let elem = unsafe { read_element_u64(ext_state.read_vreg(), vs2_base, i, sew) };
         acc = op(acc, elem, sew);
     }
     // SAFETY: element 0 always fits within register vd
     unsafe {
-        write_element_u64(state.ext_state.write_vreg(), vd.bits(), 0, sew, acc);
+        write_element_u64(ext_state.write_vreg(), vd.bits(), 0, sew, acc);
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a widening integer sum reduction.
@@ -79,8 +75,8 @@ pub unsafe fn execute_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_widening_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_widening_reduce_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vs1: VReg,
@@ -95,8 +91,6 @@ pub unsafe fn execute_widening_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, Cu
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64, Vsew) -> u64,
 {
@@ -108,20 +102,14 @@ pub unsafe fn execute_widening_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, Cu
         Vsew::E64 => unsafe { core::hint::unreachable_unchecked() },
     };
     if vl == 0 {
-        state.ext_state.reset_vstart();
+        ext_state.reset_vstart();
         return;
     }
     // SAFETY: element 0 always fits within register vs1
-    let init = unsafe {
-        read_element_u64(
-            state.ext_state.read_vreg(),
-            usize::from(vs1.bits()),
-            0,
-            wide_sew,
-        )
-    };
+    let init =
+        unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs1.bits()), 0, wide_sew) };
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vs2_base = usize::from(vs2.bits());
     let mut acc = init;
     for i in 0..vl {
@@ -129,7 +117,7 @@ pub unsafe fn execute_widening_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, Cu
             continue;
         }
         // SAFETY: same bounds argument as `execute_reduce_op`
-        let raw = unsafe { read_element_u64(state.ext_state.read_vreg(), vs2_base, i, sew) };
+        let raw = unsafe { read_element_u64(ext_state.read_vreg(), vs2_base, i, sew) };
         let elem = if sign_extend_src {
             sign_extend(raw, sew).cast_unsigned()
         } else {
@@ -139,8 +127,8 @@ pub unsafe fn execute_widening_reduce_op<Reg, Regs, ExtState, Memory, PC, IH, Cu
     }
     // SAFETY: element 0 always fits within register vd
     unsafe {
-        write_element_u64(state.ext_state.write_vreg(), vd.bits(), 0, wide_sew, acc);
+        write_element_u64(ext_state.write_vreg(), vd.bits(), 0, wide_sew, acc);
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
@@ -7,10 +7,7 @@ pub mod zve64x_store_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::load::zve64x_load_helpers;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -18,10 +15,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xStoreInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xStoreInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -36,7 +31,11 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // Whole-register store: stores `nreg` consecutive registers starting at `vs3` directly
@@ -44,25 +43,21 @@ where
             // to `nreg`. Ignores vtype, vl, masking. Honors `vstart` in byte units: the first
             // `vstart` bytes are skipped. If `vstart >= EVL`, the instruction is a no-op.
             Self::Vsr { vs3, rs1, nreg } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 if u32::from(vs3.bits()) % u32::from(nreg) != 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let vlenb = u64::from(ExtState::VLENB);
                 let evl = u64::from(nreg) * vlenb;
-                let vstart = u64::from(state.ext_state.vstart());
+                let vstart = u64::from(ext_state.vstart());
                 if vstart < evl {
-                    let base = state.regs.read(rs1).as_u64();
+                    let base = regs.read(rs1).as_u64();
                     let mut byte_off = vstart;
                     while byte_off < evl {
                         let reg_off = byte_off / vlenb;
@@ -72,54 +67,49 @@ where
                         // {1,2,4,8} and `vs3` is `nreg`-aligned (checked above), so
                         // `vs3.bits() + nreg - 1 <= 31`. `in_reg < VLENB` by construction.
                         let src = unsafe {
-                            state
-                                .ext_state
+                            ext_state
                                 .read_vreg()
                                 .get_unchecked(reg_idx)
                                 .get_unchecked(in_reg..)
                         };
-                        if let Err(error) = state.memory.write_slice(base + byte_off, src) {
-                            state.ext_state.set_vstart(byte_off as u16);
+                        if let Err(error) = memory.write_slice(base + byte_off, src) {
+                            ext_state.set_vstart(byte_off as u16);
                             return Err(ExecutionError::MemoryAccess(error));
                         }
                         byte_off += src.len() as u64;
                     }
                 }
-                state.ext_state.reset_vstart();
+                ext_state.reset_vstart();
             }
             // Mask store: stores `ceil(vl / 8)` bytes from `vs3` to memory with no masking.
             // Does not require a valid vtype: when vill is set vl is 0, so zero bytes are written.
             // Honors `vstart` at byte granularity: the first `vstart / 8` bytes are skipped.
             Self::Vsm { vs3, rs1 } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
+                let vl = ext_state.vl();
                 let evl_bytes = vl.div_ceil(u8::BITS);
-                let start_byte = u32::from(state.ext_state.vstart());
+                let start_byte = u32::from(ext_state.vstart());
                 if start_byte < evl_bytes {
-                    let base = state.regs.read(rs1).as_u64();
+                    let base = regs.read(rs1).as_u64();
                     // SAFETY: `vs3.bits() < 32` is guaranteed by `VReg`.
                     // `evl_bytes = vl.div_ceil(8) <= VLEN / 8 = VLENB` because `vl <= VLMAX <=
                     // VLEN`, so the slice `start_byte..evl_bytes` is in bounds of the
                     // `VLENB`-byte source register.
                     let src = unsafe {
-                        state
-                            .ext_state
+                        ext_state
                             .read_vreg()
                             .get_unchecked(usize::from(vs3.bits()))
                             .get_unchecked(start_byte as usize..evl_bytes as usize)
                     };
-                    state
-                        .memory
+                    memory
                         .write_slice(base + u64::from(start_byte), src)
                         .map_err(ExecutionError::MemoryAccess)?;
                 }
-                state.ext_state.reset_vstart();
+                ext_state.reset_vstart();
             }
             // Unit-stride store.
             //
@@ -127,30 +117,25 @@ where
             // `group_regs` such that `VLMAX = group_regs * VLENB / eew.bytes()` matches the
             // architectural `vl`.
             Self::Vse { vs3, rs1, vm, eew } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().data_register_count(eew, vtype.vsew()).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs3, group_regs,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs3,
+                    group_regs,
                 )?;
                 // SAFETY:
                 // - alignment: `check_register_group_alignment` verified `vs3 % group_regs == 0`
@@ -162,12 +147,13 @@ where
                 //   source/v0 overlap
                 unsafe {
                     zve64x_store_helpers::execute_unit_stride_store(
-                        state,
+                        ext_state,
+                        memory,
                         vs3,
                         vm,
-                        state.ext_state.vl(),
-                        state.ext_state.vstart(),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        ext_state.vstart(),
+                        regs.read(rs1).as_u64(),
                         eew,
                         group_regs,
                         1,
@@ -182,41 +168,37 @@ where
                 vm,
                 eew,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().data_register_count(eew, vtype.vsew()).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs3, group_regs,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs3,
+                    group_regs,
                 )?;
-                let stride = state.regs.read(rs2).as_u64().cast_signed();
+                let stride = regs.read(rs2).as_u64().cast_signed();
                 // SAFETY: same preconditions as `Vse`.
                 unsafe {
                     zve64x_store_helpers::execute_strided_store(
-                        state,
+                        ext_state,
+                        memory,
                         vs3,
                         vm,
-                        state.ext_state.vl(),
-                        state.ext_state.vstart(),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        ext_state.vstart(),
+                        regs.read(rs1).as_u64(),
                         stride,
                         eew,
                         group_regs,
@@ -232,20 +214,15 @@ where
                 vm,
                 eew: index_eew,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let data_eew = vtype.vsew().as_eew();
                 let data_group_regs = vtype.vlmul().register_count();
@@ -253,17 +230,15 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs3,
                     data_group_regs,
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     index_group_regs,
                 )?;
@@ -277,13 +252,14 @@ where
                 // - vs3/v0 overlap: stores read vs3 as a source; no restriction
                 unsafe {
                     zve64x_store_helpers::execute_indexed_store(
-                        state,
+                        ext_state,
+                        memory,
                         vs3,
                         vs2,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         data_eew,
                         index_eew,
                         data_group_regs,
@@ -301,20 +277,15 @@ where
                 vm,
                 eew: index_eew,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let data_eew = vtype.vsew().as_eew();
                 let data_group_regs = vtype.vlmul().register_count();
@@ -322,30 +293,29 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs3,
                     data_group_regs,
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     index_group_regs,
                 )?;
                 // SAFETY: identical precondition argument to `Vsuxei`
                 unsafe {
                     zve64x_store_helpers::execute_indexed_store(
-                        state,
+                        ext_state,
+                        memory,
                         vs3,
                         vs2,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         data_eew,
                         index_eew,
                         data_group_regs,
@@ -361,30 +331,26 @@ where
                 eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().data_register_count(eew, vtype.vsew()).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_store_helpers::validate_segment_store_registers::<Reg, _, _, _, _, _, _>(
-                    state, vs3, group_regs, nf,
+                zve64x_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
+                    program_counter,
+                    vs3,
+                    group_regs,
+                    nf,
                 )?;
                 // SAFETY:
                 // - `validate_segment_store_registers` guarantees `vs3 % group_regs == 0` and `vs3
@@ -393,12 +359,13 @@ where
                 // - vs3/v0 overlap: stores read vs3 as a source; no restriction
                 unsafe {
                     zve64x_store_helpers::execute_unit_stride_store(
-                        state,
+                        ext_state,
+                        memory,
                         vs3,
                         vm,
-                        state.ext_state.vl(),
-                        state.ext_state.vstart(),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        ext_state.vstart(),
+                        regs.read(rs1).as_u64(),
                         eew,
                         group_regs,
                         nf,
@@ -414,41 +381,38 @@ where
                 eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().data_register_count(eew, vtype.vsew()).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_store_helpers::validate_segment_store_registers::<Reg, _, _, _, _, _, _>(
-                    state, vs3, group_regs, nf,
+                zve64x_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
+                    program_counter,
+                    vs3,
+                    group_regs,
+                    nf,
                 )?;
-                let stride = state.regs.read(rs2).as_u64().cast_signed();
+                let stride = regs.read(rs2).as_u64().cast_signed();
                 // SAFETY: same as `Vsseg`.
                 unsafe {
                     zve64x_store_helpers::execute_strided_store(
-                        state,
+                        ext_state,
+                        memory,
                         vs3,
                         vm,
-                        state.ext_state.vl(),
-                        state.ext_state.vstart(),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        ext_state.vstart(),
+                        regs.read(rs1).as_u64(),
                         stride,
                         eew,
                         group_regs,
@@ -465,20 +429,15 @@ where
                 eew: index_eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let data_eew = vtype.vsew().as_eew();
                 let data_group_regs = vtype.vlmul().register_count();
@@ -486,18 +445,16 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_store_helpers::validate_segment_store_registers::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
+                    program_counter,
                     vs3,
                     data_group_regs,
                     nf,
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     index_group_regs,
                 )?;
@@ -508,13 +465,14 @@ where
                 // - vs3/v0 overlap: stores read vs3 as a source; no restriction
                 unsafe {
                     zve64x_store_helpers::execute_indexed_store(
-                        state,
+                        ext_state,
+                        memory,
                         vs3,
                         vs2,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         data_eew,
                         index_eew,
                         data_group_regs,
@@ -532,20 +490,15 @@ where
                 eew: index_eew,
                 nf,
             } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let data_eew = vtype.vsew().as_eew();
                 let data_group_regs = vtype.vlmul().register_count();
@@ -553,31 +506,30 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                zve64x_store_helpers::validate_segment_store_registers::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
+                    program_counter,
                     vs3,
                     data_group_regs,
                     nf,
                 )?;
-                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     index_group_regs,
                 )?;
                 // SAFETY: identical precondition argument to `Vsuxseg`
                 unsafe {
                     zve64x_store_helpers::execute_indexed_store(
-                        state,
+                        ext_state,
+                        memory,
                         vs3,
                         vs2,
                         vm,
-                        state.ext_state.vl(),
-                        u32::from(state.ext_state.vstart()),
-                        state.regs.read(rs1).as_u64(),
+                        ext_state.vl(),
+                        u32::from(ext_state.vstart()),
+                        regs.read(rs1).as_u64(),
                         data_eew,
                         index_eew,
                         data_group_regs,

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
@@ -53,7 +53,15 @@ fn exec_one(
     state: &mut TestInterpreterState<Zve64xStoreInstruction<Reg<u64>>>,
     instr: Zve64xStoreInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 // Vsr (whole-register store)

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
@@ -5,7 +5,7 @@ use crate::v::zve64x::load::zve64x_load_helpers::{
     check_register_group_alignment, mask_bit, read_group_element, snapshot_mask,
 };
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, InterpreterState, ProgramCounter, VirtualMemory, VirtualMemoryError};
+use crate::{ExecutionError, ProgramCounter, VirtualMemory, VirtualMemoryError};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
@@ -42,8 +42,8 @@ fn write_mem_element(
 /// applies only to load destinations.
 #[inline(always)]
 #[doc(hidden)]
-pub fn validate_segment_store_registers<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn validate_segment_store_registers<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vs3: VReg,
     group_regs: u8,
     nf: u8,
@@ -52,11 +52,11 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    check_register_group_alignment::<Reg, _, _, _, _, _, _>(state, vs3, group_regs)?;
+    check_register_group_alignment::<Reg, _, _, _>(program_counter, vs3, group_regs)?;
     let total = u32::from(vs3.bits()) + u32::from(nf) * u32::from(group_regs);
     if total > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -78,8 +78,9 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_unit_stride_store<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_unit_stride_store<Reg, ExtState, Memory, CustomError>(
+    ext_state: &mut ExtState,
+    memory: &mut Memory,
     vs3: VReg,
     vm: bool,
     vl: u32,
@@ -96,13 +97,12 @@ where
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let elem_bytes = eew.bytes();
     let segment_stride = u64::from(nf * elem_bytes);
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !vm && !mask_bit(&mask_buf, i) {
             continue;
@@ -125,22 +125,17 @@ where
             // Therefore,
             // `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
             let data = unsafe {
-                read_group_element(
-                    state.ext_state.read_vreg(),
-                    usize::from(field_base_reg),
-                    i,
-                    eew,
-                )
+                read_group_element(ext_state.read_vreg(), usize::from(field_base_reg), i, eew)
             };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
-            if let Err(error) = write_mem_element(&mut state.memory, addr, eew, data) {
-                state.ext_state.set_vstart(i as u16);
+            if let Err(error) = write_mem_element(memory, addr, eew, data) {
+                ext_state.set_vstart(i as u16);
                 return Err(ExecutionError::MemoryAccess(error));
             }
         }
     }
-    state.ext_state.reset_vstart();
+    ext_state.reset_vstart();
     Ok(())
 }
 
@@ -160,8 +155,9 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_strided_store<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_strided_store<Reg, ExtState, Memory, CustomError>(
+    ext_state: &mut ExtState,
+    memory: &mut Memory,
     vs3: VReg,
     vm: bool,
     vl: u32,
@@ -179,12 +175,11 @@ where
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let elem_bytes = eew.bytes();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !vm && !mask_bit(&mask_buf, i) {
             continue;
@@ -197,22 +192,17 @@ where
             // i / elems_per_reg < field_base_reg + group_regs <= vs3.bits() + nf *
             // group_regs <= 32`.
             let data = unsafe {
-                read_group_element(
-                    state.ext_state.read_vreg(),
-                    usize::from(field_base_reg),
-                    i,
-                    eew,
-                )
+                read_group_element(ext_state.read_vreg(), usize::from(field_base_reg), i, eew)
             };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
-            if let Err(error) = write_mem_element(&mut state.memory, addr, eew, data) {
-                state.ext_state.set_vstart(i as u16);
+            if let Err(error) = write_mem_element(memory, addr, eew, data) {
+                ext_state.set_vstart(i as u16);
                 return Err(ExecutionError::MemoryAccess(error));
             }
         }
     }
-    state.ext_state.reset_vstart();
+    ext_state.reset_vstart();
     Ok(())
 }
 
@@ -237,8 +227,9 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_indexed_store<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_indexed_store<Reg, ExtState, Memory, CustomError>(
+    ext_state: &mut ExtState,
+    memory: &mut Memory,
     vs3: VReg,
     vs2: VReg,
     vm: bool,
@@ -257,12 +248,11 @@ where
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let data_elem_bytes = data_eew.bytes();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     for i in vstart..vl {
         if !vm && !mask_bit(&mask_buf, i) {
             continue;
@@ -270,12 +260,7 @@ where
         // SAFETY: `i < vl <= index_group_regs * VLENB / index_eew.bytes()` (precondition), so
         // `vs2.bits() + i / (VLENB / index_eew.bytes()) < vs2.bits() + index_group_regs <= 32`.
         let index_buf = unsafe {
-            read_group_element(
-                state.ext_state.read_vreg(),
-                usize::from(vs2.bits()),
-                i,
-                index_eew,
-            )
+            read_group_element(ext_state.read_vreg(), usize::from(vs2.bits()), i, index_eew)
         };
         // SAFETY: `index_eew.bytes() <= Eew::MAX_BYTES` always holds.
         let offset = unsafe { index_buf_to_u64(index_buf, index_eew) };
@@ -288,7 +273,7 @@ where
             //                                    <= vs3.bits() + nf * data_group_regs <= 32`.
             let data = unsafe {
                 read_group_element(
-                    state.ext_state.read_vreg(),
+                    ext_state.read_vreg(),
                     usize::from(field_base_reg),
                     i,
                     data_eew,
@@ -296,12 +281,12 @@ where
             };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
-            if let Err(error) = write_mem_element(&mut state.memory, addr, data_eew, data) {
-                state.ext_state.set_vstart(i as u16);
+            if let Err(error) = write_mem_element(memory, addr, data_eew, data) {
+                ext_state.set_vstart(i as u16);
                 return Err(ExecutionError::MemoryAccess(error));
             }
         }
     }
-    state.ext_state.reset_vstart();
+    ext_state.reset_vstart();
     Ok(())
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow.rs
@@ -6,10 +6,7 @@ pub mod zve64x_widen_narrow_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
-use crate::{
-    ExecutableInstruction, ExecutionError, InterpreterState, ProgramCounter, RegisterFile,
-    VirtualMemory,
-};
+use crate::{ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, VirtualMemory};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -17,10 +14,8 @@ use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for Zve64xWidenNarrowInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xWidenNarrowInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -35,33 +30,30 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // vwaddu.vv - 2*SEW = zext(SEW) + zext(SEW)
             Self::VwadduVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 // Widening requires SEW < 64; 2*SEW must fit in ELEN=64
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -73,38 +65,38 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     Some(vs1),
                     group_regs,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -120,27 +112,20 @@ where
             }
             // vwaddu.vx - 2*SEW = zext(SEW) + zext(xlen->SEW)
             Self::VwadduVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -152,37 +137,35 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     None,
                     group_regs,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Scalar is zero-extended to 2*SEW; the low SEW bits are what matter
-                let scalar = state.regs.read(rs1).as_u64();
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -198,27 +181,20 @@ where
             }
             // vwadd.vv - 2*SEW = sext(SEW) + sext(SEW)
             Self::VwaddVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -230,38 +206,38 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     Some(vs1),
                     group_regs,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -277,27 +253,20 @@ where
             }
             // vwadd.vx - 2*SEW = sext(SEW) + sext(rs1)
             Self::VwaddVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -309,41 +278,39 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     None,
                     group_regs,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // Scalar is sign-extended from XLEN to 64 bits
                 let scalar = zve64x_widen_narrow_helpers::sign_extend_bits(
-                    state.regs.read(rs1).as_u64(),
+                    regs.read(rs1).as_u64(),
                     u32::from(Reg::XLEN),
                 )
                 .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -359,27 +326,20 @@ where
             }
             // vwsubu.vv - 2*SEW = zext(SEW) - zext(SEW)
             Self::VwsubuVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -391,38 +351,38 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     Some(vs1),
                     group_regs,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -438,27 +398,20 @@ where
             }
             // vwsubu.vx - 2*SEW = zext(SEW) - zext(rs1)
             Self::VwsubuVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -470,36 +423,34 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     None,
                     group_regs,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -515,27 +466,20 @@ where
             }
             // vwsub.vv - 2*SEW = sext(SEW) - sext(SEW)
             Self::VwsubVv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -547,38 +491,38 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     Some(vs1),
                     group_regs,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -594,27 +538,20 @@ where
             }
             // vwsub.vx - 2*SEW = sext(SEW) - sext(rs1)
             Self::VwsubVx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -626,40 +563,38 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs2,
                     None,
                     group_regs,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = zve64x_widen_narrow_helpers::sign_extend_bits(
-                    state.regs.read(rs1).as_u64(),
+                    regs.read(rs1).as_u64(),
                     u32::from(Reg::XLEN),
                 )
                 .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -675,27 +610,20 @@ where
             }
             // vwaddu.wv - 2*SEW = 2*SEW + zext(SEW)
             Self::VwadduWv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -707,22 +635,22 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
                 // vs2 is the wide source; vs1 is narrow
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     None,
@@ -731,17 +659,15 @@ where
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_w_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -756,27 +682,20 @@ where
             }
             // vwaddu.wx - 2*SEW = 2*SEW + zext(rs1)
             Self::VwadduWx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let wide_eew = match sew {
@@ -787,36 +706,32 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
                 // For .wx scalar variants vd may alias vs2 (same wide group); no narrow vs1
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     wide_group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_w_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -831,27 +746,20 @@ where
             }
             // vwadd.wv - 2*SEW = 2*SEW + sext(SEW)
             Self::VwaddWv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -863,21 +771,21 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     None,
@@ -886,17 +794,15 @@ where
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_w_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -911,27 +817,20 @@ where
             }
             // vwadd.wx - 2*SEW = 2*SEW + sext(rs1)
             Self::VwaddWx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let wide_eew = match sew {
@@ -942,39 +841,35 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     wide_group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = zve64x_widen_narrow_helpers::sign_extend_bits(
-                    state.regs.read(rs1).as_u64(),
+                    regs.read(rs1).as_u64(),
                     u32::from(Reg::XLEN),
                 )
                 .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_w_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -989,27 +884,20 @@ where
             }
             // vwsubu.wv - 2*SEW = 2*SEW - zext(SEW)
             Self::VwsubuWv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1021,21 +909,21 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     None,
@@ -1044,17 +932,15 @@ where
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_w_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1069,27 +955,20 @@ where
             }
             // vwsubu.wx - 2*SEW = 2*SEW - zext(rs1)
             Self::VwsubuWx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let wide_eew = match sew {
@@ -1100,35 +979,31 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     wide_group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_w_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -1143,27 +1018,20 @@ where
             }
             // vwsub.wv - 2*SEW = 2*SEW - sext(SEW)
             Self::VwsubWv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1175,21 +1043,21 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     vs1,
                     None,
@@ -1198,17 +1066,15 @@ where
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_w_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1223,27 +1089,20 @@ where
             }
             // vwsub.wx - 2*SEW = 2*SEW - sext(rs1)
             Self::VwsubWx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let wide_eew = match sew {
@@ -1254,39 +1113,35 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _>(
+                    program_counter,
                     vd,
                     wide_group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 let scalar = zve64x_widen_narrow_helpers::sign_extend_bits(
-                    state.regs.read(rs1).as_u64(),
+                    regs.read(rs1).as_u64(),
                     u32::from(Reg::XLEN),
                 )
                 .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_widen_w_op(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -1301,28 +1156,21 @@ where
             }
             // vnsrl.wv - SEW = (2*SEW) >> SEW (logical)
             Self::VnsrlWv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 // SEW must be < 64 so that 2*SEW fits in ELEN
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1334,35 +1182,35 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_narrow_shift(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1376,27 +1224,20 @@ where
             }
             // vnsrl.wx - SEW = (2*SEW) >> rs1 (logical)
             Self::VnsrlWx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1408,33 +1249,31 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_narrow_shift(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -1448,27 +1287,20 @@ where
             }
             // vnsrl.wi - SEW = (2*SEW) >> uimm (logical)
             Self::VnsrlWi { vd, vs2, uimm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1480,32 +1312,30 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_narrow_shift(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(u64::from(uimm)),
@@ -1519,27 +1349,20 @@ where
             }
             // vnsra.wv - SEW = (2*SEW) >> SEW (arithmetic)
             Self::VnsraWv { vd, vs2, vs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1551,35 +1374,35 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs1, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_narrow_shift(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Vreg(vs1.bits()),
@@ -1593,27 +1416,20 @@ where
             }
             // vnsra.wx - SEW = (2*SEW) >> rs1 (arithmetic)
             Self::VnsraWx { vd, vs2, rs1, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1625,33 +1441,31 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
-                let scalar = state.regs.read(rs1).as_u64();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = regs.read(rs1).as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_narrow_shift(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(scalar),
@@ -1665,27 +1479,20 @@ where
             }
             // vnsra.wi - SEW = (2*SEW) >> uimm (arithmetic)
             Self::VnsraWi { vd, vs2, uimm, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) * 2 > ExtState::ELEN {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1697,32 +1504,30 @@ where
                 };
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     },
                 )?;
-                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _, _, _, _>(
-                    state,
+                zve64x_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                    program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_narrow_shift(
-                        state,
+                        ext_state,
                         vd,
                         vs2,
                         zve64x_widen_narrow_helpers::OpSrc::Scalar(u64::from(uimm)),
@@ -1736,299 +1541,281 @@ where
             }
             // vzext.vf2 - zero-extend SEW/2 -> SEW
             Self::VzextVf2 { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 // SEW must be >= 2*8 = 16
                 if u32::from(sew.bits()) < 16 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
                 // EMUL for source = LMUL / 2; src_group = max(1, group_regs / 2)
                 let src_group = group_regs.max(2) / 2;
-                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, src_group, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    src_group,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_extension(
-                        state, vd, vs2, vm, vl, vstart, sew, 2, false,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, 2, false,
                     );
                 }
             }
             // vzext.vf4 - zero-extend SEW/4 -> SEW
             Self::VzextVf4 { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 // SEW must be >= 4*8 = 32
                 if u32::from(sew.bits()) < 32 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = group_regs.max(4) / 4;
-                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, src_group, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    src_group,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_extension(
-                        state, vd, vs2, vm, vl, vstart, sew, 4, false,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, 4, false,
                     );
                 }
             }
             // vzext.vf8 - zero-extend SEW/8 -> SEW
             Self::VzextVf8 { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 // SEW must be >= 8*8 = 64; only SEW=64 qualifies in Zve64x
                 if u32::from(sew.bits()) < 64 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = group_regs.max(8) / 8;
-                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, src_group, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    src_group,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_extension(
-                        state, vd, vs2, vm, vl, vstart, sew, 8, false,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, 8, false,
                     );
                 }
             }
             // vsext.vf2 - sign-extend SEW/2 -> SEW
             Self::VsextVf2 { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) < 16 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = group_regs.max(2) / 2;
-                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, src_group, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    src_group,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_extension(
-                        state, vd, vs2, vm, vl, vstart, sew, 2, true,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, 2, true,
                     );
                 }
             }
             // vsext.vf4 - sign-extend SEW/4 -> SEW
             Self::VsextVf4 { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) < 32 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = group_regs.max(4) / 4;
-                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, src_group, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    src_group,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_extension(
-                        state, vd, vs2, vm, vl, vstart, sew, 4, true,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, 4, true,
                     );
                 }
             }
             // vsext.vf8 - sign-extend SEW/8 -> SEW
             Self::VsextVf8 { vd, vs2, vm } => {
-                if !state.ext_state.vector_instructions_allowed() {
+                if !ext_state.vector_instructions_allowed() {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vtype = state
-                    .ext_state
+                let vtype = ext_state
                     .vtype()
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let sew = vtype.vsew();
                 if u32::from(sew.bits()) < 64 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = group_regs.max(8) / 8;
-                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vs2, src_group, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    src_group,
+                    vd,
+                    group_regs,
                 )?;
-                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _, _, _, _>(
-                    state, vd, group_regs,
+                zve64x_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
                 )?;
                 if !vm && vd.bits() == 0 {
                     Err(ExecutionError::IllegalInstruction {
-                        address: state
-                            .instruction_fetcher
-                            .old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 }
-                let vl = state.ext_state.vl();
-                let vstart = u32::from(state.ext_state.vstart());
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zve64x_widen_narrow_helpers::execute_extension(
-                        state, vd, vs2, vm, vl, vstart, sew, 8, true,
+                        ext_state, vd, vs2, vm, vl, vstart, sew, 8, true,
                     );
                 }
             }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
@@ -25,7 +25,15 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xWidenNarrowInstruction<Reg<u64>>>,
     instr: Zve64xWidenNarrowInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    instr.execute(state).map(|_| ())
+    instr
+        .execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
 }
 
 fn read_elem(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
@@ -3,7 +3,7 @@
 use crate::v::vector_registers::VectorRegistersExt;
 pub use crate::v::zve64x::arith::zve64x_arith_helpers::{OpSrc, check_vreg_group_alignment};
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, InterpreterState, ProgramCounter, VirtualMemory};
+use crate::{ExecutionError, ProgramCounter};
 use ab_riscv_primitives::instructions::v::Vsew;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
@@ -12,8 +12,8 @@ use core::fmt;
 /// `[0,32)`, without any source overlap check
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_vd_widen_no_src_check<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_vd_widen_no_src_check<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vd: VReg,
     wide_group_regs: u8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
@@ -24,7 +24,7 @@ where
     let vd_idx = vd.bits();
     if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -34,8 +34,8 @@ where
 /// does not overlap `vd` (which occupies `group_regs` registers).
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_vs_ext_alignment<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_vs_ext_alignment<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vs2: VReg,
     src_group_regs: u8,
     vd: VReg,
@@ -48,13 +48,13 @@ where
     let vs2_idx = vs2.bits();
     if !vs2_idx.is_multiple_of(src_group_regs) || vs2_idx + src_group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     // vd and vs2 must not overlap
     if ranges_overlap(vd.bits(), group_regs, vs2_idx, src_group_regs) {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -67,8 +67,8 @@ where
 /// `Vlmul::index_register_count(wide_eew, sew)`. `group_regs` is the narrow LMUL register count.
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_vd_widen_alignment<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_vd_widen_alignment<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vd: VReg,
     vs_a: VReg,
     vs_b_opt: Option<VReg>,
@@ -82,20 +82,20 @@ where
     let vd_idx = vd.bits();
     if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     let va_idx = vs_a.bits();
     if ranges_overlap(vd_idx, wide_group_regs, va_idx, group_regs) {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     if let Some(vs_b) = vs_b_opt {
         let vb_idx = vs_b.bits();
         if ranges_overlap(vd_idx, wide_group_regs, vb_idx, group_regs) {
             return Err(ExecutionError::IllegalInstruction {
-                address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+                address: program_counter.old_pc(INSTRUCTION_SIZE),
             });
         }
     }
@@ -106,8 +106,8 @@ where
 /// and fits within `[0, 32)`.
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_vs_wide_alignment<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_vs_wide_alignment<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vs: VReg,
     wide_group_regs: u8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
@@ -118,7 +118,7 @@ where
     let vs_idx = vs.bits();
     if !vs_idx.is_multiple_of(wide_group_regs) || vs_idx + wide_group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -131,8 +131,8 @@ where
 /// permit `vd` to alias the low half of the wide `vs2` register group per spec §11.7.
 #[inline(always)]
 #[doc(hidden)]
-pub fn check_vd_narrow_alignment<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub fn check_vd_narrow_alignment<Reg, Memory, PC, CustomError>(
+    program_counter: &PC,
     vd: VReg,
     group_regs: u8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
@@ -143,7 +143,7 @@ where
     let vd_idx = vd.bits();
     if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
-            address: state.instruction_fetcher.old_pc(INSTRUCTION_SIZE),
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     Ok(())
@@ -265,8 +265,8 @@ pub fn sign_extend_bits(val: u64, bits: u32) -> i64 {
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_widen_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_widen_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -283,8 +283,6 @@ pub unsafe fn execute_widen_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64) -> u64,
 {
@@ -294,7 +292,7 @@ pub unsafe fn execute_widen_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
     let sew_bits = u32::from(sew.bits());
 
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
 
@@ -303,14 +301,8 @@ pub unsafe fn execute_widen_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
             continue;
         }
         // SAFETY: `vs2` aligned to `group_regs`; `i < vl <= group_regs * (VLENB / sew_bytes)`
-        let raw_a = unsafe {
-            read_element_u64(
-                state.ext_state.read_vreg(),
-                usize::from(vs2_base),
-                i,
-                sew_bytes,
-            )
-        };
+        let raw_a =
+            unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew_bytes) };
         let wide_a = if zero_extend_a {
             raw_a
         } else {
@@ -320,12 +312,7 @@ pub unsafe fn execute_widen_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
                 let raw_b = unsafe {
-                    read_element_u64(
-                        state.ext_state.read_vreg(),
-                        usize::from(*vs1_base),
-                        i,
-                        sew_bytes,
-                    )
+                    read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew_bytes)
                 };
                 if zero_extend_b {
                     raw_b
@@ -339,17 +326,11 @@ pub unsafe fn execute_widen_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
         // SAFETY: `vd` aligned to `2*group_regs`; `i < vl <= group_regs * (VLENB / sew_bytes)`
         // so `i < 2*group_regs * (VLENB / wide_sew_bytes)` - element fits in the wide group
         unsafe {
-            write_element_u64(
-                state.ext_state.write_vreg(),
-                vd_base,
-                i,
-                wide_sew_bytes,
-                result,
-            );
+            write_element_u64(ext_state.write_vreg(), vd_base, i, wide_sew_bytes, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a widening add/subtract where `vs2` is already 2×SEW wide.
@@ -367,8 +348,8 @@ pub unsafe fn execute_widen_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError,
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_widen_w_op<Reg, Regs, ExtState, Memory, PC, IH, CustomError, F>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_widen_w_op<Reg, ExtState, CustomError, F>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -384,8 +365,6 @@ pub unsafe fn execute_widen_w_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
     F: Fn(u64, u64) -> u64,
 {
@@ -394,7 +373,7 @@ pub unsafe fn execute_widen_w_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
     let sew_bits = u32::from(sew.bits());
 
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
 
@@ -406,7 +385,7 @@ pub unsafe fn execute_widen_w_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
         // SAFETY: `vs2` aligned to `2*group_regs`; element `i` fits within it
         let wide_a = unsafe {
             read_element_u64(
-                state.ext_state.read_vreg(),
+                ext_state.read_vreg(),
                 usize::from(vs2_base),
                 i,
                 wide_sew_bytes,
@@ -418,12 +397,7 @@ pub unsafe fn execute_widen_w_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
                 // verified by caller; `i < vl <= group_regs * (VLENB / sew_bytes)`,
                 // so `vs1_base + i / elems_per_reg < vs1_base + group_regs <= 32`
                 let raw_b = unsafe {
-                    read_element_u64(
-                        state.ext_state.read_vreg(),
-                        usize::from(*vs1_base),
-                        i,
-                        sew_bytes,
-                    )
+                    read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew_bytes)
                 };
                 if zero_extend_b {
                     raw_b
@@ -436,17 +410,11 @@ pub unsafe fn execute_widen_w_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
         let result = op(wide_a, wide_b);
         // SAFETY: same as `execute_widen_op` for vd
         unsafe {
-            write_element_u64(
-                state.ext_state.write_vreg(),
-                vd_base,
-                i,
-                wide_sew_bytes,
-                result,
-            );
+            write_element_u64(ext_state.write_vreg(), vd_base, i, wide_sew_bytes, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute a narrowing right-shift.
@@ -467,8 +435,8 @@ pub unsafe fn execute_widen_w_op<Reg, Regs, ExtState, Memory, PC, IH, CustomErro
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_narrow_shift<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_narrow_shift<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     src: OpSrc,
@@ -483,8 +451,6 @@ pub unsafe fn execute_narrow_shift<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let sew_bytes = usize::from(sew.bytes());
@@ -495,7 +461,7 @@ pub unsafe fn execute_narrow_shift<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
     let shamt_mask = u64::from(wide_sew_bits - 1);
 
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
 
@@ -506,7 +472,7 @@ pub unsafe fn execute_narrow_shift<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
         // SAFETY: `vs2` is the wide source group
         let wide_val = unsafe {
             read_element_u64(
-                state.ext_state.read_vreg(),
+                ext_state.read_vreg(),
                 usize::from(vs2_base),
                 i,
                 wide_sew_bytes,
@@ -518,12 +484,7 @@ pub unsafe fn execute_narrow_shift<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
                 // verified by caller; `i < vl <= group_regs * (VLENB / sew_bytes)`,
                 // so `vs1_base + i / elems_per_reg < vs1_base + group_regs <= 32`
                 let raw = unsafe {
-                    read_element_u64(
-                        state.ext_state.read_vreg(),
-                        usize::from(*vs1_base),
-                        i,
-                        sew_bytes,
-                    )
+                    read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew_bytes)
                 };
                 raw & shamt_mask
             }
@@ -542,11 +503,11 @@ pub unsafe fn execute_narrow_shift<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
         let result = result_wide & ((1u64 << sew.bits()) - 1);
         // SAFETY: `vd` is the narrow destination group
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew_bytes, result);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew_bytes, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }
 
 /// Execute an integer extension (vzext/vsext).
@@ -566,8 +527,8 @@ pub unsafe fn execute_narrow_shift<Reg, Regs, ExtState, Memory, PC, IH, CustomEr
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-pub unsafe fn execute_extension<Reg, Regs, ExtState, Memory, PC, IH, CustomError>(
-    state: &mut InterpreterState<Regs, ExtState, Memory, PC, IH, CustomError>,
+pub unsafe fn execute_extension<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
     vm: bool,
@@ -582,8 +543,6 @@ pub unsafe fn execute_extension<Reg, Regs, ExtState, Memory, PC, IH, CustomError
     [(); ExtState::ELEN as usize]:,
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
     CustomError: fmt::Debug,
 {
     let sew_bytes = usize::from(sew.bytes());
@@ -591,7 +550,7 @@ pub unsafe fn execute_extension<Reg, Regs, ExtState, Memory, PC, IH, CustomError
     let src_sew_bits = (u32::from(sew.bits())) / u32::from(factor);
 
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(state.ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     let vd_base = vd.bits();
     let vs2_base = vs2.bits();
 
@@ -602,7 +561,7 @@ pub unsafe fn execute_extension<Reg, Regs, ExtState, Memory, PC, IH, CustomError
         // SAFETY: vs2 group covers `vl` narrow elements
         let raw = unsafe {
             read_element_u64(
-                state.ext_state.read_vreg(),
+                ext_state.read_vreg(),
                 usize::from(vs2_base),
                 i,
                 src_sew_bytes,
@@ -615,9 +574,9 @@ pub unsafe fn execute_extension<Reg, Regs, ExtState, Memory, PC, IH, CustomError
         };
         // SAFETY: vd group covers `vl` wide elements
         unsafe {
-            write_element_u64(state.ext_state.write_vreg(), vd_base, i, sew_bytes, result);
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew_bytes, result);
         }
     }
-    state.ext_state.mark_vs_dirty();
-    state.ext_state.reset_vstart();
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
 }

--- a/crates/execution/ab-riscv-interpreter/src/zicond.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicond.rs
@@ -3,17 +3,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile};
+use crate::{ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for ZicondInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for ZicondInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -21,35 +19,39 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // Conditional zero, equal to zero.
             //
             // rd = (rs2 == 0) ? 0 : rs1
             Self::CzeroEqz { rd, rs1, rs2 } => {
-                let condition = state.regs.read(rs2);
-                let src = state.regs.read(rs1);
+                let condition = regs.read(rs2);
+                let src = regs.read(rs1);
                 let result = if condition == Reg::Type::from(0u8) {
                     Reg::Type::from(0u8)
                 } else {
                     src
                 };
-                state.regs.write(rd, result);
+                regs.write(rd, result);
             }
 
             // Conditional zero, nonzero.
             //
             // rd = (rs2 != 0) ? 0 : rs1
             Self::CzeroNez { rd, rs1, rs2 } => {
-                let condition = state.regs.read(rs2);
-                let src = state.regs.read(rs1);
+                let condition = regs.read(rs2);
+                let src = regs.read(rs1);
                 let result = if condition != Reg::Type::from(0u8) {
                     Reg::Type::from(0u8)
                 } else {
                     src
                 };
-                state.regs.write(rd, result);
+                regs.write(rd, result);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -4,19 +4,15 @@
 mod tests;
 pub mod zicsr_helpers;
 
-use crate::{
-    CsrError, Csrs, ExecutableInstruction, ExecutionError, InterpreterState, RegisterFile,
-};
+use crate::{CsrError, Csrs, ExecutableInstruction, ExecutionError, RegisterFile};
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<
-        InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-        CustomError,
-    > for ZicsrInstruction<Reg>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for ZicsrInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -25,7 +21,11 @@ where
     #[inline(always)]
     fn execute(
         self,
-        state: &mut InterpreterState<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         match self {
             // Atomic read/write CSR.
@@ -39,19 +39,19 @@ where
                         csr_index: csr,
                     }));
                 }
-                zicsr_helpers::check_csr_privilege_level(&state.ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
 
-                let write_value = state.regs.read(rs1);
+                let write_value = regs.read(rs1);
 
                 // Per spec: if `rd == x0`, the CSR read (and its side effects) must not occur
                 if rd != Reg::ZERO {
-                    let raw_value = state.ext_state.read_csr(csr)?;
-                    let output_value = state.ext_state.process_csr_read(csr, raw_value)?;
-                    state.regs.write(rd, output_value);
+                    let raw_value = ext_state.read_csr(csr)?;
+                    let output_value = ext_state.process_csr_read(csr, raw_value)?;
+                    regs.write(rd, output_value);
                 }
 
-                let output_value = state.ext_state.process_csr_write(csr, write_value)?;
-                state.ext_state.write_csr(csr, output_value)?;
+                let output_value = ext_state.process_csr_write(csr, write_value)?;
+                ext_state.write_csr(csr, output_value)?;
             }
 
             // Atomic read and set bits in CSR.
@@ -65,18 +65,18 @@ where
                         csr_index: csr,
                     }));
                 }
-                zicsr_helpers::check_csr_privilege_level(&state.ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
 
-                let rs1_value = state.regs.read(rs1);
+                let rs1_value = regs.read(rs1);
 
-                let raw_value = state.ext_state.read_csr(csr)?;
-                let read_output = state.ext_state.process_csr_read(csr, raw_value)?;
-                state.regs.write(rd, read_output);
+                let raw_value = ext_state.read_csr(csr)?;
+                let read_output = ext_state.process_csr_read(csr, raw_value)?;
+                regs.write(rd, read_output);
 
                 if rs1 != Reg::ZERO {
                     let write_value = raw_value | rs1_value;
-                    let write_output = state.ext_state.process_csr_write(csr, write_value)?;
-                    state.ext_state.write_csr(csr, write_output)?;
+                    let write_output = ext_state.process_csr_write(csr, write_value)?;
+                    ext_state.write_csr(csr, write_output)?;
                 }
             }
 
@@ -91,18 +91,18 @@ where
                         csr_index: csr,
                     }));
                 }
-                zicsr_helpers::check_csr_privilege_level(&state.ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
 
-                let rs1_value = state.regs.read(rs1);
+                let rs1_value = regs.read(rs1);
 
-                let raw_value = state.ext_state.read_csr(csr)?;
-                let read_output = state.ext_state.process_csr_read(csr, raw_value)?;
-                state.regs.write(rd, read_output);
+                let raw_value = ext_state.read_csr(csr)?;
+                let read_output = ext_state.process_csr_read(csr, raw_value)?;
+                regs.write(rd, read_output);
 
                 if rs1 != Reg::ZERO {
                     let write_value = raw_value & !rs1_value;
-                    let write_output = state.ext_state.process_csr_write(csr, write_value)?;
-                    state.ext_state.write_csr(csr, write_output)?;
+                    let write_output = ext_state.process_csr_write(csr, write_value)?;
+                    ext_state.write_csr(csr, write_output)?;
                 }
             }
 
@@ -116,16 +116,16 @@ where
                         csr_index: csr,
                     }));
                 }
-                zicsr_helpers::check_csr_privilege_level(&state.ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
 
                 if rd != Reg::ZERO {
-                    let raw_value = state.ext_state.read_csr(csr)?;
-                    let output_value = state.ext_state.process_csr_read(csr, raw_value)?;
-                    state.regs.write(rd, output_value);
+                    let raw_value = ext_state.read_csr(csr)?;
+                    let output_value = ext_state.process_csr_read(csr, raw_value)?;
+                    regs.write(rd, output_value);
                 }
 
-                let output_value = state.ext_state.process_csr_write(csr, zimm.into())?;
-                state.ext_state.write_csr(csr, output_value)?;
+                let output_value = ext_state.process_csr_write(csr, zimm.into())?;
+                ext_state.write_csr(csr, output_value)?;
             }
 
             // Atomic read and set bits in CSR immediate.
@@ -139,16 +139,16 @@ where
                         csr_index: csr,
                     }));
                 }
-                zicsr_helpers::check_csr_privilege_level(&state.ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
 
-                let raw_value = state.ext_state.read_csr(csr)?;
-                let read_output = state.ext_state.process_csr_read(csr, raw_value)?;
-                state.regs.write(rd, read_output);
+                let raw_value = ext_state.read_csr(csr)?;
+                let read_output = ext_state.process_csr_read(csr, raw_value)?;
+                regs.write(rd, read_output);
 
                 if zimm != 0 {
                     let write_value = raw_value | Reg::Type::from(zimm);
-                    let write_output = state.ext_state.process_csr_write(csr, write_value)?;
-                    state.ext_state.write_csr(csr, write_output)?;
+                    let write_output = ext_state.process_csr_write(csr, write_value)?;
+                    ext_state.write_csr(csr, write_output)?;
                 }
             }
 
@@ -163,16 +163,16 @@ where
                         csr_index: csr,
                     }));
                 }
-                zicsr_helpers::check_csr_privilege_level(&state.ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
 
-                let raw_value = state.ext_state.read_csr(csr)?;
-                let read_output = state.ext_state.process_csr_read(csr, raw_value)?;
-                state.regs.write(rd, read_output);
+                let raw_value = ext_state.read_csr(csr)?;
+                let read_output = ext_state.process_csr_read(csr, raw_value)?;
+                regs.write(rd, read_output);
 
                 if zimm != 0 {
                     let write_value = raw_value & !Reg::Type::from(zimm);
-                    let write_output = state.ext_state.process_csr_write(csr, write_value)?;
-                    state.ext_state.write_csr(csr, write_output)?;
+                    let write_output = ext_state.process_csr_write(csr, write_value)?;
+                    ext_state.write_csr(csr, write_output)?;
                 }
             }
         }


### PR DESCRIPTION
This is a follow-up to https://github.com/nazar-pc/abundance/pull/654 and a stepping stone towards allowing LLVM to reason about individual registers in the future.