### PR TITLE
RISC-V improvements

### DIFF
--- a/crates/contracts/core/ab-contracts-tooling/src/build.rs
+++ b/crates/contracts/core/ab-contracts-tooling/src/build.rs
@@ -41,7 +41,10 @@ pub fn build_cdylib(options: BuildOptions<'_>) -> anyhow::Result<PathBuf> {
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         // Hack for enabling RISC-V Zknh backend in `sha2` crate since it is a nightly-only feature,
         // and they really don't like using normal features for it
-        .env("RUSTFLAGS", "--cfg sha2_backend=\"riscv-zknh-compact\"")
+        .env(
+            "RUSTFLAGS",
+            "--cfg sha2_backend=\"riscv-zknh\" --cfg sha2_backend_riscv_zknh=\"compact\"",
+        )
         .args([
             "rustc",
             "-Zbuild-std=core",

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -17,7 +17,7 @@ impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32ZcmpInstruction<Reg>
 where
-    Reg: Register<Type = u32>,
+    Reg: ZcmpRegister<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
@@ -13,7 +13,7 @@ pub fn do_push<Reg, Regs, Memory, CustomError>(
     stack_adj: u32,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
-    Reg: Register<Type = u32>,
+    Reg: ZcmpRegister<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
 {
@@ -39,7 +39,7 @@ pub fn do_pop<Reg, Regs, Memory, CustomError>(
     stack_adj: u32,
 ) -> Result<u32, ExecutionError<Reg::Type, CustomError>>
 where
-    Reg: Register<Type = u32>,
+    Reg: ZcmpRegister<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
 {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -17,7 +17,7 @@ impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64ZcmpInstruction<Reg>
 where
-    Reg: Register<Type = u64>,
+    Reg: ZcmpRegister<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
@@ -13,7 +13,7 @@ pub fn do_push<Reg, Regs, Memory, CustomError>(
     stack_adj: u32,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
-    Reg: Register<Type = u64>,
+    Reg: ZcmpRegister<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
 {
@@ -39,7 +39,7 @@ pub fn do_pop<Reg, Regs, Memory, CustomError>(
     stack_adj: u32,
 ) -> Result<u64, ExecutionError<Reg::Type, CustomError>>
 where
-    Reg: Register<Type = u64>,
+    Reg: ZcmpRegister<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
 {

--- a/crates/execution/ab-riscv-macros-common/src/code_utils.rs
+++ b/crates/execution/ab-riscv-macros-common/src/code_utils.rs
@@ -3,6 +3,8 @@
 
 const FROM_TRAIT_CONST_1: &str = "const trait ";
 const TO_TRAIT_CONST_1: &str = "trait _const";
+const FROM_TRAIT_CONST_2: &str = "const unsafe trait ";
+const TO_TRAIT_CONST_2: &str = "unsafe trait _const";
 const FROM_IMPL_CONST_1: &str = "> const ";
 const TO_IMPL_CONST_1: &str = "> cnst::";
 const FROM_IMPL_CONST_2: &str = "> const  ";
@@ -27,6 +29,7 @@ const TO_BRACKETS_CONST_2: &str = "BRCONST +";
 /// `syn` can parse it
 pub fn pre_process_rust_code(s: &mut str) {
     replace_inplace(s, FROM_TRAIT_CONST_1, TO_TRAIT_CONST_1);
+    replace_inplace(s, FROM_TRAIT_CONST_2, TO_TRAIT_CONST_2);
     replace_inplace(s, FROM_IMPL_CONST_1, TO_IMPL_CONST_1);
     replace_inplace(s, FROM_IMPL_CONST_2, TO_IMPL_CONST_2);
     replace_inplace(s, FROM_IMPL_CONST_REVERT_1, TO_IMPL_CONST_REVERT_1);
@@ -40,6 +43,7 @@ pub fn pre_process_rust_code(s: &mut str) {
 
 /// The inverse of [`pre_process_rust_code()`]
 pub fn post_process_rust_code(s: &mut str) {
+    replace_inplace(s, TO_TRAIT_CONST_2, FROM_TRAIT_CONST_2);
     replace_inplace(s, TO_TRAIT_CONST_1, FROM_TRAIT_CONST_1);
     replace_inplace(s, TO_IMPL_CONST_1, FROM_IMPL_CONST_1);
     replace_inplace(s, TO_IMPL_CONST_2, FROM_IMPL_CONST_2);

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -296,6 +296,7 @@ pub(super) fn process_enum_decoding_impl(
     let mut all_try_decode_blocks = Vec::new();
     let mut all_dependency_alignment_blocks = Vec::new();
     let mut all_dependency_size_entries = Vec::new();
+    let mut all_where_predicates = Vec::new();
     {
         let mut all_dependencies = HashSet::new();
         all_dependencies.insert(enum_name.clone());
@@ -335,7 +336,30 @@ pub(super) fn process_enum_decoding_impl(
                     .collect::<Vec<_>>();
                 all_dependency_size_entries.push((variant_idents, dependency_blocks.size));
 
+                if let Some(where_clause) = &dependency_enum_impl.item_impl.generics.where_clause {
+                    all_where_predicates.extend(where_clause.predicates.iter().cloned());
+                }
+
                 new_dependencies.extend(dependency_enum_definition.dependencies.iter().cloned());
+            }
+        }
+    }
+
+    if !all_where_predicates.is_empty() {
+        let where_clause = item_impl
+            .generics
+            .where_clause
+            .get_or_insert_with(|| parse_quote! { where });
+
+        let mut already_inserted = where_clause
+            .predicates
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        for predicate in all_where_predicates {
+            if already_inserted.insert(predicate.clone()) {
+                where_clause.predicates.push(predicate);
             }
         }
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
@@ -4,11 +4,45 @@
 mod tests;
 
 use crate::instructions::Instruction;
-use crate::registers::general_purpose::Register;
+use crate::registers::general_purpose::{EReg, Reg, Register};
 use ab_riscv_macros::instruction;
 use core::fmt;
 use core::hint::unreachable_unchecked;
 use core::marker::PhantomData;
+
+/// General purpose register with additional constraints for Zcmp extension
+///
+/// # Safety
+/// [`Register::from_bits()`] must return `Some()` for:
+/// * `1`, `8`, `9` and `18..=27` if `Self::RVE = false`
+/// * `1`, `8` and `9` if `Self::RVE = true`
+pub const unsafe trait ZcmpRegister
+where
+    Self: [const] Register,
+{
+    /// Whether this is RVE variant with the number of general purpose registers reduced to 16
+    const RVE: bool;
+}
+
+// SAFETY: [`Reg::from_bits()`] returns Some for all valid register numbers
+unsafe impl const ZcmpRegister for Reg<u32> {
+    const RVE: bool = false;
+}
+
+// SAFETY: [`Reg::from_bits()`] returns Some for all valid register numbers
+unsafe impl const ZcmpRegister for Reg<u64> {
+    const RVE: bool = false;
+}
+
+// SAFETY: [`EReg::from_bits()`] returns Some for all valid register numbers
+unsafe impl const ZcmpRegister for EReg<u32> {
+    const RVE: bool = true;
+}
+
+// SAFETY: [`EReg::from_bits()`] returns Some for all valid register numbers
+unsafe impl const ZcmpRegister for EReg<u64> {
+    const RVE: bool = true;
+}
 
 /// Values 0..=3 are reserved by the spec; only 4..=15 are valid.
 /// Construct via [`ZcmpUrlist::try_from_raw`].
@@ -55,7 +89,7 @@ pub struct ZcmpUrlist<Reg> {
 
 impl<Reg> ZcmpUrlist<Reg>
 where
-    Reg: Register,
+    Reg: ZcmpRegister,
 {
     const XLEN_32: u8 = 32;
     const XLEN_64: u8 = 64;
@@ -68,7 +102,7 @@ where
     #[inline(always)]
     pub const fn try_from_raw(raw: u8) -> Option<Self>
     where
-        Reg: [const] Register,
+        Reg: [const] ZcmpRegister,
     {
         if !(Reg::XLEN == Self::XLEN_32 || Reg::XLEN == Self::XLEN_64) {
             return None;
@@ -242,7 +276,7 @@ pub enum Rv32ZcmpInstruction<Reg> {
 #[instruction]
 impl<Reg> const Instruction for Rv32ZcmpInstruction<Reg>
 where
-    Reg: [const] Register<Type = u32>,
+    Reg: [const] ZcmpRegister<Type = u32>,
 {
     type Reg = Reg;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
@@ -4,7 +4,7 @@
 mod tests;
 
 use crate::instructions::Instruction;
-use crate::instructions::rv32::zce::zcmp::ZcmpUrlist;
+use crate::instructions::rv32::zce::zcmp::{ZcmpRegister, ZcmpUrlist};
 use crate::registers::general_purpose::Register;
 use ab_riscv_macros::instruction;
 use core::fmt;
@@ -44,7 +44,7 @@ pub enum Rv64ZcmpInstruction<Reg> {
 #[instruction]
 impl<Reg> const Instruction for Rv64ZcmpInstruction<Reg>
 where
-    Reg: [const] Register<Type = u64>,
+    Reg: [const] ZcmpRegister<Type = u64>,
 {
     type Reg = Reg;
 

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -11,7 +11,7 @@ pub use crate::instructions::rv32::c::zca::Rv32ZcaInstruction;
 pub use crate::instructions::rv32::m::Rv32MInstruction;
 pub use crate::instructions::rv32::m::zmmul::Rv32ZmmulInstruction;
 pub use crate::instructions::rv32::zce::zcb::Rv32ZcbInstruction;
-pub use crate::instructions::rv32::zce::zcmp::{Rv32ZcmpInstruction, ZcmpUrlist};
+pub use crate::instructions::rv32::zce::zcmp::{Rv32ZcmpInstruction, ZcmpRegister, ZcmpUrlist};
 pub use crate::instructions::rv32::zk::zbkb::Rv32ZbkbInstruction;
 pub use crate::instructions::rv32::zk::zbkc::Rv32ZbkcInstruction;
 pub use crate::instructions::rv32::zk::zbkx::Rv32ZbkxInstruction;

--- a/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
@@ -86,15 +86,10 @@ impl const RegType for u64 {
 }
 
 /// GPR (General Purpose Register)
-///
-/// # Safety
-/// `Self::from_bits()` must return `Some()` for `0..=31` if `Self::RVE = false` and `0..=15` if
-/// `Self::RVE = true`.
-pub const unsafe trait Register:
+pub const trait Register:
     fmt::Display + fmt::Debug + [const] Eq + [const] Destruct + Copy + Send + Sync + Sized + 'static
 {
     /// Whether this is RVE variant with the number of general purpose registers reduced to 16
-    const RVE: bool;
     /// XLEN
     const XLEN: u8 = Self::Type::BITS;
     /// Zero register
@@ -221,9 +216,7 @@ impl<Type> const PartialEq for EReg<Type> {
 
 impl<Type> const Eq for EReg<Type> {}
 
-// SAFETY: `Self::from_bits()` returns `Some()` for `0..=15`
-unsafe impl const Register for EReg<u32> {
-    const RVE: bool = true;
+impl const Register for EReg<u32> {
     const ZERO: Self = Self::Zero;
     const SP: Self = Self::Sp;
     const RA: Self = Self::Ra;
@@ -255,9 +248,7 @@ unsafe impl const Register for EReg<u32> {
     }
 }
 
-// SAFETY: `Self::from_bits()` returns `Some()` for `0..=15`
-unsafe impl const Register for EReg<u64> {
-    const RVE: bool = true;
+impl const Register for EReg<u64> {
     const ZERO: Self = Self::Zero;
     const SP: Self = Self::Sp;
     const RA: Self = Self::Ra;
@@ -289,7 +280,6 @@ unsafe impl const Register for EReg<u64> {
     }
 }
 
-// TODO: Reorder `t*` and `s*` registers to be next to each other for performance reasons?
 /// RISC-V general purpose register for RV32I/RV64I.
 ///
 /// Use `Type = u32` for RV32I and `Type = u64` for RV64I.
@@ -487,9 +477,7 @@ impl<Type> const PartialEq for Reg<Type> {
 
 impl<Type> const Eq for Reg<Type> {}
 
-// SAFETY: `Self::from_bits()` returns `Some()` for `0..=31`
-unsafe impl const Register for Reg<u32> {
-    const RVE: bool = false;
+impl const Register for Reg<u32> {
     const ZERO: Self = Self::Zero;
     const SP: Self = Self::Sp;
     const RA: Self = Self::Ra;
@@ -537,9 +525,7 @@ unsafe impl const Register for Reg<u32> {
     }
 }
 
-// SAFETY: `Self::from_bits()` returns `Some()` for `0..=31`
-unsafe impl const Register for Reg<u64> {
-    const RVE: bool = false;
+impl const Register for Reg<u64> {
     const ZERO: Self = Self::Zero;
     const SP: Self = Self::Sp;
     const RA: Self = Self::Ra;


### PR DESCRIPTION
Assortment of improvements here. The most surprising is `sha2` crate changing the name of the configuration used for enabling RISC-V Zknh support, which led to larger contract sizes.

With Zknh re-enabled the contract size decreased from 31.4 kB to just 22.3 kB.