### PR TITLE
Rename `r1s` and `r2s` fields to `rs1` and `rs2` for consistency

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -57,19 +57,19 @@ where
                     .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
-            Self::CmMva01s { r1s, r2s } => {
+            Self::CmMva01s { rs1, rs2 } => {
                 // Read both sources before any write to avoid aliasing
-                let v1 = regs.read(r1s);
-                let v2 = regs.read(r2s);
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
                 regs.write(Reg::A0, v1);
                 regs.write(Reg::A1, v2);
             }
-            Self::CmMvsa01 { r1s, r2s } => {
+            Self::CmMvsa01 { rs1, rs2 } => {
                 // Read both sources before any write to avoid aliasing
                 let a0_val = regs.read(Reg::A0);
                 let a1_val = regs.read(Reg::A1);
-                regs.write(r1s, a0_val);
-                regs.write(r2s, a1_val);
+                regs.write(rs1, a0_val);
+                regs.write(rs2, a1_val);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/tests.rs
@@ -264,8 +264,8 @@ fn test_cm_popret_clears_lsb_of_return_addr() {
 #[test]
 fn test_cm_mva01s_copies_to_a0_a1() {
     let mut state = initialize_state([Rv32ZcmpInstruction::CmMva01s {
-        r1s: Reg::S2,
-        r2s: Reg::S3,
+        rs1: Reg::S2,
+        rs2: Reg::S3,
     }]);
     state.regs.write(Reg::S2, 0x1111);
     state.regs.write(Reg::S3, 0x2222);
@@ -279,10 +279,10 @@ fn test_cm_mva01s_copies_to_a0_a1() {
 
 #[test]
 fn test_cm_mva01s_reads_before_write() {
-    // If r1s or r2s alias a0/a1, reads must occur before writes
+    // If rs1 or rs2 alias a0/a1, reads must occur before writes
     let mut state = initialize_state([Rv32ZcmpInstruction::CmMva01s {
-        r1s: Reg::S0,
-        r2s: Reg::S1,
+        rs1: Reg::S0,
+        rs2: Reg::S1,
     }]);
     state.regs.write(Reg::S0, 0xAAAA);
     state.regs.write(Reg::S1, 0xBBBB);
@@ -296,8 +296,8 @@ fn test_cm_mva01s_reads_before_write() {
 #[test]
 fn test_cm_mvsa01_copies_a0_a1_to_s_regs() {
     let mut state = initialize_state([Rv32ZcmpInstruction::CmMvsa01 {
-        r1s: Reg::S4,
-        r2s: Reg::S5,
+        rs1: Reg::S4,
+        rs2: Reg::S5,
     }]);
     state.regs.write(Reg::A0, 0x3333);
     state.regs.write(Reg::A1, 0x4444);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -57,19 +57,19 @@ where
                     .set_pc(memory, target)
                     .map_err(ExecutionError::from);
             }
-            Self::CmMva01s { r1s, r2s } => {
+            Self::CmMva01s { rs1, rs2 } => {
                 // Read both sources before any write to avoid aliasing
-                let v1 = regs.read(r1s);
-                let v2 = regs.read(r2s);
+                let v1 = regs.read(rs1);
+                let v2 = regs.read(rs2);
                 regs.write(Reg::A0, v1);
                 regs.write(Reg::A1, v2);
             }
-            Self::CmMvsa01 { r1s, r2s } => {
+            Self::CmMvsa01 { rs1, rs2 } => {
                 // Read both sources before any write to avoid aliasing
                 let a0_val = regs.read(Reg::A0);
                 let a1_val = regs.read(Reg::A1);
-                regs.write(r1s, a0_val);
-                regs.write(r2s, a1_val);
+                regs.write(rs1, a0_val);
+                regs.write(rs2, a1_val);
             }
         }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/tests.rs
@@ -222,8 +222,8 @@ fn test_cm_popret_clears_lsb_of_return_addr() {
 #[test]
 fn test_cm_mva01s_copies_to_a0_a1() {
     let mut state = initialize_state([Rv64ZcmpInstruction::CmMva01s {
-        r1s: Reg::S2,
-        r2s: Reg::S3,
+        rs1: Reg::S2,
+        rs2: Reg::S3,
     }]);
     state.regs.write(Reg::S2, 0x1111);
     state.regs.write(Reg::S3, 0x2222);
@@ -237,10 +237,10 @@ fn test_cm_mva01s_copies_to_a0_a1() {
 
 #[test]
 fn test_cm_mva01s_reads_before_write() {
-    // If r1s or r2s alias a0/a1, reads must occur before writes
+    // If rs1 or rs2 alias a0/a1, reads must occur before writes
     let mut state = initialize_state([Rv64ZcmpInstruction::CmMva01s {
-        r1s: Reg::S0,
-        r2s: Reg::S1,
+        rs1: Reg::S0,
+        rs2: Reg::S1,
     }]);
     state.regs.write(Reg::S0, 0xAAAA);
     state.regs.write(Reg::S1, 0xBBBB);
@@ -254,8 +254,8 @@ fn test_cm_mva01s_reads_before_write() {
 #[test]
 fn test_cm_mvsa01_copies_a0_a1_to_s_regs() {
     let mut state = initialize_state([Rv64ZcmpInstruction::CmMvsa01 {
-        r1s: Reg::S4,
-        r2s: Reg::S5,
+        rs1: Reg::S4,
+        rs2: Reg::S5,
     }]);
     state.regs.write(Reg::A0, 0x3333);
     state.regs.write(Reg::A1, 0x4444);

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
@@ -267,10 +267,16 @@ pub enum Rv32ZcmpInstruction<Reg> {
         urlist: ZcmpUrlist<Reg>,
         stack_adj: u32,
     },
-    /// CM.MVA01S - a0 = r1s', a1 = r2s'
-    CmMva01s { r1s: Reg, r2s: Reg },
-    /// CM.MVSA01 - r1s' = a0, r2s' = a1  (r1s' != r2s')
-    CmMvsa01 { r1s: Reg, r2s: Reg },
+    /// CM.MVA01S - a0 = r1s', a1 = r2s'.
+    ///
+    /// The fields are called both r1s/r2s and rs1/rs2 in the spec, rs1/rs2 is used here for
+    /// consistency with other instructions.
+    CmMva01s { rs1: Reg, rs2: Reg },
+    /// CM.MVSA01 - r1s' = a0, r2s' = a1  (r1s' != r2s').
+    ///
+    /// The fields are called both r1s/r2s and rs1/rs2 in the spec, rs1/rs2 is used here for
+    /// consistency with other instructions.
+    CmMvsa01 { rs1: Reg, rs2: Reg },
 }
 
 #[instruction]
@@ -338,13 +344,13 @@ where
 
                 // funct2[6:5]: 0b11 -> CM.MVA01S, 0b01 -> CM.MVSA01, others reserved
                 match funct2 {
-                    0b11 => Some(Self::CmMva01s { r1s, r2s }),
+                    0b11 => Some(Self::CmMva01s { rs1: r1s, rs2: r2s }),
                     0b01 => {
                         // CM.MVSA01 requires r1s' != r2s'
                         if r1s_bits == r2s_bits {
                             None?;
                         }
-                        Some(Self::CmMvsa01 { r1s, r2s })
+                        Some(Self::CmMvsa01 { rs1: r1s, rs2: r2s })
                     }
                     _ => None,
                 }
@@ -383,8 +389,8 @@ where
             Self::CmPopret { urlist, stack_adj } => {
                 write!(f, "cm.popret {urlist}, {stack_adj}")
             }
-            Self::CmMva01s { r1s, r2s } => write!(f, "cm.mva01s {r1s}, {r2s}"),
-            Self::CmMvsa01 { r1s, r2s } => write!(f, "cm.mvsa01 {r1s}, {r2s}"),
+            Self::CmMva01s { rs1, rs2 } => write!(f, "cm.mva01s {rs1}, {rs2}"),
+            Self::CmMvsa01 { rs1, rs2 } => write!(f, "cm.mvsa01 {rs1}, {rs2}"),
         }
     }
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp/tests.rs
@@ -300,8 +300,8 @@ fn test_cm_mva01s_s0_s1() {
     assert_eq!(
         decoded,
         Rv32ZcmpInstruction::CmMva01s {
-            r1s: Reg::S0,
-            r2s: Reg::S1,
+            rs1: Reg::S0,
+            rs2: Reg::S1,
         }
     );
 }
@@ -314,8 +314,8 @@ fn test_cm_mva01s_same_reg() {
     assert_eq!(
         decoded,
         Rv32ZcmpInstruction::CmMva01s {
-            r1s: Reg::S2,
-            r2s: Reg::S2,
+            rs1: Reg::S2,
+            rs2: Reg::S2,
         }
     );
 }
@@ -336,8 +336,8 @@ fn test_cm_mva01s_all_s_regs() {
     for (field, &expected) in expected_regs.iter().enumerate() {
         let inst = make_mv_pair(MV_FUNCT2_MVA01S, field as u16, 0);
         let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
-        if let Rv32ZcmpInstruction::CmMva01s { r1s, .. } = decoded {
-            assert_eq!(r1s, expected, "field={field}");
+        if let Rv32ZcmpInstruction::CmMva01s { rs1, .. } = decoded {
+            assert_eq!(rs1, expected, "field={field}");
         } else {
             panic!("wrong variant for field={field}");
         }
@@ -362,7 +362,7 @@ fn test_cm_mva01s_binutils_reference_encodings() {
         let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmMva01s { r1s, r2s },
+            Rv32ZcmpInstruction::CmMva01s { rs1: r1s, rs2: r2s },
             "raw={raw:#06x}"
         );
     }
@@ -378,8 +378,8 @@ fn test_cm_mvsa01_distinct_regs() {
     assert_eq!(
         decoded,
         Rv32ZcmpInstruction::CmMvsa01 {
-            r1s: Reg::S0,
-            r2s: Reg::S2,
+            rs1: Reg::S0,
+            rs2: Reg::S2,
         }
     );
 }
@@ -408,7 +408,7 @@ fn test_cm_mvsa01_binutils_reference_encodings() {
         let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmMvsa01 { r1s, r2s },
+            Rv32ZcmpInstruction::CmMvsa01 { rs1: r1s, rs2: r2s },
             "raw={raw:#06x}"
         );
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
@@ -35,10 +35,16 @@ pub enum Rv64ZcmpInstruction<Reg> {
         urlist: ZcmpUrlist<Reg>,
         stack_adj: u32,
     },
-    /// CM.MVA01S - a0 = r1s', a1 = r2s'
-    CmMva01s { r1s: Reg, r2s: Reg },
-    /// CM.MVSA01 - r1s' = a0, r2s' = a1  (r1s' != r2s')
-    CmMvsa01 { r1s: Reg, r2s: Reg },
+    /// CM.MVA01S - a0 = r1s', a1 = r2s'.
+    ///
+    /// The fields are called both r1s/r2s and rs1/rs2 in the spec, rs1/rs2 is used here for
+    /// consistency with other instructions.
+    CmMva01s { rs1: Reg, rs2: Reg },
+    /// CM.MVSA01 - r1s' = a0, r2s' = a1  (r1s' != r2s').
+    ///
+    /// The fields are called both r1s/r2s and rs1/rs2 in the spec, rs1/rs2 is used here for
+    /// consistency with other instructions.
+    CmMvsa01 { rs1: Reg, rs2: Reg },
 }
 
 #[instruction]
@@ -106,13 +112,13 @@ where
 
                 // funct2[6:5]: 0b11 -> CM.MVA01S, 0b01 -> CM.MVSA01, others reserved
                 match funct2 {
-                    0b11 => Some(Self::CmMva01s { r1s, r2s }),
+                    0b11 => Some(Self::CmMva01s { rs1: r1s, rs2: r2s }),
                     0b01 => {
                         // CM.MVSA01 requires r1s' != r2s'
                         if r1s_bits == r2s_bits {
                             None?;
                         }
-                        Some(Self::CmMvsa01 { r1s, r2s })
+                        Some(Self::CmMvsa01 { rs1: r1s, rs2: r2s })
                     }
                     _ => None,
                 }
@@ -151,8 +157,8 @@ where
             Self::CmPopret { urlist, stack_adj } => {
                 write!(f, "cm.popret {urlist}, {stack_adj}")
             }
-            Self::CmMva01s { r1s, r2s } => write!(f, "cm.mva01s {r1s}, {r2s}"),
-            Self::CmMvsa01 { r1s, r2s } => write!(f, "cm.mvsa01 {r1s}, {r2s}"),
+            Self::CmMva01s { rs1, rs2 } => write!(f, "cm.mva01s {rs1}, {rs2}"),
+            Self::CmMvsa01 { rs1, rs2 } => write!(f, "cm.mvsa01 {rs1}, {rs2}"),
         }
     }
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp/tests.rs
@@ -300,8 +300,8 @@ fn test_cm_mva01s_s0_s1() {
     assert_eq!(
         decoded,
         Rv64ZcmpInstruction::CmMva01s {
-            r1s: Reg::S0,
-            r2s: Reg::S1,
+            rs1: Reg::S0,
+            rs2: Reg::S1,
         }
     );
 }
@@ -314,8 +314,8 @@ fn test_cm_mva01s_same_reg() {
     assert_eq!(
         decoded,
         Rv64ZcmpInstruction::CmMva01s {
-            r1s: Reg::S2,
-            r2s: Reg::S2,
+            rs1: Reg::S2,
+            rs2: Reg::S2,
         }
     );
 }
@@ -336,8 +336,8 @@ fn test_cm_mva01s_all_s_regs() {
     for (field, &expected) in expected_regs.iter().enumerate() {
         let inst = make_mv_pair(MV_FUNCT2_MVA01S, field as u16, 0);
         let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
-        if let Rv64ZcmpInstruction::CmMva01s { r1s, .. } = decoded {
-            assert_eq!(r1s, expected, "field={field}");
+        if let Rv64ZcmpInstruction::CmMva01s { rs1, .. } = decoded {
+            assert_eq!(rs1, expected, "field={field}");
         } else {
             panic!("wrong variant for field={field}");
         }
@@ -362,7 +362,7 @@ fn test_cm_mva01s_binutils_reference_encodings() {
         let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmMva01s { r1s, r2s },
+            Rv64ZcmpInstruction::CmMva01s { rs1: r1s, rs2: r2s },
             "raw={raw:#06x}"
         );
     }
@@ -378,8 +378,8 @@ fn test_cm_mvsa01_distinct_regs() {
     assert_eq!(
         decoded,
         Rv64ZcmpInstruction::CmMvsa01 {
-            r1s: Reg::S0,
-            r2s: Reg::S2,
+            rs1: Reg::S0,
+            rs2: Reg::S2,
         }
     );
 }
@@ -408,7 +408,7 @@ fn test_cm_mvsa01_binutils_reference_encodings() {
         let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmMvsa01 { r1s, r2s },
+            Rv64ZcmpInstruction::CmMvsa01 { rs1: r1s, rs2: r2s },
             "raw={raw:#06x}"
         );
     }


### PR DESCRIPTION
This will help with performance in the future when `rs1` and `rs2` will be fetched from registers before execution `match`. Having different register operand names will prevent that optimization for these instructions.