### PR TITLE
Optimize instruction layout

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -244,6 +244,11 @@ unsafe impl const ZcmpRegister for ContractRegister {
 /// An instruction type used by contracts
 #[instruction(
     ignore = [Fence, FenceTso, Ecall],
+    inherit = [
+        Rv64ZcaInstruction,
+        Rv64ZcbInstruction,
+        Rv64ZcmpInstruction,
+    ],
     reorder = [
         Ld,
         Sd,
@@ -267,9 +272,6 @@ unsafe impl const ZcmpRegister for ContractRegister {
         Sh1add,
     ],
     inherit = [
-        Rv64ZcaInstruction,
-        Rv64ZcbInstruction,
-        Rv64ZcmpInstruction,
         Rv64Instruction,
         Rv64MInstruction,
         Rv64BInstruction,


### PR DESCRIPTION
This allows to draw a single line between compressed 2-byte and uncompressed 4-byte instructions. Before due to reordering there were 2 lines, resulting in worse code.