### PR TITLE
Cleanups

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -24,11 +24,6 @@ impl const RegisterFile<ContractRegister> for ContractRegisters {
 
     #[inline(always)]
     fn write(&mut self, reg: ContractRegister, value: u64) {
-        if reg == ContractRegister::Zero {
-            // Writes are ignored
-            return;
-        }
-
         // SAFETY: register offset is always within bounds
         *unsafe { self.regs.get_unchecked_mut(usize::from(reg as u8)) } = value;
     }

--- a/crates/contracts/core/ab-contracts-tooling/src/riscv64-unknown-none-abundance.json
+++ b/crates/contracts/core/ab-contracts-tooling/src/riscv64-unknown-none-abundance.json
@@ -16,7 +16,6 @@
   "panic-strategy": "immediate-abort",
   "position-independent-executables": true,
   "relro-level": "full",
-  "static-position-independent-executables": true,
   "target-pointer-width": 64,
   "relocation-model": "pie",
   "singlethread": true,

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
@@ -90,25 +90,6 @@ impl Csrs<<AbundanceRv32IMaxInstruction as Instruction>::Reg> for AbundanceRv32I
         *slot = value;
         Ok(())
     }
-
-    fn process_csr_read(&self, csr_index: u16, raw_value: u32) -> Result<u32, CsrError> {
-        let mut out = 0;
-        if !AbundanceRv32IMaxInstruction::prepare_csr_read(self, csr_index, raw_value, &mut out)? {
-            return Err(CsrError::IllegalRead { csr_index });
-        }
-
-        Ok(out)
-    }
-
-    fn process_csr_write(&mut self, csr_index: u16, write_value: u32) -> Result<u32, CsrError> {
-        let mut out = 0;
-        if !AbundanceRv32IMaxInstruction::prepare_csr_write(self, csr_index, write_value, &mut out)?
-        {
-            return Err(CsrError::IllegalWrite { csr_index });
-        }
-
-        Ok(out)
-    }
 }
 
 impl VectorRegistersBase for AbundanceRv32IMaxExtState {

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
@@ -90,25 +90,6 @@ impl Csrs<<AbundanceRv64IMaxInstruction as Instruction>::Reg> for AbundanceRv64I
         *slot = value;
         Ok(())
     }
-
-    fn process_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError> {
-        let mut out = 0;
-        if !AbundanceRv64IMaxInstruction::prepare_csr_read(self, csr_index, raw_value, &mut out)? {
-            return Err(CsrError::IllegalRead { csr_index });
-        }
-
-        Ok(out)
-    }
-
-    fn process_csr_write(&mut self, csr_index: u16, write_value: u64) -> Result<u64, CsrError> {
-        let mut out = 0;
-        if !AbundanceRv64IMaxInstruction::prepare_csr_write(self, csr_index, write_value, &mut out)?
-        {
-            return Err(CsrError::IllegalWrite { csr_index });
-        }
-
-        Ok(out)
-    }
 }
 
 impl VectorRegistersBase for AbundanceRv64IMaxExtState {

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -47,30 +47,6 @@ impl Csrs<Reg<u64>> for TimeCsrState {
     fn write_csr(&mut self, _csr_index: u16, _value: u64) -> Result<(), CsrError> {
         Ok(())
     }
-
-    fn process_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError> {
-        let mut out = 0;
-        if !<TimeCsrInstruction<Reg<u64>>>::prepare_csr_read(self, csr_index, raw_value, &mut out)?
-        {
-            return Err(CsrError::IllegalRead { csr_index });
-        }
-
-        Ok(out)
-    }
-
-    fn process_csr_write(&mut self, csr_index: u16, write_value: u64) -> Result<u64, CsrError> {
-        let mut out = 0;
-        if !<TimeCsrInstruction<Reg<u64>>>::prepare_csr_write(
-            self,
-            csr_index,
-            write_value,
-            &mut out,
-        )? {
-            return Err(CsrError::IllegalWrite { csr_index });
-        }
-
-        Ok(out)
-    }
 }
 
 impl TimeCsrState {
@@ -86,7 +62,9 @@ impl TimeCsrState {
     inherit = [ZicsrInstruction],
 )]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TimeCsrInstruction<Reg> {}
+// TODO: Do something in the generated code that requires an import and suppresses this naturally
+#[expect(dead_code, reason = "Used as a dependency below, so not truly unused")]
+pub(crate) enum TimeCsrInstruction<Reg> {}
 
 #[instruction]
 impl<Reg> const Instruction for TimeCsrInstruction<Reg>

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -100,11 +100,6 @@ where
 
     #[inline(always)]
     fn write(&mut self, reg: Reg, value: Reg::Type) {
-        if reg == Reg::ZERO {
-            // Writes are ignored
-            return;
-        }
-
         // SAFETY: register offset is always within bounds
         *unsafe { self.regs.get_unchecked_mut(usize::from(reg.offset())) } = value;
     }

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -56,6 +56,7 @@
 
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![feature(
+    bool_to_result,
     const_cmp,
     const_convert,
     const_default,
@@ -378,27 +379,50 @@ where
     /// Writes register value
     fn write_csr(&mut self, csr_index: u16, value: Reg::Type) -> Result<(), CsrError<CustomError>>;
 
+    // TODO: Remove this method once tests do not need to customize it
     /// Process CSR read.
     ///
     /// Must proxy calls to [`ExecutableInstructionCsr::prepare_csr_read()`] of the root instruction
-    /// and return the output value on success. The method is present on `Csrs` to break cycles in
-    /// the type system.
-    fn process_csr_read(
+    /// and return the output value on success. The default implementation of the method should be
+    /// fine most of the time but can be overridden in special cases or for testing purposes.
+    #[doc(hidden)]
+    fn process_csr_read<I>(
         &self,
         csr_index: u16,
         raw_value: Reg::Type,
-    ) -> Result<Reg::Type, CsrError<CustomError>>;
+    ) -> Result<Reg::Type, CsrError<CustomError>>
+    where
+        I: ExecutableInstructionCsr<Self, CustomError, Reg = Reg>,
+    {
+        let mut out = Reg::Type::default();
+        I::prepare_csr_read(self, csr_index, raw_value, &mut out)?
+            .ok_or(CsrError::IllegalRead { csr_index })?;
 
+        Ok(out)
+    }
+
+    // TODO: Remove this method once tests do not need to customize it
     /// Process CSR write.
     ///
     /// Must proxy calls to [`ExecutableInstructionCsr::prepare_csr_write()`] of the root
-    /// instruction and return the output value on success.
-    /// The method is present on `Csrs` to break cycles in the type system.
-    fn process_csr_write(
+    /// instruction and return the output value on success. The default implementation of the method
+    /// should be fine most of the time but can be overridden in special cases or for testing
+    /// purposes.
+    #[doc(hidden)]
+    fn process_csr_write<I>(
         &mut self,
         csr_index: u16,
         write_value: Reg::Type,
-    ) -> Result<Reg::Type, CsrError<CustomError>>;
+    ) -> Result<Reg::Type, CsrError<CustomError>>
+    where
+        I: ExecutableInstructionCsr<Self, CustomError, Reg = Reg>,
+    {
+        let mut out = Reg::Type::default();
+        I::prepare_csr_write(self, csr_index, write_value, &mut out)?
+            .ok_or(CsrError::IllegalWrite { csr_index })?;
+
+        Ok(out)
+    }
 }
 
 /// Custom handler for system instructions `ecall` and `ebreak`
@@ -486,6 +510,7 @@ where
 pub trait ExecutableInstructionCsr<ExtState, CustomError = CustomErrorPlaceholder>
 where
     Self: Instruction,
+    ExtState: ?Sized,
 {
     /// Prepare CSR read.
     ///

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -5,10 +5,10 @@ use crate::v::vector_registers::{
     VectorRegisterFile, VectorRegisters, VectorRegistersBase, VectorRegistersExt,
 };
 use crate::{
-    Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError,
-    FetchInstructionResult, InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
+    ExecutionError, FetchInstructionResult, InstructionFetcher, ProgramCounter,
+    ProgramCounterError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::collections::BTreeMap;
@@ -352,11 +352,17 @@ impl Csrs<Reg<u64>> for ExtState {
         Ok(())
     }
 
-    fn process_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError> {
+    fn process_csr_read<I>(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError>
+    where
+        I: ExecutableInstructionCsr<Self, Reg = Reg<u64>>,
+    {
         (self.csr.prepare_csr_read)(csr_index, raw_value)
     }
 
-    fn process_csr_write(&mut self, csr_index: u16, write_value: u64) -> Result<u64, CsrError> {
+    fn process_csr_write<I>(&mut self, csr_index: u16, write_value: u64) -> Result<u64, CsrError>
+    where
+        I: ExecutableInstructionCsr<Self, Reg = Reg<u64>>,
+    {
         (self.csr.prepare_csr_write)(csr_index, write_value)
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -53,49 +53,49 @@ where
             //
             // Reads old CSR value into rd (unless `rd == x0`, in which case no read side effects
             // occur per spec), then writes `rs1` unconditionally.
-            Self::Csrrw { rd, rs1: _, csr } => {
-                let csr_is_read_only = (csr >> 10) == 0b11;
+            Self::Csrrw {
+                rd,
+                rs1: _,
+                csr_index,
+            } => {
+                let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if csr_is_read_only {
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly {
-                        csr_index: csr,
-                    }));
+                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
                 }
-                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
                 let write_value = rs1_value;
 
                 // Per spec: if `rd == x0`, the CSR read (and its side effects) must not occur
                 if rd != Reg::ZERO {
-                    let raw_value = ext_state.read_csr(csr)?;
-                    let output_value = ext_state.process_csr_read(csr, raw_value)?;
+                    let raw_value = ext_state.read_csr(csr_index)?;
+                    let output_value = ext_state.process_csr_read(csr_index, raw_value)?;
                     regs.write(rd, output_value);
                 }
 
-                let output_value = ext_state.process_csr_write(csr, write_value)?;
-                ext_state.write_csr(csr, output_value)?;
+                let output_value = ext_state.process_csr_write(csr_index, write_value)?;
+                ext_state.write_csr(csr_index, output_value)?;
             }
 
             // Atomic read and set bits in CSR.
             //
             // Always reads old value into `rd`. Writes `(old | rs1)` only if `rs1 != x0`.
             // Accessing a read-only CSR with `rs1 == x0` is legal (pure read).
-            Self::Csrrs { rd, rs1, csr } => {
-                let csr_is_read_only = (csr >> 10) == 0b11;
+            Self::Csrrs { rd, rs1, csr_index } => {
+                let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if rs1 != Reg::ZERO && csr_is_read_only {
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly {
-                        csr_index: csr,
-                    }));
+                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
                 }
-                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                let raw_value = ext_state.read_csr(csr)?;
-                let read_output = ext_state.process_csr_read(csr, raw_value)?;
+                let raw_value = ext_state.read_csr(csr_index)?;
+                let read_output = ext_state.process_csr_read(csr_index, raw_value)?;
                 regs.write(rd, read_output);
 
                 if rs1 != Reg::ZERO {
                     let write_value = raw_value | rs1_value;
-                    let write_output = ext_state.process_csr_write(csr, write_value)?;
-                    ext_state.write_csr(csr, write_output)?;
+                    let write_output = ext_state.process_csr_write(csr_index, write_value)?;
+                    ext_state.write_csr(csr_index, write_output)?;
                 }
             }
 
@@ -103,69 +103,71 @@ where
             //
             // Always reads old value into `rd`. Writes `(old & !rs1)` only if `rs1 != x0`.
             // Accessing a read-only CSR with `rs1 == x0` is legal (pure read).
-            Self::Csrrc { rd, rs1, csr } => {
-                let csr_is_read_only = (csr >> 10) == 0b11;
+            Self::Csrrc { rd, rs1, csr_index } => {
+                let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if rs1 != Reg::ZERO && csr_is_read_only {
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly {
-                        csr_index: csr,
-                    }));
+                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
                 }
-                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                let raw_value = ext_state.read_csr(csr)?;
-                let read_output = ext_state.process_csr_read(csr, raw_value)?;
+                let raw_value = ext_state.read_csr(csr_index)?;
+                let read_output = ext_state.process_csr_read(csr_index, raw_value)?;
                 regs.write(rd, read_output);
 
                 if rs1 != Reg::ZERO {
                     let write_value = raw_value & !rs1_value;
-                    let write_output = ext_state.process_csr_write(csr, write_value)?;
-                    ext_state.write_csr(csr, write_output)?;
+                    let write_output = ext_state.process_csr_write(csr_index, write_value)?;
+                    ext_state.write_csr(csr_index, write_output)?;
                 }
             }
 
             // Atomic read/write CSR immediate.
             //
             // Same `rd == x0` optimization as Csrrw. Writes zero-extended `zimm` unconditionally.
-            Self::Csrrwi { rd, zimm, csr } => {
-                let csr_is_read_only = (csr >> 10) == 0b11;
+            Self::Csrrwi {
+                rd,
+                zimm,
+                csr_index,
+            } => {
+                let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if csr_is_read_only {
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly {
-                        csr_index: csr,
-                    }));
+                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
                 }
-                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
                 if rd != Reg::ZERO {
-                    let raw_value = ext_state.read_csr(csr)?;
-                    let output_value = ext_state.process_csr_read(csr, raw_value)?;
+                    let raw_value = ext_state.read_csr(csr_index)?;
+                    let output_value = ext_state.process_csr_read(csr_index, raw_value)?;
                     regs.write(rd, output_value);
                 }
 
-                let output_value = ext_state.process_csr_write(csr, zimm.into())?;
-                ext_state.write_csr(csr, output_value)?;
+                let output_value = ext_state.process_csr_write(csr_index, zimm.into())?;
+                ext_state.write_csr(csr_index, output_value)?;
             }
 
             // Atomic read and set bits in CSR immediate.
             //
             // Always reads old value into `rd`. Writes `(old | zimm)` only if `zimm != 0`.
             // Accessing a read-only CSR with `zimm == 0` is legal (pure read).
-            Self::Csrrsi { rd, zimm, csr } => {
-                let csr_is_read_only = (csr >> 10) == 0b11;
+            Self::Csrrsi {
+                rd,
+                zimm,
+                csr_index,
+            } => {
+                let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if zimm != 0 && csr_is_read_only {
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly {
-                        csr_index: csr,
-                    }));
+                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
                 }
-                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                let raw_value = ext_state.read_csr(csr)?;
-                let read_output = ext_state.process_csr_read(csr, raw_value)?;
+                let raw_value = ext_state.read_csr(csr_index)?;
+                let read_output = ext_state.process_csr_read(csr_index, raw_value)?;
                 regs.write(rd, read_output);
 
                 if zimm != 0 {
                     let write_value = raw_value | Reg::Type::from(zimm);
-                    let write_output = ext_state.process_csr_write(csr, write_value)?;
-                    ext_state.write_csr(csr, write_output)?;
+                    let write_output = ext_state.process_csr_write(csr_index, write_value)?;
+                    ext_state.write_csr(csr_index, write_output)?;
                 }
             }
 
@@ -173,23 +175,25 @@ where
             //
             // Always reads old value into `rd`. Writes `(old & !zimm)` only if `zimm != 0`.
             // Accessing a read-only CSR with `zimm == 0` is legal (pure read).
-            Self::Csrrci { rd, zimm, csr } => {
-                let csr_is_read_only = (csr >> 10) == 0b11;
+            Self::Csrrci {
+                rd,
+                zimm,
+                csr_index,
+            } => {
+                let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if zimm != 0 && csr_is_read_only {
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly {
-                        csr_index: csr,
-                    }));
+                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
                 }
-                zicsr_helpers::check_csr_privilege_level(ext_state, csr)?;
+                zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                let raw_value = ext_state.read_csr(csr)?;
-                let read_output = ext_state.process_csr_read(csr, raw_value)?;
+                let raw_value = ext_state.read_csr(csr_index)?;
+                let read_output = ext_state.process_csr_read(csr_index, raw_value)?;
                 regs.write(rd, read_output);
 
                 if zimm != 0 {
                     let write_value = raw_value & !Reg::Type::from(zimm);
-                    let write_output = ext_state.process_csr_write(csr, write_value)?;
-                    ext_state.write_csr(csr, write_output)?;
+                    let write_output = ext_state.process_csr_write(csr_index, write_value)?;
+                    ext_state.write_csr(csr_index, write_output)?;
                 }
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -69,11 +69,11 @@ where
                 // Per spec: if `rd == x0`, the CSR read (and its side effects) must not occur
                 if rd != Reg::ZERO {
                     let raw_value = ext_state.read_csr(csr_index)?;
-                    let output_value = ext_state.process_csr_read(csr_index, raw_value)?;
+                    let output_value = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
                     regs.write(rd, output_value);
                 }
 
-                let output_value = ext_state.process_csr_write(csr_index, write_value)?;
+                let output_value = ext_state.process_csr_write::<Self>(csr_index, write_value)?;
                 ext_state.write_csr(csr_index, output_value)?;
             }
 
@@ -89,12 +89,13 @@ where
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
                 let raw_value = ext_state.read_csr(csr_index)?;
-                let read_output = ext_state.process_csr_read(csr_index, raw_value)?;
+                let read_output = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
                 regs.write(rd, read_output);
 
                 if rs1 != Reg::ZERO {
                     let write_value = raw_value | rs1_value;
-                    let write_output = ext_state.process_csr_write(csr_index, write_value)?;
+                    let write_output =
+                        ext_state.process_csr_write::<Self>(csr_index, write_value)?;
                     ext_state.write_csr(csr_index, write_output)?;
                 }
             }
@@ -111,12 +112,13 @@ where
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
                 let raw_value = ext_state.read_csr(csr_index)?;
-                let read_output = ext_state.process_csr_read(csr_index, raw_value)?;
+                let read_output = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
                 regs.write(rd, read_output);
 
                 if rs1 != Reg::ZERO {
                     let write_value = raw_value & !rs1_value;
-                    let write_output = ext_state.process_csr_write(csr_index, write_value)?;
+                    let write_output =
+                        ext_state.process_csr_write::<Self>(csr_index, write_value)?;
                     ext_state.write_csr(csr_index, write_output)?;
                 }
             }
@@ -137,11 +139,11 @@ where
 
                 if rd != Reg::ZERO {
                     let raw_value = ext_state.read_csr(csr_index)?;
-                    let output_value = ext_state.process_csr_read(csr_index, raw_value)?;
+                    let output_value = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
                     regs.write(rd, output_value);
                 }
 
-                let output_value = ext_state.process_csr_write(csr_index, zimm.into())?;
+                let output_value = ext_state.process_csr_write::<Self>(csr_index, zimm.into())?;
                 ext_state.write_csr(csr_index, output_value)?;
             }
 
@@ -161,12 +163,13 @@ where
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
                 let raw_value = ext_state.read_csr(csr_index)?;
-                let read_output = ext_state.process_csr_read(csr_index, raw_value)?;
+                let read_output = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
                 regs.write(rd, read_output);
 
                 if zimm != 0 {
                     let write_value = raw_value | Reg::Type::from(zimm);
-                    let write_output = ext_state.process_csr_write(csr_index, write_value)?;
+                    let write_output =
+                        ext_state.process_csr_write::<Self>(csr_index, write_value)?;
                     ext_state.write_csr(csr_index, write_output)?;
                 }
             }
@@ -187,12 +190,13 @@ where
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
                 let raw_value = ext_state.read_csr(csr_index)?;
-                let read_output = ext_state.process_csr_read(csr_index, raw_value)?;
+                let read_output = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
                 regs.write(rd, read_output);
 
                 if zimm != 0 {
                     let write_value = raw_value & !Reg::Type::from(zimm);
-                    let write_output = ext_state.process_csr_write(csr_index, write_value)?;
+                    let write_output =
+                        ext_state.process_csr_write::<Self>(csr_index, write_value)?;
                     ext_state.write_csr(csr_index, write_output)?;
                 }
             }

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
@@ -57,7 +57,7 @@ fn test_csrrw_reads_old_value_into_rd() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -78,7 +78,7 @@ fn test_csrrw_writes_rs1_to_csr() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -99,7 +99,7 @@ fn test_csrrw_rd_zero_skips_read_no_side_effects() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::Zero,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -121,7 +121,7 @@ fn test_csrrw_all_ones() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -143,7 +143,7 @@ fn test_csrrw_overwrites_completely() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -169,7 +169,7 @@ fn test_csrrs_reads_old_value_into_rd() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -190,7 +190,7 @@ fn test_csrrs_sets_bits() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -211,7 +211,7 @@ fn test_csrrs_rs1_zero_no_write() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::Zero,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -232,7 +232,7 @@ fn test_csrrs_idempotent_when_bits_already_set() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -261,7 +261,7 @@ fn test_csrrc_reads_old_value_into_rd() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -282,7 +282,7 @@ fn test_csrrc_clears_bits() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -304,7 +304,7 @@ fn test_csrrc_rs1_zero_no_write() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::Zero,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -325,7 +325,7 @@ fn test_csrrc_clears_all_bits() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -349,7 +349,7 @@ fn test_csrrc_idempotent_when_bits_already_clear() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -372,7 +372,7 @@ fn test_csrrwi_reads_old_value_into_rd() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::A2,
         zimm: 0b11111,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -393,7 +393,7 @@ fn test_csrrwi_writes_zimm_zero_extended() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::A2,
         zimm: 0b11111,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -418,7 +418,7 @@ fn test_csrrwi_rd_zero_skips_read() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::Zero,
         zimm: 0b00101,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -440,7 +440,7 @@ fn test_csrrwi_zimm_zero_writes_zero() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::A1,
         zimm: 0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -462,7 +462,7 @@ fn test_csrrwi_max_zimm() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::A1,
         zimm: 31,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -485,7 +485,7 @@ fn test_csrrsi_reads_old_value_into_rd() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 0b00001,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -506,7 +506,7 @@ fn test_csrrsi_sets_bits() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 0b00111,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -527,7 +527,7 @@ fn test_csrrsi_zimm_zero_no_write() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -549,7 +549,7 @@ fn test_csrrsi_does_not_clear_existing_bits() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 0b10101,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -578,7 +578,7 @@ fn test_csrrci_reads_old_value_into_rd() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 0b00001,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -599,7 +599,7 @@ fn test_csrrci_clears_bits() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 0b11111,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -627,7 +627,7 @@ fn test_csrrci_zimm_zero_no_write() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -649,7 +649,7 @@ fn test_csrrci_does_not_set_new_bits() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 0b10101,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -670,7 +670,7 @@ fn test_csrrci_partial_clear() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 0b01010,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -694,7 +694,7 @@ fn test_csrrs_rd_zero_still_reads_no_gp_write() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::Zero,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -716,7 +716,7 @@ fn test_csrrc_rd_zero_still_reads_no_gp_write() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::Zero,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -740,7 +740,7 @@ fn test_csrrw_rd_rs1_alias() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A0,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -762,7 +762,7 @@ fn test_csrrs_rd_rs1_alias() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A0,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -784,7 +784,7 @@ fn test_csrrc_rd_rs1_alias() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A0,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -808,7 +808,7 @@ fn test_csrrw_read_only_csr_is_rejected() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(RO_CSR, 0x1234);
@@ -829,7 +829,7 @@ fn test_csrrwi_read_only_csr_is_rejected() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::A2,
         zimm: 1,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -849,7 +849,7 @@ fn test_csrrs_read_only_csr_with_nonzero_rs1_is_rejected() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(RO_CSR, 0x1234);
@@ -870,7 +870,7 @@ fn test_csrrc_read_only_csr_with_nonzero_rs1_is_rejected() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(RO_CSR, 0x1234);
@@ -891,7 +891,7 @@ fn test_csrrsi_read_only_csr_with_nonzero_zimm_is_rejected() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 1,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -911,7 +911,7 @@ fn test_csrrci_read_only_csr_with_nonzero_zimm_is_rejected() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 1,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -934,7 +934,7 @@ fn test_csrrs_read_only_csr_with_rs1_zero_is_legal() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::Zero,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(RO_CSR, 0xABCD);
@@ -953,7 +953,7 @@ fn test_csrrc_read_only_csr_with_rs1_zero_is_legal() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::Zero,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(RO_CSR, 0xABCD);
@@ -972,7 +972,7 @@ fn test_csrrsi_read_only_csr_with_zimm_zero_is_legal() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 0,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -992,7 +992,7 @@ fn test_csrrci_read_only_csr_with_zimm_zero_is_legal() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 0,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1014,7 +1014,7 @@ fn test_csrrw_last_writable_address_succeeds() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: LAST_WRITABLE_CSR,
+        csr_index: LAST_WRITABLE_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(LAST_WRITABLE_CSR, 0x10);
@@ -1035,7 +1035,7 @@ fn test_csrrw_first_read_only_address_is_rejected() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: RO_CSR,
+        csr_index: RO_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(RO_CSR, 0x10);
@@ -1072,7 +1072,7 @@ fn test_priv_user_csr_accessible_from_user_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -1090,7 +1090,7 @@ fn test_priv_user_csr_accessible_from_supervisor_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -1110,7 +1110,7 @@ fn test_priv_user_csr_accessible_from_machine_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);
@@ -1130,7 +1130,7 @@ fn test_priv_supervisor_csr_rejected_from_user_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: S_CSR,
+        csr_index: S_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(S_CSR, 0xDEAD);
@@ -1149,7 +1149,7 @@ fn test_priv_supervisor_csr_accessible_from_supervisor_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: S_CSR,
+        csr_index: S_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(S_CSR, 0);
@@ -1169,7 +1169,7 @@ fn test_priv_supervisor_csr_accessible_from_machine_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: S_CSR,
+        csr_index: S_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(S_CSR, 0);
@@ -1189,7 +1189,7 @@ fn test_priv_machine_csr_rejected_from_user_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: M_CSR,
+        csr_index: M_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(M_CSR, 0xDEAD);
@@ -1208,7 +1208,7 @@ fn test_priv_machine_csr_rejected_from_supervisor_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: M_CSR,
+        csr_index: M_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(M_CSR, 0xDEAD);
@@ -1229,7 +1229,7 @@ fn test_priv_machine_csr_accessible_from_machine_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: M_CSR,
+        csr_index: M_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(M_CSR, 0);
@@ -1251,7 +1251,7 @@ fn test_priv_check_fires_before_csr_is_read_or_written() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: S_CSR,
+        csr_index: S_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(S_CSR, 0xBEEF);
@@ -1275,7 +1275,7 @@ fn test_csrrs_privilege_check() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::Zero,
-        csr: M_CSR,
+        csr_index: M_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(M_CSR, 0xDEAD);
@@ -1295,7 +1295,7 @@ fn test_csrrc_privilege_check() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::Zero,
-        csr: M_CSR,
+        csr_index: M_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(M_CSR, 0xDEAD);
@@ -1315,7 +1315,7 @@ fn test_csrrwi_privilege_check() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::A2,
         zimm: 1,
-        csr: M_CSR,
+        csr_index: M_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1334,7 +1334,7 @@ fn test_csrrsi_privilege_check() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 1,
-        csr: S_CSR,
+        csr_index: S_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1353,7 +1353,7 @@ fn test_csrrci_privilege_check() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 1,
-        csr: S_CSR,
+        csr_index: S_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1375,7 +1375,7 @@ fn test_reserved_privilege_csr_rejected_from_supervisor_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: RESERVED_PRIV_CSR,
+        csr_index: RESERVED_PRIV_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(RESERVED_PRIV_CSR, 0xDEAD);
@@ -1396,7 +1396,7 @@ fn test_reserved_privilege_csr_rejected_from_user_mode() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: RESERVED_PRIV_CSR,
+        csr_index: RESERVED_PRIV_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(RESERVED_PRIV_CSR, 0xDEAD);
@@ -1415,7 +1415,7 @@ fn test_reserved_privilege_csr() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A1,
         rs1: Reg::A0,
-        csr: RESERVED_PRIV_CSR,
+        csr_index: RESERVED_PRIV_CSR,
         rs2: Reg::Zero,
     }]);
     // Do not initialize unknown CSR
@@ -1440,7 +1440,7 @@ fn test_csrrw_prepare_read_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0xDEAD);
@@ -1459,7 +1459,7 @@ fn test_csrrw_rd_zero_prepare_write_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::Zero,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0xDEAD);
@@ -1479,7 +1479,7 @@ fn test_csrrs_prepare_read_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0xDEAD);
@@ -1498,7 +1498,7 @@ fn test_csrrs_prepare_write_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0xDEAD);
@@ -1518,7 +1518,7 @@ fn test_csrrc_prepare_read_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0xDEAD);
@@ -1537,7 +1537,7 @@ fn test_csrrc_prepare_write_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0xDEAD);
@@ -1557,7 +1557,7 @@ fn test_csrrwi_prepare_read_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::A2,
         zimm: 1,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1576,7 +1576,7 @@ fn test_csrrwi_prepare_write_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::Zero,
         zimm: 1,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1596,7 +1596,7 @@ fn test_csrrsi_prepare_read_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 1,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1615,7 +1615,7 @@ fn test_csrrsi_prepare_write_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 1,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1635,7 +1635,7 @@ fn test_csrrci_prepare_read_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 1,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1654,7 +1654,7 @@ fn test_csrrci_prepare_write_error_is_propagated() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 1,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1676,7 +1676,7 @@ fn test_csrrw_unknown_csr_returns_error() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: UNKNOWN_CSR,
+        csr_index: UNKNOWN_CSR,
         rs2: Reg::Zero,
     }]);
     state.regs.write(Reg::A0, 0x1234u64);
@@ -1689,7 +1689,7 @@ fn test_csrrs_unknown_csr_returns_error() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: UNKNOWN_CSR,
+        csr_index: UNKNOWN_CSR,
         rs2: Reg::Zero,
     }]);
     state.regs.write(Reg::A0, 0x1u64);
@@ -1702,7 +1702,7 @@ fn test_csrrc_unknown_csr_returns_error() {
     let mut state = initialize_state([ZicsrInstruction::Csrrc {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: UNKNOWN_CSR,
+        csr_index: UNKNOWN_CSR,
         rs2: Reg::Zero,
     }]);
     state.regs.write(Reg::A0, 0x1u64);
@@ -1715,7 +1715,7 @@ fn test_csrrwi_unknown_csr_returns_error() {
     let mut state = initialize_state([ZicsrInstruction::Csrrwi {
         rd: Reg::A2,
         zimm: 1,
-        csr: UNKNOWN_CSR,
+        csr_index: UNKNOWN_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1728,7 +1728,7 @@ fn test_csrrsi_unknown_csr_returns_error() {
     let mut state = initialize_state([ZicsrInstruction::Csrrsi {
         rd: Reg::A2,
         zimm: 1,
-        csr: UNKNOWN_CSR,
+        csr_index: UNKNOWN_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1741,7 +1741,7 @@ fn test_csrrci_unknown_csr_returns_error() {
     let mut state = initialize_state([ZicsrInstruction::Csrrci {
         rd: Reg::A2,
         zimm: 1,
-        csr: UNKNOWN_CSR,
+        csr_index: UNKNOWN_CSR,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
     }]);
@@ -1757,7 +1757,7 @@ fn test_prepare_csr_read_filtered_value_reaches_rd() {
     let mut state = initialize_state([ZicsrInstruction::Csrrs {
         rd: Reg::A2,
         rs1: Reg::Zero,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0xDEAD_BEEF_1234_5678u64);
@@ -1776,7 +1776,7 @@ fn test_prepare_csr_write_filtered_value_reaches_csr() {
     let mut state = initialize_state([ZicsrInstruction::Csrrw {
         rd: Reg::A2,
         rs1: Reg::A0,
-        csr: U_CSR,
+        csr_index: U_CSR,
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_csr(U_CSR, 0);

--- a/crates/execution/ab-riscv-macros/src/build.rs
+++ b/crates/execution/ab-riscv-macros/src/build.rs
@@ -13,8 +13,7 @@ use crate::build::enum_impl::{
 };
 use crate::build::execution_impl::{
     collect_enum_csr_impls_from_dependencies, collect_enum_execution_impls_from_dependencies,
-    collect_enum_operands_impls_from_dependencies, process_execution_impl,
-    process_pending_enum_execution_impls,
+    process_execution_impl, process_pending_enum_execution_impls,
 };
 use crate::build::state::State;
 use ab_riscv_macros_common::code_utils::pre_process_rust_code;
@@ -47,10 +46,6 @@ pub fn process_instruction_macros() -> anyhow::Result<()> {
     for maybe_enum_impl in collect_original_enum_decoding_impls_from_dependencies() {
         let (item_impl, source) = maybe_enum_impl?;
         state.insert_known_original_enum_decoding_impl(item_impl, source)?;
-    }
-    for maybe_enum_operands_impl in collect_enum_operands_impls_from_dependencies() {
-        let (item_impl, source) = maybe_enum_operands_impl?;
-        state.insert_known_enum_operands_impl(item_impl, source)?;
     }
     for maybe_enum_csr_impl in collect_enum_csr_impls_from_dependencies() {
         let (item_impl, source) = maybe_enum_csr_impl?;

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -18,38 +18,7 @@ use std::{env, fs, iter, mem};
 use syn::{Ident, ImplItem, ImplItemFn, ItemImpl, parse_file, parse_quote, parse_str};
 
 const ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_EXECUTION_IMPL_PATH";
-const ENUM_OPERANDS_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_OPERANDS_IMPL_PATH";
 const ENUM_CSR_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_CSR_IMPL_PATH";
-
-pub(super) fn collect_enum_operands_impls_from_dependencies()
--> impl Iterator<Item = anyhow::Result<(ItemImpl, Rc<Path>)>> {
-    // Collect exported instruction enums from dependencies
-    env::vars().filter_map(|(key, value)| {
-        if !key.ends_with(ENUM_OPERANDS_IMPL_ENV_VAR_SUFFIX) {
-            return None;
-        }
-
-        let result = try {
-            let mut item_enum_contents = fs::read_to_string(&value).with_context(|| {
-                format!(
-                    "Failed to read Rust file `{value}` that is expected to contain instruction \
-                    enum operands implementation"
-                )
-            })?;
-            pre_process_rust_code(&mut item_enum_contents);
-            let item_impl = parse_str::<ItemImpl>(&item_enum_contents).with_context(|| {
-                format!(
-                    "Failed to parse Rust file `{value}` that is expected to contain instruction \
-                    enum operands implementation"
-                )
-            })?;
-
-            (item_impl, Rc::from(Path::new(&value)))
-        };
-
-        Some(result)
-    })
-}
 
 pub(super) fn collect_enum_csr_impls_from_dependencies()
 -> impl Iterator<Item = anyhow::Result<(ItemImpl, Rc<Path>)>> {
@@ -187,15 +156,14 @@ fn output_processed_enum_operands_impl(
     enum_name: &Ident,
     item_impl: ItemImpl,
     out_dir: &Path,
-    state: &mut State,
 ) -> anyhow::Result<()> {
     let enum_file_path = out_dir.join(format!("{}_operands_impl.rs", enum_name));
     let code = item_impl.to_token_stream().to_string();
     // Format
     let mut code = unparse(&parse_file(&code).expect("Generated code is valid; qed"));
-    // Normalize source
-    let item_impl = parse_str(&code).expect("Generated code is valid; qed");
     post_process_rust_code(&mut code);
+    // This is a hack for pulling generics from decoding impl, which is `const`
+    let code = code.replace("[const] ", "");
 
     // Avoid extra file truncation/override if it didn't change
     if fs::read_to_string(&enum_file_path).ok().as_ref() != Some(&code) {
@@ -206,13 +174,8 @@ fn output_processed_enum_operands_impl(
             )
         })?;
     }
-    println!(
-        "cargo::metadata={}{ENUM_OPERANDS_IMPL_ENV_VAR_SUFFIX}={}",
-        enum_name,
-        enum_file_path.display()
-    );
 
-    state.insert_known_enum_operands_impl(item_impl, Rc::from(enum_file_path))
+    Ok(())
 }
 
 fn output_processed_enum_csr_impl(
@@ -364,10 +327,11 @@ pub(super) fn process_enum_operands_impl(
                 }
 
                 let Some(dependency_enum_operands_impl) =
-                    state.get_known_enum_operands_impl(&dependency_enum_name)
+                    state.get_known_original_enum_decoding_impl(&dependency_enum_name)
                 else {
                     eprintln!(
-                        "{enum_name} operands is waiting on {dependency_enum_name} operands implementation"
+                        "{enum_name} operands is waiting on {dependency_enum_name} decoding \
+                        implementation"
                     );
                     state.add_pending_enum_operands_impl(PendingEnumOperandsImpl { item_impl });
                     return Ok(());
@@ -420,7 +384,7 @@ pub(super) fn process_enum_operands_impl(
         }
     });
 
-    output_processed_enum_operands_impl(&enum_name, item_impl, out_dir, state)
+    output_processed_enum_operands_impl(&enum_name, item_impl, out_dir)
 }
 
 pub(super) fn process_enum_csr_impl(

--- a/crates/execution/ab-riscv-macros/src/build/state.rs
+++ b/crates/execution/ab-riscv-macros/src/build/state.rs
@@ -37,12 +37,6 @@ pub(super) struct PendingEnumDisplayImpl {
 }
 
 #[derive(Debug)]
-pub(super) struct KnownEnumOperandsImpl {
-    pub(super) item_impl: ItemImpl,
-    pub(super) source: Rc<Path>,
-}
-
-#[derive(Debug)]
 pub(super) struct PendingEnumOperandsImpl {
     pub(super) item_impl: ItemImpl,
 }
@@ -75,7 +69,6 @@ pub(super) struct State {
     known_original_enum_decoding_impls: HashMap<Ident, KnownOriginalEnumDecodingImpl>,
     pending_enum_impls: Vec<PendingEnumImpl>,
     pending_enum_display_impls: Vec<PendingEnumDisplayImpl>,
-    known_enum_operands_impls: HashMap<Ident, KnownEnumOperandsImpl>,
     pending_enum_operands_impls: Vec<PendingEnumOperandsImpl>,
     known_enum_csr_impls: HashMap<Ident, KnownEnumCsrImpl>,
     pending_enum_csr_impls: Vec<PendingEnumCsrImpl>,
@@ -91,7 +84,6 @@ impl State {
             known_original_enum_decoding_impls: HashMap::new(),
             pending_enum_impls: Vec::new(),
             pending_enum_display_impls: Vec::new(),
-            known_enum_operands_impls: HashMap::new(),
             pending_enum_operands_impls: Vec::new(),
             known_enum_csr_impls: HashMap::new(),
             pending_enum_csr_impls: Vec::new(),
@@ -112,13 +104,6 @@ impl State {
         enum_name: &Ident,
     ) -> Option<&KnownOriginalEnumDecodingImpl> {
         self.known_original_enum_decoding_impls.get(enum_name)
-    }
-
-    pub(super) fn get_known_enum_operands_impl(
-        &self,
-        enum_name: &Ident,
-    ) -> Option<&KnownEnumOperandsImpl> {
-        self.known_enum_operands_impls.get(enum_name)
     }
 
     pub(super) fn get_known_enum_csr_impl(&self, enum_name: &Ident) -> Option<&KnownEnumCsrImpl> {
@@ -185,33 +170,6 @@ impl State {
                 source.display(),
                 entry.get().item_impl,
                 item_impl,
-            ));
-        }
-
-        Ok(())
-    }
-
-    pub(super) fn insert_known_enum_operands_impl(
-        &mut self,
-        item_impl: ItemImpl,
-        source: Rc<Path>,
-    ) -> anyhow::Result<()> {
-        let enum_name = enum_name_from_impl(&item_impl);
-
-        if let Err(OccupiedError { entry, value }) = self.known_enum_operands_impls.try_insert(
-            enum_name.clone(),
-            KnownEnumOperandsImpl {
-                item_impl,
-                source: source.clone(),
-            },
-        ) && entry.get().item_impl != value.item_impl
-        {
-            return Err(anyhow::anyhow!(
-                "Execution operands implementation for enum `{}` is already defined in `{}`, a \
-                different duplicate found in `{}`",
-                enum_name,
-                entry.get().source.display(),
-                source.display(),
             ));
         }
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/zicsr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zicsr.rs
@@ -12,12 +12,12 @@ use core::fmt;
 #[instruction]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ZicsrInstruction<Reg> {
-    Csrrw { rd: Reg, rs1: Reg, csr: u16 },
-    Csrrs { rd: Reg, rs1: Reg, csr: u16 },
-    Csrrc { rd: Reg, rs1: Reg, csr: u16 },
-    Csrrwi { rd: Reg, zimm: u8, csr: u16 },
-    Csrrsi { rd: Reg, zimm: u8, csr: u16 },
-    Csrrci { rd: Reg, zimm: u8, csr: u16 },
+    Csrrw { rd: Reg, rs1: Reg, csr_index: u16 },
+    Csrrs { rd: Reg, rs1: Reg, csr_index: u16 },
+    Csrrc { rd: Reg, rs1: Reg, csr_index: u16 },
+    Csrrwi { rd: Reg, zimm: u8, csr_index: u16 },
+    Csrrsi { rd: Reg, zimm: u8, csr_index: u16 },
+    Csrrci { rd: Reg, zimm: u8, csr_index: u16 },
 }
 
 #[instruction]
@@ -44,7 +44,7 @@ where
                         Some(Self::Csrrw {
                             rd,
                             rs1,
-                            csr: csr_bits,
+                            csr_index: csr_bits,
                         })
                     }
                     0b010 => {
@@ -52,7 +52,7 @@ where
                         Some(Self::Csrrs {
                             rd,
                             rs1,
-                            csr: csr_bits,
+                            csr_index: csr_bits,
                         })
                     }
                     0b011 => {
@@ -60,23 +60,23 @@ where
                         Some(Self::Csrrc {
                             rd,
                             rs1,
-                            csr: csr_bits,
+                            csr_index: csr_bits,
                         })
                     }
                     0b101 => Some(Self::Csrrwi {
                         rd,
                         zimm: rs1_bits,
-                        csr: csr_bits,
+                        csr_index: csr_bits,
                     }),
                     0b110 => Some(Self::Csrrsi {
                         rd,
                         zimm: rs1_bits,
-                        csr: csr_bits,
+                        csr_index: csr_bits,
                     }),
                     0b111 => Some(Self::Csrrci {
                         rd,
                         zimm: rs1_bits,
-                        csr: csr_bits,
+                        csr_index: csr_bits,
                     }),
                     _ => None,
                 }
@@ -103,12 +103,24 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Csrrw { rd, rs1, csr } => write!(f, "csrrw {rd}, {csr}, {rs1}"),
-            Self::Csrrs { rd, rs1, csr } => write!(f, "csrrs {rd}, {csr}, {rs1}"),
-            Self::Csrrc { rd, rs1, csr } => write!(f, "csrrc {rd}, {csr}, {rs1}"),
-            Self::Csrrwi { rd, zimm, csr } => write!(f, "csrrwi {rd}, {csr}, {zimm}"),
-            Self::Csrrsi { rd, zimm, csr } => write!(f, "csrrsi {rd}, {csr}, {zimm}"),
-            Self::Csrrci { rd, zimm, csr } => write!(f, "csrrci {rd}, {csr}, {zimm}"),
+            Self::Csrrw { rd, rs1, csr_index } => write!(f, "csrrw {rd}, {csr_index}, {rs1}"),
+            Self::Csrrs { rd, rs1, csr_index } => write!(f, "csrrs {rd}, {csr_index}, {rs1}"),
+            Self::Csrrc { rd, rs1, csr_index } => write!(f, "csrrc {rd}, {csr_index}, {rs1}"),
+            Self::Csrrwi {
+                rd,
+                zimm,
+                csr_index,
+            } => write!(f, "csrrwi {rd}, {csr_index}, {zimm}"),
+            Self::Csrrsi {
+                rd,
+                zimm,
+                csr_index,
+            } => write!(f, "csrrsi {rd}, {csr_index}, {zimm}"),
+            Self::Csrrci {
+                rd,
+                zimm,
+                csr_index,
+            } => write!(f, "csrrci {rd}, {csr_index}, {zimm}"),
         }
     }
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zicsr/tests.rs
@@ -12,7 +12,7 @@ fn test_csrrw() {
         Some(ZicsrInstruction::Csrrw {
             rd: Reg::Ra,
             rs1: Reg::Sp,
-            csr: 0x305,
+            csr_index: 0x305,
             rs2: Reg::Zero,
         })
     );
@@ -27,7 +27,7 @@ fn test_csrrs() {
         Some(ZicsrInstruction::Csrrs {
             rd: Reg::Gp,
             rs1: Reg::Tp,
-            csr: 0x341,
+            csr_index: 0x341,
             rs2: Reg::Zero,
         })
     );
@@ -42,7 +42,7 @@ fn test_csrrc() {
         Some(ZicsrInstruction::Csrrc {
             rd: Reg::T0,
             rs1: Reg::T1,
-            csr: 0x300,
+            csr_index: 0x300,
             rs2: Reg::Zero,
         })
     );
@@ -57,7 +57,7 @@ fn test_csrrwi() {
         Some(ZicsrInstruction::Csrrwi {
             rd: Reg::T2,
             zimm: 0b10101,
-            csr: 0x7c0,
+            csr_index: 0x7c0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
         })
@@ -73,7 +73,7 @@ fn test_csrrsi() {
         Some(ZicsrInstruction::Csrrsi {
             rd: Reg::S0,
             zimm: 0b00001,
-            csr: 0x7c1,
+            csr_index: 0x7c1,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
         })
@@ -89,7 +89,7 @@ fn test_csrrci() {
         Some(ZicsrInstruction::Csrrci {
             rd: Reg::S1,
             zimm: 0b11111,
-            csr: 0x7c2,
+            csr_index: 0x7c2,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
         })
@@ -105,7 +105,7 @@ fn test_csrrw_nop_like_encoding() {
         Some(ZicsrInstruction::Csrrw {
             rd: Reg::Zero,
             rs1: Reg::Zero,
-            csr: 0x000,
+            csr_index: 0x000,
             rs2: Reg::Zero,
         })
     );
@@ -120,7 +120,7 @@ fn test_csrrwi_nop_like_encoding() {
         Some(ZicsrInstruction::Csrrwi {
             rd: Reg::Zero,
             zimm: 0,
-            csr: 0x000,
+            csr_index: 0x000,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
         })


### PR DESCRIPTION
This simplifies a lot of things and removal of zero register check on write path improves interpreter performance a tiny bit with PGO