### PR TITLE
Add Coremark runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ab-riscv-coremark-runner"
+version = "0.0.1"
+dependencies = [
+ "ab-riscv-interpreter",
+ "ab-riscv-macros",
+ "ab-riscv-primitives",
+ "anyhow",
+ "object",
+]
+
+[[package]]
 name = "ab-riscv-interpreter"
 version = "0.0.4"
 dependencies = [

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -231,13 +231,9 @@ where
 fn read_cstring<const RAM_BASE: u64, const RAM_SIZE: usize>(
     memory: &Act4Memory<RAM_BASE, RAM_SIZE>,
     addr: u64,
-) -> Option<String> {
+) -> Option<&str> {
     let slice = memory.read_slice_up_to(addr, 512);
-    CStr::from_bytes_until_nul(slice)
-        .ok()?
-        .to_str()
-        .ok()
-        .map(str::to_owned)
+    CStr::from_bytes_until_nul(slice).ok()?.to_str().ok()
 }
 
 fn read_failure_info<const RAM_BASE: u64, const RAM_SIZE: usize, RT>(
@@ -296,7 +292,7 @@ where
         .ok()?
         .as_u64();
 
-    let test_name = read_cstring(memory, str_ptr).unwrap_or_else(|| "<unknown>".into());
+    let test_name = read_cstring(memory, str_ptr).unwrap_or("<unknown>");
 
     let xlen_hex_width = size_of::<RT>() * 2;
 

--- a/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
+++ b/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
@@ -10,10 +10,9 @@ use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_riscv_benchmarks::Benchmarks;
 use ab_riscv_benchmarks::host_utils::{
     Blake3HashChunkInternalArgs, EagerTestInstructionFetcher, Ed25519VerifyInternalArgs,
-    LazyInstructionFetcher, NoopRv64SystemInstructionHandler, RISCV_CONTRACT_BYTES, TestMemory,
-    execute,
+    LazyInstructionFetcher, RISCV_CONTRACT_BYTES, TestMemory, execute,
 };
-use ab_riscv_interpreter::basic::BasicInterpreterState;
+use ab_riscv_interpreter::basic::{BasicInterpreterState, IgnoreEcallSystemInstructionHandler};
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::Register;
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
@@ -131,7 +130,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         instruction_fetcher: unsafe {
             LazyInstructionFetcher::new(TRAP_ADDRESS, MEMORY_BASE_ADDRESS)
         },
-        system_instruction_handler: NoopRv64SystemInstructionHandler::default(),
+        system_instruction_handler: IgnoreEcallSystemInstructionHandler,
     };
 
     let mut eager_state = BasicInterpreterState {
@@ -147,7 +146,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 benchmarks_blake3_hash_chunk_addr,
             )
         },
-        system_instruction_handler: NoopRv64SystemInstructionHandler::default(),
+        system_instruction_handler: IgnoreEcallSystemInstructionHandler,
     };
 
     {

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -478,7 +478,7 @@ impl EagerTestInstructionFetcher {
             decoded_instructions.push(
                 Instruction::try_decode(instruction_word).unwrap_or(ContractInstruction::Unimp),
             );
-        };
+        }
 
         Self {
             instructions: decoded_instructions,

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -5,11 +5,10 @@ use ab_contract_file::instruction::{ContractInstruction, ContractRegister};
 use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_io_type::IoType;
 use ab_io_type::bool::Bool;
-use ab_riscv_interpreter::basic::BasicInterpreterState;
+use ab_riscv_interpreter::basic::{BasicInterpreterState, IgnoreEcallSystemInstructionHandler};
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 use core::mem::offset_of;
 use core::ops::ControlFlow;
 
@@ -490,53 +489,9 @@ impl EagerTestInstructionFetcher {
     }
 }
 
-/// System instruction handler that does nothing
-#[derive(Debug, Clone, Copy)]
-pub struct NoopRv64SystemInstructionHandler<Instruction> {
-    _phantom: PhantomData<Instruction>,
-}
-
-impl<Reg> Default for NoopRv64SystemInstructionHandler<Reg> {
-    #[inline(always)]
-    fn default() -> Self {
-        Self {
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<Reg, Regs, Memory, PC, CustomError>
-    SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>
-    for NoopRv64SystemInstructionHandler<Rv64Instruction<Reg>>
-where
-    Reg: Register<Type = u64>,
-    Regs: RegisterFile<Reg>,
-{
-    #[inline(always)]
-    fn handle_ecall(
-        &mut self,
-        _regs: &mut Regs,
-        _memory: &mut Memory,
-        _program_counter: &mut PC,
-    ) -> Result<ControlFlow<()>, ExecutionError<u64, CustomError>> {
-        // SAFETY: Contracts are statically known to not contain `ecall` instructions
-        // unsafe { unreachable_unchecked() }
-        // For some known reason this is faster than `unreachable_unchecked()`
-        Ok(ControlFlow::Continue(()))
-    }
-}
-
 /// Execute [`ContractInstruction`]s
 pub fn execute<Regs, Memory, IF>(
-    state: &mut BasicInterpreterState<
-        Regs,
-        (),
-        Memory,
-        IF,
-        NoopRv64SystemInstructionHandler<
-            Rv64Instruction<<ContractInstruction as Instruction>::Reg>,
-        >,
-    >,
+    state: &mut BasicInterpreterState<Regs, (), Memory, IF, IgnoreEcallSystemInstructionHandler>,
 ) -> Result<(), ExecutionError<u64>>
 where
     Regs: RegisterFile<<ContractInstruction as Instruction>::Reg>,

--- a/crates/execution/ab-riscv-benchmarks/tests/basic.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/basic.rs
@@ -10,10 +10,9 @@ use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_riscv_benchmarks::Benchmarks;
 use ab_riscv_benchmarks::host_utils::{
     Blake3HashChunkInternalArgs, EagerTestInstructionFetcher, Ed25519VerifyInternalArgs,
-    LazyInstructionFetcher, NoopRv64SystemInstructionHandler, RISCV_CONTRACT_BYTES, TestMemory,
-    execute,
+    LazyInstructionFetcher, RISCV_CONTRACT_BYTES, TestMemory, execute,
 };
-use ab_riscv_interpreter::basic::BasicInterpreterState;
+use ab_riscv_interpreter::basic::{BasicInterpreterState, IgnoreEcallSystemInstructionHandler};
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::Register;
 use ed25519_dalek::{Signer, SigningKey};
@@ -95,7 +94,7 @@ where
                 ext_state: (),
                 memory,
                 instruction_fetcher,
-                system_instruction_handler: NoopRv64SystemInstructionHandler::default(),
+                system_instruction_handler: IgnoreEcallSystemInstructionHandler,
             };
             execute(&mut state).unwrap();
 
@@ -118,7 +117,7 @@ where
                 ext_state: (),
                 memory,
                 instruction_fetcher,
-                system_instruction_handler: NoopRv64SystemInstructionHandler::default(),
+                system_instruction_handler: IgnoreEcallSystemInstructionHandler,
             };
             execute(&mut state).unwrap();
 

--- a/crates/execution/ab-riscv-coremark-runner/Cargo.toml
+++ b/crates/execution/ab-riscv-coremark-runner/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ab-riscv-coremark-runner"
+description = "Runner for Coremark benchmark"
+license = "0BSD AND Apache-2.0"
+version = "0.0.1"
+authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
+edition = "2024"
+include = [
+    "/src",
+    "/build.rs",
+    "/Cargo.toml",
+]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+ab-riscv-interpreter = { workspace = true }
+ab-riscv-macros = { workspace = true, features = ["proc-macro"] }
+ab-riscv-primitives = { workspace = true }
+anyhow = { workspace = true }
+object = { workspace = true, features = ["elf", "read_core"] }
+
+[build-dependencies]
+ab-riscv-macros = { workspace = true, features = ["build"] }
+
+[features]
+# This feature makes ELF building required, but not enabled by default to avoid requiring `riscv64-unknown-elf-gcc` for
+# everyone who tries to compile other parts of this repo
+build-elf-required = []
+
+[lints]
+workspace = true

--- a/crates/execution/ab-riscv-coremark-runner/build.rs
+++ b/crates/execution/ab-riscv-coremark-runner/build.rs
@@ -1,0 +1,127 @@
+use ab_riscv_macros::process_instruction_macros;
+use std::error::Error;
+use std::path::PathBuf;
+use std::process::Command;
+use std::{env, fs};
+
+const TAG: &str = "v1.01";
+const COMMIT: &str = "cfa9ab377835911f23d9b0831c7be302ed1f58de";
+const URL: &str = "https://github.com/eembc/coremark";
+
+/// RISC-V cross-compiler to use. Override with the `RISCV_CC` environment variable if your
+/// toolchain is installed under a different name.
+const DEFAULT_RISCV_CC: &str = "riscv64-unknown-elf-gcc";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    process_instruction_macros()?;
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("Always set by Cargo; qed"));
+    let coremark_dir = out_dir.join("coremark");
+
+    clone_if_needed(&coremark_dir)?;
+
+    let cc = env::var("RISCV_CC").unwrap_or_else(|_| DEFAULT_RISCV_CC.to_string());
+
+    let elf_path = out_dir.join("coremark.elf");
+
+    let coremark_sources = [
+        coremark_dir.join("core_list_join.c"),
+        coremark_dir.join("core_matrix.c"),
+        coremark_dir.join("core_state.c"),
+        coremark_dir.join("core_util.c"),
+        coremark_dir.join("core_main.c"),
+    ];
+
+    let maybe_status = Command::new(&cc)
+        // TODO: `b` is not recognized by the default RISC-V toolchain on Ubuntu 24.04 for some
+        //  reason, hence zba_zbb_zbs
+        .args(["-O3", "-march=rv64imc_zba_zbb_zbs", "-mabi=lp64"])
+        .arg(format!("-I{}", coremark_dir.display()))
+        .arg("-Isrc/coremark_port")
+        .arg("-DPERFORMANCE_RUN=1")
+        // 0 means "autodetect"
+        .arg("-DITERATIONS=0")
+        .args([
+            "-ffreestanding",
+            "-nostdlib",
+            "-nostartfiles",
+            "-static-pie",
+            "-Wl,--entry=main",
+            "-Werror",
+        ])
+        .args(coremark_sources)
+        // Our ee_printf.c replaces barebones/ee_printf.c: identical except the uart_send_char stub
+        // with #error is removed; that function is defined in core_portme.c.
+        .arg("src/coremark_port/ee_printf.c")
+        .arg("src/coremark_port/core_portme.c")
+        .arg("-o")
+        .arg(&elf_path)
+        .status();
+
+    match maybe_status {
+        Ok(status) => {
+            if !status.success() {
+                if env::var("CARGO_FEATURE_BUILD_ELF_REQUIRED").is_ok() {
+                    return Err("building coremark.elf failed".into());
+                } else {
+                    // Quietly create an empty file so that the build succeeds even if the ELF is
+                    // not
+                    fs::write(&elf_path, [])?;
+                }
+            }
+        }
+        Err(error) => {
+            if env::var("CARGO_FEATURE_BUILD_ELF_REQUIRED").is_ok() {
+                return Err(error.into());
+            } else {
+                // Quietly create an empty file so that the build succeeds even if the ELF is
+                // not
+                fs::write(&elf_path, [])?;
+            }
+        }
+    }
+
+    println!("cargo::rustc-env=COREMARK_ELF={}", elf_path.display());
+
+    println!("cargo::rerun-if-changed=src");
+    println!("cargo::rerun-if-env-changed=RISCV_CC");
+
+    Ok(())
+}
+
+fn clone_if_needed(dest: &PathBuf) -> Result<(), Box<dyn Error>> {
+    if dest.exists() {
+        if let Ok(output) = Command::new("git")
+            .current_dir(dest)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            && output.status.success()
+            && output.stdout.trim_ascii() == COMMIT.as_bytes()
+        {
+            return Ok(());
+        }
+
+        println!(
+            "cargo::warning=`coremark` commit mismatch or invalid repo; removing and re-cloning"
+        );
+        let _ = fs::remove_dir_all(dest);
+    }
+
+    let output = Command::new("git")
+        .args(["clone", "--depth", "1", "--branch", TAG, "--quiet", URL])
+        .arg(dest)
+        .output()?;
+
+    if !output.status.success() {
+        println!("cargo::error=`coremark` clone failed:");
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            println!("cargo::error={line}");
+        }
+        for line in String::from_utf8_lossy(&output.stderr).lines() {
+            println!("cargo::error={line}");
+        }
+        return Err("`coremark` clone failed".into());
+    }
+
+    Ok(())
+}

--- a/crates/execution/ab-riscv-coremark-runner/src/coremark_port/core_portme.c
+++ b/crates/execution/ab-riscv-coremark-runner/src/coremark_port/core_portme.c
@@ -1,0 +1,163 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+#include "coremark.h"
+#include "core_portme.h"
+
+#if VALIDATION_RUN
+volatile ee_s32 seed1_volatile = 0x3415;
+volatile ee_s32 seed2_volatile = 0x3415;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PERFORMANCE_RUN
+volatile ee_s32 seed1_volatile = 0x0;
+volatile ee_s32 seed2_volatile = 0x0;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PROFILE_RUN
+volatile ee_s32 seed1_volatile = 0x8;
+volatile ee_s32 seed2_volatile = 0x8;
+volatile ee_s32 seed3_volatile = 0x8;
+#endif
+volatile ee_s32 seed4_volatile = ITERATIONS;
+volatile ee_s32 seed5_volatile = 0;
+
+/* Porting : Timing functions
+    The RISC-V unprivileged `time` CSR (0xC01) is mapped by the host interpreter to nanoseconds elapsed since an
+    arbitrary point in time. Converted to microseconds here, so CLOCKS_PER_SEC is therefore 1e6.
+    */
+CORETIMETYPE
+barebones_clock()
+{
+    ee_u64 t;
+    __asm__ volatile("rdtime %0" : "=r"(t));
+    // Convert ns to µs to survive integer division in time_in_secs
+    return t / 1000;
+}
+
+#define GETMYTIME(_t)              (*(_t) = barebones_clock())
+#define MYTIMEDIFF(fin, ini)       ((fin) - (ini))
+#define TIMER_RES_DIVIDER          1
+#define SAMPLE_TIME_IMPLEMENTATION 1
+#define EE_TICKS_PER_SEC           (CLOCKS_PER_SEC / TIMER_RES_DIVIDER)
+
+/** Define Host specific (POSIX), or target specific global time variables. */
+static CORETIMETYPE start_time_val, stop_time_val;
+
+/* Function : start_time
+        This function will be called right before starting the timed portion of
+   the benchmark.
+*/
+void
+start_time(void)
+{
+    GETMYTIME(&start_time_val);
+}
+
+/* Function : stop_time
+        This function will be called right after ending the timed portion of
+   the benchmark.
+*/
+void
+stop_time(void)
+{
+    GETMYTIME(&stop_time_val);
+}
+
+/* Function : get_time
+        Return an abstract "ticks" number that signifies time on the system.
+*/
+CORE_TICKS
+get_time(void)
+{
+    CORE_TICKS elapsed
+        = (CORE_TICKS)(MYTIMEDIFF(stop_time_val, start_time_val));
+    return elapsed;
+}
+
+/* Function : time_in_secs
+        Convert the value returned by get_time to seconds.
+*/
+secs_ret
+time_in_secs(CORE_TICKS ticks)
+{
+    secs_ret retval = ((secs_ret)ticks) / (secs_ret)EE_TICKS_PER_SEC;
+    return retval;
+}
+
+ee_u32 default_num_contexts = 1;
+
+/* Output buffer */
+
+/*
+ * output_buf_storage is placed in its own ELF section so the host can discover both the guest address and the capacity
+ * (section size) without any hardcoded constants. The host reads the ".output_buf" section address and passes it to the
+ * guest via a1/argv[0]; portable_init stores it in output_buf. uart_send_char appends to it; the host reads a
+ * null-terminated string from the same address after execution ends.
+ */
+__attribute__((section(".output_buf")))
+volatile ee_u8 output_buf_storage[OUTPUT_BUF_MAX];
+
+volatile ee_u8* output_buf;
+static ee_size_t output_pos;
+
+/* Function : uart_send_char
+        Called by ee_printf for each output character.
+*/
+void
+uart_send_char(char c)
+{
+    if (output_buf != (volatile ee_u8*)NULL && output_pos < OUTPUT_BUF_MAX - 1u)
+    {
+        output_buf[output_pos++] = (ee_u8)c;
+        output_buf[output_pos] = 0;
+    }
+}
+
+/* Function : portable_init
+        Target specific initialization code.
+
+        argv[0] is cast to (ee_u8 *) and used as the output buffer address.
+        The host sets a1 = output buffer guest address before calling main,
+        which the C runtime delivers here as argv[0].
+*/
+void
+portable_init(core_portable* p, int* argc, char* argv[])
+{
+    if (sizeof(ee_ptr_int) != sizeof(ee_u8*))
+    {
+        ee_printf(
+            "ERROR! Please define ee_ptr_int to a type that holds a "
+            "pointer!\n");
+    }
+    if (sizeof(ee_u32) != 4)
+    {
+        ee_printf("ERROR! Please define ee_u32 to a 32b unsigned type!\n");
+    }
+    output_buf = (volatile ee_u8*)(ee_ptr_int)argv[0];
+    output_pos = 0;
+    p->portable_id = 1;
+}
+
+/* Function : portable_fini
+        Target specific final code
+*/
+void
+portable_fini(core_portable* p)
+{
+    p->portable_id = 0;
+}

--- a/crates/execution/ab-riscv-coremark-runner/src/coremark_port/core_portme.h
+++ b/crates/execution/ab-riscv-coremark-runner/src/coremark_port/core_portme.h
@@ -1,0 +1,197 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+/* Topic : Description
+        This file contains configuration constants required to execute on
+   the Abundance RISC-V interpreter platform.
+*/
+#ifndef CORE_PORTME_H
+#define CORE_PORTME_H
+/************************/
+/* Data types and settings */
+/************************/
+/* Configuration : HAS_FLOAT
+        No hardware FPU; Coremark uses float only for score reporting,
+        handled via integer arithmetic in ee_printf.
+*/
+#ifndef HAS_FLOAT
+#define HAS_FLOAT 0
+#endif
+/* Configuration : HAS_TIME_H
+        No time.h available on bare-metal guest.
+*/
+#ifndef HAS_TIME_H
+#define HAS_TIME_H 0
+#endif
+/* Configuration : USE_CLOCK
+        No clock() available; timing is done via rdtime CSR.
+*/
+#ifndef USE_CLOCK
+#define USE_CLOCK 0
+#endif
+/* Configuration : HAS_STDIO
+        No stdio.h available on bare-metal guest.
+*/
+#ifndef HAS_STDIO
+#define HAS_STDIO 0
+#endif
+/* Configuration : HAS_PRINTF
+        ee_printf is implemented in core_portme.c.
+*/
+#ifndef HAS_PRINTF
+#define HAS_PRINTF 0
+#endif
+
+/* Definitions : COMPILER_VERSION, COMPILER_FLAGS, MEM_LOCATION
+        Initialize these strings per platform
+*/
+#ifndef COMPILER_VERSION
+#ifdef __GNUC__
+#define COMPILER_VERSION "GCC"__VERSION__
+#else
+#define COMPILER_VERSION "Please put compiler version here (e.g. gcc 4.1)"
+#endif
+#endif
+#ifndef COMPILER_FLAGS
+#define COMPILER_FLAGS "-O3 -march=rv64imc_zba_zbb_zbs -mabi=lp64"
+#endif
+#ifndef MEM_LOCATION
+#define MEM_LOCATION "STACK"
+#endif
+
+/* Data Types :
+        To avoid compiler issues, define the data types that need to be used for
+   8b, 16b and 32b in <core_portme.h>.
+
+        *Important* :
+        ee_ptr_int needs to be the data type used to hold pointers, otherwise
+   coremark may fail!!!
+*/
+typedef signed short ee_s16;
+typedef unsigned short ee_u16;
+typedef signed int ee_s32;
+typedef double ee_f32;
+typedef unsigned char ee_u8;
+typedef unsigned int ee_u32;
+typedef unsigned long ee_ptr_int;
+typedef unsigned long ee_size_t;
+#define NULL ((void *)0)
+/* align_mem :
+        This macro is used to align an offset to point to a 32b value. It is
+   used in the Matrix algorithm to initialize the input memory blocks.
+*/
+#define align_mem(x) (void *)(4 + (((ee_ptr_int)(x)-1) & ~3))
+
+/* Configuration : CORE_TICKS
+        Using rdtime CSR which returns nanoseconds; CORETIMETYPE must be
+        wide enough to hold a 64-bit nanosecond timestamp.
+*/
+#define CORETIMETYPE ee_u64
+typedef unsigned long long ee_u64;
+typedef ee_u64 CORE_TICKS;
+
+/* Timing : CLOCKS_PER_SEC
+        barebones_clock() returns microseconds elapsed since execution start.
+*/
+#define CLOCKS_PER_SEC 1000000ULL
+
+/* Configuration : ITERATIONS
+        0 = auto-select based on timing (minimum 10 seconds for a valid run).
+*/
+#ifndef ITERATIONS
+#define ITERATIONS 0
+#endif
+
+/* Configuration : SEED_METHOD
+        Seeds come from volatile variables defined in core_portme.c.
+*/
+#ifndef SEED_METHOD
+#define SEED_METHOD SEED_VOLATILE
+#endif
+
+/* Configuration : MEM_METHOD
+        Stack allocation; Coremark declares its working set as a local in
+        iterate(), no malloc needed.
+*/
+#ifndef MEM_METHOD
+#define MEM_METHOD MEM_STACK
+#endif
+
+/* Configuration : MULTITHREAD
+        Single context only.
+*/
+#ifndef MULTITHREAD
+#define MULTITHREAD 1
+#define USE_PTHREAD 0
+#define USE_FORK    0
+#define USE_SOCKET  0
+#endif
+
+/* Configuration : MAIN_HAS_NOARGC
+        argc/argv are used to receive the output buffer pointer from the host.
+*/
+#ifndef MAIN_HAS_NOARGC
+#define MAIN_HAS_NOARGC 0
+#endif
+
+/* Configuration : MAIN_HAS_NORETURN
+        main returns normally.
+*/
+#ifndef MAIN_HAS_NORETURN
+#define MAIN_HAS_NORETURN 0
+#endif
+
+/* Variable : default_num_contexts
+        Not used for this simple port, must contain the value 1.
+*/
+extern ee_u32 default_num_contexts;
+
+typedef struct CORE_PORTABLE_S
+{
+        ee_u8 portable_id;
+} core_portable;
+
+/* target specific init/fini */
+void portable_init(core_portable* p, int* argc, char* argv[]);
+void portable_fini(core_portable* p);
+
+#if !defined(PROFILE_RUN) && !defined(PERFORMANCE_RUN) \
+    && !defined(VALIDATION_RUN)
+#if (TOTAL_DATA_SIZE == 1200)
+#define PROFILE_RUN 1
+#elif (TOTAL_DATA_SIZE == 2000)
+#define PERFORMANCE_RUN 1
+#else
+#define VALIDATION_RUN 1
+#endif
+#endif
+
+/* Output buffer : the host allocates this buffer and passes its address to
+        the guest via argv[0] (cast to ee_u8*). portable_init stores it in
+        output_buf. uart_send_char appends to it. The host reads a
+        null-terminated string from the same allocation after execution ends.
+*/
+#define OUTPUT_BUF_MAX 4096u
+
+extern volatile ee_u8* output_buf;
+
+/* uart_send_char is called by ee_printf.c for each output character */
+void uart_send_char(char c);
+
+int ee_printf(const char* fmt, ...);
+
+#endif /* CORE_PORTME_H */

--- a/crates/execution/ab-riscv-coremark-runner/src/coremark_port/ee_printf.c
+++ b/crates/execution/ab-riscv-coremark-runner/src/coremark_port/ee_printf.c
@@ -1,0 +1,680 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <coremark.h>
+#include <stdarg.h>
+
+#define ZEROPAD   (1 << 0) /* Pad with zero */
+#define SIGN      (1 << 1) /* Unsigned/signed long */
+#define PLUS      (1 << 2) /* Show plus */
+#define SPACE     (1 << 3) /* Spacer */
+#define LEFT      (1 << 4) /* Left justified */
+#define HEX_PREP  (1 << 5) /* 0x */
+#define UPPERCASE (1 << 6) /* 'ABCDEF' */
+
+#define is_digit(c) ((c) >= '0' && (c) <= '9')
+
+static char* digits = "0123456789abcdefghijklmnopqrstuvwxyz";
+static char* upper_digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+static ee_size_t strnlen(const char* s, ee_size_t count);
+
+static ee_size_t
+strnlen(const char* s, ee_size_t count)
+{
+    const char* sc;
+    for (sc = s; *sc != '\0' && count--; ++sc);
+    return sc - s;
+}
+
+static int
+skip_atoi(const char** s)
+{
+    int i = 0;
+    while (is_digit(**s))
+        i = i * 10 + *((*s)++) - '0';
+    return i;
+}
+
+static char*
+number(char* str, long num, int base, int size, int precision, int type)
+{
+    char c, sign, tmp[66];
+    char* dig = digits;
+    int i;
+
+    if (type & UPPERCASE)
+        dig = upper_digits;
+    if (type & LEFT)
+        type &= ~ZEROPAD;
+    if (base < 2 || base > 36)
+        return 0;
+
+    c = (type & ZEROPAD) ? '0' : ' ';
+    sign = 0;
+    if (type & SIGN)
+    {
+        if (num < 0)
+        {
+            sign = '-';
+            num = -num;
+            size--;
+        }
+        else if (type & PLUS)
+        {
+            sign = '+';
+            size--;
+        }
+        else if (type & SPACE)
+        {
+            sign = ' ';
+            size--;
+        }
+    }
+
+    if (type & HEX_PREP)
+    {
+        if (base == 16)
+            size -= 2;
+        else if (base == 8)
+            size--;
+    }
+
+    i = 0;
+
+    if (num == 0)
+        tmp[i++] = '0';
+    else
+    {
+        while (num != 0)
+        {
+            tmp[i++] = dig[((unsigned long)num) % (unsigned)base];
+            num = ((unsigned long)num) / (unsigned)base;
+        }
+    }
+
+    if (i > precision)
+        precision = i;
+    size -= precision;
+    if (!(type & (ZEROPAD | LEFT)))
+        while (size-- > 0)
+            *str++ = ' ';
+    if (sign)
+        *str++ = sign;
+
+    if (type & HEX_PREP)
+    {
+        if (base == 8)
+            *str++ = '0';
+        else if (base == 16)
+        {
+            *str++ = '0';
+            *str++ = digits[33];
+        }
+    }
+
+    if (!(type & LEFT))
+        while (size-- > 0)
+            *str++ = c;
+    while (i < precision--)
+        *str++ = '0';
+    while (i-- > 0)
+        *str++ = tmp[i];
+    while (size-- > 0)
+        *str++ = ' ';
+
+    return str;
+}
+
+static char*
+eaddr(char* str, unsigned char* addr, int size, int precision, int type)
+{
+    char tmp[24];
+    char* dig = digits;
+    int i, len;
+
+    if (type & UPPERCASE)
+        dig = upper_digits;
+    len = 0;
+    for (i = 0; i < 6; i++)
+    {
+        if (i != 0)
+            tmp[len++] = ':';
+        tmp[len++] = dig[addr[i] >> 4];
+        tmp[len++] = dig[addr[i] & 0x0F];
+    }
+
+    if (!(type & LEFT))
+        while (len < size--)
+            *str++ = ' ';
+    for (i = 0; i < len; ++i)
+        *str++ = tmp[i];
+    while (len < size--)
+        *str++ = ' ';
+
+    return str;
+}
+
+static char*
+iaddr(char* str, unsigned char* addr, int size, int precision, int type)
+{
+    char tmp[24];
+    int i, n, len;
+
+    len = 0;
+    for (i = 0; i < 4; i++)
+    {
+        if (i != 0)
+            tmp[len++] = '.';
+        n = addr[i];
+
+        if (n == 0)
+            tmp[len++] = digits[0];
+        else
+        {
+            if (n >= 100)
+            {
+                tmp[len++] = digits[n / 100];
+                n = n % 100;
+                tmp[len++] = digits[n / 10];
+                n = n % 10;
+            }
+            else if (n >= 10)
+            {
+                tmp[len++] = digits[n / 10];
+                n = n % 10;
+            }
+
+            tmp[len++] = digits[n];
+        }
+    }
+
+    if (!(type & LEFT))
+        while (len < size--)
+            *str++ = ' ';
+    for (i = 0; i < len; ++i)
+        *str++ = tmp[i];
+    while (len < size--)
+        *str++ = ' ';
+
+    return str;
+}
+
+#if HAS_FLOAT
+
+char* ecvtbuf(double arg, int ndigits, int* decpt, int* sign, char* buf);
+char* fcvtbuf(double arg, int ndigits, int* decpt, int* sign, char* buf);
+static void ee_bufcpy(char* d, char* s, int count);
+
+void
+ee_bufcpy(char* pd, char* ps, int count)
+{
+    char* pe = ps + count;
+    while (ps != pe)
+        *pd++ = *ps++;
+}
+
+static void
+parse_float(double value, char* buffer, char fmt, int precision)
+{
+    int decpt, sign, exp, pos;
+    char* digits = NULL;
+    char cvtbuf[80];
+    int capexp = 0;
+    int magnitude;
+
+    if (fmt == 'G' || fmt == 'E')
+    {
+        capexp = 1;
+        fmt += 'a' - 'A';
+    }
+
+    if (fmt == 'g')
+    {
+        digits = ecvtbuf(value, precision, &decpt, &sign, cvtbuf);
+        magnitude = decpt - 1;
+        if (magnitude < -4 || magnitude > precision - 1)
+        {
+            fmt = 'e';
+            precision -= 1;
+        }
+        else
+        {
+            fmt = 'f';
+            precision -= decpt;
+        }
+    }
+
+    if (fmt == 'e')
+    {
+        digits = ecvtbuf(value, precision + 1, &decpt, &sign, cvtbuf);
+
+        if (sign)
+            *buffer++ = '-';
+        *buffer++ = *digits;
+        if (precision > 0)
+            *buffer++ = '.';
+        ee_bufcpy(buffer, digits + 1, precision);
+        buffer += precision;
+        *buffer++ = capexp ? 'E' : 'e';
+
+        if (decpt == 0)
+        {
+            if (value == 0.0)
+                exp = 0;
+            else
+                exp = -1;
+        }
+        else
+            exp = decpt - 1;
+
+        if (exp < 0)
+        {
+            *buffer++ = '-';
+            exp = -exp;
+        }
+        else
+            *buffer++ = '+';
+
+        buffer[2] = (exp % 10) + '0';
+        exp = exp / 10;
+        buffer[1] = (exp % 10) + '0';
+        exp = exp / 10;
+        buffer[0] = (exp % 10) + '0';
+        buffer += 3;
+    }
+    else if (fmt == 'f')
+    {
+        digits = fcvtbuf(value, precision, &decpt, &sign, cvtbuf);
+        if (sign)
+            *buffer++ = '-';
+        if (*digits)
+        {
+            if (decpt <= 0)
+            {
+                *buffer++ = '0';
+                *buffer++ = '.';
+                for (pos = 0; pos < -decpt; pos++)
+                    *buffer++ = '0';
+                while (*digits)
+                    *buffer++ = *digits++;
+            }
+            else
+            {
+                pos = 0;
+                while (*digits)
+                {
+                    if (pos++ == decpt)
+                        *buffer++ = '.';
+                    *buffer++ = *digits++;
+                }
+            }
+        }
+        else
+        {
+            *buffer++ = '0';
+            if (precision > 0)
+            {
+                *buffer++ = '.';
+                for (pos = 0; pos < precision; pos++)
+                    *buffer++ = '0';
+            }
+        }
+    }
+
+    *buffer = '\0';
+}
+
+static void
+decimal_point(char* buffer)
+{
+    while (*buffer)
+    {
+        if (*buffer == '.')
+            return;
+        if (*buffer == 'e' || *buffer == 'E')
+            break;
+        buffer++;
+    }
+
+    if (*buffer)
+    {
+        int n = strnlen(buffer, 256);
+        while (n > 0)
+        {
+            buffer[n + 1] = buffer[n];
+            n--;
+        }
+
+        *buffer = '.';
+    }
+    else
+    {
+        *buffer++ = '.';
+        *buffer = '\0';
+    }
+}
+
+static void
+cropzeros(char* buffer)
+{
+    char* stop;
+
+    while (*buffer && *buffer != '.')
+        buffer++;
+    if (*buffer++)
+    {
+        while (*buffer && *buffer != 'e' && *buffer != 'E')
+            buffer++;
+        stop = buffer--;
+        while (*buffer == '0')
+            buffer--;
+        if (*buffer == '.')
+            buffer--;
+        while (buffer != stop)
+            *++buffer = 0;
+    }
+}
+
+static char*
+flt(char* str, double num, int size, int precision, char fmt, int flags)
+{
+    char tmp[80];
+    char c, sign;
+    int n, i;
+
+    // Left align means no zero padding
+    if (flags & LEFT)
+        flags &= ~ZEROPAD;
+
+    // Determine padding and sign char
+    c = (flags & ZEROPAD) ? '0' : ' ';
+    sign = 0;
+    if (flags & SIGN)
+    {
+        if (num < 0.0)
+        {
+            sign = '-';
+            num = -num;
+            size--;
+        }
+        else if (flags & PLUS)
+        {
+            sign = '+';
+            size--;
+        }
+        else if (flags & SPACE)
+        {
+            sign = ' ';
+            size--;
+        }
+    }
+
+    // Compute the precision value
+    if (precision < 0)
+        precision = 6; // Default precision: 6
+
+    // Convert floating point number to text
+    parse_float(num, tmp, fmt, precision);
+
+    if ((flags & HEX_PREP) && precision == 0)
+        decimal_point(tmp);
+    if (fmt == 'g' && !(flags & HEX_PREP))
+        cropzeros(tmp);
+
+    n = strnlen(tmp, 256);
+
+    // Output number with alignment and padding
+    size -= n;
+    if (!(flags & (ZEROPAD | LEFT)))
+        while (size-- > 0)
+            *str++ = ' ';
+    if (sign)
+        *str++ = sign;
+    if (!(flags & LEFT))
+        while (size-- > 0)
+            *str++ = c;
+    for (i = 0; i < n; i++)
+        *str++ = tmp[i];
+    while (size-- > 0)
+        *str++ = ' ';
+
+    return str;
+}
+
+#endif
+
+static int
+ee_vsprintf(char* buf, const char* fmt, va_list args)
+{
+    int len;
+    unsigned long num;
+    int i, base;
+    char* str;
+    char* s;
+
+    int flags; // Flags to number()
+
+    int field_width; // Width of output field
+    int precision; // Min. # of digits for integers; max number of chars for
+    // from string
+    int qualifier; // 'h', 'l', or 'L' for integer fields
+
+    for (str = buf; *fmt; fmt++)
+    {
+        if (*fmt != '%')
+        {
+            *str++ = *fmt;
+            continue;
+        }
+
+        // Process flags
+        flags = 0;
+    repeat:
+        fmt++; // This also skips first '%'
+        switch (*fmt)
+        {
+        case '-':
+            flags |= LEFT;
+            goto repeat;
+        case '+':
+            flags |= PLUS;
+            goto repeat;
+        case ' ':
+            flags |= SPACE;
+            goto repeat;
+        case '#':
+            flags |= HEX_PREP;
+            goto repeat;
+        case '0':
+            flags |= ZEROPAD;
+            goto repeat;
+        }
+
+        // Get field width
+        field_width = -1;
+        if (is_digit(*fmt))
+            field_width = skip_atoi(&fmt);
+        else if (*fmt == '*')
+        {
+            fmt++;
+            field_width = va_arg(args, int);
+            if (field_width < 0)
+            {
+                field_width = -field_width;
+                flags |= LEFT;
+            }
+        }
+
+        // Get the precision
+        precision = -1;
+        if (*fmt == '.')
+        {
+            ++fmt;
+            if (is_digit(*fmt))
+                precision = skip_atoi(&fmt);
+            else if (*fmt == '*')
+            {
+                ++fmt;
+                precision = va_arg(args, int);
+            }
+            if (precision < 0)
+                precision = 0;
+        }
+
+        // Get the conversion qualifier
+        qualifier = -1;
+        if (*fmt == 'l' || *fmt == 'L')
+        {
+            qualifier = *fmt;
+            fmt++;
+        }
+
+        // Default base
+        base = 10;
+
+        switch (*fmt)
+        {
+        case 'c':
+            if (!(flags & LEFT))
+                while (--field_width > 0)
+                    *str++ = ' ';
+            *str++ = (unsigned char)va_arg(args, int);
+            while (--field_width > 0)
+                *str++ = ' ';
+            continue;
+
+        case 's':
+            s = va_arg(args, char *);
+            if (!s)
+                s = "<NULL>";
+            len = strnlen(s, precision);
+            if (!(flags & LEFT))
+                while (len < field_width--)
+                    *str++ = ' ';
+            for (i = 0; i < len; ++i)
+                *str++ = *s++;
+            while (len < field_width--)
+                *str++ = ' ';
+            continue;
+
+        case 'p':
+            if (field_width == -1)
+            {
+                field_width = 2 * sizeof(void*);
+                flags |= ZEROPAD;
+            }
+            str = number(str,
+                         (unsigned long)va_arg(args, void *),
+                         16,
+                         field_width,
+                         precision,
+                         flags);
+            continue;
+
+        case 'A':
+            flags |= UPPERCASE;
+
+        case 'a':
+            if (qualifier == 'l')
+                str = eaddr(str,
+                            va_arg(args, unsigned char *),
+                            field_width,
+                            precision,
+                            flags);
+            else
+                str = iaddr(str,
+                            va_arg(args, unsigned char *),
+                            field_width,
+                            precision,
+                            flags);
+            continue;
+
+        // Integer number formats - set up the flags and "break"
+        case 'o':
+            base = 8;
+            break;
+
+        case 'X':
+            flags |= UPPERCASE;
+
+        case 'x':
+            base = 16;
+            break;
+
+        case 'd':
+        case 'i':
+            flags |= SIGN;
+
+        case 'u':
+            break;
+
+#if HAS_FLOAT
+
+        case 'f':
+            str = flt(str,
+                      va_arg(args, double),
+                      field_width,
+                      precision,
+                      *fmt,
+                      flags | SIGN);
+            continue;
+
+#endif
+
+        default:
+            if (*fmt != '%')
+                *str++ = '%';
+            if (*fmt)
+                *str++ = *fmt;
+            else
+                --fmt;
+            continue;
+        }
+
+        if (qualifier == 'l')
+            num = va_arg(args, unsigned long);
+        else if (flags & SIGN)
+            num = va_arg(args, int);
+        else
+            num = va_arg(args, unsigned int);
+
+        str = number(str, num, base, field_width, precision, flags);
+    }
+
+    *str = '\0';
+    return str - buf;
+}
+
+int
+ee_printf(const char* fmt, ...)
+{
+    char buf[1024], *p;
+    va_list args;
+    int n = 0;
+
+    va_start(args, fmt);
+    ee_vsprintf(buf, fmt, args);
+    va_end(args);
+    p = buf;
+    while (*p)
+    {
+        uart_send_char(*p);
+        n++;
+        p++;
+    }
+
+    return n;
+}

--- a/crates/execution/ab-riscv-coremark-runner/src/elf.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/elf.rs
@@ -1,0 +1,87 @@
+use ab_riscv_interpreter::prelude::*;
+use anyhow::Context;
+use object::{Object, ObjectSection, ObjectSymbol};
+
+pub(crate) struct LoadedElf<'a> {
+    pub(crate) entry_point: u64,
+    pub(crate) global_pointer: u64,
+    pub(crate) text_addr: u64,
+    pub(crate) text_data: &'a [u8],
+    pub(crate) output_buf_addr: u64,
+    pub(crate) output_buf_size: u32,
+}
+
+/// Load all non-empty ELF sections into guest memory
+pub(crate) fn load_elf<'a, Memory>(
+    elf: &'a [u8],
+    memory: &mut Memory,
+) -> anyhow::Result<LoadedElf<'a>>
+where
+    Memory: VirtualMemory,
+{
+    let obj = object::File::parse(elf).context("failed to parse Coremark ELF")?;
+
+    let mut output_buf_addr: Option<u64> = None;
+    let mut output_buf_size: Option<u32> = None;
+
+    for section in obj.sections() {
+        let addr = section.address();
+        if addr == 0 {
+            continue;
+        }
+
+        if section.name().ok() == Some(".output_buf") {
+            output_buf_addr = Some(addr);
+            output_buf_size = Some(
+                u32::try_from(section.size()).context(".output_buf section larger than 4 GiB")?,
+            );
+        }
+
+        let data = section.data().context("failed to read ELF section data")?;
+        if data.is_empty() {
+            continue;
+        }
+        memory
+            .write_slice(addr, data)
+            .map_err(|e| anyhow::anyhow!(e))
+            .with_context(|| format!("section at {addr:#x} does not fit in guest memory"))?;
+    }
+
+    let output_buf_addr =
+        output_buf_addr.context("ELF missing .output_buf section; check core_portme.c")?;
+    let output_buf_size =
+        output_buf_size.context("ELF missing .output_buf section; check core_portme.c")?;
+
+    // Resolve entry point via the `main` symbol rather than e_entry. With -static-pie the ELF entry
+    // point is a relocation-applying thunk that writes GOT fixups to low addresses before calling
+    // main; jumping straight to main bypasses that stub, which is correct since the interpreter
+    // loads sections verbatim and GOT entries are already at their final addresses.
+    let entry_point = obj
+        .symbols()
+        .find(|s| s.name().ok() == Some("main"))
+        .map(|s| s.address())
+        .context("no `main` symbol found in Coremark ELF")?;
+
+    let global_pointer = obj
+        .symbols()
+        .find(|s| s.name().ok() == Some("__global_pointer$"))
+        .map(|s| s.address())
+        .context("no __global_pointer$ symbol")?;
+
+    let text_section = obj
+        .section_by_name(".text")
+        .context("no .text section in Coremark ELF")?;
+    let text_addr = text_section.address();
+    let text_data = text_section
+        .data()
+        .context("failed to read .text section data")?;
+
+    Ok(LoadedElf {
+        entry_point,
+        global_pointer,
+        text_addr,
+        text_data,
+        output_buf_addr,
+        output_buf_size,
+    })
+}

--- a/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
@@ -1,0 +1,74 @@
+use crate::time_csr::TimeCsrState;
+use ab_riscv_interpreter::prelude::*;
+use ab_riscv_macros::{instruction, instruction_execution};
+use ab_riscv_primitives::prelude::*;
+use core::fmt;
+use core::ops::ControlFlow;
+
+type CoremarkRegister = Reg<u64>;
+
+/// An instruction type used by Coremark runner
+#[instruction(
+    inherit = [
+        Rv64Instruction,
+        Rv64MInstruction,
+        Rv64BInstruction,
+        Rv64ZcaInstruction,
+        TimeCsrInstruction,
+    ],
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoremarkInstruction<Reg = CoremarkRegister> {}
+
+#[instruction]
+impl<Reg> const Instruction for CoremarkInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        None
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for CoremarkInstruction<Reg>
+where
+    Reg: Register,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {}
+    }
+}
+
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for CoremarkInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+    #[inline(always)]
+    fn execute(
+        self,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
+    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
+        Ok(ControlFlow::Continue(()))
+    }
+}

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -1,0 +1,274 @@
+use crate::instruction::CoremarkInstruction;
+use ab_riscv_interpreter::prelude::*;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+/// Flat guest memory
+#[derive(Debug, Copy, Clone)]
+#[repr(align(16))]
+pub(crate) struct GuestMemory<const BASE_ADDR: u64, const SIZE: usize> {
+    data: [u8; SIZE],
+}
+
+impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for GuestMemory<BASE_ADDR, SIZE> {
+    fn read<T>(&self, address: u64) -> Result<T, VirtualMemoryError>
+    where
+        T: BasicInt,
+    {
+        let offset = address.wrapping_sub(BASE_ADDR);
+
+        if offset.saturating_add(size_of::<T>() as u64) > self.data.len() as u64 {
+            return Err(VirtualMemoryError::OutOfBoundsRead { address });
+        }
+
+        // SAFETY: Only reading basic integers from initialized memory
+        unsafe {
+            Ok(self
+                .data
+                .as_ptr()
+                .cast::<T>()
+                .byte_add(offset as usize)
+                .read_unaligned())
+        }
+    }
+
+    unsafe fn read_unchecked<T>(&self, address: u64) -> T
+    where
+        T: BasicInt,
+    {
+        // SAFETY: Guaranteed by function contract
+        unsafe {
+            let offset = address.unchecked_sub(BASE_ADDR) as usize;
+            self.data
+                .as_ptr()
+                .cast::<T>()
+                .byte_add(offset)
+                .read_unaligned()
+        }
+    }
+
+    fn read_slice(&self, address: u64, len: u32) -> Result<&[u8], VirtualMemoryError> {
+        let offset = address.wrapping_sub(BASE_ADDR);
+
+        if offset > self.data.len() as u64 {
+            return Err(VirtualMemoryError::OutOfBoundsRead { address });
+        }
+
+        self.data
+            .get(offset as usize..)
+            .and_then(|data| data.get(..len as usize))
+            .ok_or(VirtualMemoryError::OutOfBoundsRead { address })
+    }
+
+    fn read_slice_up_to(&self, address: u64, len: u32) -> &[u8] {
+        let offset = address.wrapping_sub(BASE_ADDR);
+
+        if offset > self.data.len() as u64 {
+            return &[];
+        }
+
+        let remaining = self.data.get(offset as usize..).unwrap_or_default();
+        remaining.get(..len as usize).unwrap_or(remaining)
+    }
+
+    fn write<T>(&mut self, address: u64, value: T) -> Result<(), VirtualMemoryError>
+    where
+        T: BasicInt,
+    {
+        let offset = address.wrapping_sub(BASE_ADDR);
+
+        if offset.saturating_add(size_of::<T>() as u64) > self.data.len() as u64 {
+            return Err(VirtualMemoryError::OutOfBoundsWrite { address });
+        }
+
+        // SAFETY: Only writing basic integers to initialized memory
+        unsafe {
+            self.data
+                .as_mut_ptr()
+                .cast::<T>()
+                .byte_add(offset as usize)
+                .write_unaligned(value);
+        }
+
+        Ok(())
+    }
+
+    fn write_slice(&mut self, address: u64, data: &[u8]) -> Result<(), VirtualMemoryError> {
+        let offset = address.wrapping_sub(BASE_ADDR);
+
+        if offset > self.data.len() as u64 {
+            return Err(VirtualMemoryError::OutOfBoundsWrite { address });
+        }
+
+        let len = data.len();
+        self.data
+            .get_mut(offset as usize..)
+            .and_then(|data| data.get_mut(..len))
+            .ok_or(VirtualMemoryError::OutOfBoundsWrite { address })?
+            .copy_from_slice(data);
+
+        Ok(())
+    }
+}
+
+impl<const BASE_ADDR: u64, const SIZE: usize> Default for GuestMemory<BASE_ADDR, SIZE> {
+    fn default() -> Self {
+        Self { data: [0; SIZE] }
+    }
+}
+
+/// Eager instruction handler eagerly decodes all instructions upfront
+#[derive(Debug, Default, Clone)]
+pub(crate) struct EagerInstructionFetcher {
+    instructions: Vec<CoremarkInstruction>,
+    return_trap_address: u64,
+    base_addr: u64,
+    instruction_offset: usize,
+}
+
+impl<Memory> ProgramCounter<u64, Memory> for EagerInstructionFetcher
+where
+    Memory: VirtualMemory,
+{
+    #[inline(always)]
+    fn get_pc(&self) -> u64 {
+        self.base_addr + self.instruction_offset as u64 * size_of::<u16>() as u64
+    }
+
+    #[inline]
+    fn set_pc(
+        &mut self,
+        _memory: &Memory,
+        pc: u64,
+    ) -> Result<ControlFlow<()>, ProgramCounterError<u64>> {
+        let address = pc;
+
+        if address == self.return_trap_address {
+            return Ok(ControlFlow::Break(()));
+        }
+
+        if !address.is_multiple_of(size_of::<u16>() as u64) {
+            return Err(ProgramCounterError::UnalignedInstruction { address });
+        }
+
+        let offset = address
+            .checked_sub(self.base_addr)
+            .ok_or(VirtualMemoryError::OutOfBoundsRead { address })? as usize;
+        let instruction_offset = offset / size_of::<u16>();
+
+        if instruction_offset >= self.instructions.len() {
+            return Err(VirtualMemoryError::OutOfBoundsRead { address }.into());
+        }
+
+        self.instruction_offset = instruction_offset;
+
+        Ok(ControlFlow::Continue(()))
+    }
+}
+
+impl<Memory> InstructionFetcher<CoremarkInstruction, Memory> for EagerInstructionFetcher
+where
+    Memory: VirtualMemory,
+{
+    #[inline(always)]
+    fn fetch_instruction(
+        &mut self,
+        _memory: &Memory,
+    ) -> Result<FetchInstructionResult<CoremarkInstruction>, ExecutionError<u64>> {
+        // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
+        // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
+        // one instruction can't result in out-of-bounds access.
+        let instruction = *unsafe { self.instructions.get_unchecked(self.instruction_offset) };
+        self.instruction_offset += usize::from(instruction.size()) / size_of::<u16>();
+
+        Ok(FetchInstructionResult::Instruction(instruction))
+    }
+}
+
+impl EagerInstructionFetcher {
+    /// Create a new instance with the specified instructions and base address.
+    ///
+    /// `return_trap_address` is the address at which the interpreter will stop execution
+    /// (gracefully).
+    ///
+    /// # Safety
+    /// The program counter must be valid and aligned, the instructions processed must end with a
+    /// jump instruction.
+    #[inline(always)]
+    pub(super) unsafe fn new(
+        instructions: &[u8],
+        return_trap_address: u64,
+        base_addr: u64,
+        pc: u64,
+    ) -> Self {
+        let mut decoded_instructions = Vec::with_capacity(instructions.len() / size_of::<u16>());
+
+        let mut offset = 0;
+        while let Some(instruction_bytes) = instructions.get(offset..offset + size_of::<u32>()) {
+            let decoded_instruction = u32::from_le_bytes([
+                instruction_bytes[0],
+                instruction_bytes[1],
+                instruction_bytes[2],
+                instruction_bytes[3],
+            ]);
+            // Use `Unimp` as a fallback, though contract is expected to only contain legal
+            // instructions
+            let decoded_instruction =
+                Instruction::try_decode(decoded_instruction).unwrap_or(CoremarkInstruction::Unimp);
+            decoded_instructions.push(decoded_instruction);
+            match decoded_instruction.size() {
+                2 => {
+                    offset += 2;
+                }
+                4 => {
+                    // The second half of a 32-bit instruction is a valid offset and may or may not
+                    // decode to a valid instruction on its own. Try to decode it but ignore
+                    // decoding failures.
+
+                    offset += 2;
+
+                    // Could be both 16-bit and 32-bit instruction, need to handle end of the
+                    // instruction stream
+                    let instruction_word = if let Some(instruction_bytes) =
+                        instructions.get(offset..offset + size_of::<u32>())
+                    {
+                        u32::from_le_bytes([
+                            instruction_bytes[0],
+                            instruction_bytes[1],
+                            instruction_bytes[2],
+                            instruction_bytes[3],
+                        ])
+                    } else {
+                        u32::from_le_bytes([instruction_bytes[2], instruction_bytes[3], 0, 0])
+                    };
+
+                    decoded_instructions.push(
+                        Instruction::try_decode(instruction_word)
+                            .unwrap_or(CoremarkInstruction::Unimp),
+                    );
+                    offset += 2;
+                }
+                instruction_size => {
+                    unreachable!("Invalid instruction size {instruction_size}, expected 2 or 4");
+                }
+            }
+        }
+
+        let remainder_bytes = instructions.get(offset..).unwrap_or(&[]);
+
+        if remainder_bytes.len() == size_of::<u16>() {
+            let instruction_word =
+                u32::from_le_bytes([remainder_bytes[0], remainder_bytes[1], 0, 0]);
+            decoded_instructions.push(
+                Instruction::try_decode(instruction_word).unwrap_or(CoremarkInstruction::Unimp),
+            );
+        }
+
+        Self {
+            instructions: decoded_instructions,
+            return_trap_address,
+            base_addr,
+            instruction_offset: (pc - base_addr) as usize / size_of::<u16>(),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -1,0 +1,154 @@
+#![feature(
+    const_cmp,
+    const_trait_impl,
+    const_try,
+    const_try_residual,
+    try_blocks,
+    widening_mul
+)]
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+// TODO: This feature is not actually used in this crate, but is added as a workaround for
+//  https://github.com/rust-lang/rust/issues/141492
+#![feature(generic_const_exprs)]
+
+mod elf;
+mod instruction;
+mod interpreter;
+mod time_csr;
+
+use crate::elf::{LoadedElf, load_elf};
+use crate::instruction::CoremarkInstruction;
+use crate::interpreter::{EagerInstructionFetcher, GuestMemory};
+use crate::time_csr::TimeCsrState;
+use ab_riscv_interpreter::basic::{
+    BasicInterpreterState, BasicRegisters, IgnoreEcallSystemInstructionHandler,
+};
+use ab_riscv_interpreter::prelude::*;
+use ab_riscv_primitives::prelude::*;
+use anyhow::Context;
+use core::ops::ControlFlow;
+use std::ffi::CStr;
+
+/// Coremark ELF binary compiled by build.rs for the RISC-V guest
+const COREMARK_ELF: &[u8] = include_bytes!(env!("COREMARK_ELF"));
+/// Guest virtual address of the trap / return sentinel.
+///
+/// The caller writes this into `ra` before calling `main`; when `main` returns, the interpreter
+/// sees PC = 0 and halts.
+const TRAP_ADDRESS: u64 = 0x0;
+/// Base address at which the PIE ELF is loaded into guest memory.
+///
+/// Address 0 is safe as a trap sentinel because `set_pc` checks for `TRAP_ADDRESS` before any
+/// memory access, so the interpreter halts cleanly without ever dereferencing it.
+const MEMORY_BASE_ADDRESS: u64 = 0x0;
+/// Total guest memory size.
+///
+/// Must be large enough to hold the ELF segments, stack, and output buffer.
+const MEMORY_SIZE: usize = 512 * 1024;
+
+fn execute<Regs, Memory, IF>(
+    state: &mut BasicInterpreterState<
+        Regs,
+        TimeCsrState,
+        Memory,
+        IF,
+        IgnoreEcallSystemInstructionHandler,
+    >,
+) -> Result<(), ExecutionError<u64>>
+where
+    Regs: RegisterFile<<CoremarkInstruction as Instruction>::Reg>,
+    Memory: VirtualMemory,
+    IF: InstructionFetcher<CoremarkInstruction, Memory> + ProgramCounter<u64, Memory>,
+{
+    loop {
+        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory)? {
+            FetchInstructionResult::Instruction(i) => i,
+            FetchInstructionResult::ControlFlow(ControlFlow::Continue(())) => continue,
+            FetchInstructionResult::ControlFlow(ControlFlow::Break(())) => break,
+        };
+
+        match instruction.execute(
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )? {
+            ControlFlow::Continue(()) => continue,
+            ControlFlow::Break(()) => break,
+        }
+    }
+
+    Ok(())
+}
+
+/// Read the null-terminated Coremark output string from the output buffer
+fn read_output<Memory>(memory: &Memory, addr: u64, size: u32) -> Option<&str>
+where
+    Memory: VirtualMemory,
+{
+    let slice = memory.read_slice_up_to(addr, size);
+    CStr::from_bytes_until_nul(slice).ok()?.to_str().ok()
+}
+
+fn main() -> anyhow::Result<()> {
+    if COREMARK_ELF.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Coremark ELF not found, install `riscv64-unknown-elf-gcc` and/or specify `RISCV_CC` \
+            environment variable to specify a different toolchain, use `build-elf-required` \
+            feature to make ELF building required"
+        ));
+    }
+    let mut memory = GuestMemory::<MEMORY_BASE_ADDRESS, MEMORY_SIZE>::default();
+    let LoadedElf {
+        entry_point,
+        global_pointer,
+        text_addr,
+        text_data,
+        output_buf_addr,
+        output_buf_size,
+    } = load_elf(COREMARK_ELF, &mut memory)?;
+
+    // argv is a pointer-to-pointer: write output_buf_addr as a `u64` into guest memory, then pass
+    // its address in a1. Stack pointer sits below that, 16-byte aligned per psABI.
+    let stack_top = (MEMORY_BASE_ADDRESS + MEMORY_SIZE as u64) & !0xF;
+    let argv_addr = stack_top - 8;
+    let stack_pointer = argv_addr - 8;
+
+    memory
+        .write::<u64>(argv_addr, output_buf_addr)
+        .context("argv slot does not fit in guest memory")?;
+
+    let host_start = std::time::Instant::now();
+
+    let mut regs = BasicRegisters::default();
+    regs.write(Reg::Ra, TRAP_ADDRESS);
+    regs.write(Reg::Sp, stack_pointer);
+    regs.write(Reg::Gp, global_pointer);
+    regs.write(Reg::A0, 1);
+    regs.write(Reg::A1, argv_addr);
+
+    // SAFETY: entry_point is valid and aligned; ELF was produced by a trusted compiler
+    let instruction_fetcher =
+        unsafe { EagerInstructionFetcher::new(text_data, TRAP_ADDRESS, text_addr, entry_point) };
+
+    let mut state = BasicInterpreterState {
+        regs,
+        ext_state: TimeCsrState::default(),
+        memory,
+        instruction_fetcher,
+        system_instruction_handler: IgnoreEcallSystemInstructionHandler,
+    };
+
+    execute(&mut state).context("Coremark execution failed")?;
+
+    let host_elapsed = host_start.elapsed();
+
+    let output = read_output(&state.memory, output_buf_addr, output_buf_size)
+        .context("Coremark output not found in guest memory")?;
+    print!("{output}");
+
+    println!("Host elapsed: {:.3} s", host_elapsed.as_secs_f64());
+
+    Ok(())
+}

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -1,0 +1,185 @@
+#![expect(unreachable_pub, reason = "Macro requirements and generated code")]
+
+use crate::interpreter::{EagerInstructionFetcher, GuestMemory};
+use ab_riscv_interpreter::basic::{BasicRegisters, IgnoreEcallSystemInstructionHandler};
+use ab_riscv_interpreter::prelude::*;
+use ab_riscv_macros::{instruction, instruction_execution};
+use ab_riscv_primitives::prelude::*;
+use core::fmt;
+use core::ops::ControlFlow;
+use std::time::Instant;
+
+/// State for the counter CSR (time-only)
+#[derive(Debug, Clone)]
+pub struct TimeCsrState {
+    start: Instant,
+}
+
+impl AsMut<TimeCsrState> for TimeCsrState {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut TimeCsrState {
+        self
+    }
+}
+
+impl AsRef<TimeCsrState> for TimeCsrState {
+    #[inline(always)]
+    fn as_ref(&self) -> &TimeCsrState {
+        self
+    }
+}
+
+impl Default for TimeCsrState {
+    fn default() -> Self {
+        Self {
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Csrs<Reg<u64>> for TimeCsrState {
+    fn privilege_level(&self) -> PrivilegeLevel {
+        PrivilegeLevel::Machine
+    }
+
+    fn read_csr(&self, _csr_index: u16) -> Result<u64, CsrError> {
+        Ok(0)
+    }
+
+    fn write_csr(&mut self, _csr_index: u16, _value: u64) -> Result<(), CsrError> {
+        Ok(())
+    }
+
+    fn process_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError> {
+        let mut out = 0;
+        if !<TimeCsrInstruction<Reg<u64>> as ExecutableInstruction<
+            BasicRegisters<<TimeCsrInstruction<Reg<u64>> as Instruction>::Reg>,
+            Self,
+            GuestMemory<0, 0>,
+            EagerInstructionFetcher,
+            IgnoreEcallSystemInstructionHandler,
+        >>::prepare_csr_read(self, csr_index, raw_value, &mut out)?
+        {
+            return Err(CsrError::IllegalRead { csr_index });
+        }
+
+        Ok(out)
+    }
+
+    fn process_csr_write(&mut self, csr_index: u16, write_value: u64) -> Result<u64, CsrError> {
+        let mut out = 0;
+        if !<TimeCsrInstruction<Reg<u64>> as ExecutableInstruction<
+            BasicRegisters<<TimeCsrInstruction<Reg<u64>> as Instruction>::Reg>,
+            Self,
+            GuestMemory<0, 0>,
+            EagerInstructionFetcher,
+            IgnoreEcallSystemInstructionHandler,
+        >>::prepare_csr_write(self, csr_index, write_value, &mut out)?
+        {
+            return Err(CsrError::IllegalWrite { csr_index });
+        }
+
+        Ok(out)
+    }
+}
+
+impl TimeCsrState {
+    pub(crate) fn elapsed_ns(&self) -> u64 {
+        self.start.elapsed().as_nanos() as u64
+    }
+}
+
+/// Minimal placeholder for the counter (time-only) CSR.
+///
+/// No decoded instruction variants are needed, all work happens in `prepare_csr_read`.
+#[instruction(
+    inherit = [ZicsrInstruction],
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeCsrInstruction<Reg> {}
+
+#[instruction]
+impl<Reg> const Instruction for TimeCsrInstruction<Reg>
+where
+    Reg: [const] Register,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        None
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for TimeCsrInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {}
+    }
+}
+
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for TimeCsrInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+    ExtState: AsMut<TimeCsrState> + AsRef<TimeCsrState>,
+    CustomError: fmt::Debug,
+{
+    fn prepare_csr_read(
+        ext_state: &ExtState,
+        csr_index: u16,
+        _raw_value: Reg::Type,
+        output_value: &mut Reg::Type,
+    ) -> Result<bool, CsrError<CustomError>> {
+        const CSR_TIME: u16 = 0xC01;
+
+        if csr_index == CSR_TIME {
+            // Return elapsed nanoseconds
+            *output_value = ext_state.as_ref().elapsed_ns();
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn prepare_csr_write(
+        _ext_state: &mut ExtState,
+        csr_index: u16,
+        _write_value: Reg::Type,
+        _output_value: &mut Reg::Type,
+    ) -> Result<bool, CsrError<CustomError>> {
+        const CSR_TIME: u16 = 0xC01;
+
+        if csr_index == CSR_TIME {
+            Err(CsrError::ReadOnly { csr_index })
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn execute(
+        self,
+        regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
+        match self {}
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use crate::{
     Address, CustomErrorPlaceholder, ExecutionError, FetchInstructionResult, InstructionFetcher,
-    ProgramCounter, ProgramCounterError, RegisterFile, VirtualMemory,
+    ProgramCounter, ProgramCounterError, RegisterFile, SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
 use core::marker::PhantomData;
@@ -217,5 +217,27 @@ where
             pc,
             _phantom: PhantomData,
         }
+    }
+}
+
+/// System instruction handler that ignores all system calls and does nothing for other system
+/// instructions
+#[derive(Debug, Default, Clone, Copy)]
+pub struct IgnoreEcallSystemInstructionHandler;
+
+impl<Reg, Regs, Memory, PC, CustomError>
+    SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>
+    for IgnoreEcallSystemInstructionHandler
+where
+    Reg: Register,
+    Regs: RegisterFile<Reg>,
+{
+    fn handle_ecall(
+        &mut self,
+        _regs: &mut Regs,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
+        Ok(ControlFlow::Continue(()))
     }
 }


### PR DESCRIPTION
To make performance somewhat comparable to other interpreters/VMs, I implemented Coremark runner.

Here are the initial results with eager instruction fetcher on AMD Threadripper 7970X:
```
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 13990585
Total time (secs): 13
Iterations/Sec   : 1538
Iterations       : 20000
Compiler version : GCC13.2.0
Compiler flags   : -O3 -march=rv64imc_zba_zbb_zbs -mabi=lp64
Memory location  : STACK
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x382f
Correct operation validated. See readme.txt for run and reporting rules.
Host elapsed: 21.848 s
```

Score **1538** isn't amazing, but isn't terrible either.