### PR TITLE
Make linker generate `jal` instead of `auipc + jalr` for jumps

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/lib.rs
+++ b/crates/contracts/core/ab-contract-file/src/lib.rs
@@ -55,6 +55,7 @@ use ab_contracts_common::metadata::decode::{
     MethodsMetadataDecoder,
 };
 use ab_io_type::trivial_type::TrivialType;
+use ab_io_type::unaligned::Unaligned;
 use ab_riscv_primitives::prelude::*;
 use core::iter;
 use core::iter::TrustedLen;
@@ -207,13 +208,11 @@ pub enum ContractFileParseError {
         /// Size of the file in bytes
         file_size: u32,
     },
-    /// Host call function doesn't have auipc + jalr tailcall pattern
-    #[error("The host call function doesn't have auipc + jalr tailcall pattern: {first} {second}")]
+    /// Host call function doesn't have `jal` tailcall instruction
+    #[error("The host call function doesn't have jal tailcall instruction: {instruction}")]
     InvalidHostCallFnPattern {
-        /// First instruction of the host call function
-        first: ContractInstruction,
-        /// Second instruction of the host call function
-        second: ContractInstruction,
+        /// Instruction of the host call function
+        instruction: ContractInstruction,
     },
     /// The read-only section file size is larger than the memory size
     #[error(
@@ -476,71 +475,46 @@ impl<'a> ContractFile<'a> {
                 });
             }
 
-            let instructions_bytes = file_bytes
+            let instruction_bytes = file_bytes
                 .get(header.host_call_fn_offset as usize..)
                 .ok_or(ContractFileParseError::HostCallFnOutOfRange {
                     offset: header.host_call_fn_offset,
                     code_section_offset,
                     file_size,
-                })?
-                .get(..size_of::<[u32; 2]>())
-                .ok_or(ContractFileParseError::HostCallFnOutOfRange {
-                    offset: header.host_call_fn_offset,
-                    code_section_offset,
-                    file_size,
                 })?;
-
-            let first_instruction = u32::from_le_bytes([
-                instructions_bytes[0],
-                instructions_bytes[1],
-                instructions_bytes[2],
-                instructions_bytes[3],
-            ]);
-            let second_instruction = u32::from_le_bytes([
-                instructions_bytes[4],
-                instructions_bytes[5],
-                instructions_bytes[6],
-                instructions_bytes[7],
-            ]);
-
-            let first = ContractInstruction::try_decode(first_instruction).ok_or(
-                ContractFileParseError::InvalidInstruction {
-                    instruction: first_instruction,
-                },
-            )?;
-            let second = ContractInstruction::try_decode(second_instruction).ok_or(
-                ContractFileParseError::InvalidInstruction {
-                    instruction: second_instruction,
-                },
-            )?;
-
-            // TODO: Should it be canonicalized to a fixed immediate and temporary after conversion
-            //  from ELF?
-            // Checks if two consecutive instructions are:
-            //   auipc x?, 0x?
-            //   jalr  x0, offset(x?)
-            let matches_expected_pattern = if let (
-                ContractInstruction::Auipc {
-                    rd: auipc_rd,
-                    imm: _,
-                    rs1: _,
-                    rs2: _,
-                },
-                ContractInstruction::Jalr {
-                    rd: jalr_rd,
-                    rs1: jalr_rs1,
-                    imm: _,
-                    rs2: _,
-                },
-            ) = (first, second)
+            // SAFETY: All bit patterns are valid for u32
+            let instruction = if let Some(instruction_bytes) =
+                unsafe { <Unaligned<u32>>::from_bytes(instruction_bytes) }
             {
-                auipc_rd == jalr_rs1 && jalr_rd == Register::ZERO
+                instruction_bytes.as_inner()
             } else {
-                false
+                // SAFETY: All bit patterns are valid for u16
+                let Some(instruction_bytes) =
+                    (unsafe { <Unaligned<u16>>::from_bytes(instruction_bytes) })
+                else {
+                    return Err(ContractFileParseError::HostCallFnOutOfRange {
+                        offset: header.host_call_fn_offset,
+                        code_section_offset,
+                        file_size,
+                    });
+                };
+
+                u32::from(instruction_bytes.as_inner())
+            };
+
+            let instruction = ContractInstruction::try_decode(instruction)
+                .ok_or(ContractFileParseError::InvalidInstruction { instruction })?;
+
+            // The instruction is an unconditional relative jump:
+            //   jal x0, offset
+            let matches_expected_pattern = match instruction {
+                ContractInstruction::Jal { rd, .. } => rd == Register::ZERO,
+                ContractInstruction::CJ { .. } => true,
+                _ => false,
             };
 
             if !matches_expected_pattern {
-                return Err(ContractFileParseError::InvalidHostCallFnPattern { first, second });
+                return Err(ContractFileParseError::InvalidHostCallFnPattern { instruction });
             }
 
             let address =

--- a/crates/contracts/core/ab-contracts-tooling/src/convert.rs
+++ b/crates/contracts/core/ab-contracts-tooling/src/convert.rs
@@ -429,7 +429,7 @@ fn extract_host_call_fn_offset(
         return Ok(0);
     };
 
-    if host_call_fn.size != size_of::<[u32; 2]>() as u64 {
+    if ![size_of::<u16>() as u64, size_of::<u32>() as u64].contains(&host_call_fn.size) {
         return Err(anyhow::anyhow!(
             "Host call function {HOST_CALL_FN} has invalid size {}",
             host_call_fn.size
@@ -444,7 +444,7 @@ fn extract_host_call_fn_offset(
                 input_file.len()
             )
         })?
-        .get(..size_of::<[u32; 2]>())
+        .get(..host_call_fn.size as usize)
         .context("Not enough bytes to get instructions of host call function")?;
 
     Ok(host_call_fn_offset)

--- a/crates/contracts/core/ab-contracts-tooling/src/riscv64-unknown-none-abundance.json
+++ b/crates/contracts/core/ab-contracts-tooling/src/riscv64-unknown-none-abundance.json
@@ -7,7 +7,7 @@
   "only-cdylib": true,
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+m,+b,+zbc,+zca,+zcb,+zcmp,+zicond,+zkn,+unaligned-scalar-mem",
+  "features": "+m,+b,+zbc,+zca,+zcb,+zcmp,+zicond,+zkn,+unaligned-scalar-mem,+relax",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-abiname": "lp64",


### PR DESCRIPTION
Intially I thought this was a bug in LLD (https://github.com/llvm/llvm-project/issues/198090), but turns out I was lacking some target configuration.

With this benchmarking contract size decreased from 22.3 kB to 21.7 kB. Flipper contract file is just 159 bytes.

Performance also improved, especially for ed25519 signature verification:
```
blake3_hash_chunk/interpreter/eager
                        time:   [26.029 µs 26.057 µs 26.076 µs]
                        thrpt:  [37.451 MiB/s 37.477 MiB/s 37.519 MiB/s]

ed25519_verify/interpreter/eager
                        time:   [1.4453 ms 1.4467 ms 1.4479 ms]
                        thrpt:  [690.64  elem/s 691.25  elem/s 691.89  elem/s]
```

BLAKE3 hashing seems to be about the same as after https://github.com/nazar-pc/abundance/pull/678. At very least it is certainly not slower and every jump is now one instruction instead of two, which is nice (there are no `jalr` in the contract anymore).