### PR TITLE
Add cold path hints

### DIFF
--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -9,6 +9,7 @@ use ab_riscv_interpreter::basic::{BasicInterpreterState, IgnoreEcallSystemInstru
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use alloc::vec::Vec;
+use core::hint::cold_path;
 use core::mem::offset_of;
 use core::ops::ControlFlow;
 
@@ -128,6 +129,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for TestMemory<BASE_
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset.saturating_add(size_of::<T>() as u64) > self.data.len() as u64 {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address });
         }
 
@@ -161,6 +163,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for TestMemory<BASE_
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset > self.data.len() as u64 {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address });
         }
 
@@ -174,6 +177,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for TestMemory<BASE_
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset > self.data.len() as u64 {
+            cold_path();
             return &[];
         }
 
@@ -188,6 +192,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for TestMemory<BASE_
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset.saturating_add(size_of::<T>() as u64) > self.data.len() as u64 {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsWrite { address });
         }
 
@@ -207,15 +212,21 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for TestMemory<BASE_
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset > self.data.len() as u64 {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsWrite { address });
         }
 
         let len = data.len();
-        self.data
+        let Some(target_data) = self
+            .data
             .get_mut(offset as usize..)
             .and_then(|data| data.get_mut(..len))
-            .ok_or(VirtualMemoryError::OutOfBoundsWrite { address })?
-            .copy_from_slice(data);
+        else {
+            cold_path();
+            return Err(VirtualMemoryError::OutOfBoundsWrite { address });
+        };
+
+        target_data.copy_from_slice(data);
 
         Ok(())
     }
@@ -234,11 +245,14 @@ impl<const BASE_ADDR: u64, const SIZE: usize> TestMemory<BASE_ADDR, SIZE> {
         address: u64,
         size: usize,
     ) -> Result<&mut [u8], VirtualMemoryError> {
-        let offset = address
-            .checked_sub(BASE_ADDR)
-            .ok_or(VirtualMemoryError::OutOfBoundsRead { address })? as usize;
+        let Some(offset) = address.checked_sub(BASE_ADDR) else {
+            cold_path();
+            return Err(VirtualMemoryError::OutOfBoundsRead { address });
+        };
+        let offset = offset as usize;
 
         if offset + size > self.data.len() {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address });
         }
 
@@ -269,19 +283,24 @@ where
         pc: u64,
     ) -> Result<ControlFlow<()>, ProgramCounterError<u64>> {
         if pc == self.return_trap_address {
+            cold_path();
             return Ok(ControlFlow::Break(()));
         }
 
         if !pc.is_multiple_of(u64::from(
             ContractInstruction::<ContractRegister>::alignment(),
         )) {
+            cold_path();
             return Err(ProgramCounterError::UnalignedInstruction { address: pc });
         }
 
         // Note: This will not allow reading a 16-bit instruction at the very end of memory range,
         // but that is going to be the case here anyway since code is followed by read-write memory
         // anyway
-        memory.read::<u32>(pc)?;
+        if let Err(error) = memory.read::<u32>(pc) {
+            cold_path();
+            return Err(error.into());
+        }
 
         self.pc = pc;
 
@@ -357,19 +376,26 @@ where
         let address = pc;
 
         if address == self.return_trap_address {
+            cold_path();
             return Ok(ControlFlow::Break(()));
         }
 
         if !address.is_multiple_of(size_of::<u16>() as u64) {
+            cold_path();
             return Err(ProgramCounterError::UnalignedInstruction { address });
         }
 
-        let offset = address
-            .checked_sub(self.base_addr)
-            .ok_or(VirtualMemoryError::OutOfBoundsRead { address })? as usize;
+        let Some(offset) = address.checked_sub(self.base_addr) else {
+            cold_path();
+            return Err(ProgramCounterError::MemoryAccess(
+                VirtualMemoryError::OutOfBoundsRead { address },
+            ));
+        };
+        let offset = offset as usize;
         let instruction_offset = offset / size_of::<u16>();
 
         if instruction_offset >= self.instructions.len() {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address }.into());
         }
 
@@ -499,13 +525,19 @@ where
     IF: InstructionFetcher<ContractInstruction, Memory>,
 {
     loop {
-        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory)? {
-            FetchInstructionResult::Instruction(instruction) => instruction,
-            FetchInstructionResult::ControlFlow(ControlFlow::Continue(())) => {
+        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
+            Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
+            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+                cold_path();
                 continue;
             }
-            FetchInstructionResult::ControlFlow(ControlFlow::Break(())) => {
+            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+                cold_path();
                 break;
+            }
+            Err(error) => {
+                cold_path();
+                return Err(error);
             }
         };
 
@@ -515,12 +547,17 @@ where
             &mut state.memory,
             &mut state.instruction_fetcher,
             &mut state.system_instruction_handler,
-        )? {
-            ControlFlow::Continue(()) => {
+        ) {
+            Ok(ControlFlow::Continue(())) => {
                 continue;
             }
-            ControlFlow::Break(()) => {
+            Ok(ControlFlow::Break(())) => {
+                cold_path();
                 break;
+            }
+            Err(error) => {
+                cold_path();
+                return Err(error);
             }
         }
     }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -2,6 +2,7 @@ use crate::instruction::CoremarkInstruction;
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+use std::hint::cold_path;
 
 /// Flat guest memory
 #[derive(Debug, Copy, Clone)]
@@ -18,6 +19,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for GuestMemory<BASE
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset.saturating_add(size_of::<T>() as u64) > self.data.len() as u64 {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address });
         }
 
@@ -51,6 +53,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for GuestMemory<BASE
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset > self.data.len() as u64 {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address });
         }
 
@@ -64,6 +67,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for GuestMemory<BASE
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset > self.data.len() as u64 {
+            cold_path();
             return &[];
         }
 
@@ -78,6 +82,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for GuestMemory<BASE
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset.saturating_add(size_of::<T>() as u64) > self.data.len() as u64 {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsWrite { address });
         }
 
@@ -97,15 +102,21 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for GuestMemory<BASE
         let offset = address.wrapping_sub(BASE_ADDR);
 
         if offset > self.data.len() as u64 {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsWrite { address });
         }
 
         let len = data.len();
-        self.data
+        let Some(target_data) = self
+            .data
             .get_mut(offset as usize..)
             .and_then(|data| data.get_mut(..len))
-            .ok_or(VirtualMemoryError::OutOfBoundsWrite { address })?
-            .copy_from_slice(data);
+        else {
+            cold_path();
+            return Err(VirtualMemoryError::OutOfBoundsWrite { address });
+        };
+
+        target_data.copy_from_slice(data);
 
         Ok(())
     }
@@ -144,19 +155,26 @@ where
         let address = pc;
 
         if address == self.return_trap_address {
+            cold_path();
             return Ok(ControlFlow::Break(()));
         }
 
         if !address.is_multiple_of(size_of::<u16>() as u64) {
+            cold_path();
             return Err(ProgramCounterError::UnalignedInstruction { address });
         }
 
-        let offset = address
-            .checked_sub(self.base_addr)
-            .ok_or(VirtualMemoryError::OutOfBoundsRead { address })? as usize;
+        let Some(offset) = address.checked_sub(self.base_addr) else {
+            cold_path();
+            return Err(ProgramCounterError::MemoryAccess(
+                VirtualMemoryError::OutOfBoundsRead { address },
+            ));
+        };
+        let offset = offset as usize;
         let instruction_offset = offset / size_of::<u16>();
 
         if instruction_offset >= self.instructions.len() {
+            cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address }.into());
         }
 

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -28,6 +28,7 @@ use ab_riscv_primitives::prelude::*;
 use anyhow::Context;
 use core::ops::ControlFlow;
 use std::ffi::CStr;
+use std::hint::cold_path;
 
 /// Coremark ELF binary compiled by build.rs for the RISC-V guest
 const COREMARK_ELF: &[u8] = include_bytes!(env!("COREMARK_ELF"));
@@ -61,10 +62,20 @@ where
     IF: InstructionFetcher<CoremarkInstruction, Memory> + ProgramCounter<u64, Memory>,
 {
     loop {
-        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory)? {
-            FetchInstructionResult::Instruction(i) => i,
-            FetchInstructionResult::ControlFlow(ControlFlow::Continue(())) => continue,
-            FetchInstructionResult::ControlFlow(ControlFlow::Break(())) => break,
+        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
+            Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
+            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+                cold_path();
+                continue;
+            }
+            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+                cold_path();
+                break;
+            }
+            Err(error) => {
+                cold_path();
+                return Err(error);
+            }
         };
 
         match instruction.execute(
@@ -73,9 +84,18 @@ where
             &mut state.memory,
             &mut state.instruction_fetcher,
             &mut state.system_instruction_handler,
-        )? {
-            ControlFlow::Continue(()) => continue,
-            ControlFlow::Break(()) => break,
+        ) {
+            Ok(ControlFlow::Continue(())) => {
+                continue;
+            }
+            Ok(ControlFlow::Break(())) => {
+                cold_path();
+                break;
+            }
+            Err(error) => {
+                cold_path();
+                return Err(error);
+            }
         }
     }
 

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -8,6 +8,7 @@ use crate::{
     ProgramCounter, ProgramCounterError, RegisterFile, SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
+use core::hint::cold_path;
 use core::marker::PhantomData;
 use core::ops::ControlFlow;
 
@@ -160,10 +161,12 @@ where
         pc: Address<I>,
     ) -> Result<ControlFlow<()>, ProgramCounterError<Address<I>, CustomError>> {
         if pc == self.return_trap_address {
+            cold_path();
             return Ok(ControlFlow::Break(()));
         }
 
         if !pc.as_u64().is_multiple_of(u64::from(I::alignment())) {
+            cold_path();
             return Err(ProgramCounterError::UnalignedInstruction { address: pc });
         }
 
@@ -184,7 +187,8 @@ where
         &mut self,
         memory: &Memory,
     ) -> Result<FetchInstructionResult<I>, ExecutionError<Address<I>, CustomError>> {
-        let instruction = memory.read(self.pc.as_u64()).or_else(|error| {
+        let instruction = match memory.read(self.pc.as_u64()).or_else(|error| {
+            cold_path();
             // Attempt to read a 16-bit compressed instruction
             if let Ok(instruction) = memory.read::<u16>(self.pc.as_u64())
                 && (instruction & 0b11) != 0b11
@@ -192,10 +196,18 @@ where
                 return Ok(u32::from(instruction));
             }
             Err(error)
-        })?;
+        }) {
+            Ok(instruction) => instruction,
+            Err(error) => {
+                cold_path();
+                return Err(ExecutionError::MemoryAccess(error));
+            }
+        };
 
-        let instruction = I::try_decode(instruction)
-            .ok_or(ExecutionError::IllegalInstruction { address: self.pc })?;
+        let Some(instruction) = I::try_decode(instruction) else {
+            cold_path();
+            return Err(ExecutionError::IllegalInstruction { address: self.pc });
+        };
         self.pc += instruction.size().into();
 
         Ok(FetchInstructionResult::Instruction(instruction))

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -259,12 +259,6 @@ pub trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder> 
 /// Execution errors
 #[derive(Debug, thiserror::Error)]
 pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder> {
-    /// Unaligned instruction fetch
-    #[error("Unaligned instruction fetch at address {address:#x}")]
-    UnalignedInstructionFetch {
-        /// Address of the unaligned instruction fetch
-        address: Address,
-    },
     /// Program counter error
     #[error("Program counter error: {0}")]
     ProgramCounter(#[from] ProgramCounterError<Address, CustomError>),


### PR DESCRIPTION
Now this finally added measurable performance boost outside noise:
```
blake3_hash_chunk/interpreter/eager
                        time:   [28.951 µs 29.196 µs 29.403 µs]
                        thrpt:  [33.214 MiB/s 33.449 MiB/s 33.732 MiB/s]
                 change:
                        time:   [−17.891% −17.043% −16.186%] (p = 0.00 < 0.05)
                        thrpt:  [+19.312% +20.544% +21.789%]
                        Performance has improved.

ed25519_verify/interpreter/eager
                        time:   [1.6695 ms 1.6754 ms 1.6806 ms]
                        thrpt:  [595.02  elem/s 596.88  elem/s 599.00  elem/s]
                 change:
                        time:   [−10.558% −9.1931% −7.6390%] (p = 0.00 < 0.05)
                        thrpt:  [+8.2708% +10.124% +11.805%]
                        Performance has improved.
```

Essentially treating all failure cases as "cold" because they are not really going to happen more than once during execution of the contract.