### PR TITLE
Modify some code that prevented inlining in the interpreter with explicit loops

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb/rv32_zbb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb/rv32_zbb_helpers.rs
@@ -10,7 +10,10 @@ pub fn orc_b(src: u32) -> u32 {
             unsafe { core::arch::riscv32::orc_b(src as usize) as u32 }
         }
         _ => {{
-            let bytes = src.to_le_bytes().map(|b| if b != 0 { 0xFFu8 } else { 0u8 });
+            let mut bytes = src.to_le_bytes();
+            for byte in &mut bytes {
+                *byte = if *byte != 0 { 0xFF } else { 0 };
+            }
             u32::from_le_bytes(bytes)
         }}
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
@@ -44,7 +44,10 @@ where
             Self::Brev8 { rd, rs1 } => {
                 // Reverse bits within each byte of rs1
                 let src = regs.read(rs1);
-                let bytes = src.to_le_bytes().map(u8::reverse_bits);
+                let mut bytes = src.to_le_bytes();
+                for byte in &mut bytes {
+                    *byte = byte.reverse_bits();
+                }
                 regs.write(rd, u32::from_le_bytes(bytes));
             }
             Self::Zip { rd, rs1 } => {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx/rv32_zbkx_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx/rv32_zbkx_helpers.rs
@@ -10,14 +10,17 @@ pub fn xperm4(rs1: u32, rs2: u32) -> u32 {
         }
         _ => {
             // Build nibble LUT from rs1: 8 entries for RV32
-            let lut = core::array::from_fn::<_, 8, _>(|i| ((rs1 >> (i * 4)) & 0xf) as u8);
+            let mut lut = [0; 8];
+            for (i, l) in lut.iter_mut().enumerate() {
+                *l = ((rs1 >> (i * 4)) & 0xf) as u8;
+            }
             // For each nibble of rs2, look up from lut (out-of-bounds -> 0 via get)
-            let nibbles = core::array::from_fn::<_, 8, _>(|i| {
+            let mut result = 0;
+            for i in 0..8 {
                 let idx = ((rs2 >> (i * 4)) & 0xf) as usize;
-                *lut.get(idx).unwrap_or(&0)
-            });
-            // Pack nibbles back into u32
-            nibbles.iter().enumerate().fold(0, |acc, (i, &n)| acc | (u32::from(n) << (i * 4)))
+                result |= u32::from(*lut.get(idx).unwrap_or(&0)) << (i * 4);
+            }
+            result
         }
     }
 }
@@ -32,9 +35,11 @@ pub fn xperm8(rs1: u32, rs2: u32) -> u32 {
         }
         _ => {
             let lut = rs1.to_le_bytes();
-            let result = rs2.to_le_bytes().map(|idx| {
-                *lut.get(usize::from(idx)).unwrap_or(&0)
-            });
+            let mut result = [0; _];
+            // Explicit loop to ensure inlining
+            for (&idx, r) in rs2.to_le_bytes().iter().zip(&mut result) {
+                *r = *lut.get(usize::from(idx)).unwrap_or(&0);
+            }
             u32::from_le_bytes(result)
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb/rv64_zbb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb/rv64_zbb_helpers.rs
@@ -10,7 +10,11 @@ pub fn orc_b(src: u64) -> u64 {
             unsafe { core::arch::riscv64::orc_b(src as usize) as u64 }
         }
         _ => {{
-            let bytes = src.to_le_bytes().map(|b| if b != 0 { 0xFFu8 } else { 0u8 });
+            let mut bytes = src.to_le_bytes();
+            // Explicit loop to ensure inlining
+            for byte in &mut bytes {
+                *byte = if *byte != 0 { 0xFF } else { 0 };
+            }
             u64::from_le_bytes(bytes)
         }}
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
@@ -52,7 +52,10 @@ where
             Self::Brev8 { rd, rs1 } => {
                 // Reverse bits within each byte of rs1
                 let src = regs.read(rs1);
-                let bytes = src.to_le_bytes().map(u8::reverse_bits);
+                let mut bytes = src.to_le_bytes();
+                for byte in &mut bytes {
+                    *byte = byte.reverse_bits();
+                }
                 regs.write(rd, u64::from_le_bytes(bytes));
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx/rv64_zbkx_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx/rv64_zbkx_helpers.rs
@@ -10,14 +10,18 @@ pub fn xperm4(rs1: u64, rs2: u64) -> u64 {
         }
         _ => {
             // 16 nibbles for RV64; all indices 0–15 are in-bounds, so direct indexing is safe
-            let lut = core::array::from_fn::<_, 16, _>(|i| ((rs1 >> (i * 4)) & 0xf) as u8);
+            let mut lut = [0; 16];
+            for (i, l) in lut.iter_mut().enumerate() {
+                *l = ((rs1 >> (i * 4)) & 0xf) as u8;
+            }
             // For each nibble of rs2, look up directly from lut
-            let nibbles = core::array::from_fn::<_, 16, _>(|i| {
+            let mut result = 0;
+            for i in 0..16 {
                 let idx = ((rs2 >> (i * 4)) & 0xf) as usize;
-                lut[idx]
-            });
-            // Pack nibbles back into u64
-            nibbles.iter().enumerate().fold(0, |acc, (i, &n)| acc | (u64::from(n) << (i * 4)))
+                // Pack nibbles back into u64
+                result |= u64::from(lut[idx]) << (i * 4);
+            }
+            result
         }
     }
 }
@@ -32,9 +36,11 @@ pub fn xperm8(rs1: u64, rs2: u64) -> u64 {
         }
         _ => {
             let lut = rs1.to_le_bytes();
-            let result = rs2.to_le_bytes().map(|idx| {
-                *lut.get(usize::from(idx)).unwrap_or(&0)
-            });
+            let mut result = [0; _];
+            // Explicit loop to ensure inlining
+            for (&idx, r) in rs2.to_le_bytes().iter().zip(&mut result) {
+                *r = *lut.get(usize::from(idx)).unwrap_or(&0);
+            }
             u64::from_le_bytes(result)
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd/rv64_zknd_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd/rv64_zknd_helpers.rs
@@ -10,10 +10,6 @@ mod ks {
     use crate::rv32::zk::zkn::zknd::rv32_zknd_helpers::SBOX;
     use ab_riscv_primitives::prelude::*;
 
-    /// Round constants `RC[0..=9]`, indexed by rnum (0-based).
-    /// `RC[rnum]` corresponds to FIPS 197 `Rcon[rnum+1]`.
-    const RCON: [u8; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36];
-
     /// AES key schedule step 1.
     ///
     /// Pseudocode (RISC-V Crypto spec Sail source):
@@ -40,8 +36,8 @@ mod ks {
         let b3 = u32::from(SBOX[((rotated >> 24) & 0xff) as usize]);
         let subbed = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
 
-        let result = if rnum != Rv64ZkndKsRnum::Final {
-            subbed ^ u32::from(RCON[usize::from(rnum)])
+        let result = if let Some(round_constant) = rnum.constant() {
+            subbed ^ u32::from(round_constant)
         } else {
             subbed
         };

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknd.rs
@@ -25,14 +25,14 @@ pub enum Rv64ZkndKsRnum {
     Final = 0xA,
 }
 
-impl From<Rv64ZkndKsRnum> for u8 {
+impl const From<Rv64ZkndKsRnum> for u8 {
     #[inline(always)]
     fn from(rnum: Rv64ZkndKsRnum) -> Self {
         rnum as u8
     }
 }
 
-impl From<Rv64ZkndKsRnum> for usize {
+impl const From<Rv64ZkndKsRnum> for usize {
     #[inline(always)]
     fn from(rnum: Rv64ZkndKsRnum) -> Self {
         usize::from(rnum as u8)
@@ -46,6 +46,10 @@ impl fmt::Display for Rv64ZkndKsRnum {
 }
 
 impl Rv64ZkndKsRnum {
+    /// Round constants `RC[0..=9]`, indexed by rnum (0-based).
+    /// `RC[rnum]` corresponds to FIPS 197 `Rcon[rnum+1]`.
+    const RCON: [u8; 10] = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36];
+
     /// Create from raw bits
     #[inline(always)]
     pub const fn from_bits(bits: u8) -> Option<Self> {
@@ -55,6 +59,16 @@ impl Rv64ZkndKsRnum {
             Some(unsafe { mem::transmute::<u8, Self>(bits) })
         } else {
             None
+        }
+    }
+
+    /// Round constant (unless final)
+    #[inline(always)]
+    pub const fn constant(self) -> Option<u8> {
+        if matches!(self, Rv64ZkndKsRnum::Final) {
+            None
+        } else {
+            Some(Self::RCON[usize::from(self)])
         }
     }
 }


### PR DESCRIPTION
Not all abstractions ended up being zero-cost: https://github.com/rust-lang/rust/issues/155667