### PR TITLE
Remove shift operations for `I24WithZeroedBits` and fix printing of `lui` and `auipc` instructions

### DIFF
--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
@@ -340,9 +340,9 @@ where
             Self::Bltu { rs1, rs2, imm } => write!(f, "bltu {}, {}, {}", rs1, rs2, imm),
             Self::Bgeu { rs1, rs2, imm } => write!(f, "bgeu {}, {}, {}", rs1, rs2, imm),
 
-            Self::Lui { rd, imm } => write!(f, "lui {}, 0x{:x}", rd, imm >> 12),
+            Self::Lui { rd, imm } => write!(f, "lui {}, 0x{:x}", rd, imm.to_i32() >> 12),
 
-            Self::Auipc { rd, imm } => write!(f, "auipc {}, 0x{:x}", rd, imm >> 12),
+            Self::Auipc { rd, imm } => write!(f, "auipc {}, 0x{:x}", rd, imm.to_i32() >> 12),
 
             Self::Jal { rd, imm } => write!(f, "jal {}, {}", rd, imm),
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
@@ -411,9 +411,9 @@ where
             Self::Bltu { rs1, rs2, imm } => write!(f, "bltu {}, {}, {}", rs1, rs2, imm),
             Self::Bgeu { rs1, rs2, imm } => write!(f, "bgeu {}, {}, {}", rs1, rs2, imm),
 
-            Self::Lui { rd, imm } => write!(f, "lui {}, 0x{:x}", rd, imm >> 12),
+            Self::Lui { rd, imm } => write!(f, "lui {}, 0x{:x}", rd, imm.to_i32() >> 12),
 
-            Self::Auipc { rd, imm } => write!(f, "auipc {}, 0x{:x}", rd, imm >> 12),
+            Self::Auipc { rd, imm } => write!(f, "auipc {}, 0x{:x}", rd, imm.to_i32() >> 12),
 
             Self::Jal { rd, imm } => write!(f, "jal {}, {}", rd, imm),
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/utils.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/utils.rs
@@ -248,42 +248,6 @@ impl<const LOW_ZEROED_BITS: u8> fmt::UpperHex for I24WithZeroedBits<LOW_ZEROED_B
     }
 }
 
-impl<const LOW_ZEROED_BITS: u8> const Shl<u8> for I24WithZeroedBits<LOW_ZEROED_BITS> {
-    type Output = Self;
-
-    #[inline(always)]
-    fn shl(self, rhs: u8) -> Self::Output {
-        Self::from_i32(self.to_i32().shl(rhs))
-    }
-}
-
-impl<const LOW_ZEROED_BITS: u8> const Shr<u8> for I24WithZeroedBits<LOW_ZEROED_BITS> {
-    type Output = Self;
-
-    #[inline(always)]
-    fn shr(self, rhs: u8) -> Self::Output {
-        Self::from_i32(self.to_i32().shr(rhs))
-    }
-}
-
-impl<const LOW_ZEROED_BITS: u8> const Shl<u8> for &I24WithZeroedBits<LOW_ZEROED_BITS> {
-    type Output = I24WithZeroedBits<LOW_ZEROED_BITS>;
-
-    #[inline(always)]
-    fn shl(self, rhs: u8) -> Self::Output {
-        I24WithZeroedBits::from_i32(self.to_i32().shl(rhs))
-    }
-}
-
-impl<const LOW_ZEROED_BITS: u8> const Shr<u8> for &I24WithZeroedBits<LOW_ZEROED_BITS> {
-    type Output = I24WithZeroedBits<LOW_ZEROED_BITS>;
-
-    #[inline(always)]
-    fn shr(self, rhs: u8) -> Self::Output {
-        I24WithZeroedBits::from_i32(self.to_i32().shr(rhs))
-    }
-}
-
 impl<const LOW_ZEROED_BITS: u8> From<I24WithZeroedBits<LOW_ZEROED_BITS>> for i32 {
     #[inline(always)]
     fn from(v: I24WithZeroedBits<LOW_ZEROED_BITS>) -> Self {


### PR DESCRIPTION
This is a small regression caused by https://github.com/nazar-pc/abundance/pull/670 that is only reproducible when trying to print an instruction (`fmt::Display` impl)