### PR TITLE
Reduce RISC-V instruction immediates

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -171,7 +171,7 @@ where
                 if regs.read(rs1) == regs.read(rs2) {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                     return program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
@@ -179,7 +179,7 @@ where
                 if regs.read(rs1) != regs.read(rs2) {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                     return program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
@@ -187,7 +187,7 @@ where
                 if regs.read(rs1).cast_signed() < regs.read(rs2).cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                     return program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
@@ -195,7 +195,7 @@ where
                 if regs.read(rs1).cast_signed() >= regs.read(rs2).cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                     return program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
@@ -203,7 +203,7 @@ where
                 if regs.read(rs1) < regs.read(rs2) {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                     return program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
@@ -211,18 +211,18 @@ where
                 if regs.read(rs1) >= regs.read(rs2) {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                     return program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
                         .map_err(ExecutionError::from);
                 }
             }
 
             Self::Lui { rd, imm } => {
-                regs.write(rd, imm.cast_unsigned());
+                regs.write(rd, imm.to_i32().cast_unsigned());
             }
 
             Self::Auipc { rd, imm } => {
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                regs.write(rd, old_pc.wrapping_add(imm.cast_unsigned()));
+                regs.write(rd, old_pc.wrapping_add(imm.to_i32().cast_unsigned()));
             }
 
             Self::Jal { rd, imm } => {
@@ -230,7 +230,7 @@ where
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 regs.write(rd, pc);
                 return program_counter
-                    .set_pc(memory, old_pc.wrapping_add(imm.cast_unsigned()))
+                    .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
                     .map_err(ExecutionError::from);
             }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -71,7 +71,7 @@ where
                 regs.write(Reg::SP, value);
             }
             Self::CLui { rd, nzimm } => {
-                regs.write(rd, nzimm.cast_unsigned());
+                regs.write(rd, nzimm.to_i32().cast_unsigned());
             }
             Self::CSrli { rd, shamt } => {
                 let value = regs.read(rd) >> shamt;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
@@ -185,7 +185,7 @@ fn test_caddi16sp_negative() {
 fn test_clui() {
     let mut state = initialize_state([Rv32ZcaInstruction::CLui {
         rd: Reg::A0,
-        nzimm: 0x1000,
+        nzimm: I24::from_i32(0x1000),
     }]);
     execute(&mut state).unwrap();
     assert_eq!(state.regs.read(Reg::A0), 0x1000);

--- a/crates/execution/ab-riscv-interpreter/src/rv32/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/tests.rs
@@ -561,7 +561,7 @@ fn test_beq_taken() {
     let mut state = initialize_state([Rv32Instruction::Beq {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 8,
+        imm: I24::from_i32(8),
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -582,7 +582,7 @@ fn test_beq_not_taken() {
         Rv32Instruction::Beq {
             rs1: Reg::A0,
             rs2: Reg::A1,
-            imm: 8,
+            imm: I24::from_i32(8),
         },
         Rv32Instruction::Addi {
             rd: Reg::A2,
@@ -606,7 +606,7 @@ fn test_bne_taken() {
     let mut state = initialize_state([Rv32Instruction::Bne {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 8,
+        imm: I24::from_i32(8),
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -626,7 +626,7 @@ fn test_blt_taken() {
     let mut state = initialize_state([Rv32Instruction::Blt {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 12,
+        imm: I24::from_i32(12),
     }]);
 
     state.regs.write(Reg::A0, (-10i32).cast_unsigned());
@@ -646,7 +646,7 @@ fn test_bge_taken() {
     let mut state = initialize_state([Rv32Instruction::Bge {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 16,
+        imm: I24::from_i32(16),
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -666,7 +666,7 @@ fn test_bltu_taken() {
     let mut state = initialize_state([Rv32Instruction::Bltu {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 20,
+        imm: I24::from_i32(20),
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -686,7 +686,7 @@ fn test_bgeu_taken() {
     let mut state = initialize_state([Rv32Instruction::Bgeu {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 24,
+        imm: I24::from_i32(24),
     }]);
 
     state.regs.write(Reg::A0, 20);
@@ -709,7 +709,7 @@ fn test_jal() {
         Rv32Instruction::Jal {
             rd: Reg::Ra,
             // Skip next instruction
-            imm: 8,
+            imm: I24::from_i32(8),
         },
         Rv32Instruction::Addi {
             rd: Reg::A2,
@@ -808,7 +808,7 @@ fn test_lui() {
     let mut state = initialize_state([Rv32Instruction::Lui {
         rd: Reg::A0,
         // Already shifted - bits [31:12]
-        imm: 0x12345000u32.cast_signed(),
+        imm: I24WithZeroedBits::from_i32(0x12345000u32.cast_signed()),
     }]);
 
     execute(&mut state).unwrap();
@@ -820,7 +820,7 @@ fn test_lui() {
 fn test_lui_negative() {
     let mut state = initialize_state([Rv32Instruction::Lui {
         rd: Reg::A0,
-        imm: 0xfffff000u32.cast_signed(),
+        imm: I24WithZeroedBits::from_i32(0xfffff000u32.cast_signed()),
     }]);
 
     execute(&mut state).unwrap();
@@ -834,7 +834,7 @@ fn test_auipc() {
     let mut state = initialize_state([Rv32Instruction::Auipc {
         rd: Reg::A0,
         // Already shifted - bits [31:12]
-        imm: 0x12345000u32.cast_signed(),
+        imm: I24WithZeroedBits::from_i32(0x12345000u32.cast_signed()),
     }]);
 
     let initial_pc = state.instruction_fetcher.get_pc();
@@ -851,7 +851,7 @@ fn test_auipc() {
 fn test_auipc_negative() {
     let mut state = initialize_state([Rv32Instruction::Auipc {
         rd: Reg::A0,
-        imm: 0xfffff000u32.cast_signed(),
+        imm: I24WithZeroedBits::from_i32(0xfffff000u32.cast_signed()),
     }]);
 
     let initial_pc = state.instruction_fetcher.get_pc();

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
@@ -10,7 +10,7 @@ pub fn do_push<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
-    stack_adj: u32,
+    stack_adj: u8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: ZcmpRegister<Type = u32>,
@@ -24,7 +24,7 @@ where
         memory.write(store_addr, regs.read(reg))?;
         store_addr = store_addr.wrapping_sub(size_of::<Reg::Type>() as u64);
     }
-    regs.write(Reg::SP, sp.wrapping_sub(stack_adj));
+    regs.write(Reg::SP, sp.wrapping_sub(u32::from(stack_adj)));
     Ok(())
 }
 
@@ -36,7 +36,7 @@ pub fn do_pop<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
-    stack_adj: u32,
+    stack_adj: u8,
 ) -> Result<u32, ExecutionError<Reg::Type, CustomError>>
 where
     Reg: ZcmpRegister<Type = u32>,
@@ -44,7 +44,7 @@ where
     Memory: VirtualMemory,
 {
     let sp = regs.read(Reg::SP);
-    let new_sp = sp.wrapping_add(stack_adj);
+    let new_sp = sp.wrapping_add(u32::from(stack_adj));
     // Restore from [new_sp-4, new_sp-8, ...], matching push order
     let mut load_addr = u64::from(new_sp.wrapping_sub(size_of::<Reg::Type>() as u32));
     for reg in urlist.reg_list() {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca/tests.rs
@@ -164,7 +164,7 @@ fn test_caddi16sp_negative() {
 fn test_clui() {
     let mut state = initialize_state([Rv64ZcaInstruction::CLui {
         rd: Reg::A0,
-        nzimm: 0x1000,
+        nzimm: I24::from_i32(0x1000),
     }]);
     execute(&mut state).unwrap();
     assert_eq!(state.regs.read(Reg::A0), 0x1000);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/tests.rs
@@ -743,7 +743,7 @@ fn test_beq_taken() {
         rs1: Reg::A0,
         rs2: Reg::A1,
         // Branch offset from PC before increment
-        imm: 8,
+        imm: I24::from_i32(8),
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -767,7 +767,7 @@ fn test_beq_not_taken() {
         Rv64Instruction::Beq {
             rs1: Reg::A0,
             rs2: Reg::A1,
-            imm: 8,
+            imm: I24::from_i32(8),
         },
         Rv64Instruction::Addi {
             rd: Reg::A2,
@@ -791,7 +791,7 @@ fn test_bne_taken() {
     let mut state = initialize_state([Rv64Instruction::Bne {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 8,
+        imm: I24::from_i32(8),
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -811,7 +811,7 @@ fn test_blt_taken() {
     let mut state = initialize_state([Rv64Instruction::Blt {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 12,
+        imm: I24::from_i32(12),
     }]);
 
     state.regs.write(Reg::A0, (-10i64).cast_unsigned());
@@ -831,7 +831,7 @@ fn test_bge_taken() {
     let mut state = initialize_state([Rv64Instruction::Bge {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 16,
+        imm: I24::from_i32(16),
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -851,7 +851,7 @@ fn test_bltu_taken() {
     let mut state = initialize_state([Rv64Instruction::Bltu {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 20,
+        imm: I24::from_i32(20),
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -871,7 +871,7 @@ fn test_bgeu_taken() {
     let mut state = initialize_state([Rv64Instruction::Bgeu {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: 24,
+        imm: I24::from_i32(24),
     }]);
 
     state.regs.write(Reg::A0, 20);
@@ -894,7 +894,7 @@ fn test_jal() {
         Rv64Instruction::Jal {
             rd: Reg::Ra,
             // Skip next instruction
-            imm: 8,
+            imm: I24::from_i32(8),
         },
         Rv64Instruction::Addi {
             rd: Reg::A2,
@@ -993,7 +993,7 @@ fn test_lui() {
     let mut state = initialize_state([Rv64Instruction::Lui {
         rd: Reg::A0,
         // Already shifted - bits [31:12]
-        imm: 0x12345000,
+        imm: I24WithZeroedBits::from_i32(0x12345000),
     }]);
 
     execute(&mut state).unwrap();
@@ -1006,7 +1006,7 @@ fn test_lui_negative() {
     let mut state = initialize_state([Rv64Instruction::Lui {
         rd: Reg::A0,
         // 0xFFFFF000 as upper 20 bits (already shifted)
-        imm: 0xfffff000u32.cast_signed(),
+        imm: I24WithZeroedBits::from_i32(0xfffff000u32.cast_signed()),
     }]);
 
     execute(&mut state).unwrap();
@@ -1020,7 +1020,7 @@ fn test_auipc() {
     let mut state = initialize_state([Rv64Instruction::Auipc {
         rd: Reg::A0,
         // Already shifted - bits [31:12]
-        imm: 0x12345000,
+        imm: I24WithZeroedBits::from_i32(0x12345000),
     }]);
 
     let initial_pc = state.instruction_fetcher.get_pc();
@@ -1038,7 +1038,7 @@ fn test_auipc_negative() {
     let mut state = initialize_state([Rv64Instruction::Auipc {
         rd: Reg::A0,
         // Negative immediate (all upper bits set)
-        imm: 0xfffff000u32.cast_signed(),
+        imm: I24WithZeroedBits::from_i32(0xfffff000u32.cast_signed()),
     }]);
 
     let initial_pc = state.instruction_fetcher.get_pc();

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
@@ -10,7 +10,7 @@ pub fn do_push<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
-    stack_adj: u32,
+    stack_adj: u8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: ZcmpRegister<Type = u64>,
@@ -36,7 +36,7 @@ pub fn do_pop<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
-    stack_adj: u32,
+    stack_adj: u8,
 ) -> Result<u64, ExecutionError<Reg::Type, CustomError>>
 where
     Reg: ZcmpRegister<Type = u64>,

--- a/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
@@ -10,7 +10,10 @@ use std::rc::Rc;
 use std::{env, fs};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{Error, Ident, ItemEnum, Meta, Token, Variant, bracketed, parse_file, parse_str, parse2};
+use syn::{
+    Error, Ident, ItemEnum, Meta, Token, Variant, bracketed, parse_file, parse_quote, parse_str,
+    parse2,
+};
 
 const ENUM_DEFINITION_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_DEFINITION_PATH";
 const ENUM_DEPENDENCIES_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_DEPENDENCIES";
@@ -210,6 +213,23 @@ pub(super) fn process_enum_definition(
             // Restore documentation attributes
             item_enum.attrs.push(removed_attribute);
         }
+    }
+
+    let has_repr_align = item_enum.attrs.iter().any(|attr| {
+        if !attr.path().is_ident("repr") {
+            return false;
+        }
+        // Parse the repr(...) token stream and look for align(...)
+        attr.parse_args_with(|input: ParseStream<'_>| {
+            let nested = input.parse_terminated(Meta::parse, Token![,])?;
+            Ok(nested.iter().any(|meta| meta.path().is_ident("align")))
+        })
+        .unwrap_or_default()
+    });
+
+    if !has_repr_align {
+        // Alignment improves performance significantly during execution
+        item_enum.attrs.push(parse_quote! { #[repr(align(4))] });
     }
 
     let dependencies = match attribute.meta {

--- a/crates/execution/ab-riscv-primitives/src/instructions.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions.rs
@@ -4,6 +4,7 @@ pub mod rv32;
 pub mod rv64;
 #[cfg(test)]
 mod test_utils;
+pub mod utils;
 pub mod v;
 pub mod zicond;
 pub mod zicsr;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
@@ -9,6 +9,7 @@ pub mod zce;
 pub mod zk;
 
 use crate::instructions::Instruction;
+use crate::instructions::utils::{I24, I24WithZeroedBits};
 use crate::registers::general_purpose::Register;
 use ab_riscv_macros::instruction;
 use core::fmt;
@@ -56,21 +57,21 @@ pub enum Rv32Instruction<Reg> {
     Sw { rs2: Reg, rs1: Reg, imm: i16 },
 
     // B-type
-    Beq { rs1: Reg, rs2: Reg, imm: i32 },
-    Bne { rs1: Reg, rs2: Reg, imm: i32 },
-    Blt { rs1: Reg, rs2: Reg, imm: i32 },
-    Bge { rs1: Reg, rs2: Reg, imm: i32 },
-    Bltu { rs1: Reg, rs2: Reg, imm: i32 },
-    Bgeu { rs1: Reg, rs2: Reg, imm: i32 },
+    Beq { rs1: Reg, rs2: Reg, imm: I24 },
+    Bne { rs1: Reg, rs2: Reg, imm: I24 },
+    Blt { rs1: Reg, rs2: Reg, imm: I24 },
+    Bge { rs1: Reg, rs2: Reg, imm: I24 },
+    Bltu { rs1: Reg, rs2: Reg, imm: I24 },
+    Bgeu { rs1: Reg, rs2: Reg, imm: I24 },
 
     // Lui (U-type)
-    Lui { rd: Reg, imm: i32 },
+    Lui { rd: Reg, imm: I24WithZeroedBits<12> },
 
     // Auipc (U-type)
-    Auipc { rd: Reg, imm: i32 },
+    Auipc { rd: Reg, imm: I24WithZeroedBits<12> },
 
     // Jal (J-type)
-    Jal { rd: Reg, imm: i32 },
+    Jal { rd: Reg, imm: I24 },
 
     // Fence
     Fence { pred: u8, succ: u8 },
@@ -204,7 +205,7 @@ where
                 let imm11 = ((instruction >> 7) & 1).cast_signed();
                 let imm = (imm12 << 12) | (imm11 << 11) | (imm10_5 << 5) | (imm4_1 << 1);
                 // Sign extend
-                let imm = (imm << 19) >> 19;
+                let imm = I24::from_i32((imm << 19) >> 19);
                 match funct3 {
                     0b000 => Some(Self::Beq { rs1, rs2, imm }),
                     0b001 => Some(Self::Bne { rs1, rs2, imm }),
@@ -218,13 +219,13 @@ where
             // Lui (U-type)
             0b0110111 => {
                 let rd = Reg::from_bits(rd_bits)?;
-                let imm = (instruction & 0xffff_f000).cast_signed();
+                let imm = I24WithZeroedBits::from_i32((instruction & 0xffff_f000).cast_signed());
                 Some(Self::Lui { rd, imm })
             }
             // Auipc (U-type)
             0b0010111 => {
                 let rd = Reg::from_bits(rd_bits)?;
-                let imm = (instruction & 0xffff_f000).cast_signed();
+                let imm = I24WithZeroedBits::from_i32((instruction & 0xffff_f000).cast_signed());
                 Some(Self::Auipc { rd, imm })
             }
             // Jal (J-type)
@@ -236,7 +237,7 @@ where
                 let imm19_12 = ((instruction >> 12) & 0b1111_1111).cast_signed();
                 let imm = (imm20 << 20) | (imm19_12 << 12) | (imm11 << 11) | (imm10_1 << 1);
                 // Sign extend
-                let imm = (imm << 11) >> 11;
+                let imm = I24::from_i32((imm << 11) >> 11);
                 Some(Self::Jal { rd, imm })
             }
             // Fence (I-type like, simplified for EM)

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
@@ -4,6 +4,7 @@
 mod tests;
 
 use crate::instructions::Instruction;
+use crate::instructions::utils::I24;
 use crate::registers::general_purpose::Register;
 use ab_riscv_macros::instruction;
 use core::fmt;
@@ -33,7 +34,7 @@ pub enum Rv32ZcaInstruction<Reg> {
     /// C.ADDI16SP  sp += nzimm  (nzimm != 0)
     CAddi16sp { nzimm: i16 },
     /// C.LUI  rd = sext(nzimm << 12)  (rd != x0, rd != x2, nzimm != 0)
-    CLui { rd: Reg, nzimm: i32 },
+    CLui { rd: Reg, nzimm: I24 },
     /// C.SRLI  rd' >>= shamt  (logical, 5-bit shamt; shamt=0 is a HINT)
     CSrli { rd: Reg, shamt: u8 },
     /// C.SRAI  rd' >>= shamt  (arithmetic, 5-bit shamt; shamt=0 is a HINT)
@@ -283,7 +284,7 @@ where
                             None?;
                         }
                         // Sign-extend from bit 17 (18-bit nzimm -> i32)
-                        let nzimm = (raw << 14) >> 14;
+                        let nzimm = I24::from_i32((raw << 14) >> 14);
                         Some(Self::CLui { rd, nzimm })
                     }
                 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca/tests.rs
@@ -3,6 +3,7 @@
 
 use crate::instructions::Instruction;
 use crate::instructions::rv32::c::zca::Rv32ZcaInstruction;
+use crate::instructions::utils::I24;
 use crate::registers::general_purpose::{EReg, Reg};
 
 /// Build a CIW (C.ADDI4SPN) encoding.
@@ -406,7 +407,7 @@ fn test_clui() {
         decoded,
         Rv32ZcaInstruction::CLui {
             rd: Reg::A0,
-            nzimm: 0x1000
+            nzimm: I24::from_i32(0x1000)
         }
     );
 }
@@ -420,7 +421,7 @@ fn test_clui_negative() {
         decoded,
         Rv32ZcaInstruction::CLui {
             rd: Reg::A0,
-            nzimm: -4096
+            nzimm: I24::from_i32(-4096)
         }
     );
 }
@@ -440,7 +441,7 @@ fn test_clui_hint_rd0_positive() {
         decoded,
         Rv32ZcaInstruction::CLui {
             rd: Reg::Zero,
-            nzimm: 0x1000
+            nzimm: I24::from_i32(0x1000)
         }
     );
 }
@@ -454,7 +455,7 @@ fn test_clui_hint_rd0_negative() {
         decoded,
         Rv32ZcaInstruction::CLui {
             rd: Reg::Zero,
-            nzimm: -4096
+            nzimm: I24::from_i32(-4096)
         }
     );
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/tests.rs
@@ -5,6 +5,7 @@ use crate::instructions::rv32::Rv32Instruction;
 use crate::instructions::test_utils::{
     make_b_type, make_i_type, make_j_type, make_r_type, make_s_type, make_u_type,
 };
+use crate::instructions::utils::{I24, I24WithZeroedBits};
 use crate::registers::general_purpose::{EReg, Reg};
 
 // R-type
@@ -655,7 +656,7 @@ fn test_beq() {
             Rv32Instruction::Beq {
                 rs1: Reg::Ra,
                 rs2: Reg::Sp,
-                imm: 0x100
+                imm: I24::from_i32(0x100)
             }
         );
     }
@@ -669,7 +670,7 @@ fn test_beq() {
             Rv32Instruction::Beq {
                 rs1: Reg::Ra,
                 rs2: Reg::Sp,
-                imm: -8
+                imm: I24::from_i32(-8)
             }
         );
     }
@@ -684,7 +685,7 @@ fn test_bne() {
         Rv32Instruction::Bne {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -698,7 +699,7 @@ fn test_blt() {
         Rv32Instruction::Blt {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -712,7 +713,7 @@ fn test_bge() {
         Rv32Instruction::Bge {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -726,7 +727,7 @@ fn test_bltu() {
         Rv32Instruction::Bltu {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -740,7 +741,7 @@ fn test_bgeu() {
         Rv32Instruction::Bgeu {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -755,7 +756,7 @@ fn test_lui() {
         decoded,
         Rv32Instruction::Lui {
             rd: Reg::Ra,
-            imm: 0x12345000
+            imm: I24WithZeroedBits::from_i32(0x12345000)
         }
     );
 }
@@ -770,7 +771,7 @@ fn test_auipc() {
         decoded,
         Rv32Instruction::Auipc {
             rd: Reg::Ra,
-            imm: 0x12345000
+            imm: I24WithZeroedBits::from_i32(0x12345000)
         }
     );
 }
@@ -787,7 +788,7 @@ fn test_jal() {
             decoded,
             Rv32Instruction::Jal {
                 rd: Reg::Ra,
-                imm: 0x1000
+                imm: I24::from_i32(0x1000)
             }
         );
     }
@@ -800,7 +801,7 @@ fn test_jal() {
             decoded,
             Rv32Instruction::Jal {
                 rd: Reg::Ra,
-                imm: -0x1000
+                imm: I24::from_i32(-0x1000)
             }
         );
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
@@ -188,7 +188,7 @@ where
     ///
     /// Values sourced from the Zcmp spec Table 3.
     #[inline(always)]
-    pub const fn stack_adj_base(self) -> u32 {
+    pub const fn stack_adj_base(self) -> u8 {
         match Reg::XLEN {
             // RV32: each register is 4 bytes; base = ceil(n_regs * 4 / 16) * 16
             Self::XLEN_32 => match self.inner {
@@ -250,22 +250,22 @@ pub enum Rv32ZcmpInstruction<Reg> {
     /// `stack_adj = urlist.stack_adj_base() + spimm * 16` from the encoding.
     CmPush {
         urlist: ZcmpUrlist<Reg>,
-        stack_adj: u32,
+        stack_adj: u8,
     },
     /// CM.POP - pop reg_list, increment sp by `stack_adj` (no return)
     CmPop {
         urlist: ZcmpUrlist<Reg>,
-        stack_adj: u32,
+        stack_adj: u8,
     },
     /// CM.POPRETZ - pop reg_list, set a0=0, increment sp, return
     CmPopretz {
         urlist: ZcmpUrlist<Reg>,
-        stack_adj: u32,
+        stack_adj: u8,
     },
     /// CM.POPRET - pop reg_list, increment sp, return
     CmPopret {
         urlist: ZcmpUrlist<Reg>,
-        stack_adj: u32,
+        stack_adj: u8,
     },
     /// CM.MVA01S - a0 = r1s', a1 = r2s'
     CmMva01s { r1s: Reg, r2s: Reg },
@@ -309,7 +309,7 @@ where
             0b11 => {
                 let op_sel = ((inst >> 9) & 0b11) as u8;
                 let urlist = ZcmpUrlist::try_from_raw(((inst >> 4) & 0xf) as u8)?;
-                let spimm = ((inst >> 2) & 0b11) as u32;
+                let spimm = ((inst >> 2) & 0b11) as u8;
                 let stack_adj = urlist.stack_adj_base() + spimm * 16;
                 match op_sel {
                     0b00 => Some(Self::CmPush { urlist, stack_adj }),

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp/tests.rs
@@ -35,7 +35,7 @@ const MV_FUNCT2_MVA01S: u16 = 0b11;
 const MV_FUNCT2_MVSA01: u16 = 0b01;
 
 /// Compute the expected stack_adj for a given urlist raw value and spimm.
-fn expected_stack_adj(urlist_raw: u8, spimm: u32) -> u32 {
+fn expected_stack_adj(urlist_raw: u8, spimm: u8) -> u8 {
     ZcmpUrlist::<Reg<u32>>::try_from_raw(urlist_raw)
         .unwrap()
         .stack_adj_base()

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
@@ -9,6 +9,7 @@ pub mod zce;
 pub mod zk;
 
 use crate::instructions::Instruction;
+use crate::instructions::utils::{I24, I24WithZeroedBits};
 use crate::registers::general_purpose::Register;
 use ab_riscv_macros::instruction;
 use core::fmt;
@@ -72,21 +73,21 @@ pub enum Rv64Instruction<Reg> {
     Sd { rs2: Reg, rs1: Reg, imm: i16 },
 
     // B-type
-    Beq { rs1: Reg, rs2: Reg, imm: i32 },
-    Bne { rs1: Reg, rs2: Reg, imm: i32 },
-    Blt { rs1: Reg, rs2: Reg, imm: i32 },
-    Bge { rs1: Reg, rs2: Reg, imm: i32 },
-    Bltu { rs1: Reg, rs2: Reg, imm: i32 },
-    Bgeu { rs1: Reg, rs2: Reg, imm: i32 },
+    Beq { rs1: Reg, rs2: Reg, imm: I24 },
+    Bne { rs1: Reg, rs2: Reg, imm: I24 },
+    Blt { rs1: Reg, rs2: Reg, imm: I24 },
+    Bge { rs1: Reg, rs2: Reg, imm: I24 },
+    Bltu { rs1: Reg, rs2: Reg, imm: I24 },
+    Bgeu { rs1: Reg, rs2: Reg, imm: I24 },
 
     // Lui (U-type)
-    Lui { rd: Reg, imm: i32 },
+    Lui { rd: Reg, imm: I24WithZeroedBits<12> },
 
     // Auipc (U-type)
-    Auipc { rd: Reg, imm: i32 },
+    Auipc { rd: Reg, imm: I24WithZeroedBits<12> },
 
     // Jal (J-type)
-    Jal { rd: Reg, imm: i32 },
+    Jal { rd: Reg, imm: I24 },
 
     // Fence
     Fence { pred: u8, succ: u8 },
@@ -261,7 +262,7 @@ where
                 let imm11 = ((instruction >> 7) & 1).cast_signed();
                 let imm = (imm12 << 12) | (imm11 << 11) | (imm10_5 << 5) | (imm4_1 << 1);
                 // Sign extend
-                let imm = (imm << 19) >> 19;
+                let imm = I24::from_i32((imm << 19) >> 19);
                 match funct3 {
                     0b000 => Some(Self::Beq { rs1, rs2, imm }),
                     0b001 => Some(Self::Bne { rs1, rs2, imm }),
@@ -275,13 +276,13 @@ where
             // Lui (U-type)
             0b0110111 => {
                 let rd = Reg::from_bits(rd_bits)?;
-                let imm = (instruction & 0xffff_f000).cast_signed();
+                let imm = I24WithZeroedBits::from_i32((instruction & 0xffff_f000).cast_signed());
                 Some(Self::Lui { rd, imm })
             }
             // Auipc (U-type)
             0b0010111 => {
                 let rd = Reg::from_bits(rd_bits)?;
-                let imm = (instruction & 0xffff_f000).cast_signed();
+                let imm = I24WithZeroedBits::from_i32((instruction & 0xffff_f000).cast_signed());
                 Some(Self::Auipc { rd, imm })
             }
             // Jal (J-type)
@@ -293,7 +294,7 @@ where
                 let imm19_12 = ((instruction >> 12) & 0b1111_1111).cast_signed();
                 let imm = (imm20 << 20) | (imm19_12 << 12) | (imm11 << 11) | (imm10_1 << 1);
                 // Sign extend
-                let imm = (imm << 11) >> 11;
+                let imm = I24::from_i32((imm << 11) >> 11);
                 Some(Self::Jal { rd, imm })
             }
             // Fence (I-type like, simplified for EM)

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
@@ -4,6 +4,7 @@
 mod tests;
 
 use crate::instructions::Instruction;
+use crate::instructions::utils::I24;
 use crate::registers::general_purpose::Register;
 use ab_riscv_macros::instruction;
 use core::fmt;
@@ -37,7 +38,7 @@ pub enum Rv64ZcaInstruction<Reg> {
     /// C.ADDI16SP  sp += nzimm*16  (nzimm != 0)
     CAddi16sp { nzimm: i16 },
     /// C.LUI  rd = sext(nzimm << 12)  (rd != x0, rd != x2, nzimm != 0)
-    CLui { rd: Reg, nzimm: i32 },
+    CLui { rd: Reg, nzimm: I24 },
     /// C.SRLI  rd' >>= shamt  (logical right shift; shamt=0 with rd'=x0 is a HINT)
     CSrli { rd: Reg, shamt: u8 },
     /// C.SRAI  rd' >>= shamt  (arithmetic right shift; shamt=0 with rd'=x0 is a HINT)
@@ -325,7 +326,7 @@ where
                             None?;
                         }
                         // Sign-extend from bit 17 (18-bit nzimm -> i32)
-                        let nzimm = (raw << 14) >> 14;
+                        let nzimm = I24::from_i32((raw << 14) >> 14);
                         Some(Self::CLui { rd, nzimm })
                     }
                 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca/tests.rs
@@ -3,6 +3,7 @@
 
 use crate::instructions::Instruction;
 use crate::instructions::rv64::c::zca::Rv64ZcaInstruction;
+use crate::instructions::utils::I24;
 use crate::registers::general_purpose::{EReg, Reg};
 
 /// Build a CIW (C.ADDI4SPN) encoding.
@@ -441,7 +442,7 @@ fn test_clui() {
         decoded,
         Rv64ZcaInstruction::CLui {
             rd: Reg::A0,
-            nzimm: 0x1000
+            nzimm: I24::from_i32(0x1000)
         }
     );
 }
@@ -455,7 +456,7 @@ fn test_clui_negative() {
         decoded,
         Rv64ZcaInstruction::CLui {
             rd: Reg::A0,
-            nzimm: -4096
+            nzimm: I24::from_i32(-4096)
         }
     );
 }
@@ -475,7 +476,7 @@ fn test_clui_hint_rd0_positive() {
         decoded,
         Rv64ZcaInstruction::CLui {
             rd: Reg::Zero,
-            nzimm: 0x1000
+            nzimm: I24::from_i32(0x1000)
         }
     );
 }
@@ -489,7 +490,7 @@ fn test_clui_hint_rd0_negative() {
         decoded,
         Rv64ZcaInstruction::CLui {
             rd: Reg::Zero,
-            nzimm: -4096
+            nzimm: I24::from_i32(-4096)
         }
     );
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/tests.rs
@@ -5,6 +5,7 @@ use crate::instructions::rv64::Rv64Instruction;
 use crate::instructions::test_utils::{
     make_b_type, make_i_type, make_j_type, make_r_type, make_s_type, make_u_type,
 };
+use crate::instructions::utils::{I24, I24WithZeroedBits};
 use crate::registers::general_purpose::{EReg, Reg};
 
 // R-type
@@ -883,7 +884,7 @@ fn test_beq() {
             Rv64Instruction::Beq {
                 rs1: Reg::Ra,
                 rs2: Reg::Sp,
-                imm: 0x100
+                imm: I24::from_i32(0x100)
             }
         );
     }
@@ -897,7 +898,7 @@ fn test_beq() {
             Rv64Instruction::Beq {
                 rs1: Reg::Ra,
                 rs2: Reg::Sp,
-                imm: -8
+                imm: I24::from_i32(-8)
             }
         );
     }
@@ -912,7 +913,7 @@ fn test_bne() {
         Rv64Instruction::Bne {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -926,7 +927,7 @@ fn test_blt() {
         Rv64Instruction::Blt {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -940,7 +941,7 @@ fn test_bge() {
         Rv64Instruction::Bge {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -954,7 +955,7 @@ fn test_bltu() {
         Rv64Instruction::Bltu {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -968,7 +969,7 @@ fn test_bgeu() {
         Rv64Instruction::Bgeu {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: 0x100
+            imm: I24::from_i32(0x100)
         }
     );
 }
@@ -983,7 +984,7 @@ fn test_lui() {
         decoded,
         Rv64Instruction::Lui {
             rd: Reg::Ra,
-            imm: 0x12345000
+            imm: I24WithZeroedBits::from_i32(0x12345000)
         }
     );
 }
@@ -998,7 +999,7 @@ fn test_auipc() {
         decoded,
         Rv64Instruction::Auipc {
             rd: Reg::Ra,
-            imm: 0x12345000
+            imm: I24WithZeroedBits::from_i32(0x12345000)
         }
     );
 }
@@ -1015,7 +1016,7 @@ fn test_jal() {
             decoded,
             Rv64Instruction::Jal {
                 rd: Reg::Ra,
-                imm: 0x1000
+                imm: I24::from_i32(0x1000)
             }
         );
     }
@@ -1028,7 +1029,7 @@ fn test_jal() {
             decoded,
             Rv64Instruction::Jal {
                 rd: Reg::Ra,
-                imm: -0x1000
+                imm: I24::from_i32(-0x1000)
             }
         );
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
@@ -18,22 +18,22 @@ pub enum Rv64ZcmpInstruction<Reg> {
     /// `stack_adj = urlist.stack_adj_base() + spimm * 16` from the encoding.
     CmPush {
         urlist: ZcmpUrlist<Reg>,
-        stack_adj: u32,
+        stack_adj: u8,
     },
     /// CM.POP - pop reg_list, increment sp by `stack_adj` (no return)
     CmPop {
         urlist: ZcmpUrlist<Reg>,
-        stack_adj: u32,
+        stack_adj: u8,
     },
     /// CM.POPRETZ - pop reg_list, set a0=0, increment sp, return
     CmPopretz {
         urlist: ZcmpUrlist<Reg>,
-        stack_adj: u32,
+        stack_adj: u8,
     },
     /// CM.POPRET - pop reg_list, increment sp, return
     CmPopret {
         urlist: ZcmpUrlist<Reg>,
-        stack_adj: u32,
+        stack_adj: u8,
     },
     /// CM.MVA01S - a0 = r1s', a1 = r2s'
     CmMva01s { r1s: Reg, r2s: Reg },
@@ -77,7 +77,7 @@ where
             0b11 => {
                 let op_sel = ((inst >> 9) & 0b11) as u8;
                 let urlist = ZcmpUrlist::try_from_raw(((inst >> 4) & 0xf) as u8)?;
-                let spimm = ((inst >> 2) & 0b11) as u32;
+                let spimm = ((inst >> 2) & 0b11) as u8;
                 let stack_adj = urlist.stack_adj_base() + spimm * 16;
                 match op_sel {
                     0b00 => Some(Self::CmPush { urlist, stack_adj }),

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp/tests.rs
@@ -35,7 +35,7 @@ const MV_FUNCT2_MVA01S: u16 = 0b11;
 const MV_FUNCT2_MVSA01: u16 = 0b01;
 
 /// Compute the expected stack_adj for a given urlist raw value and spimm.
-fn expected_stack_adj(urlist_raw: u8, spimm: u32) -> u32 {
+fn expected_stack_adj(urlist_raw: u8, spimm: u8) -> u8 {
     ZcmpUrlist::<Reg<u64>>::try_from_raw(urlist_raw)
         .unwrap()
         .stack_adj_base()

--- a/crates/execution/ab-riscv-primitives/src/instructions/utils.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/utils.rs
@@ -1,0 +1,331 @@
+//! Utility types
+
+#[cfg(test)]
+mod tests;
+
+use core::fmt;
+use core::ops::{Shl, Shr};
+
+/// New type for unsigned integers that stores 24-bit numbers
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct U24([u8; 3]);
+
+impl fmt::Debug for U24 {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.to_u32(), f)
+    }
+}
+
+impl fmt::Display for U24 {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.to_u32(), f)
+    }
+}
+
+impl fmt::LowerHex for U24 {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.to_u32(), f)
+    }
+}
+
+impl fmt::UpperHex for U24 {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.to_u32(), f)
+    }
+}
+
+impl const Shl<u8> for U24 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shl(self, rhs: u8) -> Self::Output {
+        Self::from_u32(self.to_u32().shl(rhs))
+    }
+}
+
+impl const Shr<u8> for U24 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shr(self, rhs: u8) -> Self::Output {
+        Self::from_u32(self.to_u32().shr(rhs))
+    }
+}
+
+impl const Shl<u8> for &U24 {
+    type Output = U24;
+
+    #[inline(always)]
+    fn shl(self, rhs: u8) -> Self::Output {
+        U24::from_u32(self.to_u32().shl(rhs))
+    }
+}
+
+impl const Shr<u8> for &U24 {
+    type Output = U24;
+
+    #[inline(always)]
+    fn shr(self, rhs: u8) -> Self::Output {
+        U24::from_u32(self.to_u32().shr(rhs))
+    }
+}
+
+impl From<U24> for u32 {
+    #[inline(always)]
+    fn from(v: U24) -> Self {
+        v.to_u32()
+    }
+}
+
+impl From<U24> for u64 {
+    #[inline(always)]
+    fn from(v: U24) -> Self {
+        u64::from(v.to_u32())
+    }
+}
+
+impl U24 {
+    /// Create a new `U24` from an unsigned 32-bit integer.
+    ///
+    /// The input value is truncated to 24 bits, providing larger value panics in a debug build.
+    #[inline(always)]
+    pub const fn from_u32(v: u32) -> Self {
+        let b = v.to_le_bytes();
+        debug_assert!(
+            (v << u8::BITS) >> u8::BITS == v,
+            "Input value exceeds 24 bits"
+        );
+        Self([b[0], b[1], b[2]])
+    }
+
+    /// Convert to an unsigned 32-bit integer
+    #[inline(always)]
+    pub const fn to_u32(self) -> u32 {
+        let [a, b, c] = self.0;
+        u32::from_le_bytes([a, b, c, 0])
+    }
+}
+
+/// New type for signed integers that stores 24-bit numbers
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct I24([u8; 3]);
+
+impl fmt::Debug for I24 {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.to_i32(), f)
+    }
+}
+
+impl fmt::Display for I24 {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.to_i32(), f)
+    }
+}
+
+impl fmt::LowerHex for I24 {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.to_i32(), f)
+    }
+}
+
+impl fmt::UpperHex for I24 {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.to_i32(), f)
+    }
+}
+
+impl const Shl<u8> for I24 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shl(self, rhs: u8) -> Self::Output {
+        Self::from_i32(self.to_i32().shl(rhs))
+    }
+}
+
+impl const Shr<u8> for I24 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shr(self, rhs: u8) -> Self::Output {
+        Self::from_i32(self.to_i32().shr(rhs))
+    }
+}
+
+impl const Shl<u8> for &I24 {
+    type Output = I24;
+
+    #[inline(always)]
+    fn shl(self, rhs: u8) -> Self::Output {
+        I24::from_i32(self.to_i32().shl(rhs))
+    }
+}
+
+impl const Shr<u8> for &I24 {
+    type Output = I24;
+
+    #[inline(always)]
+    fn shr(self, rhs: u8) -> Self::Output {
+        I24::from_i32(self.to_i32().shr(rhs))
+    }
+}
+
+impl From<I24> for i32 {
+    #[inline(always)]
+    fn from(v: I24) -> Self {
+        v.to_i32()
+    }
+}
+
+impl From<I24> for i64 {
+    #[inline(always)]
+    fn from(v: I24) -> Self {
+        i64::from(v.to_i32())
+    }
+}
+
+impl I24 {
+    /// Create a new `I24` from a signed 32-bit integer.
+    ///
+    /// The input value is truncated to 24 bits, providing larger value panics in a debug build.
+    #[inline(always)]
+    pub const fn from_i32(v: i32) -> Self {
+        let b = v.to_le_bytes();
+        debug_assert!(
+            (v << u8::BITS) >> u8::BITS == v,
+            "Input value exceeds 24 bits"
+        );
+        Self([b[0], b[1], b[2]])
+    }
+
+    /// Convert to a signed 32-bit integer
+    #[inline(always)]
+    pub const fn to_i32(self) -> i32 {
+        let [a, b, c] = self.0;
+        // Sign-extend
+        i32::from_le_bytes([a, b, c, 0]) << u8::BITS >> u8::BITS
+    }
+}
+
+/// New type for signed integers that stores 32-bit numbers with `LOW_ZEROED_BITS` low bits zeroed
+/// and truncated to 24-bits
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct I24WithZeroedBits<const LOW_ZEROED_BITS: u8>([u8; 3]);
+
+impl<const LOW_ZEROED_BITS: u8> fmt::Debug for I24WithZeroedBits<LOW_ZEROED_BITS> {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.to_i32(), f)
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> fmt::Display for I24WithZeroedBits<LOW_ZEROED_BITS> {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.to_i32(), f)
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> fmt::LowerHex for I24WithZeroedBits<LOW_ZEROED_BITS> {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.to_i32(), f)
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> fmt::UpperHex for I24WithZeroedBits<LOW_ZEROED_BITS> {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.to_i32(), f)
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> const Shl<u8> for I24WithZeroedBits<LOW_ZEROED_BITS> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shl(self, rhs: u8) -> Self::Output {
+        Self::from_i32(self.to_i32().shl(rhs))
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> const Shr<u8> for I24WithZeroedBits<LOW_ZEROED_BITS> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn shr(self, rhs: u8) -> Self::Output {
+        Self::from_i32(self.to_i32().shr(rhs))
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> const Shl<u8> for &I24WithZeroedBits<LOW_ZEROED_BITS> {
+    type Output = I24WithZeroedBits<LOW_ZEROED_BITS>;
+
+    #[inline(always)]
+    fn shl(self, rhs: u8) -> Self::Output {
+        I24WithZeroedBits::from_i32(self.to_i32().shl(rhs))
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> const Shr<u8> for &I24WithZeroedBits<LOW_ZEROED_BITS> {
+    type Output = I24WithZeroedBits<LOW_ZEROED_BITS>;
+
+    #[inline(always)]
+    fn shr(self, rhs: u8) -> Self::Output {
+        I24WithZeroedBits::from_i32(self.to_i32().shr(rhs))
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> From<I24WithZeroedBits<LOW_ZEROED_BITS>> for i32 {
+    #[inline(always)]
+    fn from(v: I24WithZeroedBits<LOW_ZEROED_BITS>) -> Self {
+        v.to_i32()
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> From<I24WithZeroedBits<LOW_ZEROED_BITS>> for i64 {
+    #[inline(always)]
+    fn from(v: I24WithZeroedBits<LOW_ZEROED_BITS>) -> Self {
+        i64::from(v.to_i32())
+    }
+}
+
+impl<const LOW_ZEROED_BITS: u8> I24WithZeroedBits<LOW_ZEROED_BITS> {
+    /// Create a new `I24WithZeroedBits` from a signed 32-bit integer.
+    ///
+    /// The input value is shifted right arithmetically by `LOW_ZEROED_BITS` before being stored.
+    /// When converted back with [`Self::to_i32`], the value is shifted back with low bits being
+    /// zero.
+    #[inline(always)]
+    pub const fn from_i32(v_original: i32) -> Self {
+        let v = v_original >> LOW_ZEROED_BITS;
+        let b = v.to_le_bytes();
+        let return_value = Self([b[0], b[1], b[2]]);
+
+        debug_assert!(
+            return_value.to_i32() == v_original,
+            "Input has non-zero low bits"
+        );
+
+        return_value
+    }
+
+    /// Convert to a signed 32-bit integer
+    #[inline(always)]
+    pub const fn to_i32(self) -> i32 {
+        let [a, b, c] = self.0;
+        // Sign-extend and shift back
+        (((i32::from_le_bytes([a, b, c, 0]) << u8::BITS >> u8::BITS) << LOW_ZEROED_BITS)
+            .cast_unsigned()
+            & (u32::MAX << LOW_ZEROED_BITS))
+            .cast_signed()
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/utils/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/utils/tests.rs
@@ -1,0 +1,357 @@
+use crate::instructions::utils::{I24, I24WithZeroedBits, U24};
+
+// U24
+
+#[test]
+fn u24_zero_roundtrip() {
+    assert_eq!(U24::from_u32(0).to_u32(), 0);
+}
+
+#[test]
+fn u24_one_roundtrip() {
+    assert_eq!(U24::from_u32(1).to_u32(), 1);
+}
+
+#[test]
+fn u24_max_value_roundtrip() {
+    // 2^24 - 1 = 16_777_215
+    let max = 0x00FF_FFFF_u32;
+    assert_eq!(U24::from_u32(max).to_u32(), max);
+}
+
+#[test]
+fn u24_midpoint_roundtrip() {
+    let v = 0x0080_0000_u32;
+    assert_eq!(U24::from_u32(v).to_u32(), v);
+}
+
+#[test]
+fn u24_byte_boundary_values() {
+    for v in [0x0000_00FF_u32, 0x0000_FF00, 0x00FF_0000] {
+        assert_eq!(U24::from_u32(v).to_u32(), v);
+    }
+}
+
+#[test]
+fn u24_alternating_bit_pattern() {
+    // 0xAAAAAA fits in 24 bits
+    let v = 0x00AA_AAAA_u32;
+    assert_eq!(U24::from_u32(v).to_u32(), v);
+}
+
+#[test]
+fn u24_little_endian_byte_order() {
+    // Verify internal storage is LE: from_u32(0x010203) => [0x03, 0x02, 0x01]
+    let u = U24::from_u32(0x00_01_02_03);
+    assert_eq!(u.0, [0x03, 0x02, 0x01]);
+}
+
+#[test]
+fn u24_from_u32_into_u32_trait() {
+    let v = 0x00AB_CDEF_u32;
+    let u = U24::from_u32(v);
+    let out: u32 = u.into();
+    assert_eq!(out, v);
+}
+
+#[test]
+fn u24_from_u32_into_u64_trait() {
+    let v = 0x00AB_CDEF_u32;
+    let u = U24::from_u32(v);
+    let out: u64 = u.into();
+    assert_eq!(out, v as u64);
+}
+
+#[test]
+fn u24_high_byte_not_leaked() {
+    // to_u32 must zero the 4th byte unconditionally
+    let u = U24([0xFF, 0xFF, 0xFF]);
+    assert_eq!(u.to_u32(), 0x00FF_FFFF);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn u24_from_u32_overflow_panics_in_debug() {
+    // 0x0100_0000 exceeds 24 bits
+    let _ = U24::from_u32(0x0100_0000);
+}
+
+#[test]
+fn u24_default_is_zero() {
+    assert_eq!(U24::default().to_u32(), 0);
+}
+
+// I24
+
+#[test]
+fn i24_zero_roundtrip() {
+    assert_eq!(I24::from_i32(0).to_i32(), 0);
+}
+
+#[test]
+fn i24_positive_one_roundtrip() {
+    assert_eq!(I24::from_i32(1).to_i32(), 1);
+}
+
+#[test]
+fn i24_negative_one_roundtrip() {
+    assert_eq!(I24::from_i32(-1).to_i32(), -1);
+}
+
+#[test]
+fn i24_max_positive_roundtrip() {
+    // 2^23 - 1 = 8_388_607
+    let max = 0x007F_FFFF_i32;
+    assert_eq!(I24::from_i32(max).to_i32(), max);
+}
+
+#[test]
+fn i24_min_negative_roundtrip() {
+    // -2^23 = -8_388_608
+    let min = -0x0080_0000_i32;
+    assert_eq!(I24::from_i32(min).to_i32(), min);
+}
+
+#[test]
+fn i24_negative_one_stored_as_all_ff() {
+    let i = I24::from_i32(-1);
+    assert_eq!(i.0, [0xFF, 0xFF, 0xFF]);
+}
+
+#[test]
+fn i24_sign_extension_positive_boundary() {
+    // 0x7FFFFF is max positive; 0x800000 would be the sign bit — must not be stored
+    let v = 0x007F_FFFF_i32;
+    let recovered = I24::from_i32(v).to_i32();
+    assert_eq!(recovered, v);
+    assert!(recovered > 0);
+}
+
+#[test]
+fn i24_sign_extension_negative_boundary() {
+    let v = -0x0080_0000_i32;
+    let recovered = I24::from_i32(v).to_i32();
+    assert_eq!(recovered, v);
+    assert!(recovered < 0);
+}
+
+#[test]
+fn i24_alternating_bit_pattern_positive() {
+    // 0x2AAAAA fits in 23 bits (positive)
+    let v = 0x002A_AAAA_i32;
+    assert_eq!(I24::from_i32(v).to_i32(), v);
+}
+
+#[test]
+fn i24_alternating_bit_pattern_negative() {
+    let v = -0x002A_AAAB_i32;
+    assert_eq!(I24::from_i32(v).to_i32(), v);
+}
+
+#[test]
+fn i24_little_endian_byte_order_positive() {
+    // 0x010203: LE bytes [0x03, 0x02, 0x01]
+    let i = I24::from_i32(0x0001_0203);
+    assert_eq!(i.0, [0x03, 0x02, 0x01]);
+}
+
+#[test]
+fn i24_into_i32_trait() {
+    let v = -42_i32;
+    let i = I24::from_i32(v);
+    let out: i32 = i.into();
+    assert_eq!(out, v);
+}
+
+#[test]
+fn i24_into_i64_trait() {
+    let v = -42_i32;
+    let i = I24::from_i32(v);
+    let out: i64 = i.into();
+    assert_eq!(out, v as i64);
+}
+
+#[test]
+fn i24_to_i32_sign_extends_high_bit() {
+    // Manually construct a value with bit 23 set (sign bit for I24)
+    let i = I24([0x00, 0x00, 0x80]);
+    // Should sign-extend to -8_388_608
+    assert_eq!(i.to_i32(), -8_388_608_i32);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_from_i32_overflow_positive_panics_in_debug() {
+    // 0x0080_0000 = 8_388_608, one above max positive I24
+    let _ = I24::from_i32(0x0080_0000);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_from_i32_overflow_negative_panics_in_debug() {
+    // -8_388_609, one below min I24
+    let _ = I24::from_i32(-0x0080_0001);
+}
+
+#[test]
+fn i24_default_is_zero() {
+    assert_eq!(I24::default().to_i32(), 0);
+}
+
+// I24WithZeroedBits
+
+// LOW_ZEROED_BITS = 0 (degenerate: behaves identically to I24)
+
+#[test]
+fn i24_with_zeroed_bits_zero_bits_zero_roundtrip() {
+    assert_eq!(I24WithZeroedBits::<0>::from_i32(0).to_i32(), 0);
+}
+
+#[test]
+fn i24_with_zeroed_bits_zero_bits_positive_roundtrip() {
+    let v = 0x007F_FFFF_i32;
+    assert_eq!(I24WithZeroedBits::<0>::from_i32(v).to_i32(), v);
+}
+
+#[test]
+fn i24_with_zeroed_bits_zero_bits_negative_roundtrip() {
+    let v = -0x0080_0000_i32;
+    assert_eq!(I24WithZeroedBits::<0>::from_i32(v).to_i32(), v);
+}
+
+// LOW_ZEROED_BITS = 1
+
+#[test]
+fn i24_with_zeroed_bits_one_bit_even_value_roundtrip() {
+    // Even values have low bit 0, so the round-trip is lossless
+    let v = 100_i32;
+    assert_eq!(I24WithZeroedBits::<1>::from_i32(v).to_i32(), v);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_with_zeroed_bits_one_bit_odd_value_panics_in_debug() {
+    // Low bit is set; from_i32 now requires alignment, not truncation
+    let _ = I24WithZeroedBits::<1>::from_i32(101);
+}
+
+#[test]
+fn i24_with_zeroed_bits_one_bit_negative_even_roundtrip() {
+    let v = -100_i32;
+    assert_eq!(I24WithZeroedBits::<1>::from_i32(v).to_i32(), v);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_with_zeroed_bits_one_bit_negative_odd_panics_in_debug() {
+    // Low bit is set; from_i32 now requires alignment, not truncation
+    let _ = I24WithZeroedBits::<1>::from_i32(-101);
+}
+
+#[test]
+fn i24_with_zeroed_bits_one_bit_max_representable_positive() {
+    // Value must fit in 24 bits and have low bit clear: 0x7FFFFE
+    let v = 0x007F_FFFE_i32;
+    assert_eq!(I24WithZeroedBits::<1>::from_i32(v).to_i32(), v);
+}
+
+#[test]
+fn i24_with_zeroed_bits_one_bit_min_representable_negative() {
+    // -0x00800000 is even, so round-trip is lossless
+    let v = -0x0080_0000_i32;
+    assert_eq!(I24WithZeroedBits::<1>::from_i32(v).to_i32(), v);
+}
+
+// LOW_ZEROED_BITS = 4
+
+#[test]
+fn i24_with_zeroed_bits_four_bits_aligned_positive_roundtrip() {
+    // Must be a multiple of 16 and fit in 24 bits
+    let v = 0x0000_0010_i32;
+    assert_eq!(I24WithZeroedBits::<4>::from_i32(v).to_i32(), v);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_with_zeroed_bits_four_bits_unaligned_positive_panics_in_debug() {
+    // Low nibble is set; from_i32 now requires alignment, not truncation
+    let _ = I24WithZeroedBits::<4>::from_i32(0x1F);
+}
+
+#[test]
+fn i24_with_zeroed_bits_four_bits_aligned_negative_roundtrip() {
+    let v = -0x0000_0010_i32;
+    assert_eq!(I24WithZeroedBits::<4>::from_i32(v).to_i32(), v);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_with_zeroed_bits_four_bits_unaligned_negative_panics_in_debug() {
+    // Low nibble is set; from_i32 now requires alignment, not truncation
+    let _ = I24WithZeroedBits::<4>::from_i32(-1);
+}
+
+#[test]
+fn i24_with_zeroed_bits_four_bits_max_representable_positive() {
+    // Value must fit in 24 bits with low 4 bits clear: 0x7FFFF0
+    let v = 0x007F_FFF0_i32;
+    assert_eq!(I24WithZeroedBits::<4>::from_i32(v).to_i32(), v);
+}
+
+#[test]
+fn i24_with_zeroed_bits_four_bits_min_representable_negative() {
+    // -0x00800000 is 4-bit aligned and fits in 24 bits
+    let v = -0x0080_0000_i32;
+    assert_eq!(I24WithZeroedBits::<4>::from_i32(v).to_i32(), v);
+}
+
+#[test]
+fn i24_with_zeroed_bits_four_bits_zero_roundtrip() {
+    assert_eq!(I24WithZeroedBits::<4>::from_i32(0).to_i32(), 0);
+}
+
+#[test]
+fn i24_with_zeroed_bits_four_bits_mask_zeroes_low_bits() {
+    // to_i32 must always return a value with low 4 bits clear for aligned inputs
+    for raw in [-0x0080_0000_i32, -0x0000_0010, 0, 0x0000_0010, 0x007F_FFF0] {
+        let out = I24WithZeroedBits::<4>::from_i32(raw).to_i32();
+        assert_eq!(out & 0xF, 0, "low bits not zeroed for input {raw}");
+    }
+}
+
+#[test]
+fn i24_with_zeroed_bits_default_is_zero() {
+    assert_eq!(I24WithZeroedBits::<4>::default().to_i32(), 0);
+}
+
+// overflow guards
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_with_zeroed_bits_four_bits_overflow_positive_panics_in_debug() {
+    // Low bits set ensures round-trip mismatch regardless of overflow path
+    let _ = I24WithZeroedBits::<4>::from_i32(0x0080_0001);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_with_zeroed_bits_four_bits_overflow_negative_panics_in_debug() {
+    let _ = I24WithZeroedBits::<4>::from_i32(-0x0800_0001);
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic]
+fn i24_with_zeroed_bits_one_bit_overflow_positive_panics_in_debug() {
+    // After storing, 0x01000000 does not fit in 24 bits
+    let _ = I24WithZeroedBits::<1>::from_i32(0x0100_0000);
+}

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -37,6 +37,7 @@ pub use crate::instructions::rv64::zk::zkn::Rv64ZknInstruction;
 pub use crate::instructions::rv64::zk::zkn::zknd::{Rv64ZkndInstruction, Rv64ZkndKsRnum};
 pub use crate::instructions::rv64::zk::zkn::zkne::Rv64ZkneInstruction;
 pub use crate::instructions::rv64::zk::zkn::zknh::Rv64ZknhInstruction;
+pub use crate::instructions::utils::{I24, I24WithZeroedBits};
 pub use crate::instructions::v::zve64x::Zve64xInstruction;
 pub use crate::instructions::v::zve64x::arith::Zve64xArithInstruction;
 pub use crate::instructions::v::zve64x::config::Zve64xConfigInstruction;


### PR DESCRIPTION
This can be leveraged later to add more fields to enum variants without increasing enum size.

The performance is basically identical to before.