### PR TITLE
Update Rust toolchain

### DIFF
--- a/crates/contracts/core/ab-contracts-macros-impl/src/contract.rs
+++ b/crates/contracts/core/ab-contracts-macros-impl/src/contract.rs
@@ -209,7 +209,10 @@ fn process_trait_impl(mut item_impl: ItemImpl, trait_name: &Ident) -> Result<Tok
         #[cfg(feature = "guest")]
         #[used]
         #[unsafe(no_mangle)]
-        #[unsafe(link_section = "ab-contract-metadata")]
+        #[cfg_attr(
+            target_env = "abundance",
+            unsafe(link_section = "ab-contract-metadata")
+        )]
         static #static_name: [::core::primitive::u8; <dyn #trait_name as ::ab_contracts_macros::__private::ContractTraitDefinition>::METADATA.len()] = unsafe {
             *<dyn #trait_name as ::ab_contracts_macros::__private::ContractTraitDefinition>::METADATA.as_ptr().cast()
         };
@@ -451,7 +454,10 @@ fn process_struct_impl(mut item_impl: ItemImpl) -> Result<TokenStream, Error> {
         #[cfg(feature = "guest")]
         #[used]
         #[unsafe(no_mangle)]
-        #[unsafe(link_section = "ab-contract-metadata")]
+        #[cfg_attr(
+            target_env = "abundance",
+            unsafe(link_section = "ab-contract-metadata")
+        )]
         static #static_name: [
             ::core::primitive::u8;
             <#struct_name as ::ab_contracts_macros::__private::Contract>::MAIN_CONTRACT_METADATA

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -572,9 +572,14 @@ pub(super) fn process_enum_display_impl(
             return true;
         }
 
+        let mut has_ignore = false;
         let mut rs1_found = false;
         let mut rs2_found = false;
         for field in &pat_struct.fields {
+            if let Pat::Wild(_) = &*field.pat {
+                has_ignore = true;
+            }
+
             let Member::Named(ident) = &field.member else {
                 return false;
             };
@@ -587,6 +592,19 @@ pub(super) fn process_enum_display_impl(
         }
 
         if !rs1_found || !rs2_found {
+            if has_ignore {
+                // This prevents clippy warnings
+                pat_struct.fields = mem::take(&mut pat_struct.fields)
+                    .into_iter()
+                    .filter_map(|field| {
+                        if let Pat::Wild(_) = &*field.pat {
+                            return None;
+                        }
+
+                        Some(field)
+                    })
+                    .collect();
+            }
             pat_struct.rest.replace(PatRest {
                 attrs: vec![],
                 dot2_token: Default::default(),

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
@@ -1,5 +1,5 @@
 use quote::{ToTokens, quote};
-use std::iter;
+use std::{iter, mem};
 use syn::token::Semi;
 use syn::{
     Arm, Block, Expr, ExprBlock, ExprMatch, Ident, Member, Pat, PatRest, PathArguments, Stmt,
@@ -53,9 +53,14 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
         // Fix up match pattern after `rs1`/`rs2` fields were added automatically
         if let Pat::Struct(pat_struct) = &mut arm.pat {
             if pat_struct.rest.is_none() {
+                let mut has_ignore = false;
                 let mut rs1_found = false;
                 let mut rs2_found = false;
                 for field in &pat_struct.fields {
+                    if let Pat::Wild(_) = &*field.pat {
+                        has_ignore = true;
+                    }
+
                     let Member::Named(ident) = &field.member else {
                         break;
                     };
@@ -68,6 +73,19 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
                 }
 
                 if !rs1_found || !rs2_found {
+                    if has_ignore {
+                        // This prevents clippy warnings
+                        pat_struct.fields = mem::take(&mut pat_struct.fields)
+                            .into_iter()
+                            .filter_map(|field| {
+                                if let Pat::Wild(_) = &*field.pat {
+                                    return None;
+                                }
+
+                                Some(field)
+                            })
+                            .collect();
+                    }
                     pat_struct.rest.replace(PatRest {
                         attrs: vec![],
                         dot2_token: Default::default(),

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -4,8 +4,9 @@
 //! structures used (`ab-proof-of-space` also supports `K=25`, but this crate doesn't for now).
 
 #![cfg_attr(target_arch = "spirv", no_std)]
-#![feature(generic_const_exprs, step_trait, uint_bit_width)]
+#![feature(generic_const_exprs, step_trait)]
 #![cfg_attr(not(target_arch = "spirv"), feature(iter_array_chunks, portable_simd))]
+#![cfg_attr(target_arch = "spirv", feature(uint_bit_width))]
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![cfg_attr(all(test, not(target_arch = "spirv")), feature(maybe_uninit_fill))]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-04-11"
+channel = "nightly-2026-05-03"
 components = ["miri", "rust-src"]
 targets = []
 profile = "default"


### PR DESCRIPTION
Unfortunately, this is the best that can be done at the moment due to https://github.com/rust-lang/rust/issues/156296.

Macro update was needed due to new clippy lint (it didn't like `_` + `..` in `{ rd, rs1: _, rs2, .. }`).