### PR TITLE
Improve LLVM SROA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,7 @@ dependencies = [
  "ab-riscv-primitives",
  "criterion",
  "ed25519-dalek 3.0.0-pre.7",
+ "replace_with",
 ]
 
 [[package]]
@@ -769,6 +770,7 @@ dependencies = [
  "ab-riscv-primitives",
  "anyhow",
  "object",
+ "replace_with",
 ]
 
 [[package]]

--- a/crates/execution/ab-riscv-benchmarks/Cargo.toml
+++ b/crates/execution/ab-riscv-benchmarks/Cargo.toml
@@ -28,6 +28,7 @@ ab-blake3 = { workspace = true }
 ab-contracts-macros = { workspace = true }
 ab-core-primitives = { workspace = true }
 ab-io-type = { workspace = true }
+replace_with = { workspace = true }
 
 [target.'cfg(not(target_env = "abundance"))'.dependencies]
 ab-contract-file = { workspace = true }

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -13,6 +13,7 @@ use alloc::vec::Vec;
 use core::hint::cold_path;
 use core::mem::offset_of;
 use core::ops::ControlFlow;
+use replace_with::replace_with_or_abort_and_return;
 
 /// Contract file bytes
 pub const RISCV_CONTRACT_BYTES: &[u8] = cfg_select! {
@@ -357,8 +358,10 @@ impl LazyInstructionFetcher {
 #[derive(Debug, Clone)]
 #[repr(C, align(16))]
 pub struct EagerTestInstructionFetcher {
-    instructions: Box<[ContractInstruction]>,
     decoded_instruction_byte_offset: usize,
+    // A simple raw pointer separate field helps LLVM with SROA and aliasing analysis, so it can
+    // retain this pointer in the native register
+    instructions: Box<[ContractInstruction]>,
     base_addr: u64,
     return_trap_address: u64,
 }
@@ -532,9 +535,9 @@ impl EagerTestInstructionFetcher {
         }
 
         Self {
-            instructions: decoded_instructions.into_boxed_slice(),
             decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
                 * size_of::<ContractInstruction>(),
+            instructions: decoded_instructions.into_boxed_slice(),
             base_addr,
             return_trap_address,
         }
@@ -550,50 +553,56 @@ where
     Memory: VirtualMemory,
     IF: InstructionFetcher<ContractInstruction, Memory>,
 {
-    loop {
-        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
-            Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
-                cold_path();
-                continue;
-            }
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
-                cold_path();
-                break;
-            }
-            Err(error) => {
-                cold_path();
-                return Err(error);
-            }
-        };
+    replace_with_or_abort_and_return(
+        &mut state.instruction_fetcher,
+        #[inline(always)]
+        |mut instruction_fetcher| {
+            loop {
+                let instruction = match instruction_fetcher.fetch_instruction(&state.memory) {
+                    Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
+                    Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+                        cold_path();
+                        continue;
+                    }
+                    Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+                        cold_path();
+                        break;
+                    }
+                    Err(error) => {
+                        cold_path();
+                        return (Err(error), instruction_fetcher);
+                    }
+                };
 
-        let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
-        let rs1rs2_values = Rs1Rs2OperandValues {
-            rs1_value: state.regs.read(rs1),
-            rs2_value: state.regs.read(rs2),
-        };
+                let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
+                let rs1rs2_values = Rs1Rs2OperandValues {
+                    rs1_value: state.regs.read(rs1),
+                    rs2_value: state.regs.read(rs2),
+                };
 
-        match instruction.execute(
-            rs1rs2_values,
-            &mut state.regs,
-            &mut state.ext_state,
-            &mut state.memory,
-            &mut state.instruction_fetcher,
-            &mut state.system_instruction_handler,
-        ) {
-            Ok(ControlFlow::Continue((rd, rd_value))) => {
-                state.regs.write(rd, rd_value);
+                match instruction.execute(
+                    rs1rs2_values,
+                    &mut state.regs,
+                    &mut state.ext_state,
+                    &mut state.memory,
+                    &mut instruction_fetcher,
+                    &mut state.system_instruction_handler,
+                ) {
+                    Ok(ControlFlow::Continue((rd, rd_value))) => {
+                        state.regs.write(rd, rd_value);
+                    }
+                    Ok(ControlFlow::Break(())) => {
+                        cold_path();
+                        break;
+                    }
+                    Err(error) => {
+                        cold_path();
+                        return (Err(error), instruction_fetcher);
+                    }
+                }
             }
-            Ok(ControlFlow::Break(())) => {
-                cold_path();
-                break;
-            }
-            Err(error) => {
-                cold_path();
-                return Err(error);
-            }
-        }
-    }
 
-    Ok(())
+            (Ok(()), instruction_fetcher)
+        },
+    )
 }

--- a/crates/execution/ab-riscv-coremark-runner/Cargo.toml
+++ b/crates/execution/ab-riscv-coremark-runner/Cargo.toml
@@ -20,6 +20,7 @@ ab-riscv-macros = { workspace = true, features = ["proc-macro"] }
 ab-riscv-primitives = { workspace = true }
 anyhow = { workspace = true }
 object = { workspace = true, features = ["elf", "read_core"] }
+replace_with = { workspace = true }
 
 [build-dependencies]
 ab-riscv-macros = { workspace = true, features = ["build"] }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -132,11 +132,13 @@ impl<const BASE_ADDR: u64, const SIZE: usize> Default for GuestMemory<BASE_ADDR,
 }
 
 /// Eager instruction handler eagerly decodes all instructions upfront
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 #[repr(C, align(16))]
 pub(crate) struct EagerInstructionFetcher {
-    instructions: Box<[CoremarkInstruction]>,
     decoded_instruction_byte_offset: usize,
+    // A simple raw pointer separate field helps LLVM with SROA and aliasing analysis, so it can
+    // retain this pointer in the native register
+    instructions: Box<[CoremarkInstruction]>,
     base_addr: u64,
     return_trap_address: u64,
 }
@@ -307,9 +309,9 @@ impl EagerInstructionFetcher {
         }
 
         Self {
-            instructions: decoded_instructions.into_boxed_slice(),
             decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
                 * size_of::<CoremarkInstruction>(),
+            instructions: decoded_instructions.into_boxed_slice(),
             base_addr,
             return_trap_address,
         }

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -27,6 +27,7 @@ use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use anyhow::Context;
 use core::ops::ControlFlow;
+use replace_with::replace_with_or_abort_and_return;
 use std::ffi::CStr;
 use std::hint::cold_path;
 
@@ -61,52 +62,58 @@ where
     Memory: VirtualMemory,
     IF: InstructionFetcher<CoremarkInstruction, Memory> + ProgramCounter<u64, Memory>,
 {
-    loop {
-        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
-            Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
-                cold_path();
-                continue;
-            }
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
-                cold_path();
-                break;
-            }
-            Err(error) => {
-                cold_path();
-                return Err(error);
-            }
-        };
+    replace_with_or_abort_and_return(
+        &mut state.instruction_fetcher,
+        #[inline(always)]
+        |mut instruction_fetcher| {
+            loop {
+                let instruction = match instruction_fetcher.fetch_instruction(&state.memory) {
+                    Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
+                    Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+                        cold_path();
+                        continue;
+                    }
+                    Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+                        cold_path();
+                        break;
+                    }
+                    Err(error) => {
+                        cold_path();
+                        return (Err(error), instruction_fetcher);
+                    }
+                };
 
-        let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
-        let rs1rs2_values = Rs1Rs2OperandValues {
-            rs1_value: state.regs.read(rs1),
-            rs2_value: state.regs.read(rs2),
-        };
+                let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
+                let rs1rs2_values = Rs1Rs2OperandValues {
+                    rs1_value: state.regs.read(rs1),
+                    rs2_value: state.regs.read(rs2),
+                };
 
-        match instruction.execute(
-            rs1rs2_values,
-            &mut state.regs,
-            &mut state.ext_state,
-            &mut state.memory,
-            &mut state.instruction_fetcher,
-            &mut state.system_instruction_handler,
-        ) {
-            Ok(ControlFlow::Continue((rd, rd_value))) => {
-                state.regs.write(rd, rd_value);
+                match instruction.execute(
+                    rs1rs2_values,
+                    &mut state.regs,
+                    &mut state.ext_state,
+                    &mut state.memory,
+                    &mut instruction_fetcher,
+                    &mut state.system_instruction_handler,
+                ) {
+                    Ok(ControlFlow::Continue((rd, rd_value))) => {
+                        state.regs.write(rd, rd_value);
+                    }
+                    Ok(ControlFlow::Break(())) => {
+                        cold_path();
+                        break;
+                    }
+                    Err(error) => {
+                        cold_path();
+                        return (Err(error), instruction_fetcher);
+                    }
+                }
             }
-            Ok(ControlFlow::Break(())) => {
-                cold_path();
-                break;
-            }
-            Err(error) => {
-                cold_path();
-                return Err(error);
-            }
-        }
-    }
 
-    Ok(())
+            (Ok(()), instruction_fetcher)
+        },
+    )
 }
 
 /// Read the null-terminated Coremark output string from the output buffer


### PR DESCRIPTION
This results in further minor improvement in benchmark performance on top of https://github.com/nazar-pc/abundance/pull/685:
```
blake3_hash_chunk/interpreter/eager
                        time:   [23.421 µs 23.484 µs 23.520 µs]
                        thrpt:  [41.520 MiB/s 41.584 MiB/s 41.696 MiB/s]
                 change:
                        time:   [−6.2576% −6.0281% −5.8153%] (p = 0.00 < 0.05)
                        thrpt:  [+6.1743% +6.4148% +6.6754%]
                        Performance has improved.

ed25519_verify/interpreter/eager
                        time:   [1.3011 ms 1.3039 ms 1.3057 ms]
                        thrpt:  [765.89  elem/s 766.94  elem/s 768.60  elem/s]
                 change:
                        time:   [−7.7839% −7.2270% −6.7192%] (p = 0.00 < 0.05)
                        thrpt:  [+7.2032% +7.7900% +8.4410%]
                        Performance has improved.
```

It is kind of unfortunate that LLVM can't figure this out by default and requires such convincing, but what can we do about it... With this the pointer is stored permanently in the native register.