### PR TITLE
Refactor executable instruction

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -303,11 +303,20 @@ where
 }
 
 #[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for ContractInstruction<Reg> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for ContractInstruction<Reg>
+{
+}
+
+#[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for ContractInstruction<Reg>
 where
-    Reg: Register<Type = u64>,
+    Reg: Register,
 {
     #[inline(always)]
     fn execute(

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
@@ -61,11 +61,20 @@ where
 }
 
 #[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for AbundanceRv32IMaxInstructionPrototype<Reg> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for AbundanceRv32IMaxInstructionPrototype<Reg>
+{
+}
+
+#[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for AbundanceRv32IMaxInstructionPrototype<Reg>
 where
-    Reg: Register<Type = u32>,
+    Reg: Register,
 {
     fn execute(
         self,

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
@@ -1,6 +1,4 @@
 use crate::abundance_rv32i_max::instruction::AbundanceRv32IMaxInstruction;
-use crate::interpreter::{Act4Memory, Act4SystemHandler};
-use ab_riscv_interpreter::basic::{BasicInstructionFetcher, BasicRegisters};
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use std::collections::BTreeMap;
@@ -95,14 +93,7 @@ impl Csrs<<AbundanceRv32IMaxInstruction as Instruction>::Reg> for AbundanceRv32I
 
     fn process_csr_read(&self, csr_index: u16, raw_value: u32) -> Result<u32, CsrError> {
         let mut out = 0;
-        if !<AbundanceRv32IMaxInstruction as ExecutableInstruction<
-            BasicRegisters<<AbundanceRv32IMaxInstruction as Instruction>::Reg>,
-            Self,
-            Act4Memory<0, 0>,
-            BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
-            Act4SystemHandler,
-        >>::prepare_csr_read(self, csr_index, raw_value, &mut out)?
-        {
+        if !AbundanceRv32IMaxInstruction::prepare_csr_read(self, csr_index, raw_value, &mut out)? {
             return Err(CsrError::IllegalRead { csr_index });
         }
 
@@ -111,13 +102,7 @@ impl Csrs<<AbundanceRv32IMaxInstruction as Instruction>::Reg> for AbundanceRv32I
 
     fn process_csr_write(&mut self, csr_index: u16, write_value: u32) -> Result<u32, CsrError> {
         let mut out = 0;
-        if !<AbundanceRv32IMaxInstruction as ExecutableInstruction<
-            BasicRegisters<<AbundanceRv32IMaxInstruction as Instruction>::Reg>,
-            Self,
-            Act4Memory<0, 0>,
-            BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
-            Act4SystemHandler,
-        >>::prepare_csr_write(self, csr_index, write_value, &mut out)?
+        if !AbundanceRv32IMaxInstruction::prepare_csr_write(self, csr_index, write_value, &mut out)?
         {
             return Err(CsrError::IllegalWrite { csr_index });
         }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
@@ -61,11 +61,20 @@ where
 }
 
 #[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for AbundanceRv64IMaxInstructionPrototype<Reg> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for AbundanceRv64IMaxInstructionPrototype<Reg>
+{
+}
+
+#[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for AbundanceRv64IMaxInstructionPrototype<Reg>
 where
-    Reg: Register<Type = u64>,
+    Reg: Register,
 {
     fn execute(
         self,

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
@@ -1,6 +1,4 @@
 use crate::abundance_rv64i_max::instruction::AbundanceRv64IMaxInstruction;
-use crate::interpreter::{Act4Memory, Act4SystemHandler};
-use ab_riscv_interpreter::basic::{BasicInstructionFetcher, BasicRegisters};
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use std::collections::BTreeMap;
@@ -95,14 +93,7 @@ impl Csrs<<AbundanceRv64IMaxInstruction as Instruction>::Reg> for AbundanceRv64I
 
     fn process_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError> {
         let mut out = 0;
-        if !<AbundanceRv64IMaxInstruction as ExecutableInstruction<
-            BasicRegisters<<AbundanceRv64IMaxInstruction as Instruction>::Reg>,
-            Self,
-            Act4Memory<0, 0>,
-            BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
-            Act4SystemHandler,
-        >>::prepare_csr_read(self, csr_index, raw_value, &mut out)?
-        {
+        if !AbundanceRv64IMaxInstruction::prepare_csr_read(self, csr_index, raw_value, &mut out)? {
             return Err(CsrError::IllegalRead { csr_index });
         }
 
@@ -111,13 +102,7 @@ impl Csrs<<AbundanceRv64IMaxInstruction as Instruction>::Reg> for AbundanceRv64I
 
     fn process_csr_write(&mut self, csr_index: u16, write_value: u64) -> Result<u64, CsrError> {
         let mut out = 0;
-        if !<AbundanceRv64IMaxInstruction as ExecutableInstruction<
-            BasicRegisters<<AbundanceRv64IMaxInstruction as Instruction>::Reg>,
-            Self,
-            Act4Memory<0, 0>,
-            BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
-            Act4SystemHandler,
-        >>::prepare_csr_write(self, csr_index, write_value, &mut out)?
+        if !AbundanceRv64IMaxInstruction::prepare_csr_write(self, csr_index, write_value, &mut out)?
         {
             return Err(CsrError::IllegalWrite { csr_index });
         }

--- a/crates/execution/ab-riscv-act4-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/instruction.rs
@@ -47,8 +47,10 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg> ExecutableInstructionOperands for MachineModePlaceholder<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for MachineModePlaceholder<Reg>
 where
     Reg: Register,
@@ -86,7 +88,15 @@ where
             Ok(false)
         }
     }
+}
 
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for MachineModePlaceholder<Reg>
+where
+    Reg: Register,
+{
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -403,13 +403,7 @@ fn run_rv32i_max_test(
             }
         };
 
-        let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-            BasicRegisters<_>,
-            AbundanceRv32IMaxExtState,
-            Act4Memory<RAM_BASE, RAM_SIZE>,
-            BasicInstructionFetcher<AbundanceRv32IMaxInstruction>,
-            Act4SystemHandler,
-        >>::get_rs1_rs2_operands(instruction);
+        let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
         let rs1rs2_values = Rs1Rs2OperandValues {
             rs1_value: state.regs.read(rs1),
             rs2_value: state.regs.read(rs2),
@@ -542,13 +536,7 @@ fn run_rv64i_max_test(
             }
         };
 
-        let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-            BasicRegisters<_>,
-            AbundanceRv64IMaxExtState,
-            Act4Memory<RAM_BASE, RAM_SIZE>,
-            BasicInstructionFetcher<AbundanceRv64IMaxInstruction>,
-            Act4SystemHandler,
-        >>::get_rs1_rs2_operands(instruction);
+        let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
         let rs1rs2_values = Rs1Rs2OperandValues {
             rs1_value: state.regs.read(rs1),
             rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -555,13 +555,7 @@ where
             }
         };
 
-        let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-            Regs,
-            (),
-            Memory,
-            IF,
-            IgnoreEcallSystemInstructionHandler,
-        >>::get_rs1_rs2_operands(instruction);
+        let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
         let rs1rs2_values = Rs1Rs2OperandValues {
             rs1_value: state.regs.read(rs1),
             rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
@@ -54,11 +54,20 @@ where
 }
 
 #[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for CoremarkInstruction<Reg> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for CoremarkInstruction<Reg>
+{
+}
+
+#[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for CoremarkInstruction<Reg>
 where
-    Reg: Register<Type = u64>,
+    Reg: Register,
 {
     #[inline(always)]
     fn execute(

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -78,13 +78,7 @@ where
             }
         };
 
-        let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-            Regs,
-            TimeCsrState,
-            Memory,
-            IF,
-            IgnoreEcallSystemInstructionHandler,
-        >>::get_rs1_rs2_operands(instruction);
+        let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
         let rs1rs2_values = Rs1Rs2OperandValues {
             rs1_value: state.regs.read(rs1),
             rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -1,7 +1,5 @@
 #![expect(unreachable_pub, reason = "Macro requirements and generated code")]
 
-use crate::interpreter::{EagerInstructionFetcher, GuestMemory};
-use ab_riscv_interpreter::basic::{BasicRegisters, IgnoreEcallSystemInstructionHandler};
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;
@@ -52,13 +50,7 @@ impl Csrs<Reg<u64>> for TimeCsrState {
 
     fn process_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError> {
         let mut out = 0;
-        if !<TimeCsrInstruction<Reg<u64>> as ExecutableInstruction<
-            BasicRegisters<<TimeCsrInstruction<Reg<u64>> as Instruction>::Reg>,
-            Self,
-            GuestMemory<0, 0>,
-            EagerInstructionFetcher,
-            IgnoreEcallSystemInstructionHandler,
-        >>::prepare_csr_read(self, csr_index, raw_value, &mut out)?
+        if !<TimeCsrInstruction<Reg<u64>>>::prepare_csr_read(self, csr_index, raw_value, &mut out)?
         {
             return Err(CsrError::IllegalRead { csr_index });
         }
@@ -68,14 +60,12 @@ impl Csrs<Reg<u64>> for TimeCsrState {
 
     fn process_csr_write(&mut self, csr_index: u16, write_value: u64) -> Result<u64, CsrError> {
         let mut out = 0;
-        if !<TimeCsrInstruction<Reg<u64>> as ExecutableInstruction<
-            BasicRegisters<<TimeCsrInstruction<Reg<u64>> as Instruction>::Reg>,
-            Self,
-            GuestMemory<0, 0>,
-            EagerInstructionFetcher,
-            IgnoreEcallSystemInstructionHandler,
-        >>::prepare_csr_write(self, csr_index, write_value, &mut out)?
-        {
+        if !<TimeCsrInstruction<Reg<u64>>>::prepare_csr_write(
+            self,
+            csr_index,
+            write_value,
+            &mut out,
+        )? {
             return Err(CsrError::IllegalWrite { csr_index });
         }
 
@@ -132,13 +122,14 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg> ExecutableInstructionOperands for TimeCsrInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for TimeCsrInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     ExtState: AsMut<TimeCsrState> + AsRef<TimeCsrState>,
-    CustomError: fmt::Debug,
 {
     fn prepare_csr_read(
         ext_state: &ExtState,
@@ -171,7 +162,17 @@ where
             Ok(false)
         }
     }
+}
 
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for TimeCsrInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+    ExtState: AsMut<TimeCsrState> + AsRef<TimeCsrState>,
+    CustomError: fmt::Debug,
+{
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -380,7 +380,7 @@ where
 
     /// Process CSR read.
     ///
-    /// Must proxy calls to [`ExecutableInstruction::prepare_csr_read()`] of the root instruction
+    /// Must proxy calls to [`ExecutableInstructionCsr::prepare_csr_read()`] of the root instruction
     /// and return the output value on success. The method is present on `Csrs` to break cycles in
     /// the type system.
     fn process_csr_read(
@@ -391,8 +391,8 @@ where
 
     /// Process CSR write.
     ///
-    /// Must proxy calls to [`ExecutableInstruction::prepare_csr_write()`] of the root instruction
-    /// and return the output value on success.
+    /// Must proxy calls to [`ExecutableInstructionCsr::prepare_csr_write()`] of the root
+    /// instruction and return the output value on success.
     /// The method is present on `Csrs` to break cycles in the type system.
     fn process_csr_write(
         &mut self,
@@ -471,15 +471,20 @@ pub struct Rs1Rs2OperandValues<RegType> {
     pub rs2_value: RegType,
 }
 
-/// Trait for executable instructions
-pub trait ExecutableInstruction<
-    Regs,
-    ExtState,
-    Memory,
-    PC,
-    InstructionHandler,
-    CustomError = CustomErrorPlaceholder,
-> where
+/// `rs1`/`rs2` instruction operands
+pub trait ExecutableInstructionOperands
+where
+    Self: Instruction,
+{
+    /// `rs1`/`rs2` instruction operands.
+    ///
+    /// Returns zero register for `rs1`/`rs2` that were missing in the original instruction
+    /// definition.
+    fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg>;
+}
+
+pub trait ExecutableInstructionCsr<ExtState, CustomError = CustomErrorPlaceholder>
+where
     Self: Instruction,
 {
     /// Prepare CSR read.
@@ -539,13 +544,19 @@ pub trait ExecutableInstruction<
         // The default implementation is to not allow anything
         Ok(false)
     }
+}
 
-    /// `rs1`/`rs2` instruction operands.
-    ///
-    /// Returns zero register for `rs1`/rs2` that were missing in the original instruction
-    /// definition.
-    fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg>;
-
+/// Trait for executable instructions
+pub trait ExecutableInstruction<
+    Regs,
+    ExtState,
+    Memory,
+    PC,
+    InstructionHandler,
+    CustomError = CustomErrorPlaceholder,
+> where
+    Self: ExecutableInstructionOperands + ExecutableInstructionCsr<ExtState, CustomError>,
+{
     /// Execute instruction.
     ///
     /// Instructions might place additional constraints on `ExtState` to require additional

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -29,7 +29,8 @@ pub use crate::v::zve64x::widen_narrow::zve64x_widen_narrow_helpers;
 pub use crate::v::zve64x::zve64x_helpers;
 pub use crate::zicsr::zicsr_helpers;
 pub use crate::{
-    BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError, FetchInstructionResult,
-    InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
+    ExecutableInstructionOperands, ExecutionError, FetchInstructionResult, InstructionFetcher,
+    ProgramCounter, ProgramCounterError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -11,12 +11,24 @@ pub mod zce;
 pub mod zk;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32Instruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32Instruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
@@ -7,11 +7,23 @@ pub mod zbs;
 
 use crate::rv32::b::zbb::rv32_zbb_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32BInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32BInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
@@ -4,11 +4,23 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZbaInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZbaInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
@@ -5,11 +5,23 @@ pub mod rv32_zbb_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZbbInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZbbInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
@@ -5,11 +5,23 @@ pub mod rv32_zbc_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZbcInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZbcInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
@@ -4,11 +4,23 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZbsInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZbsInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -4,12 +4,24 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZcaInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZcaInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
@@ -5,11 +5,23 @@ mod tests;
 pub mod zmmul;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32MInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32MInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
@@ -1,11 +1,24 @@
 //! RV32 Zmmul extension (multiplication subset of M extension)
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZmmulInstruction<Reg> where Reg: Register<Type = u32>
+{}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZmmulInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -6,12 +6,24 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZcbInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZcbInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -5,12 +5,27 @@ pub mod rv32_zcmp_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZcmpInstruction<Reg> where
+    Reg: ZcmpRegister<Type = u32>
+{
+}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZcmpInstruction<Reg>
+where
+    Reg: ZcmpRegister<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
@@ -5,11 +5,23 @@ pub mod rv32_zbkb_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZbkbInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZbkbInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
@@ -2,11 +2,23 @@
 
 use crate::rv32::b::zbc::rv32_zbc_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZbkcInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZbkcInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
@@ -8,11 +8,23 @@ pub mod rv32_zbkx_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZbkxInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZbkxInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
@@ -11,11 +11,23 @@ use crate::rv32::zk::zkn::zknd::rv32_zknd_helpers;
 use crate::rv32::zk::zkn::zkne::rv32_zkne_helpers;
 use crate::rv32::zk::zkn::zknh::rv32_zknh_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZknInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZknInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
@@ -5,11 +5,23 @@ pub mod rv32_zknd_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZkndInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZkndInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
@@ -5,11 +5,23 @@ pub mod rv32_zkne_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZkneInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZkneInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
@@ -5,11 +5,23 @@ pub mod rv32_zknh_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZknhInstruction<Reg> where Reg: Register<Type = u32> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZknhInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -11,12 +11,24 @@ pub mod zce;
 pub mod zk;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64Instruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64Instruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
@@ -7,11 +7,23 @@ pub mod zbs;
 
 use crate::rv64::b::zbb::rv64_zbb_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64BInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64BInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
@@ -4,11 +4,23 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZbaInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZbaInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
@@ -5,11 +5,23 @@ pub mod rv64_zbb_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZbbInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZbbInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
@@ -5,11 +5,23 @@ pub mod rv64_zbc_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZbcInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZbcInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
@@ -4,11 +4,23 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZbsInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZbsInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -4,12 +4,24 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZcaInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZcaInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
@@ -5,11 +5,23 @@ mod tests;
 pub mod zmmul;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64MInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64MInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
@@ -1,11 +1,24 @@
 //! RV64 Zmmul extension (multiplication subset of M extension)
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZmmulInstruction<Reg> where Reg: Register<Type = u64>
+{}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZmmulInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -4,12 +4,24 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZcbInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZcbInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -5,12 +5,27 @@ pub mod rv64_zcmp_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZcmpInstruction<Reg> where
+    Reg: ZcmpRegister<Type = u64>
+{
+}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZcmpInstruction<Reg>
+where
+    Reg: ZcmpRegister<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
@@ -4,11 +4,23 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZbkbInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZbkbInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
@@ -2,11 +2,23 @@
 
 use crate::rv64::b::zbc::rv64_zbc_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZbkcInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZbkcInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
@@ -8,11 +8,23 @@ pub mod rv64_zbkx_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZbkxInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZbkxInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
@@ -10,11 +10,23 @@ use crate::rv64::zk::zkn::zknd::rv64_zknd_helpers;
 use crate::rv64::zk::zkn::zkne::rv64_zkne_helpers;
 use crate::rv64::zk::zkn::zknh::rv64_zknh_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZknInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZknInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
@@ -5,11 +5,23 @@ pub mod rv64_zknd_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZkndInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZkndInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
@@ -9,11 +9,23 @@ mod tests;
 
 use crate::rv64::zk::zkn::zknd::rv64_zknd_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZkneInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZkneInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
@@ -5,11 +5,23 @@ pub mod rv64_zknh_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZknhInstruction<Reg> where Reg: Register<Type = u64> {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZknhInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x.rs
@@ -25,13 +25,25 @@ use crate::v::zve64x::store::zve64x_store_helpers;
 use crate::v::zve64x::widen_narrow::zve64x_widen_narrow_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
-    CsrError, Csrs, ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith.rs
@@ -7,13 +7,24 @@ pub mod zve64x_arith_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xArithInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xArithInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
@@ -1,11 +1,8 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TestInstructionFetcher, TestInstructionHandler, TestInterpreterState, TestMemory,
-    initialize_state,
-};
+use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
 
@@ -34,13 +31,7 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xArithInstruction<Reg<u64>>>,
     instr: Zve64xArithInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/config.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/config.rs
@@ -6,8 +6,8 @@ pub mod zve64x_config_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::{
-    CsrError, ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -15,17 +15,14 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg> ExecutableInstructionOperands for Zve64xConfigInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Zve64xConfigInstruction<Reg>
 where
     Reg: Register,
-    Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
-    [(); ExtState::ELEN as usize]:,
-    [(); ExtState::VLEN as usize]:,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    CustomError: fmt::Debug,
+    ExtState: Csrs<Reg, CustomError>,
 {
     /// Validate reads to vector CSRs from Zicsr instructions.
     ///
@@ -105,7 +102,21 @@ where
             Ok(false)
         }
     }
+}
 
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xConfigInstruction<Reg>
+where
+    Reg: Register,
+    Regs: RegisterFile<Reg>,
+    ExtState: VectorRegistersExt<Reg, CustomError>,
+    [(); ExtState::ELEN as usize]:,
+    [(); ExtState::VLEN as usize]:,
+    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    CustomError: fmt::Debug,
+{
     #[inline(always)]
     fn execute(
         self,

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/tests.rs
@@ -1,9 +1,6 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TestInstructionFetcher, TestInstructionHandler, TestMemory, execute, initialize_state,
-};
+use crate::rv64::test_utils::{ExtState, execute, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersBase, VectorRegistersExt};
-use crate::{Csrs, ExecutableInstruction, RegisterFile};
+use crate::{Csrs, ExecutableInstructionCsr, RegisterFile};
 use ab_riscv_primitives::prelude::*;
 
 /// Encode a vtype immediate from SEW, LMUL, vta, vma fields
@@ -757,13 +754,12 @@ fn prepare_csr_read_passes_through_vector_csrs() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_read(&state.ext_state, VCsr::Vstart as u16, 42, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_read(
+        &state.ext_state,
+        VCsr::Vstart as u16,
+        42,
+        &mut output,
+    );
     assert!(result.unwrap());
     assert_eq!(output, 42);
 }
@@ -774,13 +770,8 @@ fn prepare_csr_read_ignores_non_vector_csrs() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_read(&state.ext_state, 0x300, 42, &mut output);
+    let result =
+        <Zve64xConfigInstruction<_>>::prepare_csr_read(&state.ext_state, 0x300, 42, &mut output);
     // Returns Ok(false) meaning "not handled by this extension"
     assert!(!result.unwrap());
 }
@@ -801,13 +792,12 @@ fn prepare_csr_read_works_for_all_vector_csrs() {
 
     for csr_index in csr_indices {
         let mut output = 0u64;
-        let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            BasicRegisters<Reg<u64>>,
-            ExtState,
-            TestMemory,
-            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-            TestInstructionHandler,
-        >>::prepare_csr_read(&state.ext_state, csr_index, 0xFF, &mut output);
+        let result = <Zve64xConfigInstruction<_>>::prepare_csr_read(
+            &state.ext_state,
+            csr_index,
+            0xFF,
+            &mut output,
+        );
         assert!(result.unwrap(), "CSR {csr_index:#x} should be handled");
         assert_eq!(output, 0xFF, "CSR {csr_index:#x} should pass through");
     }
@@ -819,13 +809,12 @@ fn prepare_csr_write_rejects_read_only_vl() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vl as u16, 42, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vl as u16,
+        42,
+        &mut output,
+    );
     assert!(result.is_err());
 }
 
@@ -835,14 +824,12 @@ fn prepare_csr_write_rejects_read_only_vtype() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result =
-        <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            BasicRegisters<Reg<u64>>,
-            ExtState,
-            TestMemory,
-            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-            TestInstructionHandler,
-        >>::prepare_csr_write(&mut state.ext_state, VCsr::Vtype as u16, 42, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vtype as u16,
+        42,
+        &mut output,
+    );
     assert!(result.is_err());
 }
 
@@ -852,14 +839,12 @@ fn prepare_csr_write_rejects_read_only_vlenb() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result =
-        <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            BasicRegisters<Reg<u64>>,
-            ExtState,
-            TestMemory,
-            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-            TestInstructionHandler,
-        >>::prepare_csr_write(&mut state.ext_state, VCsr::Vlenb as u16, 42, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vlenb as u16,
+        42,
+        &mut output,
+    );
     assert!(result.is_err());
 }
 
@@ -869,14 +854,12 @@ fn prepare_csr_write_vxsat_masks_to_1_bit() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result =
-        <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            BasicRegisters<Reg<u64>>,
-            ExtState,
-            TestMemory,
-            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-            TestInstructionHandler,
-        >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxsat as u16, 0xFF, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vxsat as u16,
+        0xFF,
+        &mut output,
+    );
     assert!(result.unwrap());
     assert_eq!(output, 1);
 }
@@ -887,14 +870,12 @@ fn prepare_csr_write_vxrm_masks_to_2_bits() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result =
-        <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            BasicRegisters<Reg<u64>>,
-            ExtState,
-            TestMemory,
-            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-            TestInstructionHandler,
-        >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxrm as u16, 0xFF, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vxrm as u16,
+        0xFF,
+        &mut output,
+    );
     assert!(result.unwrap());
     assert_eq!(output, 0b11);
 }
@@ -905,14 +886,12 @@ fn prepare_csr_write_vcsr_masks_to_3_bits() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result =
-        <Zve64xConfigInstruction<_> as ExecutableInstruction<
-            BasicRegisters<Reg<u64>>,
-            ExtState,
-            TestMemory,
-            TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-            TestInstructionHandler,
-        >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0xFFFF, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vcsr as u16,
+        0xFFFF,
+        &mut output,
+    );
     assert!(result.unwrap());
     assert_eq!(output, 0b111);
 }
@@ -923,13 +902,7 @@ fn prepare_csr_write_vstart_passes_full_value() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
         &mut state.ext_state,
         VCsr::Vstart as u16,
         0x1234,
@@ -945,13 +918,12 @@ fn prepare_csr_write_ignores_non_vector_csrs() {
     let mut state = initialize_state::<Zve64xConfigInstruction<_>, _>([]);
     state.ext_state.init_vector_csrs();
 
-    let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, 0x300, 42, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        0x300,
+        42,
+        &mut output,
+    );
     assert!(!result.unwrap());
 }
 
@@ -1356,13 +1328,12 @@ fn prepare_csr_write_vxsat_mirrors_into_vcsr() {
     state.ext_state.write_csr(VCsr::Vcsr as u16, 0b100).unwrap();
 
     let mut output = 0u64;
-    let result = <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxsat as u16, 1, &mut output);
+    let result = <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vxsat as u16,
+        1,
+        &mut output,
+    );
     assert!(result.unwrap());
     assert_eq!(output, 1);
 
@@ -1379,13 +1350,12 @@ fn prepare_csr_write_vxsat_clear_mirrors_into_vcsr() {
     state.ext_state.write_csr(VCsr::Vcsr as u16, 0b111).unwrap();
 
     let mut output = 0u64;
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxsat as u16, 0, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vxsat as u16,
+        0,
+        &mut output,
+    )
     .unwrap();
 
     // vcsr should now be 0b110: vxrm=0b11 preserved, vxsat=0
@@ -1401,13 +1371,12 @@ fn prepare_csr_write_vxrm_mirrors_into_vcsr() {
     state.ext_state.write_csr(VCsr::Vcsr as u16, 0b001).unwrap();
 
     let mut output = 0u64;
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxrm as u16, 0b11, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vxrm as u16,
+        0b11,
+        &mut output,
+    )
     .unwrap();
     assert_eq!(output, 0b11);
 
@@ -1424,13 +1393,12 @@ fn prepare_csr_write_vxrm_clear_mirrors_into_vcsr() {
     state.ext_state.write_csr(VCsr::Vcsr as u16, 0b111).unwrap();
 
     let mut output = 0u64;
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxrm as u16, 0b00, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vxrm as u16,
+        0b00,
+        &mut output,
+    )
     .unwrap();
 
     // vcsr should now be 0b001: vxrm=0b00, vxsat=1 preserved
@@ -1448,13 +1416,12 @@ fn prepare_csr_write_vcsr_mirrors_into_vxsat_and_vxrm() {
 
     let mut output = 0u64;
     // Write vcsr = 0b101 (vxrm=0b10, vxsat=1)
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0b101, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vcsr as u16,
+        0b101,
+        &mut output,
+    )
     .unwrap();
     assert_eq!(output, 0b101);
 
@@ -1474,13 +1441,12 @@ fn prepare_csr_write_vcsr_zero_clears_vxsat_and_vxrm() {
     state.ext_state.write_csr(VCsr::Vxrm as u16, 0b11).unwrap();
 
     let mut output = 0u64;
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vcsr as u16,
+        0,
+        &mut output,
+    )
     .unwrap();
 
     let vxsat = state.ext_state.read_csr(VCsr::Vxsat as u16).unwrap();
@@ -1497,13 +1463,12 @@ fn prepare_csr_write_vcsr_masks_then_mirrors() {
 
     let mut output = 0u64;
     // Write 0xFF to vcsr; should mask to 0b111, then mirror
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0xFF, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vcsr as u16,
+        0xFF,
+        &mut output,
+    )
     .unwrap();
     assert_eq!(output, 0b111);
 
@@ -1522,13 +1487,12 @@ fn mirroring_roundtrip_vxsat_to_vcsr_and_back() {
     let mut output = 0u64;
 
     // Write vxrm=0b10 via vcsr
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vcsr as u16, 0b100, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vcsr as u16,
+        0b100,
+        &mut output,
+    )
     .unwrap();
     // Now write the masked vcsr value to the CSR storage itself
     state
@@ -1537,13 +1501,12 @@ fn mirroring_roundtrip_vxsat_to_vcsr_and_back() {
         .unwrap();
 
     // Write vxsat=1 directly
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_write(&mut state.ext_state, VCsr::Vxsat as u16, 1, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_write(
+        &mut state.ext_state,
+        VCsr::Vxsat as u16,
+        1,
+        &mut output,
+    )
     .unwrap();
     state
         .ext_state
@@ -1576,13 +1539,12 @@ fn prepare_csr_read_vcsr_reflects_separate_csr_values() {
 
     let mut output = 0u64;
     let raw = state.ext_state.read_csr(VCsr::Vcsr as u16).unwrap();
-    <Zve64xConfigInstruction<_> as ExecutableInstruction<
-        BasicRegisters<Reg<u64>>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xConfigInstruction<_>>,
-        TestInstructionHandler,
-    >>::prepare_csr_read(&state.ext_state, VCsr::Vcsr as u16, raw, &mut output)
+    <Zve64xConfigInstruction<_>>::prepare_csr_read(
+        &state.ext_state,
+        VCsr::Vcsr as u16,
+        raw,
+        &mut output,
+    )
     .unwrap();
     assert_eq!(output, 0b101);
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
@@ -7,13 +7,24 @@ pub mod zve64x_fixed_point_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xFixedPointInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xFixedPointInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
@@ -1,12 +1,9 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TestInstructionFetcher, TestInstructionHandler, TestInterpreterState, TestMemory,
-    initialize_state,
-};
+use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::v::zve64x::arith::zve64x_arith_helpers::sign_extend;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
 
@@ -43,13 +40,7 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xFixedPointInstruction<Reg<u64>>>,
     instr: Zve64xFixedPointInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -7,13 +7,24 @@ pub mod zve64x_load_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xLoadInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xLoadInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
@@ -1,15 +1,12 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TEST_BASE_ADDR, TestInstructionFetcher, TestInstructionHandler, TestInterpreterState,
-    TestMemory, initialize_state,
-};
+use crate::rv64::test_utils::{TEST_BASE_ADDR, TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
 use core::array;
+
 // With TEST_VLEN=128 and TEST_VLENB=16, the VLMAX values are:
 //   E8/M1=16, E16/M1=8, E32/M1=4, E64/M1=2
 //   E8/M2=32, E16/M2=16, E32/M2=8, E64/M2=4
@@ -79,13 +76,7 @@ fn exec_one(
     state: &mut TestInterpreterState<Zve64xLoadInstruction<Reg<u64>>>,
     instr: Zve64xLoadInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
@@ -7,13 +7,24 @@ pub mod zve64x_mask_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xMaskInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xMaskInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
@@ -1,13 +1,11 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TestInstructionFetcher, TestInstructionHandler, TestInterpreterState, TestMemory,
-    initialize_state,
-};
+use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
+
 // With TEST_VLEN=128, VLENB=16:
 //   E8/M1 -> VLMAX=16, 1 reg
 //   E16/M1 -> VLMAX=8, 1 reg
@@ -38,13 +36,7 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xMaskInstruction<Reg<u64>>>,
     instr: Zve64xMaskInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
@@ -7,13 +7,24 @@ pub mod zve64x_muldiv_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xMulDivInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xMulDivInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
@@ -1,14 +1,12 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TestInstructionFetcher, TestInstructionHandler, TestInterpreterState, TestMemory,
-    initialize_state,
-};
+use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::v::zve64x::muldiv::zve64x_muldiv_helpers::widening_dest_register_count;
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
+
 // With TEST_VLEN=128, VLENB=16:
 //   E8/M1  -> VLMAX=16, 1 reg
 //   E16/M1 -> VLMAX=8,  1 reg
@@ -41,13 +39,7 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xMulDivInstruction<Reg<u64>>>,
     instr: Zve64xMulDivInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
@@ -7,13 +7,24 @@ pub mod zve64x_perm_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xPermInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xPermInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
@@ -1,12 +1,11 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TestInstructionFetcher, TestInstructionHandler, TestMemory, initialize_state,
-};
+use crate::rv64::test_utils::initialize_state;
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
+
 // With TEST_VLEN=128, VLENB=16:
 //   E8/M1   -> VLMAX=16, 1 reg,  16 elems/reg
 //   E16/M1  -> VLMAX=8,  1 reg,  8 elems/reg
@@ -40,13 +39,7 @@ fn exec(
     state: &mut crate::rv64::test_utils::TestInterpreterState<Zve64xPermInstruction<Reg<u64>>>,
     instr: Zve64xPermInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction.rs
@@ -8,13 +8,24 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::arith::zve64x_arith_helpers;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xReductionInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xReductionInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
@@ -1,11 +1,8 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TestInstructionFetcher, TestInstructionHandler, TestInterpreterState, TestMemory,
-    initialize_state,
-};
+use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
 
@@ -31,13 +28,7 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xReductionInstruction<Reg<u64>>>,
     instr: Zve64xReductionInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
@@ -8,13 +8,24 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::load::zve64x_load_helpers;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xStoreInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xStoreInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
@@ -1,15 +1,12 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TEST_BASE_ADDR, TestInstructionFetcher, TestInstructionHandler, TestInterpreterState,
-    TestMemory, initialize_state,
-};
+use crate::rv64::test_utils::{TEST_BASE_ADDR, TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
 use core::array;
+
 // With TEST_VLEN=128 and TEST_VLENB=16:
 //   E8/M1  VLMAX=16, E16/M1 VLMAX=8, E32/M1 VLMAX=4, E64/M1 VLMAX=2
 //   E8/M2  VLMAX=32, E16/M2 VLMAX=16
@@ -59,13 +56,7 @@ fn exec_one(
     state: &mut TestInterpreterState<Zve64xStoreInstruction<Reg<u64>>>,
     instr: Zve64xStoreInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow.rs
@@ -7,13 +7,24 @@ pub mod zve64x_widen_narrow_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers;
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xWidenNarrowInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xWidenNarrowInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
@@ -1,11 +1,8 @@
-use crate::basic::BasicRegisters;
-use crate::rv64::test_utils::{
-    ExtState, TestInstructionFetcher, TestInstructionHandler, TestInterpreterState, TestMemory,
-    initialize_state,
-};
+use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
 
@@ -31,13 +28,7 @@ fn exec(
     state: &mut TestInterpreterState<Zve64xWidenNarrowInstruction<Reg<u64>>>,
     instr: Zve64xWidenNarrowInstruction<Reg<u64>>,
 ) -> Result<(), ExecutionError<u64>> {
-    let Rs1Rs2Operands { rs1, rs2 } = <_ as ExecutableInstruction<
-        BasicRegisters<_>,
-        ExtState,
-        TestMemory,
-        TestInstructionFetcher<Zve64xWidenNarrowInstruction<_>>,
-        TestInstructionHandler,
-    >>::get_rs1_rs2_operands(instr);
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
     let rs1rs2_values = Rs1Rs2OperandValues {
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),

--- a/crates/execution/ab-riscv-interpreter/src/zicond.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicond.rs
@@ -4,11 +4,23 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for ZicondInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for ZicondInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -5,12 +5,23 @@ mod tests;
 pub mod zicsr_helpers;
 
 use crate::{
-    CsrError, Csrs, ExecutableInstruction, ExecutionError, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands,
+    CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for ZicsrInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for ZicsrInstruction<Reg>
+where
+    Reg: Register,
+{
+}
 
 #[instruction_execution]
 impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>

--- a/crates/execution/ab-riscv-macros-impl/src/instruction.rs
+++ b/crates/execution/ab-riscv-macros-impl/src/instruction.rs
@@ -37,8 +37,8 @@ fn process_enum_impl(item_impl: ItemImpl) -> Result<TokenStream, Error> {
         return Err(Error::new(
             item_impl.span(),
             format!(
-                "Expected `impl` for `{}`, `#[instruction]` attribute must be added to a simple \
-                instruction enum implementation",
+                "Expected `impl` for `{}`, `#[instruction]` attribute must be added to enum trait \
+                implementation",
                 item_impl.self_ty.to_token_stream(),
             ),
         ));
@@ -56,7 +56,7 @@ fn process_enum_impl(item_impl: ItemImpl) -> Result<TokenStream, Error> {
             item_impl.span(),
             format!(
                 "Expected `#[instruction] impl Instruction for {0}` or \
-                `#[instruction] impl Display for {0}`, but no trait was not found",
+                `#[instruction] impl Display for {0}`, but no trait was found",
                 item_impl.self_ty.to_token_stream()
             ),
         ));

--- a/crates/execution/ab-riscv-macros-impl/src/instruction_execution.rs
+++ b/crates/execution/ab-riscv-macros-impl/src/instruction_execution.rs
@@ -15,8 +15,8 @@ pub(super) fn instruction_execution(
         Error::new(
             error.span(),
             format!(
-                "`#[instruction_execution]` must be applied to enum implementation: {error}: {}",
-                item
+                "`#[instruction_execution]` must be applied to enum trait implementation: \
+                {error}: {item}"
             ),
         )
     })?;
@@ -25,8 +25,8 @@ pub(super) fn instruction_execution(
         return Err(Error::new(
             item_impl.span(),
             format!(
-                "Expected `impl` for `{}`, `#[instruction_execution]` attribute must be added to a \
-                simple instruction enum implementation",
+                "Expected `impl` for `{}`, `#[instruction_execution]` attribute must be added to \
+                enum trait implementation",
                 item_impl.self_ty.to_token_stream(),
             ),
         ));
@@ -38,10 +38,55 @@ pub(super) fn instruction_execution(
         .expect("Path is never empty; qed")
         .ident
         .clone();
-    let enum_file_path = format!("/{}_execution_impl.rs", enum_name);
 
-    // Replace enum implementation with a processed impl stored in a Rust file
-    Ok(quote! {
-        include!(concat!(env!("OUT_DIR"), #enum_file_path));
-    })
+    let Some((_, trait_path, _)) = &item_impl.trait_ else {
+        return Err(Error::new(
+            item_impl.span(),
+            format!(
+                "Expected `#[instruction_execution] impl ExecutableInstructionOperands for {0}` or \
+                `#[instruction_execution] impl ExecutableInstructionCsr for {0}` or \
+                `#[instruction_execution] impl ExecutableInstruction for {0}`, but no trait was \
+                found",
+                item_impl.self_ty.to_token_stream()
+            ),
+        ));
+    };
+
+    let last_trait_segment_path = trait_path
+        .segments
+        .last()
+        .expect("Path is never empty; qed");
+
+    if last_trait_segment_path.ident == "ExecutableInstructionOperands" {
+        let enum_file_path = format!("/{}_operands_impl.rs", enum_name);
+
+        // Replace enum implementation with a processed impl stored in a Rust file
+        Ok(quote! {
+            include!(concat!(env!("OUT_DIR"), #enum_file_path));
+        })
+    } else if last_trait_segment_path.ident == "ExecutableInstructionCsr" {
+        let enum_file_path = format!("/{}_csr_impl.rs", enum_name);
+
+        // Replace enum implementation with a processed impl stored in a Rust file
+        Ok(quote! {
+            include!(concat!(env!("OUT_DIR"), #enum_file_path));
+        })
+    } else if last_trait_segment_path.ident == "ExecutableInstruction" {
+        let enum_file_path = format!("/{}_execution_impl.rs", enum_name);
+
+        // Replace enum implementation with a processed impl stored in a Rust file
+        Ok(quote! {
+            include!(concat!(env!("OUT_DIR"), #enum_file_path));
+        })
+    } else {
+        Err(Error::new(
+            item_impl.span(),
+            format!(
+                "Expected `impl` for `{}`, `#[instruction_execution]` attribute must be added to a \
+                trait implementation, but trait `{}` is not supported",
+                item_impl.self_ty.to_token_stream(),
+                last_trait_segment_path.ident
+            ),
+        ))
+    }
 }

--- a/crates/execution/ab-riscv-macros-impl/src/lib.rs
+++ b/crates/execution/ab-riscv-macros-impl/src/lib.rs
@@ -129,15 +129,20 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Processes `#[instruction_execution]` attribute on enum execution implementation.
 ///
-/// It must be applied to enum, whose definition is already annotated with `#[instruction]` macro.
+/// It must be applied to implementation of traits `ExecutableInstructionOperands`,
+/// `ExecutableInstructionCsr` and `ExecutableInstruction`, whose definition is already annotated
+/// with `#[instruction]` macro.
 ///
-/// Similarly to that macro, this macro will process the contents of the `ExecutableInstruction`
-/// trait implementation. `execute()`, `prepare_csr_read()` and `prepare_csr_write()` methods will
-/// end up containing both inherited and own execution logic according to the ordering set in
-/// `#[instruction]`. `get_rs1_rs2_operands()` method will be generated from scratch.
+/// Similarly to that macro, this macro will process the contents of trait implementations.
 ///
-/// There are constraints on the `execute()` method body, it must have one or both (but nothing
-/// else) of the following:
+/// `ExecutableInstructionOperands::get_rs1_rs2_operands()` method will be generated from scratch.
+///
+/// `ExecutableInstruction::execute()`, `ExecutableInstructionCsr::prepare_csr_read()` and
+/// `ExecutableInstructionCsr::prepare_csr_write()` methods will end up containing both inherited
+/// and own execution logic according to the ordering set in `#[instruction]`.
+///
+/// There are constraints on the `ExecutableInstruction::execute()` method body, it must have one or
+/// both (but nothing else) of the following:
 /// * matching in the following style: `match self { Self::Variant { .. } }`
 ///   * note that `Self` must be used instead of the explicit type name, such that it works when
 ///     inherited
@@ -145,6 +150,10 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Also requires `process_instruction_macros()` in `build.rs` to function, see `#[instruction]`
 /// macro documentation.
+///
+/// `ExecutableInstructionCsr::prepare_csr_read()` and
+/// `ExecutableInstructionCsr::prepare_csr_write()` methods can't contain `return` in them,
+/// similarly to instruction decoding implementation processed by `#[instruction]` macro.
 #[proc_macro_attribute]
 pub fn instruction_execution(attr: TokenStream, item: TokenStream) -> TokenStream {
     instruction_execution::instruction_execution(attr.into(), item.into())

--- a/crates/execution/ab-riscv-macros/src/build.rs
+++ b/crates/execution/ab-riscv-macros/src/build.rs
@@ -12,7 +12,8 @@ use crate::build::enum_impl::{
     process_pending_enum_impls,
 };
 use crate::build::execution_impl::{
-    collect_enum_execution_impls_from_dependencies, process_execution_impl,
+    collect_enum_csr_impls_from_dependencies, collect_enum_execution_impls_from_dependencies,
+    collect_enum_operands_impls_from_dependencies, process_execution_impl,
     process_pending_enum_execution_impls,
 };
 use crate::build::state::State;
@@ -46,6 +47,14 @@ pub fn process_instruction_macros() -> anyhow::Result<()> {
     for maybe_enum_impl in collect_original_enum_decoding_impls_from_dependencies() {
         let (item_impl, source) = maybe_enum_impl?;
         state.insert_known_original_enum_decoding_impl(item_impl, source)?;
+    }
+    for maybe_enum_operands_impl in collect_enum_operands_impls_from_dependencies() {
+        let (item_impl, source) = maybe_enum_operands_impl?;
+        state.insert_known_enum_operands_impl(item_impl, source)?;
+    }
+    for maybe_enum_csr_impl in collect_enum_csr_impls_from_dependencies() {
+        let (item_impl, source) = maybe_enum_csr_impl?;
+        state.insert_known_enum_csr_impl(item_impl, source)?;
     }
     for maybe_enum_execution_impl in collect_enum_execution_impls_from_dependencies() {
         let (item_impl, source) = maybe_enum_execution_impl?;

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -240,7 +240,7 @@ pub(super) fn process_enum_impl(
     let Some((_, trait_path, _)) = &item_impl.trait_ else {
         return Some(Err(anyhow::anyhow!(
             "Expected `#[instruction] impl Instruction for {0}` or \
-            `#[instruction] impl Display for {0}`, but no trait was not found",
+            `#[instruction] impl Display for {0}`, but no trait was found",
             item_impl.self_ty.to_token_stream()
         )));
     };
@@ -688,7 +688,7 @@ pub(super) fn process_pending_enum_impls(out_dir: &Path, state: &mut State) -> a
 
             if pending_enums.len() == last_pending_enums_count {
                 return Err(anyhow::anyhow!(
-                    "Failed to process instruction macros, circular dependency detected, \
+                    "Failed to process `#[instruction]` macro, circular dependency detected, \
                     pending_enums: {:?}",
                     pending_enums
                         .iter()
@@ -714,7 +714,7 @@ pub(super) fn process_pending_enum_impls(out_dir: &Path, state: &mut State) -> a
 
             if pending_enums.len() == last_pending_enums_count {
                 return Err(anyhow::anyhow!(
-                    "Failed to process instruction macros, circular dependency detected, \
+                    "Failed to process `#[instruction]` macro, circular dependency detected, \
                     pending_enums: {:?}",
                     pending_enums
                         .iter()

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -4,7 +4,9 @@ mod forbidden_checker;
 use crate::build::enum_impl::enum_name_from_impl;
 use crate::build::execution_impl::extract_matches::extract_variant_arms;
 use crate::build::execution_impl::forbidden_checker::block_contains_forbidden_syntax;
-use crate::build::state::{PendingEnumExecutionImpl, State};
+use crate::build::state::{
+    PendingEnumCsrImpl, PendingEnumExecutionImpl, PendingEnumOperandsImpl, State,
+};
 use ab_riscv_macros_common::code_utils::{post_process_rust_code, pre_process_rust_code};
 use anyhow::Context;
 use prettyplease::unparse;
@@ -16,6 +18,68 @@ use std::{env, fs, iter, mem};
 use syn::{Ident, ImplItem, ImplItemFn, ItemImpl, parse_file, parse_quote, parse_str};
 
 const ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_EXECUTION_IMPL_PATH";
+const ENUM_OPERANDS_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_OPERANDS_IMPL_PATH";
+const ENUM_CSR_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_CSR_IMPL_PATH";
+
+pub(super) fn collect_enum_operands_impls_from_dependencies()
+-> impl Iterator<Item = anyhow::Result<(ItemImpl, Rc<Path>)>> {
+    // Collect exported instruction enums from dependencies
+    env::vars().filter_map(|(key, value)| {
+        if !key.ends_with(ENUM_OPERANDS_IMPL_ENV_VAR_SUFFIX) {
+            return None;
+        }
+
+        let result = try {
+            let mut item_enum_contents = fs::read_to_string(&value).with_context(|| {
+                format!(
+                    "Failed to read Rust file `{value}` that is expected to contain instruction \
+                    enum operands implementation"
+                )
+            })?;
+            pre_process_rust_code(&mut item_enum_contents);
+            let item_impl = parse_str::<ItemImpl>(&item_enum_contents).with_context(|| {
+                format!(
+                    "Failed to parse Rust file `{value}` that is expected to contain instruction \
+                    enum operands implementation"
+                )
+            })?;
+
+            (item_impl, Rc::from(Path::new(&value)))
+        };
+
+        Some(result)
+    })
+}
+
+pub(super) fn collect_enum_csr_impls_from_dependencies()
+-> impl Iterator<Item = anyhow::Result<(ItemImpl, Rc<Path>)>> {
+    // Collect exported instruction enums from dependencies
+    env::vars().filter_map(|(key, value)| {
+        if !key.ends_with(ENUM_CSR_IMPL_ENV_VAR_SUFFIX) {
+            return None;
+        }
+
+        let result = try {
+            let mut item_enum_contents = fs::read_to_string(&value).with_context(|| {
+                format!(
+                    "Failed to read Rust file `{value}` that is expected to contain instruction \
+                    enum csr implementation"
+                )
+            })?;
+            pre_process_rust_code(&mut item_enum_contents);
+            let item_impl = parse_str::<ItemImpl>(&item_enum_contents).with_context(|| {
+                format!(
+                    "Failed to parse Rust file `{value}` that is expected to contain instruction \
+                    enum csr implementation"
+                )
+            })?;
+
+            (item_impl, Rc::from(Path::new(&value)))
+        };
+
+        Some(result)
+    })
+}
 
 pub(super) fn collect_enum_execution_impls_from_dependencies()
 -> impl Iterator<Item = anyhow::Result<(ItemImpl, Rc<Path>)>> {
@@ -119,6 +183,70 @@ fn extract_execute_fn_from_impl_mut(impl_item: &mut [ImplItem]) -> Option<&mut I
     None
 }
 
+fn output_processed_enum_operands_impl(
+    enum_name: &Ident,
+    item_impl: ItemImpl,
+    out_dir: &Path,
+    state: &mut State,
+) -> anyhow::Result<()> {
+    let enum_file_path = out_dir.join(format!("{}_operands_impl.rs", enum_name));
+    let code = item_impl.to_token_stream().to_string();
+    // Format
+    let mut code = unparse(&parse_file(&code).expect("Generated code is valid; qed"));
+    // Normalize source
+    let item_impl = parse_str(&code).expect("Generated code is valid; qed");
+    post_process_rust_code(&mut code);
+
+    // Avoid extra file truncation/override if it didn't change
+    if fs::read_to_string(&enum_file_path).ok().as_ref() != Some(&code) {
+        fs::write(&enum_file_path, code).with_context(|| {
+            format!(
+                "Failed to write generated Rust file with instruction operands implementation for \
+                `{enum_name}`",
+            )
+        })?;
+    }
+    println!(
+        "cargo::metadata={}{ENUM_OPERANDS_IMPL_ENV_VAR_SUFFIX}={}",
+        enum_name,
+        enum_file_path.display()
+    );
+
+    state.insert_known_enum_operands_impl(item_impl, Rc::from(enum_file_path))
+}
+
+fn output_processed_enum_csr_impl(
+    enum_name: &Ident,
+    item_impl: ItemImpl,
+    out_dir: &Path,
+    state: &mut State,
+) -> anyhow::Result<()> {
+    let enum_file_path = out_dir.join(format!("{}_csr_impl.rs", enum_name));
+    let code = item_impl.to_token_stream().to_string();
+    // Format
+    let mut code = unparse(&parse_file(&code).expect("Generated code is valid; qed"));
+    // Normalize source
+    let item_impl = parse_str(&code).expect("Generated code is valid; qed");
+    post_process_rust_code(&mut code);
+
+    // Avoid extra file truncation/override if it didn't change
+    if fs::read_to_string(&enum_file_path).ok().as_ref() != Some(&code) {
+        fs::write(&enum_file_path, code).with_context(|| {
+            format!(
+                "Failed to write generated Rust file with instruction csr implementation for \
+                `{enum_name}`",
+            )
+        })?;
+    }
+    println!(
+        "cargo::metadata={}{ENUM_CSR_IMPL_ENV_VAR_SUFFIX}={}",
+        enum_name,
+        enum_file_path.display()
+    );
+
+    state.insert_known_enum_csr_impl(item_impl, Rc::from(enum_file_path))
+}
+
 fn output_processed_enum_execution_impl(
     enum_name: &Ident,
     item_impl: ItemImpl,
@@ -170,8 +298,9 @@ pub(super) fn process_execution_impl(
 
     let Some((_, trait_path, _)) = &item_impl.trait_ else {
         return Some(Err(anyhow::anyhow!(
-            "Expected `#[instruction_execution] impl Instruction for {0}` or \
-            `#[instruction_execution] impl Display for {0}`, but no trait was not found",
+            "Expected  `#[instruction_execution] impl ExecutableInstructionOperands for {0}` or \
+            `#[instruction_execution] impl ExecutableInstructionCsr for {0}` or \
+            `#[instruction_execution] impl ExecutableInstruction for {0}`, but no trait was found",
             item_impl.self_ty.to_token_stream()
         )));
     };
@@ -182,7 +311,11 @@ pub(super) fn process_execution_impl(
         .expect("Path is never empty; qed");
 
     Some(
-        if last_trait_segment_path.ident == "ExecutableInstruction" {
+        if last_trait_segment_path.ident == "ExecutableInstructionOperands" {
+            process_enum_operands_impl(item_impl, out_dir, state)
+        } else if last_trait_segment_path.ident == "ExecutableInstructionCsr" {
+            process_enum_csr_impl(item_impl, out_dir, state)
+        } else if last_trait_segment_path.ident == "ExecutableInstruction" {
             process_enum_execution_impl(item_impl, out_dir, state)
         } else {
             Err(anyhow::anyhow!(
@@ -195,37 +328,120 @@ pub(super) fn process_execution_impl(
     )
 }
 
-pub(super) fn process_enum_execution_impl(
+pub(super) fn process_enum_operands_impl(
     mut item_impl: ItemImpl,
     out_dir: &Path,
     state: &mut State,
 ) -> anyhow::Result<()> {
     let enum_name = enum_name_from_impl(&item_impl);
 
-    let Some(execute_fn) = extract_execute_fn_from_impl_mut(&mut item_impl.items) else {
-        Err(anyhow::anyhow!(
-            "Unexpected `impl` for `{}`, `#[instruction_execution]` attribute must be added to a \
-            trait implementation, but no `execute` method was found",
-            item_impl.self_ty.to_token_stream()
-        ))?
+    let Some(enum_definition) = state.get_known_enum_definition(&enum_name) else {
+        eprintln!("{enum_name} operands is waiting on its definition");
+        state.add_pending_enum_operands_impl(PendingEnumOperandsImpl { item_impl });
+        return Ok(());
     };
-    // execute_fn.attrs.push(
-    //     parse_quote! { #[expect(clippy::type_complexity, reason = "Generic return type")] },
-    // );
-    let execute_block = &mut execute_fn.block;
+
+    let mut all_where_predicates = Vec::new();
+    {
+        let mut all_dependencies = HashSet::new();
+        all_dependencies.insert(enum_name.clone());
+        let mut new_dependencies = enum_definition.dependencies.clone();
+
+        while !new_dependencies.is_empty() {
+            for dependency_enum_name in mem::take(&mut new_dependencies) {
+                let Some(dependency_enum_definition) =
+                    state.get_known_enum_definition(&dependency_enum_name)
+                else {
+                    eprintln!(
+                        "{enum_name} operands is waiting on {dependency_enum_name} definition"
+                    );
+                    state.add_pending_enum_operands_impl(PendingEnumOperandsImpl { item_impl });
+                    return Ok(());
+                };
+
+                if !all_dependencies.insert(dependency_enum_name.clone()) {
+                    continue;
+                }
+
+                let Some(dependency_enum_operands_impl) =
+                    state.get_known_enum_operands_impl(&dependency_enum_name)
+                else {
+                    eprintln!(
+                        "{enum_name} operands is waiting on {dependency_enum_name} operands implementation"
+                    );
+                    state.add_pending_enum_operands_impl(PendingEnumOperandsImpl { item_impl });
+                    return Ok(());
+                };
+
+                if let Some(where_clause) = &dependency_enum_operands_impl
+                    .item_impl
+                    .generics
+                    .where_clause
+                {
+                    all_where_predicates.extend(where_clause.predicates.iter().cloned());
+                }
+                new_dependencies.extend(dependency_enum_definition.dependencies.iter().cloned());
+            }
+        }
+    }
+
+    {
+        let where_clause = item_impl
+            .generics
+            .where_clause
+            .get_or_insert(parse_quote! { where });
+        let mut already_inserted = where_clause
+            .predicates
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        for predicate in all_where_predicates {
+            if already_inserted.contains(&predicate) {
+                continue;
+            }
+            already_inserted.insert(predicate.clone());
+            where_clause.predicates.push(predicate);
+        }
+    }
+
+    item_impl.items.push({
+        let all_instructions = enum_definition
+            .instructions
+            .iter()
+            .map(|variant| &variant.ident);
+
+        parse_quote! {
+            #[inline(always)]
+            fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg> {
+                match self {
+                    #( Self::#all_instructions { rs1, rs2, .. } => Rs1Rs2Operands { rs1, rs2 }, )*
+                }
+            }
+        }
+    });
+
+    output_processed_enum_operands_impl(&enum_name, item_impl, out_dir, state)
+}
+
+pub(super) fn process_enum_csr_impl(
+    mut item_impl: ItemImpl,
+    out_dir: &Path,
+    state: &mut State,
+) -> anyhow::Result<()> {
+    let enum_name = enum_name_from_impl(&item_impl);
 
     let Some(enum_definition) = state.get_known_enum_definition(&enum_name) else {
-        state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+        eprintln!("{enum_name} CSR is waiting on its definition");
+        state.add_pending_enum_csr_impl(PendingEnumCsrImpl { item_impl });
         return Ok(());
     };
 
     // TODO: This should be changed to recursively combine all fundamental extensions instead of
     //  combined ones instead, such that extension D that depends two extensions B and C that both
     //  depend on the same extension A will get A included in D once rather than twice. This is
-    //  caused by `get_known_enum_execution_impl` returning final extension implementation and not
+    //  caused by `get_known_enum_csr_impl` returning final extension implementation and not
     //  its original state as defined in the source code. Essentially, in addition to the final
     //  version, the original body of the implementation needs to be retained and used.
-    let mut all_execute_blocks = Vec::new();
     let mut all_prepare_csr_read_fns = Vec::new();
     let mut all_prepare_csr_write_fns = Vec::new();
     let mut all_where_predicates = Vec::new();
@@ -239,7 +455,8 @@ pub(super) fn process_enum_execution_impl(
                 let Some(dependency_enum_definition) =
                     state.get_known_enum_definition(&dependency_enum_name)
                 else {
-                    state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+                    eprintln!("{enum_name} CSR is waiting on {dependency_enum_name} definition");
+                    state.add_pending_enum_csr_impl(PendingEnumCsrImpl { item_impl });
                     return Ok(());
                 };
 
@@ -247,29 +464,25 @@ pub(super) fn process_enum_execution_impl(
                     continue;
                 }
 
-                let Some(dependency_enum_execution_impl) =
-                    state.get_known_enum_execution_impl(&dependency_enum_name)
+                let Some(dependency_enum_csr_impl) =
+                    state.get_known_enum_csr_impl(&dependency_enum_name)
                 else {
-                    state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+                    eprintln!(
+                        "{enum_name} CSR is waiting on {dependency_enum_name} CSR implementation"
+                    );
+                    state.add_pending_enum_csr_impl(PendingEnumCsrImpl { item_impl });
                     return Ok(());
                 };
 
                 all_prepare_csr_read_fns.extend(extract_prepare_csr_read_fn(
-                    &dependency_enum_execution_impl.item_impl,
+                    &dependency_enum_csr_impl.item_impl,
                 ));
                 all_prepare_csr_write_fns.extend(extract_prepare_csr_write_fn(
-                    &dependency_enum_execution_impl.item_impl,
+                    &dependency_enum_csr_impl.item_impl,
                 ));
 
-                all_execute_blocks.push(
-                    &extract_execute_fn(&dependency_enum_execution_impl.item_impl)
-                        .expect("Dependencies are all valid; qed")
-                        .block,
-                );
-                if let Some(where_clause) = &dependency_enum_execution_impl
-                    .item_impl
-                    .generics
-                    .where_clause
+                if let Some(where_clause) =
+                    &dependency_enum_csr_impl.item_impl.generics.where_clause
                 {
                     all_where_predicates.extend(where_clause.predicates.iter().cloned());
                 }
@@ -278,7 +491,11 @@ pub(super) fn process_enum_execution_impl(
         }
     }
 
-    if let Some(where_clause) = &mut item_impl.generics.where_clause {
+    {
+        let where_clause = item_impl
+            .generics
+            .where_clause
+            .get_or_insert(parse_quote! { where });
         let mut already_inserted = where_clause
             .predicates
             .iter()
@@ -291,57 +508,15 @@ pub(super) fn process_enum_execution_impl(
             already_inserted.insert(predicate.clone());
             where_clause.predicates.push(predicate);
         }
-    } else {
-        Err(anyhow::anyhow!(
-            "Missing where clause on `#[instruction_execution] impl Instruction for {enum_name}`"
-        ))?;
     }
-
-    let all_execute_blocks = all_execute_blocks
-        .into_iter()
-        .chain(iter::once(&*execute_block));
-
-    let mut all_instructions = HashMap::new();
-    for block in all_execute_blocks {
-        for maybe_instruction in extract_variant_arms(block)? {
-            let (variant_name, instruction_arm) = maybe_instruction?;
-            all_instructions.insert(variant_name, instruction_arm);
-        }
-    }
-
-    let all_instructions = enum_definition
-        .instructions
-        .iter()
-        .map(|variant| {
-            let ident = &variant.ident;
-            all_instructions
-                .remove(ident)
-                .with_context(|| {
-                    format!(
-                        "Instruction `{ident}` not found in all_instructions for enum `{enum_name}`"
-                    )
-                })
-                .map(|arm| (ident, arm))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    *execute_block = {
-        let all_instructions = all_instructions.iter().map(|(_ident, arm)| arm);
-
-        parse_quote! {{
-            match self {
-                #( #all_instructions )*
-            }
-        }}
-    };
 
     // Composition for `prepare_csr_read` method
     let maybe_prepare_csr_read_fn = extract_prepare_csr_read_fn_mut(&mut item_impl);
     if let Some(prepare_csr_read_fn) = maybe_prepare_csr_read_fn {
         (!block_contains_forbidden_syntax(&prepare_csr_read_fn.block)).ok_or_else(|| {
             anyhow::anyhow!(
-                "Expected `#[instruction_execution] impl Instruction for {enum_name}` must not \
-                have `return` in `prepare_csr_read` method"
+                "Expected `#[instruction_execution] impl ExecutableInstructionCsr for {enum_name}` \
+                must not have `return` in `prepare_csr_read` method"
             )
         })?;
 
@@ -374,8 +549,8 @@ pub(super) fn process_enum_execution_impl(
     if let Some(prepare_csr_write_fn) = maybe_prepare_csr_write_fn {
         (!block_contains_forbidden_syntax(&prepare_csr_write_fn.block)).ok_or_else(|| {
             anyhow::anyhow!(
-                "Expected `#[instruction_execution] impl Instruction for {enum_name}` must not \
-                have `return` in `prepare_csr_write` method",
+                "Expected `#[instruction_execution] impl ExecutableInstructionCsr for {enum_name}` \
+                must not have `return` in `prepare_csr_write` method",
             )
         })?;
 
@@ -413,18 +588,142 @@ pub(super) fn process_enum_execution_impl(
         )] },
     ]);
 
-    item_impl.items.push({
-        let all_instructions = all_instructions.iter().map(|(ident, _arm)| ident);
+    output_processed_enum_csr_impl(&enum_name, item_impl, out_dir, state)
+}
 
-        parse_quote! {
-            #[inline(always)]
-            fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg> {
-                match self {
-                    #( Self::#all_instructions { rs1, rs2, .. } => Rs1Rs2Operands { rs1, rs2 }, )*
+pub(super) fn process_enum_execution_impl(
+    mut item_impl: ItemImpl,
+    out_dir: &Path,
+    state: &mut State,
+) -> anyhow::Result<()> {
+    let enum_name = enum_name_from_impl(&item_impl);
+
+    let Some(execute_fn) = extract_execute_fn_from_impl_mut(&mut item_impl.items) else {
+        Err(anyhow::anyhow!(
+            "Unexpected `impl` for `{}`, `#[instruction_execution]` attribute must be added to a \
+            trait implementation, but no `execute` method was found",
+            item_impl.self_ty.to_token_stream()
+        ))?
+    };
+    let execute_block = &mut execute_fn.block;
+
+    let Some(enum_definition) = state.get_known_enum_definition(&enum_name) else {
+        eprintln!("{enum_name} execution is waiting on its definition");
+        state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+        return Ok(());
+    };
+
+    let mut all_execute_blocks = Vec::new();
+    let mut all_where_predicates = Vec::new();
+    {
+        let mut all_dependencies = HashSet::new();
+        all_dependencies.insert(enum_name.clone());
+        let mut new_dependencies = enum_definition.dependencies.clone();
+
+        while !new_dependencies.is_empty() {
+            for dependency_enum_name in mem::take(&mut new_dependencies) {
+                let Some(dependency_enum_definition) =
+                    state.get_known_enum_definition(&dependency_enum_name)
+                else {
+                    eprintln!(
+                        "{enum_name} execution is waiting on {dependency_enum_name} definition"
+                    );
+                    state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+                    return Ok(());
+                };
+
+                if !all_dependencies.insert(dependency_enum_name.clone()) {
+                    continue;
                 }
+
+                let Some(dependency_enum_execution_impl) =
+                    state.get_known_enum_execution_impl(&dependency_enum_name)
+                else {
+                    eprintln!(
+                        "{enum_name} execution is waiting on {dependency_enum_name} execution \
+                        implementation"
+                    );
+                    state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+                    return Ok(());
+                };
+
+                all_execute_blocks.push(
+                    &extract_execute_fn(&dependency_enum_execution_impl.item_impl)
+                        .expect("Dependencies are all valid; qed")
+                        .block,
+                );
+                if let Some(where_clause) = &dependency_enum_execution_impl
+                    .item_impl
+                    .generics
+                    .where_clause
+                {
+                    all_where_predicates.extend(where_clause.predicates.iter().cloned());
+                }
+                new_dependencies.extend(dependency_enum_definition.dependencies.iter().cloned());
             }
         }
-    });
+    }
+
+    if let Some(where_clause) = &mut item_impl.generics.where_clause {
+        let mut already_inserted = where_clause
+            .predicates
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        for predicate in all_where_predicates {
+            if already_inserted.contains(&predicate) {
+                continue;
+            }
+            already_inserted.insert(predicate.clone());
+            where_clause.predicates.push(predicate);
+        }
+    } else {
+        Err(anyhow::anyhow!(
+            "Missing where clause on `#[instruction_execution] impl ExecutableInstruction for \
+            {enum_name}`"
+        ))?;
+    }
+
+    let all_execute_blocks = all_execute_blocks
+        .into_iter()
+        .chain(iter::once(&*execute_block));
+
+    let mut all_instructions = HashMap::new();
+    for block in all_execute_blocks {
+        for maybe_instruction in extract_variant_arms(block)? {
+            let (variant_name, instruction_arm) = maybe_instruction?;
+            all_instructions.insert(variant_name, instruction_arm);
+        }
+    }
+
+    let all_instructions = enum_definition
+        .instructions
+        .iter()
+        .map(|variant| {
+            let ident = &variant.ident;
+            all_instructions.remove(ident).with_context(|| {
+                format!(
+                    "Instruction `{ident}` not found in all_instructions for enum `{enum_name}`"
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    *execute_block = parse_quote! {{
+        match self {
+            #( #all_instructions )*
+        }
+    }};
+
+    // Comments will be stripped, this will suppress some of the lints that are caused by it
+    item_impl.attrs.extend([
+        parse_quote! { #[expect(clippy::allow_attributes, reason = "Attribute below")] },
+        parse_quote! { #[allow(
+            clippy::undocumented_unsafe_blocks,
+            reason = "Comments will be stripped, this will suppress some of the lints that are \
+            caused by it"
+        )] },
+    ]);
 
     output_processed_enum_execution_impl(&enum_name, item_impl, out_dir, state)
 }
@@ -434,28 +733,83 @@ pub(super) fn process_pending_enum_execution_impls(
     out_dir: &Path,
     state: &mut State,
 ) -> anyhow::Result<()> {
-    let mut last_pending_enums_count = 0;
-    loop {
-        let pending_enums = state.take_pending_enum_execution_impls();
+    {
+        let mut last_pending_enums_count = 0;
+        loop {
+            let pending_enums = state.take_pending_enum_operands_impls();
 
-        if pending_enums.is_empty() {
-            break;
+            if pending_enums.is_empty() {
+                break;
+            }
+
+            if pending_enums.len() == last_pending_enums_count {
+                return Err(anyhow::anyhow!(
+                    "Failed to process instruction `#[instruction_execution]` macro on \
+                    `ExecutableInstructionOperands`, circular dependency detected, pending_enums: \
+                    {:?}",
+                    pending_enums
+                        .iter()
+                        .map(|pending_enum| enum_name_from_impl(&pending_enum.item_impl))
+                        .collect::<Vec<_>>()
+                ));
+            }
+            last_pending_enums_count = pending_enums.len();
+
+            for PendingEnumOperandsImpl { item_impl } in pending_enums {
+                process_enum_operands_impl(item_impl, out_dir, state)?;
+            }
         }
+    }
+    {
+        let mut last_pending_enums_count = 0;
+        loop {
+            let pending_enums = state.take_pending_enum_csr_impls();
 
-        if pending_enums.len() == last_pending_enums_count {
-            return Err(anyhow::anyhow!(
-                "Failed to process instruction execution macros, circular dependency detected, \
-                pending_enums: {:?}",
-                pending_enums
-                    .iter()
-                    .map(|pending_enum| enum_name_from_impl(&pending_enum.item_impl))
-                    .collect::<Vec<_>>()
-            ));
+            if pending_enums.is_empty() {
+                break;
+            }
+
+            if pending_enums.len() == last_pending_enums_count {
+                return Err(anyhow::anyhow!(
+                    "Failed to process instruction `#[instruction_execution]` macro on \
+                    `ExecutableInstructionCsr`, circular dependency detected, pending_enums: {:?}",
+                    pending_enums
+                        .iter()
+                        .map(|pending_enum| enum_name_from_impl(&pending_enum.item_impl))
+                        .collect::<Vec<_>>()
+                ));
+            }
+            last_pending_enums_count = pending_enums.len();
+
+            for PendingEnumCsrImpl { item_impl } in pending_enums {
+                process_enum_csr_impl(item_impl, out_dir, state)?;
+            }
         }
-        last_pending_enums_count = pending_enums.len();
+    }
+    {
+        let mut last_pending_enums_count = 0;
+        loop {
+            let pending_enums = state.take_pending_enum_execution_impls();
 
-        for PendingEnumExecutionImpl { item_impl } in pending_enums {
-            process_enum_execution_impl(item_impl, out_dir, state)?;
+            if pending_enums.is_empty() {
+                break;
+            }
+
+            if pending_enums.len() == last_pending_enums_count {
+                return Err(anyhow::anyhow!(
+                    "Failed to process instruction `#[instruction_execution]` macro on \
+                    `ExecutableInstruction`, circular dependency detected, pending_enums: {:?}",
+                    pending_enums
+                        .iter()
+                        .map(|pending_enum| enum_name_from_impl(&pending_enum.item_impl))
+                        .collect::<Vec<_>>()
+                ));
+            }
+            last_pending_enums_count = pending_enums.len();
+
+            for PendingEnumExecutionImpl { item_impl } in pending_enums {
+                process_enum_execution_impl(item_impl, out_dir, state)?;
+            }
         }
     }
 

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -166,249 +166,267 @@ pub(super) fn process_execution_impl(
                 .is_ident("instruction_execution")
                 .then_some(index)
         })?;
+    item_impl.attrs.remove(attribute_index);
 
-    let result = try {
-        let enum_name = enum_name_from_impl(&item_impl);
-
-        let Some(execute_fn) = extract_execute_fn_from_impl_mut(&mut item_impl.items) else {
-            Err(anyhow::anyhow!(
-                "Unexpected `impl` for `{}`, `#[instruction_execution]` attribute must be added to \
-                a simple instruction enum implementation, but no `execute` method was found",
-                item_impl.self_ty.to_token_stream()
-            ))?
-        };
-        // execute_fn.attrs.push(
-        //     parse_quote! { #[expect(clippy::type_complexity, reason = "Generic return type")] },
-        // );
-        let execute_block = &mut execute_fn.block;
-
-        let Some(enum_definition) = state.get_known_enum_definition(&enum_name) else {
-            state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
-            return Some(Ok(()));
-        };
-
-        // TODO: This should be changed to recursively combine all fundamental extensions instead of
-        //  combined ones instead, such that extension D that depends two extensions B and C that
-        //  both depend on the same extension A will get A included in D once rather than twice.
-        //  This is caused by `get_known_enum_execution_impl` returning final extension
-        //  implementation and not its original state as defined in the source code. Essentially, in
-        //  addition to the final version, the original body of the implementation needs to be
-        //  retained and used.
-        let mut all_execute_blocks = Vec::new();
-        let mut all_prepare_csr_read_fns = Vec::new();
-        let mut all_prepare_csr_write_fns = Vec::new();
-        let mut all_where_predicates = Vec::new();
-        {
-            let mut all_dependencies = HashSet::new();
-            all_dependencies.insert(enum_name.clone());
-            let mut new_dependencies = enum_definition.dependencies.clone();
-
-            while !new_dependencies.is_empty() {
-                for dependency_enum_name in mem::take(&mut new_dependencies) {
-                    let Some(dependency_enum_definition) =
-                        state.get_known_enum_definition(&dependency_enum_name)
-                    else {
-                        state.add_pending_enum_execution_impl(PendingEnumExecutionImpl {
-                            item_impl,
-                        });
-                        return Some(Ok(()));
-                    };
-
-                    if !all_dependencies.insert(dependency_enum_name.clone()) {
-                        continue;
-                    }
-
-                    let Some(dependency_enum_execution_impl) =
-                        state.get_known_enum_execution_impl(&dependency_enum_name)
-                    else {
-                        state.add_pending_enum_execution_impl(PendingEnumExecutionImpl {
-                            item_impl,
-                        });
-                        return Some(Ok(()));
-                    };
-
-                    all_prepare_csr_read_fns.extend(extract_prepare_csr_read_fn(
-                        &dependency_enum_execution_impl.item_impl,
-                    ));
-                    all_prepare_csr_write_fns.extend(extract_prepare_csr_write_fn(
-                        &dependency_enum_execution_impl.item_impl,
-                    ));
-
-                    all_execute_blocks.push(
-                        &extract_execute_fn(&dependency_enum_execution_impl.item_impl)
-                            .expect("Dependencies are all valid; qed")
-                            .block,
-                    );
-                    if let Some(where_clause) = &dependency_enum_execution_impl
-                        .item_impl
-                        .generics
-                        .where_clause
-                    {
-                        all_where_predicates.extend(where_clause.predicates.iter().cloned());
-                    }
-                    new_dependencies
-                        .extend(dependency_enum_definition.dependencies.iter().cloned());
-                }
-            }
-        }
-
-        if let Some(where_clause) = &mut item_impl.generics.where_clause {
-            let mut already_inserted = where_clause
-                .predicates
-                .iter()
-                .cloned()
-                .collect::<HashSet<_>>();
-            for predicate in all_where_predicates {
-                if already_inserted.contains(&predicate) {
-                    continue;
-                }
-                already_inserted.insert(predicate.clone());
-                where_clause.predicates.push(predicate);
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "Missing where clause on `#[instruction_execution] impl Instruction for \
-                {enum_name}`"
-            ))?;
-        }
-
-        let all_execute_blocks = all_execute_blocks
-            .into_iter()
-            .chain(iter::once(&*execute_block));
-
-        let mut all_instructions = HashMap::new();
-        for block in all_execute_blocks {
-            for maybe_instruction in extract_variant_arms(block)? {
-                let (variant_name, instruction_arm) = maybe_instruction?;
-                all_instructions.insert(variant_name, instruction_arm);
-            }
-        }
-
-        let all_instructions = enum_definition
-            .instructions
-            .iter()
-            .map(|variant| {
-                let ident = &variant.ident;
-                all_instructions
-                    .remove(ident)
-                    .with_context(|| {
-                        format!(
-                            "Instruction `{ident}` not found in all_instructions for enum \
-                            `{enum_name}`"
-                        )
-                    })
-                    .map(|arm| (ident, arm))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        *execute_block = {
-            let all_instructions = all_instructions.iter().map(|(_ident, arm)| arm);
-
-            parse_quote! {{
-                match self {
-                    #( #all_instructions )*
-                }
-            }}
-        };
-
-        // Composition for `prepare_csr_read` method
-        let maybe_prepare_csr_read_fn = extract_prepare_csr_read_fn_mut(&mut item_impl);
-        if let Some(prepare_csr_read_fn) = maybe_prepare_csr_read_fn {
-            (!block_contains_forbidden_syntax(&prepare_csr_read_fn.block)).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Expected `#[instruction_execution] impl Instruction for {enum_name}` must not \
-                    have `return` in `prepare_csr_read` method"
-                )
-            })?;
-
-            let all_prepare_csr_read_blocks = all_prepare_csr_read_fns
-                .iter()
-                .map(|impl_item_fn| &impl_item_fn.block)
-                .chain(iter::once(&prepare_csr_read_fn.block));
-            prepare_csr_read_fn.block = parse_quote! {{
-                let mut accepted_by_at_least_one = false;
-                #( if #all_prepare_csr_read_blocks? { accepted_by_at_least_one = true; } )*
-
-                Ok(accepted_by_at_least_one)
-            }};
-        } else if let Some(&first_prepare_csr_read_fn) = all_prepare_csr_read_fns.first() {
-            let all_prepare_csr_read_blocks = all_prepare_csr_read_fns
-                .iter()
-                .map(|impl_item_fn| &impl_item_fn.block);
-            let mut base_fn = first_prepare_csr_read_fn.clone();
-            base_fn.block = parse_quote! {{
-                let mut accepted_by_at_least_one = false;
-                #( if #all_prepare_csr_read_blocks? { accepted_by_at_least_one = true; } )*
-
-                Ok(accepted_by_at_least_one)
-            }};
-            item_impl.items.push(ImplItem::Fn(base_fn));
-        }
-
-        // Composition for `prepare_csr_write` method
-        let maybe_prepare_csr_write_fn = extract_prepare_csr_write_fn_mut(&mut item_impl);
-        if let Some(prepare_csr_write_fn) = maybe_prepare_csr_write_fn {
-            (!block_contains_forbidden_syntax(&prepare_csr_write_fn.block)).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Expected `#[instruction_execution] impl Instruction for {enum_name}` must not \
-                    have `return` in `prepare_csr_write` method",
-                )
-            })?;
-
-            let all_prepare_csr_write_blocks = all_prepare_csr_write_fns
-                .iter()
-                .map(|impl_item_fn| &impl_item_fn.block)
-                .chain(iter::once(&prepare_csr_write_fn.block));
-            prepare_csr_write_fn.block = parse_quote! {{
-                let mut accepted_by_at_least_one = false;
-                #( if #all_prepare_csr_write_blocks? { accepted_by_at_least_one = true; } )*
-
-                Ok(accepted_by_at_least_one)
-            }};
-        } else if let Some(&first_prepare_csr_write_fn) = all_prepare_csr_write_fns.first() {
-            let all_prepare_csr_write_blocks = all_prepare_csr_write_fns
-                .iter()
-                .map(|impl_item_fn| &impl_item_fn.block);
-            let mut base_fn = first_prepare_csr_write_fn.clone();
-            base_fn.block = parse_quote! {{
-                let mut accepted_by_at_least_one = false;
-                #( if #all_prepare_csr_write_blocks? { accepted_by_at_least_one = true; } )*
-
-                Ok(accepted_by_at_least_one)
-            }};
-            item_impl.items.push(ImplItem::Fn(base_fn));
-        }
-
-        // Only remove after successful processing, so that the function can be called repeatedly
-        // with the same input if the implementation is still pending
-        item_impl.attrs.remove(attribute_index);
-        // Comments will be stripped, this will suppress some of the lints that are caused by it
-        item_impl.attrs.extend([
-            parse_quote! { #[expect(clippy::allow_attributes, reason = "Attribute below")] },
-            parse_quote! { #[allow(
-                clippy::undocumented_unsafe_blocks,
-                reason = "Comments will be stripped, this will suppress some of the lints that are \
-                caused by it"
-            )] },
-        ]);
-
-        item_impl.items.push({
-            let all_instructions = all_instructions.iter().map(|(ident, _arm)| ident);
-
-            parse_quote! {
-                #[inline(always)]
-                fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg> {
-                    match self {
-                        #( Self::#all_instructions { rs1, rs2, .. } => Rs1Rs2Operands { rs1, rs2 }, )*
-                    }
-                }
-            }
-        });
-
-        output_processed_enum_execution_impl(&enum_name, item_impl, out_dir, state)?
+    let Some((_, trait_path, _)) = &item_impl.trait_ else {
+        return Some(Err(anyhow::anyhow!(
+            "Expected `#[instruction_execution] impl Instruction for {0}` or \
+            `#[instruction_execution] impl Display for {0}`, but no trait was not found",
+            item_impl.self_ty.to_token_stream()
+        )));
     };
 
-    Some(result)
+    let last_trait_segment_path = trait_path
+        .segments
+        .last()
+        .expect("Path is never empty; qed");
+
+    Some(
+        if last_trait_segment_path.ident == "ExecutableInstruction" {
+            process_enum_execution_impl(item_impl, out_dir, state)
+        } else {
+            Err(anyhow::anyhow!(
+                "Expected `impl` for `{}`, `#[instruction_execution]` attribute must be added to a \
+                trait implementation, but trait `{}` is not supported",
+                item_impl.self_ty.to_token_stream(),
+                last_trait_segment_path.ident
+            ))
+        },
+    )
+}
+
+pub(super) fn process_enum_execution_impl(
+    mut item_impl: ItemImpl,
+    out_dir: &Path,
+    state: &mut State,
+) -> anyhow::Result<()> {
+    let enum_name = enum_name_from_impl(&item_impl);
+
+    let Some(execute_fn) = extract_execute_fn_from_impl_mut(&mut item_impl.items) else {
+        Err(anyhow::anyhow!(
+            "Unexpected `impl` for `{}`, `#[instruction_execution]` attribute must be added to a \
+            trait implementation, but no `execute` method was found",
+            item_impl.self_ty.to_token_stream()
+        ))?
+    };
+    // execute_fn.attrs.push(
+    //     parse_quote! { #[expect(clippy::type_complexity, reason = "Generic return type")] },
+    // );
+    let execute_block = &mut execute_fn.block;
+
+    let Some(enum_definition) = state.get_known_enum_definition(&enum_name) else {
+        state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+        return Ok(());
+    };
+
+    // TODO: This should be changed to recursively combine all fundamental extensions instead of
+    //  combined ones instead, such that extension D that depends two extensions B and C that both
+    //  depend on the same extension A will get A included in D once rather than twice. This is
+    //  caused by `get_known_enum_execution_impl` returning final extension implementation and not
+    //  its original state as defined in the source code. Essentially, in addition to the final
+    //  version, the original body of the implementation needs to be retained and used.
+    let mut all_execute_blocks = Vec::new();
+    let mut all_prepare_csr_read_fns = Vec::new();
+    let mut all_prepare_csr_write_fns = Vec::new();
+    let mut all_where_predicates = Vec::new();
+    {
+        let mut all_dependencies = HashSet::new();
+        all_dependencies.insert(enum_name.clone());
+        let mut new_dependencies = enum_definition.dependencies.clone();
+
+        while !new_dependencies.is_empty() {
+            for dependency_enum_name in mem::take(&mut new_dependencies) {
+                let Some(dependency_enum_definition) =
+                    state.get_known_enum_definition(&dependency_enum_name)
+                else {
+                    state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+                    return Ok(());
+                };
+
+                if !all_dependencies.insert(dependency_enum_name.clone()) {
+                    continue;
+                }
+
+                let Some(dependency_enum_execution_impl) =
+                    state.get_known_enum_execution_impl(&dependency_enum_name)
+                else {
+                    state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+                    return Ok(());
+                };
+
+                all_prepare_csr_read_fns.extend(extract_prepare_csr_read_fn(
+                    &dependency_enum_execution_impl.item_impl,
+                ));
+                all_prepare_csr_write_fns.extend(extract_prepare_csr_write_fn(
+                    &dependency_enum_execution_impl.item_impl,
+                ));
+
+                all_execute_blocks.push(
+                    &extract_execute_fn(&dependency_enum_execution_impl.item_impl)
+                        .expect("Dependencies are all valid; qed")
+                        .block,
+                );
+                if let Some(where_clause) = &dependency_enum_execution_impl
+                    .item_impl
+                    .generics
+                    .where_clause
+                {
+                    all_where_predicates.extend(where_clause.predicates.iter().cloned());
+                }
+                new_dependencies.extend(dependency_enum_definition.dependencies.iter().cloned());
+            }
+        }
+    }
+
+    if let Some(where_clause) = &mut item_impl.generics.where_clause {
+        let mut already_inserted = where_clause
+            .predicates
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        for predicate in all_where_predicates {
+            if already_inserted.contains(&predicate) {
+                continue;
+            }
+            already_inserted.insert(predicate.clone());
+            where_clause.predicates.push(predicate);
+        }
+    } else {
+        Err(anyhow::anyhow!(
+            "Missing where clause on `#[instruction_execution] impl Instruction for {enum_name}`"
+        ))?;
+    }
+
+    let all_execute_blocks = all_execute_blocks
+        .into_iter()
+        .chain(iter::once(&*execute_block));
+
+    let mut all_instructions = HashMap::new();
+    for block in all_execute_blocks {
+        for maybe_instruction in extract_variant_arms(block)? {
+            let (variant_name, instruction_arm) = maybe_instruction?;
+            all_instructions.insert(variant_name, instruction_arm);
+        }
+    }
+
+    let all_instructions = enum_definition
+        .instructions
+        .iter()
+        .map(|variant| {
+            let ident = &variant.ident;
+            all_instructions
+                .remove(ident)
+                .with_context(|| {
+                    format!(
+                        "Instruction `{ident}` not found in all_instructions for enum `{enum_name}`"
+                    )
+                })
+                .map(|arm| (ident, arm))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    *execute_block = {
+        let all_instructions = all_instructions.iter().map(|(_ident, arm)| arm);
+
+        parse_quote! {{
+            match self {
+                #( #all_instructions )*
+            }
+        }}
+    };
+
+    // Composition for `prepare_csr_read` method
+    let maybe_prepare_csr_read_fn = extract_prepare_csr_read_fn_mut(&mut item_impl);
+    if let Some(prepare_csr_read_fn) = maybe_prepare_csr_read_fn {
+        (!block_contains_forbidden_syntax(&prepare_csr_read_fn.block)).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Expected `#[instruction_execution] impl Instruction for {enum_name}` must not \
+                have `return` in `prepare_csr_read` method"
+            )
+        })?;
+
+        let all_prepare_csr_read_blocks = all_prepare_csr_read_fns
+            .iter()
+            .map(|impl_item_fn| &impl_item_fn.block)
+            .chain(iter::once(&prepare_csr_read_fn.block));
+        prepare_csr_read_fn.block = parse_quote! {{
+            let mut accepted_by_at_least_one = false;
+            #( if #all_prepare_csr_read_blocks? { accepted_by_at_least_one = true; } )*
+
+            Ok(accepted_by_at_least_one)
+        }};
+    } else if let Some(&first_prepare_csr_read_fn) = all_prepare_csr_read_fns.first() {
+        let all_prepare_csr_read_blocks = all_prepare_csr_read_fns
+            .iter()
+            .map(|impl_item_fn| &impl_item_fn.block);
+        let mut base_fn = first_prepare_csr_read_fn.clone();
+        base_fn.block = parse_quote! {{
+            let mut accepted_by_at_least_one = false;
+            #( if #all_prepare_csr_read_blocks? { accepted_by_at_least_one = true; } )*
+
+            Ok(accepted_by_at_least_one)
+        }};
+        item_impl.items.push(ImplItem::Fn(base_fn));
+    }
+
+    // Composition for `prepare_csr_write` method
+    let maybe_prepare_csr_write_fn = extract_prepare_csr_write_fn_mut(&mut item_impl);
+    if let Some(prepare_csr_write_fn) = maybe_prepare_csr_write_fn {
+        (!block_contains_forbidden_syntax(&prepare_csr_write_fn.block)).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Expected `#[instruction_execution] impl Instruction for {enum_name}` must not \
+                have `return` in `prepare_csr_write` method",
+            )
+        })?;
+
+        let all_prepare_csr_write_blocks = all_prepare_csr_write_fns
+            .iter()
+            .map(|impl_item_fn| &impl_item_fn.block)
+            .chain(iter::once(&prepare_csr_write_fn.block));
+        prepare_csr_write_fn.block = parse_quote! {{
+            let mut accepted_by_at_least_one = false;
+            #( if #all_prepare_csr_write_blocks? { accepted_by_at_least_one = true; } )*
+
+            Ok(accepted_by_at_least_one)
+        }};
+    } else if let Some(&first_prepare_csr_write_fn) = all_prepare_csr_write_fns.first() {
+        let all_prepare_csr_write_blocks = all_prepare_csr_write_fns
+            .iter()
+            .map(|impl_item_fn| &impl_item_fn.block);
+        let mut base_fn = first_prepare_csr_write_fn.clone();
+        base_fn.block = parse_quote! {{
+            let mut accepted_by_at_least_one = false;
+            #( if #all_prepare_csr_write_blocks? { accepted_by_at_least_one = true; } )*
+
+            Ok(accepted_by_at_least_one)
+        }};
+        item_impl.items.push(ImplItem::Fn(base_fn));
+    }
+
+    // Comments will be stripped, this will suppress some of the lints that are caused by it
+    item_impl.attrs.extend([
+        parse_quote! { #[expect(clippy::allow_attributes, reason = "Attribute below")] },
+        parse_quote! { #[allow(
+            clippy::undocumented_unsafe_blocks,
+            reason = "Comments will be stripped, this will suppress some of the lints that are \
+            caused by it"
+        )] },
+    ]);
+
+    item_impl.items.push({
+        let all_instructions = all_instructions.iter().map(|(ident, _arm)| ident);
+
+        parse_quote! {
+            #[inline(always)]
+            fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg> {
+                match self {
+                    #( Self::#all_instructions { rs1, rs2, .. } => Rs1Rs2Operands { rs1, rs2 }, )*
+                }
+            }
+        }
+    });
+
+    output_processed_enum_execution_impl(&enum_name, item_impl, out_dir, state)
 }
 
 /// Process remaining enums that were waiting for dependencies
@@ -437,9 +455,7 @@ pub(super) fn process_pending_enum_execution_impls(
         last_pending_enums_count = pending_enums.len();
 
         for PendingEnumExecutionImpl { item_impl } in pending_enums {
-            if let Some(result) = process_execution_impl(item_impl, out_dir, state) {
-                result?;
-            }
+            process_enum_execution_impl(item_impl, out_dir, state)?;
         }
     }
 

--- a/crates/execution/ab-riscv-macros/src/build/state.rs
+++ b/crates/execution/ab-riscv-macros/src/build/state.rs
@@ -37,6 +37,28 @@ pub(super) struct PendingEnumDisplayImpl {
 }
 
 #[derive(Debug)]
+pub(super) struct KnownEnumOperandsImpl {
+    pub(super) item_impl: ItemImpl,
+    pub(super) source: Rc<Path>,
+}
+
+#[derive(Debug)]
+pub(super) struct PendingEnumOperandsImpl {
+    pub(super) item_impl: ItemImpl,
+}
+
+#[derive(Debug)]
+pub(super) struct KnownEnumCsrImpl {
+    pub(super) item_impl: ItemImpl,
+    pub(super) source: Rc<Path>,
+}
+
+#[derive(Debug)]
+pub(super) struct PendingEnumCsrImpl {
+    pub(super) item_impl: ItemImpl,
+}
+
+#[derive(Debug)]
 pub(super) struct KnownEnumExecutionImpl {
     pub(super) item_impl: ItemImpl,
     pub(super) source: Rc<Path>,
@@ -53,6 +75,10 @@ pub(super) struct State {
     known_original_enum_decoding_impls: HashMap<Ident, KnownOriginalEnumDecodingImpl>,
     pending_enum_impls: Vec<PendingEnumImpl>,
     pending_enum_display_impls: Vec<PendingEnumDisplayImpl>,
+    known_enum_operands_impls: HashMap<Ident, KnownEnumOperandsImpl>,
+    pending_enum_operands_impls: Vec<PendingEnumOperandsImpl>,
+    known_enum_csr_impls: HashMap<Ident, KnownEnumCsrImpl>,
+    pending_enum_csr_impls: Vec<PendingEnumCsrImpl>,
     known_enum_execution_impls: HashMap<Ident, KnownEnumExecutionImpl>,
     pending_enum_execution_impls: Vec<PendingEnumExecutionImpl>,
 }
@@ -65,6 +91,10 @@ impl State {
             known_original_enum_decoding_impls: HashMap::new(),
             pending_enum_impls: Vec::new(),
             pending_enum_display_impls: Vec::new(),
+            known_enum_operands_impls: HashMap::new(),
+            pending_enum_operands_impls: Vec::new(),
+            known_enum_csr_impls: HashMap::new(),
+            pending_enum_csr_impls: Vec::new(),
             known_enum_execution_impls: HashMap::new(),
             pending_enum_execution_impls: Vec::new(),
         }
@@ -82,6 +112,17 @@ impl State {
         enum_name: &Ident,
     ) -> Option<&KnownOriginalEnumDecodingImpl> {
         self.known_original_enum_decoding_impls.get(enum_name)
+    }
+
+    pub(super) fn get_known_enum_operands_impl(
+        &self,
+        enum_name: &Ident,
+    ) -> Option<&KnownEnumOperandsImpl> {
+        self.known_enum_operands_impls.get(enum_name)
+    }
+
+    pub(super) fn get_known_enum_csr_impl(&self, enum_name: &Ident) -> Option<&KnownEnumCsrImpl> {
+        self.known_enum_csr_impls.get(enum_name)
     }
 
     pub(super) fn get_known_enum_execution_impl(
@@ -150,6 +191,60 @@ impl State {
         Ok(())
     }
 
+    pub(super) fn insert_known_enum_operands_impl(
+        &mut self,
+        item_impl: ItemImpl,
+        source: Rc<Path>,
+    ) -> anyhow::Result<()> {
+        let enum_name = enum_name_from_impl(&item_impl);
+
+        if let Err(OccupiedError { entry, value }) = self.known_enum_operands_impls.try_insert(
+            enum_name.clone(),
+            KnownEnumOperandsImpl {
+                item_impl,
+                source: source.clone(),
+            },
+        ) && entry.get().item_impl != value.item_impl
+        {
+            return Err(anyhow::anyhow!(
+                "Execution operands implementation for enum `{}` is already defined in `{}`, a \
+                different duplicate found in `{}`",
+                enum_name,
+                entry.get().source.display(),
+                source.display(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn insert_known_enum_csr_impl(
+        &mut self,
+        item_impl: ItemImpl,
+        source: Rc<Path>,
+    ) -> anyhow::Result<()> {
+        let enum_name = enum_name_from_impl(&item_impl);
+
+        if let Err(OccupiedError { entry, value }) = self.known_enum_csr_impls.try_insert(
+            enum_name.clone(),
+            KnownEnumCsrImpl {
+                item_impl,
+                source: source.clone(),
+            },
+        ) && entry.get().item_impl != value.item_impl
+        {
+            return Err(anyhow::anyhow!(
+                "Execution CSR implementation for enum `{}` is already defined in `{}`, a \
+                different duplicate found in `{}`",
+                enum_name,
+                entry.get().source.display(),
+                source.display(),
+            ));
+        }
+
+        Ok(())
+    }
+
     pub(super) fn insert_known_enum_execution_impl(
         &mut self,
         item_impl: ItemImpl,
@@ -206,6 +301,26 @@ impl State {
 
     pub(super) fn take_pending_enum_impls(&mut self) -> Vec<PendingEnumImpl> {
         mem::take(&mut self.pending_enum_impls)
+    }
+
+    pub(super) fn add_pending_enum_operands_impl(
+        &mut self,
+        pending_enum_operands_impl: PendingEnumOperandsImpl,
+    ) {
+        self.pending_enum_operands_impls
+            .push(pending_enum_operands_impl);
+    }
+
+    pub(super) fn take_pending_enum_operands_impls(&mut self) -> Vec<PendingEnumOperandsImpl> {
+        mem::take(&mut self.pending_enum_operands_impls)
+    }
+
+    pub(super) fn add_pending_enum_csr_impl(&mut self, pending_enum_csr_impl: PendingEnumCsrImpl) {
+        self.pending_enum_csr_impls.push(pending_enum_csr_impl);
+    }
+
+    pub(super) fn take_pending_enum_csr_impls(&mut self) -> Vec<PendingEnumCsrImpl> {
+        mem::take(&mut self.pending_enum_csr_impls)
     }
 
     pub(super) fn add_pending_enum_execution_impl(


### PR DESCRIPTION
Getting `rs1`/`rs2` operands and using CSR APIs was very awkward due to large number of generics on `ExecutableInstruction`. Now `ExecutableInstructionOperands` and `ExecutableInstructionCsr` traits are split off from `ExecutableInstruction`, making usability a lot better.

Instruction implementation, unfortunately, requires more boilerplate now, but I think it is worth it. Extending or modifying those traits in the future would be way easier too (if necessary).