### PR TITLE
Faster instruction fetcher

### DIFF
--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -359,8 +359,8 @@ impl LazyInstructionFetcher {
 pub struct EagerTestInstructionFetcher {
     instructions: Box<[ContractInstruction]>,
     decoded_instruction_byte_offset: usize,
-    return_trap_address: u64,
     base_addr: u64,
+    return_trap_address: u64,
 }
 
 impl<Memory> ProgramCounter<u64, Memory> for EagerTestInstructionFetcher
@@ -535,8 +535,8 @@ impl EagerTestInstructionFetcher {
             instructions: decoded_instructions.into_boxed_slice(),
             decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
                 * size_of::<ContractInstruction>(),
-            return_trap_address,
             base_addr,
+            return_trap_address,
         }
     }
 }

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -358,7 +358,7 @@ impl LazyInstructionFetcher {
 #[repr(C, align(16))]
 pub struct EagerTestInstructionFetcher {
     instructions: Box<[ContractInstruction]>,
-    instruction_offset: usize,
+    decoded_instruction_byte_offset: usize,
     return_trap_address: u64,
     base_addr: u64,
 }
@@ -369,7 +369,9 @@ where
 {
     #[inline(always)]
     fn get_pc(&self) -> u64 {
-        self.base_addr + self.instruction_offset as u64 * size_of::<u16>() as u64
+        self.base_addr
+            + self.decoded_instruction_byte_offset as u64 * size_of::<u16>() as u64
+                / size_of::<ContractInstruction>() as u64
     }
 
     #[inline]
@@ -404,7 +406,8 @@ where
             return Err(VirtualMemoryError::OutOfBoundsRead { address }.into());
         }
 
-        self.instruction_offset = instruction_offset;
+        self.decoded_instruction_byte_offset =
+            instruction_offset * size_of::<ContractInstruction>();
 
         Ok(ControlFlow::Continue(()))
     }
@@ -422,8 +425,16 @@ where
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
         // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
-        let instruction = *unsafe { self.instructions.get_unchecked(self.instruction_offset) };
-        self.instruction_offset += usize::from(instruction.size()) / size_of::<u16>();
+        let instruction = unsafe {
+            // Reading through byte offset rather than index to avoid extra computation (converting
+            // an index to a byte offset) on each fetch
+            self.instructions
+                .as_ptr()
+                .byte_add(self.decoded_instruction_byte_offset)
+                .read()
+        };
+        self.decoded_instruction_byte_offset +=
+            usize::from(instruction.size()) / size_of::<u16>() * size_of::<ContractInstruction>();
 
         Ok(FetchInstructionResult::Instruction(instruction))
     }
@@ -522,7 +533,8 @@ impl EagerTestInstructionFetcher {
 
         Self {
             instructions: decoded_instructions.into_boxed_slice(),
-            instruction_offset: (pc - base_addr) as usize / size_of::<u16>(),
+            decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
+                * size_of::<ContractInstruction>(),
             return_trap_address,
             base_addr,
         }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -136,7 +136,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> Default for GuestMemory<BASE_ADDR,
 #[repr(C, align(16))]
 pub(crate) struct EagerInstructionFetcher {
     instructions: Box<[CoremarkInstruction]>,
-    instruction_offset: usize,
+    decoded_instruction_byte_offset: usize,
     return_trap_address: u64,
     base_addr: u64,
 }
@@ -147,7 +147,9 @@ where
 {
     #[inline(always)]
     fn get_pc(&self) -> u64 {
-        self.base_addr + self.instruction_offset as u64 * size_of::<u16>() as u64
+        self.base_addr
+            + self.decoded_instruction_byte_offset as u64 * size_of::<u16>() as u64
+                / size_of::<CoremarkInstruction>() as u64
     }
 
     #[inline]
@@ -182,7 +184,8 @@ where
             return Err(VirtualMemoryError::OutOfBoundsRead { address }.into());
         }
 
-        self.instruction_offset = instruction_offset;
+        self.decoded_instruction_byte_offset =
+            instruction_offset * size_of::<CoremarkInstruction>();
 
         Ok(ControlFlow::Continue(()))
     }
@@ -200,8 +203,16 @@ where
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
         // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
-        let instruction = *unsafe { self.instructions.get_unchecked(self.instruction_offset) };
-        self.instruction_offset += usize::from(instruction.size()) / size_of::<u16>();
+        let instruction = unsafe {
+            // Reading through byte offset rather than index to avoid extra computation (converting
+            // an index to a byte offset) on each fetch
+            self.instructions
+                .as_ptr()
+                .byte_add(self.decoded_instruction_byte_offset)
+                .read()
+        };
+        self.decoded_instruction_byte_offset +=
+            usize::from(instruction.size()) / size_of::<u16>() * size_of::<CoremarkInstruction>();
 
         Ok(FetchInstructionResult::Instruction(instruction))
     }
@@ -297,7 +308,8 @@ impl EagerInstructionFetcher {
 
         Self {
             instructions: decoded_instructions.into_boxed_slice(),
-            instruction_offset: (pc - base_addr) as usize / size_of::<u16>(),
+            decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
+                * size_of::<CoremarkInstruction>(),
             return_trap_address,
             base_addr,
         }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -137,8 +137,8 @@ impl<const BASE_ADDR: u64, const SIZE: usize> Default for GuestMemory<BASE_ADDR,
 pub(crate) struct EagerInstructionFetcher {
     instructions: Box<[CoremarkInstruction]>,
     decoded_instruction_byte_offset: usize,
-    return_trap_address: u64,
     base_addr: u64,
+    return_trap_address: u64,
 }
 
 impl<Memory> ProgramCounter<u64, Memory> for EagerInstructionFetcher
@@ -310,8 +310,8 @@ impl EagerInstructionFetcher {
             instructions: decoded_instructions.into_boxed_slice(),
             decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
                 * size_of::<CoremarkInstruction>(),
-            return_trap_address,
             base_addr,
+            return_trap_address,
         }
     }
 }


### PR DESCRIPTION
Turns out, in a tight look even a single shift isn't free. By storing byte offset instead of index, performance of instruction fetcher increased:

```
blake3_hash_chunk/interpreter/eager
                        time:   [24.732 µs 24.779 µs 24.866 µs]
                        thrpt:  [39.273 MiB/s 39.410 MiB/s 39.487 MiB/s]
                 change:
                        time:   [−5.5264% −5.2876% −4.9948%] (p = 0.00 < 0.05)
                        thrpt:  [+5.2574% +5.5828% +5.8496%]
                        Performance has improved.

ed25519_verify/interpreter/eager
                        time:   [1.3732 ms 1.3784 ms 1.3828 ms]
                        thrpt:  [723.16  elem/s 725.50  elem/s 728.20  elem/s]
                 change:
                        time:   [−5.4184% −5.1885% −4.9165%] (p = 0.00 < 0.05)
                        thrpt:  [+5.1707% +5.4725% +5.7288%]
                        Performance has improved.
```

Also CoreMark score increased from ~1538 to 1666:
```
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 12850187
Total time (secs): 12
Iterations/Sec   : 1666
Iterations       : 20000
Compiler version : GCC13.2.0
Compiler flags   : -O3 -march=rv64imc_zba_zbb_zbs -mabi=lp64
Memory location  : STACK
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x382f
Correct operation validated. See readme.txt for run and reporting rules.
Host elapsed: 20.044 s
```