### PR TITLE
Conditional instruction dependencies

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -31,6 +31,47 @@ impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32ZcbInstruction<Reg>
 where
     Reg: Register<Type = u32>,
+{
+    #[inline(always)]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
+    ) -> Result<
+        ControlFlow<(), (Self::Reg, <Self::Reg as Register>::Type)>,
+        ExecutionError<Reg::Type, CustomError>,
+    > {
+        Ok(ControlFlow::Continue(Default::default()))
+    }
+}
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZcbOnlyInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZcbOnlyInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
+
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZcbOnlyInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb/tests.rs
@@ -6,7 +6,7 @@ use ab_riscv_primitives::prelude::*;
 
 #[test]
 fn test_clbu_zero_extends() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLbu {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLbu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -22,7 +22,7 @@ fn test_clbu_zero_extends() {
 
 #[test]
 fn test_clbu_with_uimm_offset() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLbu {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLbu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 3,
@@ -37,7 +37,7 @@ fn test_clbu_with_uimm_offset() {
 
 #[test]
 fn test_clbu_oob() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLbu {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLbu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -54,7 +54,7 @@ fn test_clbu_oob() {
 
 #[test]
 fn test_clhu_zero_extends() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLhu {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLhu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -69,7 +69,7 @@ fn test_clhu_zero_extends() {
 
 #[test]
 fn test_clhu_with_uimm2() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLhu {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLhu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 2,
@@ -87,7 +87,7 @@ fn test_clhu_with_uimm2() {
 
 #[test]
 fn test_clhu_oob() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLhu {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLhu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -104,7 +104,7 @@ fn test_clhu_oob() {
 
 #[test]
 fn test_clh_sign_extends() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLh {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLh {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -119,7 +119,7 @@ fn test_clh_sign_extends() {
 
 #[test]
 fn test_clh_sign_extends_positive() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLh {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLh {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -134,7 +134,7 @@ fn test_clh_sign_extends_positive() {
 
 #[test]
 fn test_clh_oob() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CLh {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CLh {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -151,7 +151,7 @@ fn test_clh_oob() {
 
 #[test]
 fn test_csb() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSb {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSb {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 0,
@@ -165,7 +165,7 @@ fn test_csb() {
 
 #[test]
 fn test_csb_with_uimm_offset() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSb {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSb {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 1,
@@ -179,7 +179,7 @@ fn test_csb_with_uimm_offset() {
 
 #[test]
 fn test_csb_oob() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSb {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSb {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 0,
@@ -193,7 +193,7 @@ fn test_csb_oob() {
 
 #[test]
 fn test_csh() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSh {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSh {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 0,
@@ -207,7 +207,7 @@ fn test_csh() {
 
 #[test]
 fn test_csh_oob() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSh {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSh {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 0,
@@ -223,7 +223,7 @@ fn test_csh_oob() {
 
 #[test]
 fn test_czext_b() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CZextB {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CZextB {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -235,7 +235,7 @@ fn test_czext_b() {
 
 #[test]
 fn test_czext_b_zero() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CZextB {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CZextB {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -247,7 +247,7 @@ fn test_czext_b_zero() {
 
 #[test]
 fn test_csext_b_negative() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSextB {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSextB {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -259,7 +259,7 @@ fn test_csext_b_negative() {
 
 #[test]
 fn test_csext_b_positive() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSextB {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSextB {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -271,7 +271,7 @@ fn test_csext_b_positive() {
 
 #[test]
 fn test_czext_h() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CZextH {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CZextH {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -283,7 +283,7 @@ fn test_czext_h() {
 
 #[test]
 fn test_csext_h_negative() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSextH {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSextH {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -295,7 +295,7 @@ fn test_csext_h_negative() {
 
 #[test]
 fn test_csext_h_positive() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CSextH {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CSextH {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -307,7 +307,7 @@ fn test_csext_h_positive() {
 
 #[test]
 fn test_cnot() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CNot {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CNot {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -319,7 +319,7 @@ fn test_cnot() {
 
 #[test]
 fn test_cnot_all_zeros() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CNot {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CNot {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -331,7 +331,7 @@ fn test_cnot_all_zeros() {
 
 #[test]
 fn test_cmul() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CMul {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CMul {
         rd: Reg::S0,
         rs2: Reg::S1,
         rs1: Reg::Zero,
@@ -344,7 +344,7 @@ fn test_cmul() {
 
 #[test]
 fn test_cmul_wraps_32bit() {
-    let mut state = initialize_state([Rv32ZcbInstruction::CMul {
+    let mut state = initialize_state([Rv32ZcbOnlyInstruction::CMul {
         rd: Reg::S0,
         rs2: Reg::S1,
         rs1: Reg::Zero,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -33,6 +33,47 @@ impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32ZcmpInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u32>,
+{
+    #[inline(always)]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
+    ) -> Result<
+        ControlFlow<(), (Self::Reg, <Self::Reg as Register>::Type)>,
+        ExecutionError<Reg::Type, CustomError>,
+    > {
+        Ok(ControlFlow::Continue(Default::default()))
+    }
+}
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv32ZcmpOnlyInstruction<Reg> where
+    Reg: ZcmpRegister<Type = u32>
+{
+}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZcmpOnlyInstruction<Reg>
+where
+    Reg: ZcmpRegister<Type = u32>,
+{
+}
+
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZcmpOnlyInstruction<Reg>
+where
+    Reg: ZcmpRegister<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/tests.rs
@@ -7,7 +7,7 @@ use ab_riscv_primitives::prelude::*;
 #[test]
 fn test_cm_push_ra_only_decrements_sp() {
     // urlist=4 ({ra}), stack_adj=16 -> base=16
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -28,7 +28,7 @@ fn test_cm_push_ra_only_decrements_sp() {
 #[test]
 fn test_cm_push_stack_adj_adds_extra() {
     // urlist=4 ({ra}), stack_adj=32 -> base=16 + 16 extra
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 32,
         rs1: Reg::Zero,
@@ -50,7 +50,7 @@ fn test_cm_push_stack_adj_adds_extra() {
 #[test]
 fn test_cm_push_ra_s0() {
     // urlist=5 ({ra, s0}), stack_adj=16
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(5).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -76,7 +76,7 @@ fn test_cm_push_ra_s0() {
 #[test]
 fn test_cm_push_ra_s0_s1() {
     // urlist=6 ({ra, s0, s1}), stack_adj=16
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(6).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -106,7 +106,7 @@ fn test_cm_push_ra_s0_s1() {
 #[test]
 fn test_cm_push_max_urlist() {
     // urlist=15 ({ra, s0-s11}), stack_adj=64
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(15).unwrap(),
         stack_adj: 64,
         rs1: Reg::Zero,
@@ -124,7 +124,7 @@ fn test_cm_push_max_urlist() {
 #[test]
 fn test_cm_pop_restores_and_increments_sp() {
     // urlist=4 ({ra}), stack_adj=16
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPop {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPop {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -145,7 +145,7 @@ fn test_cm_pop_restores_and_increments_sp() {
 #[test]
 fn test_cm_pop_ra_s0() {
     // urlist=5, stack_adj=16
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPop {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPop {
         urlist: ZcmpUrlist::try_from_raw(5).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -171,7 +171,7 @@ fn test_cm_pop_ra_s0() {
 #[test]
 fn test_cm_pop_stack_adj_extra() {
     // urlist=4, stack_adj=32 -> base=16 + 16 extra
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPop {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPop {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 32,
         rs1: Reg::Zero,
@@ -193,7 +193,7 @@ fn test_cm_pop_stack_adj_extra() {
 
 #[test]
 fn test_cm_popretz_zeros_a0_and_jumps() {
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPopretz {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPopretz {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -216,7 +216,7 @@ fn test_cm_popretz_zeros_a0_and_jumps() {
 
 #[test]
 fn test_cm_popretz_clears_lsb_of_return_addr() {
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPopretz {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPopretz {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -238,7 +238,7 @@ fn test_cm_popretz_clears_lsb_of_return_addr() {
 
 #[test]
 fn test_cm_popret_restores_and_jumps() {
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPopret {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPopret {
         urlist: ZcmpUrlist::try_from_raw(5).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -265,7 +265,7 @@ fn test_cm_popret_restores_and_jumps() {
 
 #[test]
 fn test_cm_popret_clears_lsb_of_return_addr() {
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPopret {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPopret {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -287,7 +287,7 @@ fn test_cm_popret_clears_lsb_of_return_addr() {
 
 #[test]
 fn test_cm_mva01s_copies_to_a0_a1() {
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmMva01s {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmMva01s {
         rs1: Reg::S2,
         rs2: Reg::S3,
     }]);
@@ -304,7 +304,7 @@ fn test_cm_mva01s_copies_to_a0_a1() {
 #[test]
 fn test_cm_mva01s_reads_before_write() {
     // If rs1 or rs2 alias a0/a1, reads must occur before writes
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmMva01s {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmMva01s {
         rs1: Reg::S0,
         rs2: Reg::S1,
     }]);
@@ -319,7 +319,7 @@ fn test_cm_mva01s_reads_before_write() {
 
 #[test]
 fn test_cm_mvsa01_copies_a0_a1_to_s_regs() {
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmMvsa01 {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmMvsa01 {
         rs1: Reg::S4,
         rs2: Reg::S5,
     }]);
@@ -340,7 +340,7 @@ fn test_push_pop_round_trip_ra_s0_s1() {
     let sp_start = TEST_BASE_ADDR + 0x800;
 
     // PUSH {ra, s0, s1}
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(6).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -355,7 +355,7 @@ fn test_push_pop_round_trip_ra_s0_s1() {
     assert_eq!(sp_after_push, sp_start - 16);
 
     // POP from the same memory
-    let mut state2 = initialize_state([Rv32ZcmpInstruction::CmPop {
+    let mut state2 = initialize_state([Rv32ZcmpOnlyInstruction::CmPop {
         urlist: ZcmpUrlist::try_from_raw(6).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -380,7 +380,7 @@ fn test_push_pop_round_trip_ra_s0_s1() {
 #[test]
 fn test_cm_push_oob_memory() {
     // sp very low -> sp-4 underflows into unmapped memory
-    let mut state = initialize_state([Rv32ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv32ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -29,6 +29,47 @@ impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64ZcbInstruction<Reg>
 where
     Reg: Register<Type = u64>,
+{
+    #[inline(always)]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
+    ) -> Result<
+        ControlFlow<(), (Self::Reg, <Self::Reg as Register>::Type)>,
+        ExecutionError<Reg::Type, CustomError>,
+    > {
+        Ok(ControlFlow::Continue(Default::default()))
+    }
+}
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZcbOnlyInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZcbOnlyInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
+
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZcbOnlyInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb/tests.rs
@@ -6,7 +6,7 @@ use ab_riscv_primitives::prelude::*;
 
 #[test]
 fn test_clbu_zero_extends() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLbu {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLbu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -22,7 +22,7 @@ fn test_clbu_zero_extends() {
 
 #[test]
 fn test_clbu_with_uimm_offset() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLbu {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLbu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 3,
@@ -37,7 +37,7 @@ fn test_clbu_with_uimm_offset() {
 
 #[test]
 fn test_clbu_oob() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLbu {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLbu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -54,7 +54,7 @@ fn test_clbu_oob() {
 
 #[test]
 fn test_clhu_zero_extends() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLhu {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLhu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -69,7 +69,7 @@ fn test_clhu_zero_extends() {
 
 #[test]
 fn test_clhu_with_uimm2() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLhu {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLhu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 2,
@@ -84,7 +84,7 @@ fn test_clhu_with_uimm2() {
 
 #[test]
 fn test_clhu_oob() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLhu {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLhu {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -101,7 +101,7 @@ fn test_clhu_oob() {
 
 #[test]
 fn test_clh_sign_extends_negative() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLh {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLh {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -116,7 +116,7 @@ fn test_clh_sign_extends_negative() {
 
 #[test]
 fn test_clh_sign_extends_positive() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLh {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLh {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -131,7 +131,7 @@ fn test_clh_sign_extends_positive() {
 
 #[test]
 fn test_clh_oob() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CLh {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CLh {
         rd: Reg::A1,
         rs1: Reg::A0,
         uimm: 0,
@@ -148,7 +148,7 @@ fn test_clh_oob() {
 
 #[test]
 fn test_csb_stores_low_byte() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CSb {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CSb {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 1,
@@ -162,7 +162,7 @@ fn test_csb_stores_low_byte() {
 
 #[test]
 fn test_csb_oob() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CSb {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CSb {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 0,
@@ -178,7 +178,7 @@ fn test_csb_oob() {
 
 #[test]
 fn test_csh_stores_low_halfword() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CSh {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CSh {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 0,
@@ -192,7 +192,7 @@ fn test_csh_stores_low_halfword() {
 
 #[test]
 fn test_csh_oob() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CSh {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CSh {
         rs1: Reg::A0,
         rs2: Reg::A1,
         uimm: 0,
@@ -208,7 +208,7 @@ fn test_csh_oob() {
 
 #[test]
 fn test_czext_b() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CZextB {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CZextB {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -220,7 +220,7 @@ fn test_czext_b() {
 
 #[test]
 fn test_czext_b_zero() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CZextB {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CZextB {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -234,7 +234,7 @@ fn test_czext_b_zero() {
 
 #[test]
 fn test_csext_b_negative() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CSextB {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CSextB {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -246,7 +246,7 @@ fn test_csext_b_negative() {
 
 #[test]
 fn test_csext_b_positive() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CSextB {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CSextB {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -260,7 +260,7 @@ fn test_csext_b_positive() {
 
 #[test]
 fn test_czext_h() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CZextH {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CZextH {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -274,7 +274,7 @@ fn test_czext_h() {
 
 #[test]
 fn test_csext_h_negative() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CSextH {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CSextH {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -286,7 +286,7 @@ fn test_csext_h_negative() {
 
 #[test]
 fn test_csext_h_positive() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CSextH {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CSextH {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -300,7 +300,7 @@ fn test_csext_h_positive() {
 
 #[test]
 fn test_czext_w() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CZextW {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CZextW {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -312,7 +312,7 @@ fn test_czext_w() {
 
 #[test]
 fn test_czext_w_zeros_upper() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CZextW {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CZextW {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -326,7 +326,7 @@ fn test_czext_w_zeros_upper() {
 
 #[test]
 fn test_cnot() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CNot {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CNot {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -338,7 +338,7 @@ fn test_cnot() {
 
 #[test]
 fn test_cnot_all_zeros() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CNot {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CNot {
         rd: Reg::A0,
         rs1: Reg::Zero,
         rs2: Reg::Zero,
@@ -352,7 +352,7 @@ fn test_cnot_all_zeros() {
 
 #[test]
 fn test_cmul_basic() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CMul {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CMul {
         rd: Reg::S0,
         rs2: Reg::S1,
         rs1: Reg::Zero,
@@ -365,7 +365,7 @@ fn test_cmul_basic() {
 
 #[test]
 fn test_cmul_wraps() {
-    let mut state = initialize_state([Rv64ZcbInstruction::CMul {
+    let mut state = initialize_state([Rv64ZcbOnlyInstruction::CMul {
         rd: Reg::S0,
         rs2: Reg::S1,
         rs1: Reg::Zero,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -33,6 +33,47 @@ impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64ZcmpInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u64>,
+{
+    #[inline(always)]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
+    ) -> Result<
+        ControlFlow<(), (Self::Reg, <Self::Reg as Register>::Type)>,
+        ExecutionError<Reg::Type, CustomError>,
+    > {
+        Ok(ControlFlow::Continue(Default::default()))
+    }
+}
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Rv64ZcmpOnlyInstruction<Reg> where
+    Reg: ZcmpRegister<Type = u64>
+{
+}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZcmpOnlyInstruction<Reg>
+where
+    Reg: ZcmpRegister<Type = u64>,
+{
+}
+
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZcmpOnlyInstruction<Reg>
+where
+    Reg: ZcmpRegister<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/tests.rs
@@ -7,7 +7,7 @@ use ab_riscv_primitives::prelude::*;
 #[test]
 fn test_cm_push_ra_only_decrements_sp() {
     // urlist=4 ({ra}), stack_adj=16 -> base=16
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -25,7 +25,7 @@ fn test_cm_push_ra_only_decrements_sp() {
 #[test]
 fn test_cm_push_stack_adj_adds_extra() {
     // urlist=4 ({ra}), stack_adj=32 -> base=16 + 16 extra
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 32,
         rs1: Reg::Zero,
@@ -44,7 +44,7 @@ fn test_cm_push_stack_adj_adds_extra() {
 #[test]
 fn test_cm_push_ra_s0() {
     // urlist=5 ({ra, s0}), stack_adj=16
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(5).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -64,7 +64,7 @@ fn test_cm_push_ra_s0() {
 #[test]
 fn test_cm_push_ra_s0_s1() {
     // urlist=6 ({ra, s0, s1}), stack_adj=32
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(6).unwrap(),
         stack_adj: 32,
         rs1: Reg::Zero,
@@ -85,7 +85,7 @@ fn test_cm_push_ra_s0_s1() {
 #[test]
 fn test_cm_push_max_urlist() {
     // urlist=15 ({ra, s0-s11}), stack_adj=112
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(15).unwrap(),
         stack_adj: 112,
         rs1: Reg::Zero,
@@ -103,7 +103,7 @@ fn test_cm_push_max_urlist() {
 #[test]
 fn test_cm_pop_restores_and_increments_sp() {
     // urlist=4 ({ra}), stack_adj=16
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPop {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPop {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -121,7 +121,7 @@ fn test_cm_pop_restores_and_increments_sp() {
 #[test]
 fn test_cm_pop_ra_s0() {
     // urlist=5, stack_adj=16
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPop {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPop {
         urlist: ZcmpUrlist::try_from_raw(5).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -141,7 +141,7 @@ fn test_cm_pop_ra_s0() {
 #[test]
 fn test_cm_pop_stack_adj_extra() {
     // urlist=4, stack_adj=48 -> base=16 + 32 extra
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPop {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPop {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 48,
         rs1: Reg::Zero,
@@ -160,7 +160,7 @@ fn test_cm_pop_stack_adj_extra() {
 
 #[test]
 fn test_cm_popretz_zeros_a0_and_jumps() {
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPopretz {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPopretz {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -180,7 +180,7 @@ fn test_cm_popretz_zeros_a0_and_jumps() {
 
 #[test]
 fn test_cm_popretz_clears_lsb_of_return_addr() {
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPopretz {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPopretz {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -202,7 +202,7 @@ fn test_cm_popretz_clears_lsb_of_return_addr() {
 
 #[test]
 fn test_cm_popret_restores_and_jumps() {
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPopret {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPopret {
         urlist: ZcmpUrlist::try_from_raw(5).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -223,7 +223,7 @@ fn test_cm_popret_restores_and_jumps() {
 
 #[test]
 fn test_cm_popret_clears_lsb_of_return_addr() {
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPopret {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPopret {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,
@@ -245,7 +245,7 @@ fn test_cm_popret_clears_lsb_of_return_addr() {
 
 #[test]
 fn test_cm_mva01s_copies_to_a0_a1() {
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmMva01s {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmMva01s {
         rs1: Reg::S2,
         rs2: Reg::S3,
     }]);
@@ -262,7 +262,7 @@ fn test_cm_mva01s_copies_to_a0_a1() {
 #[test]
 fn test_cm_mva01s_reads_before_write() {
     // If rs1 or rs2 alias a0/a1, reads must occur before writes
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmMva01s {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmMva01s {
         rs1: Reg::S0,
         rs2: Reg::S1,
     }]);
@@ -277,7 +277,7 @@ fn test_cm_mva01s_reads_before_write() {
 
 #[test]
 fn test_cm_mvsa01_copies_a0_a1_to_s_regs() {
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmMvsa01 {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmMvsa01 {
         rs1: Reg::S4,
         rs2: Reg::S5,
     }]);
@@ -298,7 +298,7 @@ fn test_push_pop_round_trip_ra_s0_s1() {
     let sp_start = TEST_BASE_ADDR + 0x800;
 
     // PUSH {ra, s0, s1}
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(6).unwrap(),
         stack_adj: 32,
         rs1: Reg::Zero,
@@ -317,7 +317,7 @@ fn test_push_pop_round_trip_ra_s0_s1() {
     state.regs.write(Reg::S1, 0);
 
     // POP from the same memory
-    let mut state2 = initialize_state([Rv64ZcmpInstruction::CmPop {
+    let mut state2 = initialize_state([Rv64ZcmpOnlyInstruction::CmPop {
         urlist: ZcmpUrlist::try_from_raw(6).unwrap(),
         stack_adj: 32,
         rs1: Reg::Zero,
@@ -342,7 +342,7 @@ fn test_push_pop_round_trip_ra_s0_s1() {
 #[test]
 fn test_cm_push_oob_memory() {
     // sp very low -> sp-8 underflows into unmapped memory
-    let mut state = initialize_state([Rv64ZcmpInstruction::CmPush {
+    let mut state = initialize_state([Rv64ZcmpOnlyInstruction::CmPush {
         urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
         stack_adj: 16,
         rs1: Reg::Zero,

--- a/crates/execution/ab-riscv-macros-impl/src/lib.rs
+++ b/crates/execution/ab-riscv-macros-impl/src/lib.rs
@@ -5,6 +5,7 @@ mod instruction_execution;
 
 use proc_macro::TokenStream;
 
+// TODO: Support `conflict` (`Zcmp` conflicts with `Zcd` for example)
 /// Processes `#[instruction]` attribute on both enum definitions and implementations.
 ///
 /// # Enum definition
@@ -25,11 +26,16 @@ use proc_macro::TokenStream;
 ///     ignore = [E],
 ///     inherit = [BaseInstruction],
 ///     reorder = [D, A],
+///     if = [OptionalX]
 /// )]
 /// struct Extended<Reg> {
 ///     A(Reg),
 ///     B(Reg),
 ///     C(Reg),
+///     #[instruction(
+///         if = [OptionalY],
+///         if = [OptionalZ1, OptionalZ2],
+///     )]
 ///     D(Reg),
 ///     E(Reg),
 /// }
@@ -48,8 +54,8 @@ use proc_macro::TokenStream;
 /// }
 /// ```
 ///
-/// Note that both `reorder`, `ignore` and `inherit` attributes can be specified multiple times, and
-/// reordering can reference any variant from both the `BaseInstruction` and `Extended` enums.
+/// Note that all attribute parameters can be specified multiple times, and reordering can reference
+/// any variant from both the `BaseInstruction` and `Extended` enums.
 ///
 /// This, of course, only works when enums have compatible generics.
 ///
@@ -68,6 +74,26 @@ use proc_macro::TokenStream;
 ///   * `inherit` includes all remaining variants of the corresponding enum that were not explicitly
 ///     reordered or ignored anywhere in the definition
 ///   * own variants that were not explicitly reordered or ignored are placed at the end of the enum
+///
+/// `reorder` is a niche feature that physically moves the variants, allowing certain variants to be
+/// next to each other for more efficient code generation (enum discriminant and execution code
+/// locality).
+///
+/// `inherit` is used both for dependencies (`Zve64x` depends on `Zicsr`) and for direct inclusion
+/// during composition (`B` contains `Zba`, `Zbb` and `Zbs`).
+///
+/// `ignore` can be used to create subsets of extensions (`Zmmul` is a multiply-only subset of `M`).
+///
+/// `if` on both enum and variant levels specifies soft optional dependencies on other instructions
+/// or variants when this instruction is inherited further up the chain. Variants are always present
+/// in the enum where they are defined, such that tests can be written against them without extra
+/// effort. In this example above, all instructions require `OptionalX` enum or variant to be
+/// included alongside `Extended` itself, while variant `D` specifically requires either `OptionalY`
+/// or `OptionalZ1` + `OptionalZ2` to be present.
+///
+/// These `if` conditions allow modeling things like `Zcf` part of `C` extension only being
+/// available when `F` extension is also available or `Zcb`'s `c.sext.b` only present when `Zbb`
+/// extension is also available.
 ///
 /// # Enum decoding implementation
 ///

--- a/crates/execution/ab-riscv-macros/src/build.rs
+++ b/crates/execution/ab-riscv-macros/src/build.rs
@@ -1,7 +1,7 @@
 mod enum_definition;
 mod enum_impl;
 mod execution_impl;
-mod shared_impl;
+mod shared;
 mod state;
 
 use crate::build::enum_definition::{
@@ -39,9 +39,23 @@ pub fn process_instruction_macros() -> anyhow::Result<()> {
     let mut state = State::new();
 
     for maybe_enum_definition in collect_enum_definitions_from_dependencies() {
-        let (original_item_enum, item_enum, dependencies, source) = maybe_enum_definition?;
+        let (
+            original_item_enum,
+            item_enum,
+            ignored_instructions,
+            direct_dependencies,
+            dependencies_for_enablement,
+            source,
+        ) = maybe_enum_definition?;
 
-        state.insert_known_enum_definition(original_item_enum, item_enum, dependencies, source)?;
+        state.insert_known_enum_definition(
+            original_item_enum,
+            item_enum,
+            ignored_instructions,
+            direct_dependencies,
+            dependencies_for_enablement,
+            source,
+        )?;
     }
     for maybe_enum_impl in collect_original_enum_decoding_impls_from_dependencies() {
         let (item_impl, source) = maybe_enum_impl?;

--- a/crates/execution/ab-riscv-macros/src/build.rs
+++ b/crates/execution/ab-riscv-macros/src/build.rs
@@ -39,9 +39,9 @@ pub fn process_instruction_macros() -> anyhow::Result<()> {
     let mut state = State::new();
 
     for maybe_enum_definition in collect_enum_definitions_from_dependencies() {
-        let (item_enum, dependencies, source) = maybe_enum_definition?;
+        let (original_item_enum, item_enum, dependencies, source) = maybe_enum_definition?;
 
-        state.insert_known_enum_definition(item_enum, dependencies, source)?;
+        state.insert_known_enum_definition(original_item_enum, item_enum, dependencies, source)?;
     }
     for maybe_enum_impl in collect_original_enum_decoding_impls_from_dependencies() {
         let (item_impl, source) = maybe_enum_impl?;

--- a/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
@@ -1,13 +1,16 @@
+use crate::build::shared::collect_all_dependencies;
 use crate::build::state::{PendingEnumDefinition, State};
 use ab_riscv_macros_common::code_utils::pre_process_rust_code;
 use anyhow::Context;
 use prettyplease::unparse;
 use quote::{ToTokens, format_ident};
+use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 use std::{env, fs, mem};
+use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{
@@ -18,11 +21,14 @@ use syn::{
 const ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ORIGINAL_ENUM_DEFINITION_PATH";
 const ENUM_DEFINITION_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_DEFINITION_PATH";
 const ENUM_DEPENDENCIES_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_DEPENDENCIES";
+const ENUM_IGNORED_INSTRUCTIONS_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_IGNORED_INSTRUCTIONS";
+const ENUM_DEPENDENCIES_FOR_ENABLEMENT_ENV_VAR_SUFFIX: &str =
+    "__INSTRUCTION_ENUM_DEPENDENCIES_FOR_ENABLEMENT";
 
-/// Attribute for `#[instruction]` macro used on enum definition
+/// Attribute for `#[instruction]` macro used on an enum definition
 #[derive(Debug, Default)]
-pub(super) struct InstructionDefinition {
-    pub(super) items: Punctuated<InstructionDefinitionItem, Token![,]>,
+struct InstructionDefinition {
+    items: Punctuated<InstructionDefinitionItem, Token![,]>,
 }
 
 impl Parse for InstructionDefinition {
@@ -35,49 +41,104 @@ impl Parse for InstructionDefinition {
 
 /// Attribute item for `#[instruction]` macro used on enum definition
 #[derive(Debug)]
-pub(super) enum InstructionDefinitionItem {
+enum InstructionDefinitionItem {
     /// Specifies the order of instruction variants
     Reorder(Vec<Ident>),
     /// Specifies ignored instruction variants or whole enums
     Ignore(Vec<Ident>),
-    /// Specifies the inherited instruction variants
+    /// Specifies the inherited instruction enums
     Inherit(Vec<Ident>),
+    /// Makes instruction optional depending on the presence of instruction variants or whole enums
+    If(Rc<[Ident]>),
 }
 
 impl InstructionDefinitionItem {
     fn parse(input: ParseStream<'_>) -> Result<Self, Error> {
-        let key: Ident = input.parse()?;
+        let key = input.call::<Ident>(Ident::parse_any)?;
         input.parse::<Token![=]>()?;
 
         let content;
         bracketed!(content in input);
 
-        let values: Punctuated<Ident, Token![,]> =
-            content.parse_terminated(Ident::parse, Token![,])?;
+        let values = content.parse_terminated(Ident::parse, Token![,])?;
 
         match key.to_string().as_str() {
             "reorder" => Ok(Self::Reorder(values.into_iter().collect())),
             "ignore" => Ok(Self::Ignore(values.into_iter().collect())),
             "inherit" => Ok(Self::Inherit(values.into_iter().collect())),
+            "if" => Ok(Self::If(values.into_iter().collect())),
             _ => Err(Error::new_spanned(key, "unknown instruction attribute key")),
         }
     }
 }
 
+/// `#[instruction]` attribute on an enum variant
+#[derive(Debug, Default)]
+struct InstructionVariant {
+    items: Punctuated<InstructionVariantItem, Token![,]>,
+}
+
+impl Parse for InstructionVariant {
+    fn parse(input: ParseStream<'_>) -> Result<Self, Error> {
+        Ok(Self {
+            items: input.parse_terminated(InstructionVariantItem::parse, Token![,])?,
+        })
+    }
+}
+
+/// Attribute item for `#[instruction]` macro used on enum definition
+#[derive(Debug)]
+enum InstructionVariantItem {
+    /// Makes instruction optional depending on the presence of instruction variants or whole enums
+    If(Rc<[Ident]>),
+}
+
+impl InstructionVariantItem {
+    fn parse(input: ParseStream<'_>) -> Result<Self, Error> {
+        let key = input.call::<Ident>(Ident::parse_any)?;
+        input.parse::<Token![=]>()?;
+
+        let content;
+        bracketed!(content in input);
+
+        let values = content.parse_terminated(Ident::parse, Token![,])?;
+
+        match key.to_string().as_str() {
+            "if" => Ok(Self::If(values.into_iter().collect())),
+            _ => Err(Error::new_spanned(key, "unknown instruction attribute key")),
+        }
+    }
+}
+
+#[derive(Debug)]
 struct KnownInstruction {
     instruction: Rc<Variant>,
     source: Rc<Path>,
+    /// Dependencies for enablement of this instruction, if there are multiple elements in a
+    /// vector, any is sufficient to enable the instruction
+    dependencies_for_enablement: HashSet<Rc<[Ident]>>,
 }
 
 struct ProcessedEnumDefinition {
     item_enum: ItemEnum,
     original_item_enum: ItemEnum,
-    dependencies: Vec<Ident>,
+    ignored_instructions: HashSet<Ident>,
+    direct_dependencies: Rc<[Ident]>,
+    dependencies_for_enablement: HashSet<Rc<[Ident]>>,
 }
 
 // TODO: Data structures for various `collect_*()` return types
-pub(super) fn collect_enum_definitions_from_dependencies()
--> impl Iterator<Item = anyhow::Result<(ItemEnum, ItemEnum, Vec<Ident>, Rc<Path>)>> {
+#[expect(clippy::type_complexity, reason = "Internal function")]
+pub(super) fn collect_enum_definitions_from_dependencies() -> impl Iterator<
+    Item = anyhow::Result<(
+        ItemEnum,
+        ItemEnum,
+        HashSet<Ident>,
+        Rc<[Ident]>,
+        HashSet<Rc<[Ident]>>,
+        Rc<Path>,
+    )>,
+> {
     // Collect exported instruction enums from dependencies
     env::vars().filter_map(|(key, original_source)| {
         if !key.ends_with(ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX) {
@@ -123,18 +184,49 @@ pub(super) fn collect_enum_definitions_from_dependencies()
                 )
             })?;
             let dependencies = dependencies_string
-                .split('=')
-                .nth(1)
-                .with_context(|| {
-                    format!(
-                        "Dependency must follow the pattern \
-                        `Instruction=InstructionA,InstructionB`: {dependencies_string}"
-                    )
-                })?
                 .split(',')
                 .filter(|dependency| !dependency.is_empty())
                 .map(|dependency| format_ident!("{dependency}"))
-                .collect::<Vec<_>>();
+                .collect::<Rc<[_]>>();
+            let dependencies_for_enablement_key = format!(
+                "{}{ENUM_DEPENDENCIES_FOR_ENABLEMENT_ENV_VAR_SUFFIX}",
+                &key[..key.len() - ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX.len()]
+            );
+            let dependencies_for_enablement_string = env::var(&dependencies_for_enablement_key)
+                .with_context(|| {
+                    format!(
+                        "Failed to read environment variable `{dependencies_for_enablement_key}` \
+                        that is expected to contain instruction enum dependencies_for_enablement"
+                    )
+                })?;
+            let dependencies_for_enablement = dependencies_for_enablement_string
+                .split(',')
+                .map(|dependencies| {
+                    dependencies
+                        .split('+')
+                        .filter(|dependency| !dependency.is_empty())
+                        .map(|dependency| format_ident!("{dependency}"))
+                        .collect::<Rc<[_]>>()
+                })
+                .filter(|dependencies| !dependencies.is_empty())
+                .collect::<HashSet<_>>();
+
+            let ignored_instructions_key = format!(
+                "{}{ENUM_IGNORED_INSTRUCTIONS_ENV_VAR_SUFFIX}",
+                &key[..key.len() - ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX.len()]
+            );
+            let ignored_instructions_string =
+                env::var(&ignored_instructions_key).with_context(|| {
+                    format!(
+                        "Failed to read environment variable `{ignored_instructions_key}` that is \
+                    expected to contain ignored instructions"
+                    )
+                })?;
+            let ignored_instructions = ignored_instructions_string
+                .split(',')
+                .filter(|dependency| !dependency.is_empty())
+                .map(|dependency| format_ident!("{dependency}"))
+                .collect();
 
             let mut original_item_enum_contents = fs::read_to_string(&original_source)
                 .with_context(|| {
@@ -164,11 +256,28 @@ pub(super) fn collect_enum_definitions_from_dependencies()
                 original_item_enum.ident
             );
             println!(
+                "cargo::metadata={}{ENUM_IGNORED_INSTRUCTIONS_ENV_VAR_SUFFIX}=\
+                {ignored_instructions_string}",
+                original_item_enum.ident
+            );
+            println!(
                 "cargo::metadata={}{ENUM_DEPENDENCIES_ENV_VAR_SUFFIX}={dependencies_string}",
                 original_item_enum.ident
             );
+            println!(
+                "cargo::metadata={}{ENUM_DEPENDENCIES_FOR_ENABLEMENT_ENV_VAR_SUFFIX}=\
+                {dependencies_for_enablement_string}",
+                item_enum.ident
+            );
 
-            (original_item_enum, item_enum, dependencies, source)
+            (
+                original_item_enum,
+                item_enum,
+                ignored_instructions,
+                dependencies,
+                dependencies_for_enablement,
+                source,
+            )
         };
 
         Some(result)
@@ -183,7 +292,9 @@ fn output_processed_enum_definition(
     let ProcessedEnumDefinition {
         mut item_enum,
         mut original_item_enum,
-        dependencies,
+        ignored_instructions,
+        direct_dependencies,
+        dependencies_for_enablement,
     } = processed_enum_definition;
 
     let enum_name = original_item_enum.ident.clone();
@@ -273,8 +384,16 @@ fn output_processed_enum_definition(
             original_enum_file_path.display()
         );
         println!(
-            "cargo::metadata={enum_name}{ENUM_DEPENDENCIES_ENV_VAR_SUFFIX}={enum_name}={}",
-            dependencies
+            "cargo::metadata={enum_name}{ENUM_IGNORED_INSTRUCTIONS_ENV_VAR_SUFFIX}={}",
+            ignored_instructions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+        println!(
+            "cargo::metadata={enum_name}{ENUM_DEPENDENCIES_ENV_VAR_SUFFIX}={}",
+            direct_dependencies
                 .iter()
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
@@ -282,10 +401,27 @@ fn output_processed_enum_definition(
         );
     }
 
+    println!(
+        "cargo::metadata={enum_name}{ENUM_DEPENDENCIES_FOR_ENABLEMENT_ENV_VAR_SUFFIX}={}",
+        dependencies_for_enablement
+            .iter()
+            .map(|idents| {
+                idents
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("+")
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+    );
+
     state.insert_known_enum_definition(
         original_item_enum,
         item_enum,
-        dependencies,
+        ignored_instructions,
+        direct_dependencies,
+        dependencies_for_enablement,
         Rc::from(enum_file_path),
     )
 }
@@ -298,11 +434,12 @@ pub(super) fn process_enum_definition(
     out_dir: &Path,
     state: &mut State,
 ) -> anyhow::Result<()> {
+    let original_item_enum = item_enum.clone();
     let Some(attribute_index) = item_enum
         .attrs
         .iter()
         .enumerate()
-        .find_map(|(index, attr)| attr.meta.path().is_ident("instruction").then_some(index))
+        .find_map(|(index, attr)| attr.path().is_ident("instruction").then_some(index))
     else {
         // Enum without `#[instruction]` attribute, skip it
         return Ok(());
@@ -378,8 +515,12 @@ pub(super) fn process_enum_definition(
         }
     };
 
-    let Some(processed_enum_definition) =
-        process_enum_definition_inherited(instruction_definition, item_enum, state)?
+    let Some(processed_enum_definition) = process_enum_definition_inherited(
+        instruction_definition,
+        original_item_enum,
+        item_enum,
+        state,
+    )?
     else {
         return Ok(());
     };
@@ -387,59 +528,328 @@ pub(super) fn process_enum_definition(
     output_processed_enum_definition(processed_enum_definition, out_dir, state)
 }
 
-fn process_enum_definition_inherited(
-    instruction_definition: InstructionDefinition,
-    item_enum: ItemEnum,
+enum GetAllInheritedInstructionsError {
+    MissingDependency(Ident),
+    Error(anyhow::Error),
+}
+
+impl From<Ident> for GetAllInheritedInstructionsError {
+    fn from(value: Ident) -> Self {
+        Self::MissingDependency(value)
+    }
+}
+
+impl From<anyhow::Error> for GetAllInheritedInstructionsError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Error(value)
+    }
+}
+
+/// Collects all inherited instructions from dependencies recursively alongside their dependencies
+/// for enablement, while taking into consideration ignored instructions
+fn get_all_inherited_instructions(
+    ignored_instructions: &HashSet<Ident>,
+    direct_dependencies: &[Ident],
+    dependencies_for_enablement: &HashSet<Rc<[Ident]>>,
     state: &mut State,
-) -> anyhow::Result<Option<ProcessedEnumDefinition>> {
+) -> anyhow::Result<HashMap<Ident, KnownInstruction>, GetAllInheritedInstructionsError> {
     let mut all_inherited_instructions = HashMap::<Ident, KnownInstruction>::new();
-    let mut dependencies = Vec::new();
 
-    for item in &instruction_definition.items {
-        match item {
-            InstructionDefinitionItem::Reorder(_) | InstructionDefinitionItem::Ignore(_) => {
-                // Ignore for now
-            }
-            InstructionDefinitionItem::Inherit(inherit_enums) => {
-                for inherit_enum in inherit_enums {
-                    dependencies.push(inherit_enum.clone());
-                    let Some(known_enum) = state.get_known_enum_definition(inherit_enum) else {
-                        state.add_pending_enum_definition(PendingEnumDefinition {
-                            instruction_definition,
-                            item_enum,
-                        });
-                        return Ok(None);
-                    };
+    for dependency_enum_name in direct_dependencies {
+        let Some(dependency_enum_definition) =
+            state.get_known_enum_definition(dependency_enum_name)
+        else {
+            return Err(GetAllInheritedInstructionsError::MissingDependency(
+                dependency_enum_name.clone(),
+            ));
+        };
 
-                    for known_instruction in &known_enum.instructions {
-                        match all_inherited_instructions.entry(known_instruction.ident.clone()) {
-                            Entry::Occupied(entry) => {
-                                let existing_known_instruction = entry.get();
-                                if &existing_known_instruction.instruction != known_instruction {
-                                    return Err(anyhow::anyhow!(
-                                        "Duplicate instruction definition that is not identical to \
-                                        an existing one: `{}` ({}) != `{}` ({})",
-                                        existing_known_instruction.instruction.to_token_stream(),
-                                        existing_known_instruction.source.display(),
-                                        known_instruction.to_token_stream(),
-                                        known_enum.source.display(),
-                                    ));
-                                }
-                            }
-                            Entry::Vacant(entry) => {
-                                let instruction = Rc::new(known_instruction);
-
-                                entry.insert(KnownInstruction {
-                                    instruction: Rc::clone(&instruction),
-                                    source: Rc::clone(&known_enum.source),
-                                });
-                            }
-                        }
+        for instruction in &dependency_enum_definition.own_instructions {
+            let instruction_variant = instruction
+                .attrs
+                .iter()
+                .find_map(|attribute| {
+                    if !attribute.path().is_ident("instruction") {
+                        return None;
                     }
+
+                    Some(match attribute.meta.clone() {
+                        Meta::Path(_) => {
+                            return None;
+                        }
+                        Meta::List(meta_list) => parse2::<InstructionVariant>(meta_list.tokens)
+                            .with_context(|| {
+                                format!(
+                                    "Failed to parse `#[instruction(...)]` attribute on {} variant",
+                                    instruction.ident
+                                )
+                            }),
+                        Meta::NameValue(meta_name_value) => Err(anyhow::anyhow!(
+                            "Unexpected `#[instruction = {}]` attribute on {} variant",
+                            Meta::NameValue(meta_name_value).to_token_stream(),
+                            instruction.ident,
+                        )),
+                    })
+                })
+                .transpose()?
+                .unwrap_or_default();
+            let instruction_dependencies_for_enablement = instruction_variant
+                .items
+                .iter()
+                .map(|item| match item {
+                    InstructionVariantItem::If(if_dependency) => Rc::clone(if_dependency),
+                })
+                .collect();
+
+            match all_inherited_instructions.entry(instruction.ident.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let existing_known_instruction = entry.get_mut();
+                    if &existing_known_instruction.instruction != instruction {
+                        return Err(GetAllInheritedInstructionsError::Error(anyhow::anyhow!(
+                            "Duplicate instruction definition that is not identical to an existing \
+                            one: `{}` ({}) != `{}` ({})",
+                            existing_known_instruction.instruction.to_token_stream(),
+                            existing_known_instruction.source.display(),
+                            instruction.to_token_stream(),
+                            dependency_enum_definition.source.display(),
+                        )));
+                    }
+
+                    // Combine dependencies that come from different sources, so any of them can
+                    // satisfy the requirements in the end
+                    existing_known_instruction
+                        .dependencies_for_enablement
+                        .extend(instruction_dependencies_for_enablement);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(KnownInstruction {
+                        instruction: Rc::clone(instruction),
+                        source: Rc::clone(&dependency_enum_definition.source),
+                        dependencies_for_enablement: instruction_dependencies_for_enablement,
+                    });
+                }
+            }
+        }
+
+        let dependency_ignored_instructions =
+            Rc::clone(&dependency_enum_definition.ignored_instructions);
+        let dependency_direct_dependencies =
+            Rc::clone(&dependency_enum_definition.direct_dependencies);
+        let dependency_dependencies_for_enablement = dependency_enum_definition
+            .dependencies_for_enablement
+            .clone();
+        let source = Rc::clone(&dependency_enum_definition.source);
+
+        for (ident, known_instruction) in get_all_inherited_instructions(
+            &dependency_ignored_instructions,
+            &dependency_direct_dependencies,
+            &dependency_dependencies_for_enablement,
+            state,
+        )? {
+            match all_inherited_instructions.entry(ident.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let existing_known_instruction = entry.get_mut();
+                    if existing_known_instruction.instruction != known_instruction.instruction {
+                        return Err(GetAllInheritedInstructionsError::Error(anyhow::anyhow!(
+                            "Duplicate instruction definition that is not identical to an existing \
+                            one: `{}` ({}) != `{}` ({})",
+                            existing_known_instruction.instruction.to_token_stream(),
+                            existing_known_instruction.source.display(),
+                            known_instruction.instruction.to_token_stream(),
+                            source.display(),
+                        )));
+                    }
+
+                    // Combine dependencies that come from different sources, so any of them can
+                    // satisfy the requirements in the end
+                    existing_known_instruction
+                        .dependencies_for_enablement
+                        .extend(
+                            known_instruction
+                                .dependencies_for_enablement
+                                .iter()
+                                .cloned(),
+                        );
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(known_instruction);
                 }
             }
         }
     }
+
+    if !ignored_instructions.is_empty() {
+        all_inherited_instructions.retain(|instruction_name, _inherited_instruction| {
+            !ignored_instructions.contains(instruction_name)
+        });
+    }
+
+    // Extend dependencies of instructions
+    if !dependencies_for_enablement.is_empty() {
+        let dependencies_for_enablement_cache = &RefCell::new(HashMap::new());
+
+        for inherited_instruction in all_inherited_instructions.values_mut() {
+            if inherited_instruction.dependencies_for_enablement.is_empty() {
+                inherited_instruction
+                    .dependencies_for_enablement
+                    .clone_from(dependencies_for_enablement);
+            } else {
+                let instruction_dependencies_for_enablement =
+                    &mem::take(&mut inherited_instruction.dependencies_for_enablement);
+                inherited_instruction.dependencies_for_enablement = dependencies_for_enablement
+                    .iter()
+                    .flat_map(move |dependencies_for_enablement| {
+                        instruction_dependencies_for_enablement.iter().map(
+                            move |instruction_dependencies_for_enablement| {
+                                // Use cache to share allocations
+                                let cache_key = (
+                                    Rc::clone(instruction_dependencies_for_enablement),
+                                    dependencies_for_enablement,
+                                );
+
+                                Rc::clone(
+                                    dependencies_for_enablement_cache
+                                        .borrow_mut()
+                                        .entry(cache_key)
+                                        .or_insert_with(|| {
+                                            // Combine instruction's and enum's dependencies
+                                            instruction_dependencies_for_enablement
+                                                .iter()
+                                                .chain(dependencies_for_enablement.as_ref())
+                                                .cloned()
+                                                .collect::<Rc<[_]>>()
+                                        }),
+                                )
+                            },
+                        )
+                    })
+                    .collect();
+            }
+        }
+    }
+
+    Ok(all_inherited_instructions)
+}
+
+/// Resolve dependencies and clean up unsatisfied dependencies from the map produced by
+/// [`get_all_inherited_instructions()`]
+fn process_dependencies_for_enablement(
+    all_inherited_instructions: &mut HashMap<Ident, KnownInstruction>,
+    state: &State,
+) {
+    let mut last_fully_available_instructions = usize::MAX;
+    let mut fully_available_instructions = HashSet::with_capacity(all_inherited_instructions.len());
+    let mut enum_dependencies_for_enablement_cache = HashMap::new();
+
+    while last_fully_available_instructions != fully_available_instructions.len() {
+        last_fully_available_instructions = fully_available_instructions.len();
+        enum_dependencies_for_enablement_cache.clear();
+
+        for (instruction_name, inherited_instruction) in all_inherited_instructions.iter() {
+            if fully_available_instructions.contains(instruction_name) {
+                continue;
+            }
+
+            if inherited_instruction.dependencies_for_enablement.is_empty() {
+                // No dependencies
+                fully_available_instructions.insert(instruction_name.clone());
+                continue;
+            }
+
+            if inherited_instruction
+                .dependencies_for_enablement
+                .iter()
+                .any(|instruction_dependencies_for_enablement| {
+                    instruction_dependencies_for_enablement.iter().all(
+                        |instruction_dependency_for_enablement| {
+                            if fully_available_instructions
+                                .contains(instruction_dependency_for_enablement)
+                            {
+                                // Depends on another fully available instruction variant
+                                return true;
+                            }
+
+                            // Potentially depends on the whole enum, in which case all its variants
+                            // must be available
+                            *enum_dependencies_for_enablement_cache
+                                .entry(instruction_dependency_for_enablement)
+                                .or_insert_with(|| {
+                                    state
+                                        .get_known_enum_definition(
+                                            instruction_dependency_for_enablement,
+                                        )
+                                        .is_some_and(|enum_definition| {
+                                            enum_definition.instructions.iter().all(|variant| {
+                                                fully_available_instructions
+                                                    .contains(&variant.ident)
+                                            })
+                                        })
+                                })
+                        },
+                    )
+                })
+            {
+                fully_available_instructions.insert(instruction_name.clone());
+            }
+        }
+    }
+
+    all_inherited_instructions.retain(|instruction_name, _inherited_instruction| {
+        fully_available_instructions.contains(instruction_name)
+    });
+}
+
+fn process_enum_definition_inherited(
+    instruction_definition: InstructionDefinition,
+    original_item_enum: ItemEnum,
+    mut item_enum: ItemEnum,
+    state: &mut State,
+) -> anyhow::Result<Option<ProcessedEnumDefinition>> {
+    let enum_name = &original_item_enum.ident;
+
+    let mut all_reordered_instructions = HashSet::new();
+    let mut direct_dependencies = Vec::new();
+    let mut dependencies_for_enablement = HashSet::new();
+
+    for item in &instruction_definition.items {
+        match item {
+            InstructionDefinitionItem::Reorder(reorder_variants) => {
+                // Collect reordered instructions to make sure they are later placed at the correct
+                // location and not ignored
+                all_reordered_instructions.extend(reorder_variants);
+            }
+            InstructionDefinitionItem::Ignore(_) => {
+                // Ignore for now
+            }
+            InstructionDefinitionItem::Inherit(inherit_enums) => {
+                direct_dependencies.extend(inherit_enums.iter().cloned());
+            }
+            InstructionDefinitionItem::If(if_dependency) => {
+                dependencies_for_enablement.insert(Rc::clone(if_dependency));
+            }
+        }
+    }
+
+    let direct_dependencies = direct_dependencies.into_iter().collect::<Rc<[_]>>();
+    let dependencies_for_enablement = dependencies_for_enablement.into_iter().collect();
+
+    let mut all_inherited_instructions = match get_all_inherited_instructions(
+        &HashSet::new(),
+        &direct_dependencies,
+        &HashSet::new(),
+        state,
+    ) {
+        Ok(all_inherited_instructions) => all_inherited_instructions,
+        Err(GetAllInheritedInstructionsError::MissingDependency(dependency_enum_name)) => {
+            eprintln!("{enum_name} definition is waiting on {dependency_enum_name} definition");
+            state.add_pending_enum_definition(PendingEnumDefinition { original_item_enum });
+            return Ok(None);
+        }
+        Err(GetAllInheritedInstructionsError::Error(error)) => {
+            return Err(error);
+        }
+    };
+    process_dependencies_for_enablement(&mut all_inherited_instructions, state);
 
     let mut own_instructions = item_enum
         .variants
@@ -447,17 +857,8 @@ fn process_enum_definition_inherited(
         .map(|variant| (variant.ident.clone(), Rc::new(variant.clone())))
         .collect::<HashMap<_, _>>();
 
-    let mut all_reordered_instructions = HashSet::new();
-
-    // Quick scan over reordered instructions to make sure they are later placed at the correct
-    // location and not ignored
-    for item in &instruction_definition.items {
-        if let InstructionDefinitionItem::Reorder(reorder_variants) = item {
-            all_reordered_instructions.extend(reorder_variants);
-        }
-    }
-
     let mut processed_instructions = HashSet::new();
+    let mut ignored_instructions = HashSet::new();
     let mut instructions = Vec::new();
 
     for item in &instruction_definition.items {
@@ -496,41 +897,82 @@ fn process_enum_definition_inherited(
                     {
                         if !all_reordered_instructions.contains(ignore_item) {
                             processed_instructions.insert(ignore_item.clone());
-                        }
-                    } else if let Some(known_enum) = state.get_known_enum_definition(ignore_item) {
-                        for known_instruction in &known_enum.instructions {
-                            if !all_reordered_instructions.contains(&known_instruction.ident) {
-                                processed_instructions.insert(known_instruction.ident.clone());
-                            }
+                            ignored_instructions.insert(ignore_item.clone());
                         }
                     } else {
-                        state.add_pending_enum_definition(PendingEnumDefinition {
-                            instruction_definition,
-                            item_enum,
-                        });
-                        return Ok(None);
+                        let Some(known_enum) = state.get_known_enum_definition(ignore_item) else {
+                            eprintln!(
+                                "{enum_name} definition is waiting on {ignore_item} ignore item"
+                            );
+                            state.add_pending_enum_definition(PendingEnumDefinition {
+                                original_item_enum,
+                            });
+                            return Ok(None);
+                        };
+
+                        // All instructions, including recursive dependencies
+                        let all_instructions = known_enum.instructions.iter().chain(
+                            collect_all_dependencies(
+                                state,
+                                known_enum.direct_dependencies.iter().cloned(),
+                            )
+                            .expect(
+                                "Available parent definition means all dependencies are already \
+                                resolved; qed",
+                            )
+                            .into_iter()
+                            .flat_map(|(_, known_enum)| known_enum.instructions.iter()),
+                        );
+
+                        for known_instruction in all_instructions {
+                            if !all_reordered_instructions.contains(&known_instruction.ident) {
+                                processed_instructions.insert(known_instruction.ident.clone());
+                                ignored_instructions.insert(known_instruction.ident.clone());
+                            }
+                        }
                     }
                 }
             }
             InstructionDefinitionItem::Inherit(inherit_enums) => {
                 for inherit_enum in inherit_enums {
                     let Some(known_enum) = state.get_known_enum_definition(inherit_enum) else {
+                        eprintln!(
+                            "{enum_name} definition is waiting on {inherit_enum} inherit enum"
+                        );
                         state.add_pending_enum_definition(PendingEnumDefinition {
-                            instruction_definition,
-                            item_enum,
+                            original_item_enum,
                         });
                         return Ok(None);
                     };
 
-                    for known_instruction in &known_enum.instructions {
+                    // All instructions, including recursive dependencies
+                    let all_instructions = known_enum.instructions.iter().chain(
+                        collect_all_dependencies(
+                            state,
+                            known_enum.direct_dependencies.iter().cloned(),
+                        )
+                        .expect(
+                            "Available parent definition means all dependencies are already \
+                            resolved; qed",
+                        )
+                        .into_iter()
+                        .flat_map(|(_, known_enum)| known_enum.instructions.iter()),
+                    );
+
+                    for known_instruction in all_instructions {
                         if !(all_reordered_instructions.contains(&known_instruction.ident)
                             || processed_instructions.contains(&known_instruction.ident))
                         {
                             processed_instructions.insert(known_instruction.ident.clone());
-                            instructions.push(Rc::clone(known_instruction));
+                            if all_inherited_instructions.contains_key(&known_instruction.ident) {
+                                instructions.push(Rc::clone(known_instruction));
+                            }
                         }
                     }
                 }
+            }
+            InstructionDefinitionItem::If(_) => {
+                // Already processed above
             }
         }
     }
@@ -541,18 +983,20 @@ fn process_enum_definition_inherited(
         }
     }
 
-    let original_item_enum = item_enum;
-    let mut item_enum = original_item_enum.clone();
-    item_enum.variants = Punctuated::from_iter(
-        instructions
-            .into_iter()
-            .map(|instruction| instruction.as_ref().clone()),
-    );
+    item_enum.variants = Punctuated::from_iter(instructions.into_iter().map(|instruction| {
+        let mut instruction = instruction.as_ref().clone();
+        instruction
+            .attrs
+            .retain(|attribute| !attribute.path().is_ident("instruction"));
+        instruction
+    }));
 
     Ok(Some(ProcessedEnumDefinition {
         item_enum,
         original_item_enum,
-        dependencies,
+        ignored_instructions,
+        direct_dependencies,
+        dependencies_for_enablement,
     }))
 }
 
@@ -575,22 +1019,14 @@ pub(super) fn process_pending_enum_definitions(
                 pending_enums: {:?}",
                 pending_enums
                     .iter()
-                    .map(|pending_enum| &pending_enum.item_enum.ident)
+                    .map(|pending_enum| &pending_enum.original_item_enum.ident)
                     .collect::<Vec<_>>()
             ));
         }
         last_pending_enums_count = pending_enums.len();
 
-        for PendingEnumDefinition {
-            instruction_definition,
-            item_enum,
-        } in pending_enums
-        {
-            if let Some(processed_enum_definition) =
-                process_enum_definition_inherited(instruction_definition, item_enum, state)?
-            {
-                output_processed_enum_definition(processed_enum_definition, out_dir, state)?;
-            }
+        for PendingEnumDefinition { original_item_enum } in pending_enums {
+            process_enum_definition(original_item_enum, out_dir, state)?
         }
     }
 

--- a/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
@@ -15,6 +15,7 @@ use syn::{
     parse_quote, parse_str, parse2,
 };
 
+const ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ORIGINAL_ENUM_DEFINITION_PATH";
 const ENUM_DEFINITION_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_DEFINITION_PATH";
 const ENUM_DEPENDENCIES_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_DEPENDENCIES";
 
@@ -70,21 +71,50 @@ struct KnownInstruction {
 
 struct ProcessedEnumDefinition {
     item_enum: ItemEnum,
+    original_item_enum: ItemEnum,
     dependencies: Vec<Ident>,
 }
 
+// TODO: Data structures for various `collect_*()` return types
 pub(super) fn collect_enum_definitions_from_dependencies()
--> impl Iterator<Item = anyhow::Result<(ItemEnum, Vec<Ident>, Rc<Path>)>> {
+-> impl Iterator<Item = anyhow::Result<(ItemEnum, ItemEnum, Vec<Ident>, Rc<Path>)>> {
     // Collect exported instruction enums from dependencies
-    env::vars().filter_map(|(key, source)| {
-        if !key.ends_with(ENUM_DEFINITION_ENV_VAR_SUFFIX) {
+    env::vars().filter_map(|(key, original_source)| {
+        if !key.ends_with(ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX) {
             return None;
         }
 
         let result = try {
+            let definition_key = format!(
+                "{}{ENUM_DEFINITION_ENV_VAR_SUFFIX}",
+                &key[..key.len() - ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX.len()]
+            );
+            let source = env::var(&definition_key).with_context(|| {
+                format!(
+                    "Failed to read environment variable `{definition_key}` that is expected to \
+                    contain instruction enum definition"
+                )
+            })?;
+            let source = Rc::from(Path::new(&source));
+            let mut item_enum_contents = fs::read_to_string(&source).with_context(|| {
+                format!(
+                    "Failed to read Rust file `{}` that is expected to contain instruction enum \
+                    definition",
+                    source.display()
+                )
+            })?;
+            pre_process_rust_code(&mut item_enum_contents);
+            let item_enum = parse_str::<ItemEnum>(&item_enum_contents).with_context(|| {
+                format!(
+                    "Failed to parse Rust file `{}` that is expected to contain instruction enum \
+                    definition",
+                    source.display()
+                )
+            })?;
+
             let dependencies_key = format!(
                 "{}{ENUM_DEPENDENCIES_ENV_VAR_SUFFIX}",
-                &key[..key.len() - ENUM_DEFINITION_ENV_VAR_SUFFIX.len()]
+                &key[..key.len() - ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX.len()]
             );
             let dependencies_string = env::var(&dependencies_key).with_context(|| {
                 format!(
@@ -106,23 +136,21 @@ pub(super) fn collect_enum_definitions_from_dependencies()
                 .map(|dependency| format_ident!("{dependency}"))
                 .collect::<Vec<_>>();
 
-            let source = Rc::from(Path::new(&source));
-
-            let mut item_enum_contents = fs::read_to_string(&source).with_context(|| {
-                format!(
-                    "Failed to read Rust file `{}` that is expected to contain instruction \
-                    enum definition",
-                    source.display()
-                )
-            })?;
-            pre_process_rust_code(&mut item_enum_contents);
-            let item_enum = parse_str::<ItemEnum>(&item_enum_contents).with_context(|| {
-                format!(
-                    "Failed to parse Rust file `{}` that is expected to contain instruction \
-                    enum definition",
-                    source.display()
-                )
-            })?;
+            let mut original_item_enum_contents = fs::read_to_string(&original_source)
+                .with_context(|| {
+                    format!(
+                        "Failed to read Rust file `{original_source}` that is expected to contain \
+                        instruction enum definition"
+                    )
+                })?;
+            pre_process_rust_code(&mut original_item_enum_contents);
+            let original_item_enum = parse_str::<ItemEnum>(&original_item_enum_contents)
+                .with_context(|| {
+                    format!(
+                        "Failed to parse Rust file `{original_source}` that is expected to contain \
+                        instruction enum definition",
+                    )
+                })?;
 
             // Re-export metadata so it is available for downstream crates even if they don't depend
             // directly on a crate where upstream instruction is defined
@@ -132,11 +160,15 @@ pub(super) fn collect_enum_definitions_from_dependencies()
                 source.display()
             );
             println!(
+                "cargo::metadata={}{ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX}={original_source}",
+                original_item_enum.ident
+            );
+            println!(
                 "cargo::metadata={}{ENUM_DEPENDENCIES_ENV_VAR_SUFFIX}={dependencies_string}",
-                item_enum.ident
+                original_item_enum.ident
             );
 
-            (item_enum, dependencies, source)
+            (original_item_enum, item_enum, dependencies, source)
         };
 
         Some(result)
@@ -150,82 +182,112 @@ fn output_processed_enum_definition(
 ) -> anyhow::Result<()> {
     let ProcessedEnumDefinition {
         mut item_enum,
+        mut original_item_enum,
         dependencies,
     } = processed_enum_definition;
 
-    for variant in &mut item_enum.variants {
-        let mut sorted_fields: FieldsNamed = parse_quote! {{
-            #[
-                doc = "First register operand (placeholder, instruction doesn't have it, should be \
-                set to Reg::ZERO)"
-            ]
-            #[doc(hidden)]
-            rs1: Reg,
-            #[
-                doc = "Second register operand (placeholder, instruction doesn't have it, should \
-                be set to Reg::ZERO)"
-            ]
-            #[doc(hidden)]
-            rs2: Reg,
-        }};
-        match &mut variant.fields {
-            Fields::Named(fields) => {
-                for field in mem::take(&mut fields.named) {
-                    if let Some(ident) = &field.ident {
-                        if ident == "rs1" {
-                            sorted_fields.named[0] = field;
-                            continue;
-                        } else if ident == "rs2" {
-                            sorted_fields.named[1] = field;
-                            continue;
+    let enum_name = original_item_enum.ident.clone();
+
+    let enum_file_path = {
+        for variant in &mut item_enum.variants {
+            let mut sorted_fields: FieldsNamed = parse_quote! {{
+                #[
+                    doc = "First register operand (placeholder, instruction doesn't have it, \
+                    should be set to Reg::ZERO)"
+                ]
+                #[doc(hidden)]
+                rs1: Reg,
+                #[
+                    doc = "Second register operand (placeholder, instruction doesn't have it, \
+                    should be set to Reg::ZERO)"
+                ]
+                #[doc(hidden)]
+                rs2: Reg,
+            }};
+            match &mut variant.fields {
+                Fields::Named(fields) => {
+                    for field in mem::take(&mut fields.named) {
+                        if let Some(ident) = &field.ident {
+                            if ident == "rs1" {
+                                sorted_fields.named[0] = field;
+                                continue;
+                            } else if ident == "rs2" {
+                                sorted_fields.named[1] = field;
+                                continue;
+                            }
                         }
+                        sorted_fields.named.push(field);
                     }
-                    sorted_fields.named.push(field);
+                }
+                Fields::Unnamed(_) => {
+                    return Err(anyhow::anyhow!(
+                        "Enum variants must use named fields: {}::{}(..)",
+                        item_enum.ident,
+                        variant.ident
+                    ));
+                }
+                Fields::Unit => {
+                    // Nothing to do here
                 }
             }
-            Fields::Unnamed(_) => {
-                return Err(anyhow::anyhow!(
-                    "Enum variants must use named fields: {}::{}(..)",
-                    item_enum.ident,
-                    variant.ident
-                ));
-            }
-            Fields::Unit => {
-                // Nothing to do here
-            }
+
+            variant.fields = Fields::Named(sorted_fields);
         }
 
-        variant.fields = Fields::Named(sorted_fields);
+        let enum_file_path = out_dir.join(format!("{enum_name}_definition.rs"));
+        let code = item_enum.to_token_stream().to_string();
+        // Format
+        let code = unparse(&parse_file(&code).expect("Generated code is valid; qed"));
+        // Normalize source
+        item_enum = parse_str(&code).expect("Generated code is valid; qed");
+
+        // Avoid extra file truncation/override if it didn't change
+        if fs::read_to_string(&enum_file_path).ok().as_ref() != Some(&code) {
+            fs::write(&enum_file_path, code).with_context(|| {
+                format!("Failed to write generated Rust file with instruction enum `{enum_name}`")
+            })?;
+        }
+        println!(
+            "cargo::metadata={enum_name}{ENUM_DEFINITION_ENV_VAR_SUFFIX}={}",
+            enum_file_path.display()
+        );
+
+        enum_file_path
+    };
+    {
+        let original_enum_file_path = out_dir.join(format!("{enum_name}_original_definition.rs"));
+        let code = original_item_enum.to_token_stream().to_string();
+        // Format
+        let code = unparse(&parse_file(&code).expect("Original code is valid; qed"));
+        // Normalize source
+        original_item_enum = parse_str(&code).expect("Original code is valid; qed");
+
+        // Avoid extra file truncation/override if it didn't change
+        if fs::read_to_string(&original_enum_file_path).ok().as_ref() != Some(&code) {
+            fs::write(&original_enum_file_path, code).with_context(|| {
+                format!("Failed to write original Rust file with instruction enum `{enum_name}`")
+            })?;
+        }
+        println!(
+            "cargo::metadata={enum_name}{ORIGINAL_ENUM_DEFINITION_ENV_VAR_SUFFIX}={}",
+            original_enum_file_path.display()
+        );
+        println!(
+            "cargo::metadata={enum_name}{ENUM_DEPENDENCIES_ENV_VAR_SUFFIX}={enum_name}={}",
+            dependencies
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(","),
+        );
     }
 
-    let enum_name = item_enum.ident.clone();
-    let enum_file_path = out_dir.join(format!("{enum_name}_definition.rs"));
-    let code = item_enum.to_token_stream().to_string();
-    // Format
-    let code = unparse(&parse_file(&code).expect("Generated code is valid; qed"));
-    // Normalize source
-    let item_enum = parse_str(&code).expect("Generated code is valid; qed");
-
-    // Avoid extra file truncation/override if it didn't change
-    if fs::read_to_string(&enum_file_path).ok().as_ref() != Some(&code) {
-        fs::write(&enum_file_path, code).with_context(|| {
-            format!("Failed to write generated Rust file with instruction enum `{enum_name}`")
-        })?;
-    }
-    println!(
-        "cargo::metadata={enum_name}{ENUM_DEFINITION_ENV_VAR_SUFFIX}={}",
-        enum_file_path.display()
-    );
-    println!(
-        "cargo::metadata={enum_name}{ENUM_DEPENDENCIES_ENV_VAR_SUFFIX}={enum_name}={}",
-        dependencies
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(","),
-    );
-
-    state.insert_known_enum_definition(item_enum, dependencies, Rc::from(enum_file_path))
+    state.insert_known_enum_definition(
+        original_item_enum,
+        item_enum,
+        dependencies,
+        Rc::from(enum_file_path),
+    )
 }
 
 /// Identify enums with an `#[instruction]` attribute and generate Rust files with the enum
@@ -327,10 +389,10 @@ pub(super) fn process_enum_definition(
 
 fn process_enum_definition_inherited(
     instruction_definition: InstructionDefinition,
-    mut item_enum: ItemEnum,
+    item_enum: ItemEnum,
     state: &mut State,
 ) -> anyhow::Result<Option<ProcessedEnumDefinition>> {
-    let mut all_known_instructions = HashMap::<Ident, KnownInstruction>::new();
+    let mut all_inherited_instructions = HashMap::<Ident, KnownInstruction>::new();
     let mut dependencies = Vec::new();
 
     for item in &instruction_definition.items {
@@ -350,7 +412,7 @@ fn process_enum_definition_inherited(
                     };
 
                     for known_instruction in &known_enum.instructions {
-                        match all_known_instructions.entry(known_instruction.ident.clone()) {
+                        match all_inherited_instructions.entry(known_instruction.ident.clone()) {
                             Entry::Occupied(entry) => {
                                 let existing_known_instruction = entry.get();
                                 if &existing_known_instruction.instruction != known_instruction {
@@ -410,18 +472,19 @@ fn process_enum_definition_inherited(
                     }
                     processed_instructions.insert(reorder_variant.clone());
 
-                    let instruction = if let Some(instruction) =
-                        own_instructions.remove(reorder_variant)
-                    {
-                        instruction
-                    } else if let Some(instruction) = all_known_instructions.get(reorder_variant) {
-                        Rc::clone(&instruction.instruction)
-                    } else {
-                        return Err(anyhow::anyhow!(
-                            "Unknown reorder instruction `{reorder_variant}` in \
-                            `#[instruction(...)]` attribute"
-                        ));
-                    };
+                    let instruction =
+                        if let Some(instruction) = own_instructions.remove(reorder_variant) {
+                            instruction
+                        } else if let Some(instruction) =
+                            all_inherited_instructions.get(reorder_variant)
+                        {
+                            Rc::clone(&instruction.instruction)
+                        } else {
+                            return Err(anyhow::anyhow!(
+                                "Unknown reorder instruction `{reorder_variant}` in \
+                                `#[instruction(...)]` attribute"
+                            ));
+                        };
 
                     instructions.push(instruction);
                 }
@@ -429,7 +492,7 @@ fn process_enum_definition_inherited(
             InstructionDefinitionItem::Ignore(ignore_items) => {
                 for ignore_item in ignore_items {
                     if own_instructions.contains_key(ignore_item)
-                        || all_known_instructions.contains_key(ignore_item)
+                        || all_inherited_instructions.contains_key(ignore_item)
                     {
                         if !all_reordered_instructions.contains(ignore_item) {
                             processed_instructions.insert(ignore_item.clone());
@@ -478,6 +541,8 @@ fn process_enum_definition_inherited(
         }
     }
 
+    let original_item_enum = item_enum;
+    let mut item_enum = original_item_enum.clone();
     item_enum.variants = Punctuated::from_iter(
         instructions
             .into_iter()
@@ -486,6 +551,7 @@ fn process_enum_definition_inherited(
 
     Ok(Some(ProcessedEnumDefinition {
         item_enum,
+        original_item_enum,
         dependencies,
     }))
 }

--- a/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
@@ -68,6 +68,11 @@ struct KnownInstruction {
     source: Rc<Path>,
 }
 
+struct ProcessedEnumDefinition {
+    item_enum: ItemEnum,
+    dependencies: Vec<Ident>,
+}
+
 pub(super) fn collect_enum_definitions_from_dependencies()
 -> impl Iterator<Item = anyhow::Result<(ItemEnum, Vec<Ident>, Rc<Path>)>> {
     // Collect exported instruction enums from dependencies
@@ -139,11 +144,15 @@ pub(super) fn collect_enum_definitions_from_dependencies()
 }
 
 fn output_processed_enum_definition(
-    mut item_enum: ItemEnum,
-    dependencies: Vec<Ident>,
+    processed_enum_definition: ProcessedEnumDefinition,
     out_dir: &Path,
     state: &mut State,
 ) -> anyhow::Result<()> {
+    let ProcessedEnumDefinition {
+        mut item_enum,
+        dependencies,
+    } = processed_enum_definition;
+
     for variant in &mut item_enum.variants {
         let mut sorted_fields: FieldsNamed = parse_quote! {{
             #[
@@ -307,20 +316,20 @@ pub(super) fn process_enum_definition(
         }
     };
 
-    let Some(result) = process_enum_definition_inherited(instruction_definition, item_enum, state)?
+    let Some(processed_enum_definition) =
+        process_enum_definition_inherited(instruction_definition, item_enum, state)?
     else {
         return Ok(());
     };
-    let (item_enum, dependencies) = result;
 
-    output_processed_enum_definition(item_enum, dependencies, out_dir, state)
+    output_processed_enum_definition(processed_enum_definition, out_dir, state)
 }
 
 fn process_enum_definition_inherited(
     instruction_definition: InstructionDefinition,
     mut item_enum: ItemEnum,
     state: &mut State,
-) -> anyhow::Result<Option<(ItemEnum, Vec<Ident>)>> {
+) -> anyhow::Result<Option<ProcessedEnumDefinition>> {
     let mut all_known_instructions = HashMap::<Ident, KnownInstruction>::new();
     let mut dependencies = Vec::new();
 
@@ -475,7 +484,10 @@ fn process_enum_definition_inherited(
             .map(|instruction| instruction.as_ref().clone()),
     );
 
-    Ok(Some((item_enum, dependencies)))
+    Ok(Some(ProcessedEnumDefinition {
+        item_enum,
+        dependencies,
+    }))
 }
 
 /// Process remaining enums that were waiting for dependencies
@@ -508,10 +520,10 @@ pub(super) fn process_pending_enum_definitions(
             item_enum,
         } in pending_enums
         {
-            if let Some((item_enum, dependencies)) =
+            if let Some(processed_enum_definition) =
                 process_enum_definition_inherited(instruction_definition, item_enum, state)?
             {
-                output_processed_enum_definition(item_enum, dependencies, out_dir, state)?;
+                output_processed_enum_definition(processed_enum_definition, out_dir, state)?;
             }
         }
     }

--- a/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_definition.rs
@@ -307,19 +307,6 @@ pub(super) fn process_enum_definition(
         }
     };
 
-    if instruction_definition.items.iter().any(|item| match item {
-        InstructionDefinitionItem::Reorder(_) | InstructionDefinitionItem::Ignore(_) => false,
-        InstructionDefinitionItem::Inherit(enums) => enums
-            .iter()
-            .any(|enum_name| state.get_known_enum_definition(enum_name).is_none()),
-    }) {
-        state.add_pending_enum_definition(PendingEnumDefinition {
-            instruction_definition,
-            item_enum,
-        });
-        return Ok(());
-    }
-
     let Some(result) = process_enum_definition_inherited(instruction_definition, item_enum, state)?
     else {
         return Ok(());

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -5,7 +5,7 @@ mod ignored_variants_remover;
 use crate::build::enum_impl::add_missing_fields::add_missing_rs_fields;
 use crate::build::enum_impl::forbidden_checker::block_contains_forbidden_syntax;
 use crate::build::enum_impl::ignored_variants_remover::remove_ignored_variants;
-use crate::build::shared_impl::collect_all_dependencies;
+use crate::build::shared::collect_all_dependencies;
 use crate::build::state::{PendingEnumDisplayImpl, PendingEnumImpl, State};
 use ab_riscv_macros_common::code_utils::{post_process_rust_code, pre_process_rust_code};
 use anyhow::Context;
@@ -295,15 +295,17 @@ pub(super) fn process_enum_decoding_impl(
         return Ok(());
     };
 
-    let all_dependencies =
-        match collect_all_dependencies(state, enum_definition.dependencies.clone()) {
-            Ok(all_dependencies) => all_dependencies,
-            Err(dependency_enum_name) => {
-                eprintln!("{enum_name} decoding is waiting on {dependency_enum_name} definition");
-                state.add_pending_enum_impl(PendingEnumImpl { item_impl });
-                return Ok(());
-            }
-        };
+    let all_dependencies = match collect_all_dependencies(
+        state,
+        enum_definition.direct_dependencies.iter().cloned(),
+    ) {
+        Ok(all_dependencies) => all_dependencies,
+        Err(dependency_enum_name) => {
+            eprintln!("{enum_name} decoding is waiting on {dependency_enum_name} definition");
+            state.add_pending_enum_impl(PendingEnumImpl { item_impl });
+            return Ok(());
+        }
+    };
 
     let mut all_try_decode_blocks = Vec::new();
     let mut all_dependency_alignment_blocks = Vec::new();
@@ -494,15 +496,17 @@ pub(super) fn process_enum_display_impl(
         return Ok(());
     };
 
-    let all_dependencies =
-        match collect_all_dependencies(state, enum_definition.dependencies.clone()) {
-            Ok(all_dependencies) => all_dependencies,
-            Err(dependency_enum_name) => {
-                eprintln!("{enum_name} display is waiting on {dependency_enum_name} definition");
-                state.add_pending_enum_display_impl(PendingEnumDisplayImpl { item_impl });
-                return Ok(());
-            }
-        };
+    let all_dependencies = match collect_all_dependencies(
+        state,
+        enum_definition.direct_dependencies.iter().cloned(),
+    ) {
+        Ok(all_dependencies) => all_dependencies,
+        Err(dependency_enum_name) => {
+            eprintln!("{enum_name} display is waiting on {dependency_enum_name} definition");
+            state.add_pending_enum_display_impl(PendingEnumDisplayImpl { item_impl });
+            return Ok(());
+        }
+    };
 
     let mut variants_from_dependencies = HashMap::new();
 

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -4,7 +4,7 @@ mod forbidden_checker;
 use crate::build::enum_impl::enum_name_from_impl;
 use crate::build::execution_impl::extract_matches::extract_variant_arms;
 use crate::build::execution_impl::forbidden_checker::block_contains_forbidden_syntax;
-use crate::build::shared_impl::collect_all_dependencies;
+use crate::build::shared::collect_all_dependencies;
 use crate::build::state::{
     PendingEnumCsrImpl, PendingEnumExecutionImpl, PendingEnumOperandsImpl, State,
 };
@@ -305,15 +305,17 @@ pub(super) fn process_enum_operands_impl(
         return Ok(());
     };
 
-    let all_dependencies =
-        match collect_all_dependencies(state, enum_definition.dependencies.clone()) {
-            Ok(all_dependencies) => all_dependencies,
-            Err(dependency_enum_name) => {
-                eprintln!("{enum_name} operands is waiting on {dependency_enum_name} definition");
-                state.add_pending_enum_operands_impl(PendingEnumOperandsImpl { item_impl });
-                return Ok(());
-            }
-        };
+    let all_dependencies = match collect_all_dependencies(
+        state,
+        enum_definition.direct_dependencies.iter().cloned(),
+    ) {
+        Ok(all_dependencies) => all_dependencies,
+        Err(dependency_enum_name) => {
+            eprintln!("{enum_name} operands is waiting on {dependency_enum_name} definition");
+            state.add_pending_enum_operands_impl(PendingEnumOperandsImpl { item_impl });
+            return Ok(());
+        }
+    };
 
     let mut all_where_predicates = Vec::new();
 
@@ -388,15 +390,17 @@ pub(super) fn process_enum_csr_impl(
         return Ok(());
     };
 
-    let all_dependencies =
-        match collect_all_dependencies(state, enum_definition.dependencies.clone()) {
-            Ok(all_dependencies) => all_dependencies,
-            Err(dependency_enum_name) => {
-                eprintln!("{enum_name} CSR is waiting on {dependency_enum_name} definition");
-                state.add_pending_enum_csr_impl(PendingEnumCsrImpl { item_impl });
-                return Ok(());
-            }
-        };
+    let all_dependencies = match collect_all_dependencies(
+        state,
+        enum_definition.direct_dependencies.iter().cloned(),
+    ) {
+        Ok(all_dependencies) => all_dependencies,
+        Err(dependency_enum_name) => {
+            eprintln!("{enum_name} CSR is waiting on {dependency_enum_name} definition");
+            state.add_pending_enum_csr_impl(PendingEnumCsrImpl { item_impl });
+            return Ok(());
+        }
+    };
 
     let mut all_prepare_csr_read_fns = Vec::new();
     let mut all_prepare_csr_write_fns = Vec::new();
@@ -562,15 +566,17 @@ pub(super) fn process_enum_execution_impl(
         return Ok(());
     };
 
-    let all_dependencies =
-        match collect_all_dependencies(state, enum_definition.dependencies.clone()) {
-            Ok(all_dependencies) => all_dependencies,
-            Err(dependency_enum_name) => {
-                eprintln!("{enum_name} execution is waiting on {dependency_enum_name} definition");
-                state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
-                return Ok(());
-            }
-        };
+    let all_dependencies = match collect_all_dependencies(
+        state,
+        enum_definition.direct_dependencies.iter().cloned(),
+    ) {
+        Ok(all_dependencies) => all_dependencies,
+        Err(dependency_enum_name) => {
+            eprintln!("{enum_name} execution is waiting on {dependency_enum_name} definition");
+            state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+            return Ok(());
+        }
+    };
 
     let mut all_execute_blocks = Vec::new();
     let mut all_where_predicates = Vec::new();

--- a/crates/execution/ab-riscv-macros/src/build/shared.rs
+++ b/crates/execution/ab-riscv-macros/src/build/shared.rs
@@ -2,12 +2,15 @@ use crate::build::state::{KnownEnumDefinition, State};
 use std::collections::VecDeque;
 use syn::Ident;
 
-pub(super) fn collect_all_dependencies(
+pub(super) fn collect_all_dependencies<InitialDependencies>(
     state: &State,
-    initial_dependencies: Vec<Ident>,
-) -> Result<Vec<(Ident, &KnownEnumDefinition)>, Ident> {
+    initial_dependencies: InitialDependencies,
+) -> Result<Vec<(Ident, &KnownEnumDefinition)>, Ident>
+where
+    InitialDependencies: Iterator<Item = Ident>,
+{
     let mut all_dependencies = Vec::new();
-    let mut new_dependencies = VecDeque::from(initial_dependencies);
+    let mut new_dependencies = VecDeque::from_iter(initial_dependencies);
 
     while let Some(dependency_enum_name) = new_dependencies.pop_front() {
         let Some(dependency_enum_definition) =
@@ -17,7 +20,12 @@ pub(super) fn collect_all_dependencies(
         };
 
         all_dependencies.push((dependency_enum_name, dependency_enum_definition));
-        new_dependencies.extend(dependency_enum_definition.dependencies.iter().cloned());
+        new_dependencies.extend(
+            dependency_enum_definition
+                .direct_dependencies
+                .iter()
+                .cloned(),
+        );
     }
 
     Ok(all_dependencies)

--- a/crates/execution/ab-riscv-macros/src/build/state.rs
+++ b/crates/execution/ab-riscv-macros/src/build/state.rs
@@ -9,6 +9,7 @@ use syn::{Ident, ItemEnum, ItemImpl, Variant};
 
 #[derive(Debug)]
 pub(super) struct KnownEnumDefinition {
+    pub(super) own_instructions: Vec<Rc<Variant>>,
     pub(super) instructions: Vec<Rc<Variant>>,
     pub(super) dependencies: Vec<Ident>,
     pub(super) source: Rc<Path>,
@@ -119,24 +120,30 @@ impl State {
 
     pub(super) fn insert_known_enum_definition(
         &mut self,
+        original_item_enum: ItemEnum,
         item_enum: ItemEnum,
         dependencies: Vec<Ident>,
         source: Rc<Path>,
     ) -> anyhow::Result<()> {
         let known_enum_definition = KnownEnumDefinition {
+            own_instructions: original_item_enum
+                .variants
+                .into_iter()
+                .map(Rc::new)
+                .collect(),
             instructions: item_enum.variants.into_iter().map(Rc::new).collect(),
             dependencies,
             source,
         };
         if let Err(OccupiedError { entry, value }) = self
             .known_enum_definitions
-            .try_insert(item_enum.ident.clone(), known_enum_definition)
-            && entry.get().instructions != value.instructions
+            .try_insert(original_item_enum.ident.clone(), known_enum_definition)
+            && entry.get().own_instructions != value.own_instructions
         {
             return Err(anyhow::anyhow!(
                 "Instruction enum `{}` is already defined in `{}`, a different duplicate found in \
                 `{}`",
-                item_enum.ident,
+                original_item_enum.ident,
                 entry.get().source.display(),
                 value.source.display(),
             ));

--- a/crates/execution/ab-riscv-macros/src/build/state.rs
+++ b/crates/execution/ab-riscv-macros/src/build/state.rs
@@ -1,7 +1,6 @@
-use crate::build::enum_definition::InstructionDefinition;
 use crate::build::enum_impl::enum_name_from_impl;
-use std::collections::HashMap;
 use std::collections::hash_map::OccupiedError;
+use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::path::Path;
 use std::rc::Rc;
@@ -11,14 +10,15 @@ use syn::{Ident, ItemEnum, ItemImpl, Variant};
 pub(super) struct KnownEnumDefinition {
     pub(super) own_instructions: Vec<Rc<Variant>>,
     pub(super) instructions: Vec<Rc<Variant>>,
-    pub(super) dependencies: Vec<Ident>,
+    pub(super) ignored_instructions: Rc<HashSet<Ident>>,
+    pub(super) direct_dependencies: Rc<[Ident]>,
+    pub(super) dependencies_for_enablement: HashSet<Rc<[Ident]>>,
     pub(super) source: Rc<Path>,
 }
 
 #[derive(Debug)]
 pub(super) struct PendingEnumDefinition {
-    pub(super) instruction_definition: InstructionDefinition,
-    pub(super) item_enum: ItemEnum,
+    pub(super) original_item_enum: ItemEnum,
 }
 
 #[derive(Debug)]
@@ -122,7 +122,9 @@ impl State {
         &mut self,
         original_item_enum: ItemEnum,
         item_enum: ItemEnum,
-        dependencies: Vec<Ident>,
+        ignored_instructions: HashSet<Ident>,
+        direct_dependencies: Rc<[Ident]>,
+        dependencies_for_enablement: HashSet<Rc<[Ident]>>,
         source: Rc<Path>,
     ) -> anyhow::Result<()> {
         let known_enum_definition = KnownEnumDefinition {
@@ -132,7 +134,9 @@ impl State {
                 .map(Rc::new)
                 .collect(),
             instructions: item_enum.variants.into_iter().map(Rc::new).collect(),
-            dependencies,
+            ignored_instructions: Rc::new(ignored_instructions),
+            direct_dependencies,
+            dependencies_for_enablement,
             source,
         };
         if let Err(OccupiedError { entry, value }) = self

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb.rs
@@ -4,6 +4,8 @@
 mod tests;
 
 use crate::instructions::Instruction;
+use crate::instructions::rv32::c::zca::Rv32ZcaInstruction;
+use crate::instructions::utils::I24;
 use crate::registers::general_purpose::Register;
 use ab_riscv_macros::instruction;
 use core::fmt;
@@ -11,9 +13,51 @@ use core::fmt;
 /// RISC-V RV32 Zcb compressed instruction set.
 ///
 /// All register operands are prime-field (x8–x15) registers.
+#[instruction(
+    inherit = [Rv32ZcaInstruction, Rv32ZcbOnlyInstruction],
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rv32ZcbInstruction<Reg> {}
+
+#[instruction]
+impl<Reg> const Instruction for Rv32ZcbInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        None
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u16>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u16>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32ZcbInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {}
+    }
+}
+
+/// Instruction that contains isolated Zcb instructions without inheriting Zca for testing purposes
 #[instruction]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Rv32ZcbInstruction<Reg> {
+#[rustfmt::skip]
+#[doc(hidden)]
+pub enum Rv32ZcbOnlyInstruction<Reg> {
     // Q00 loads / stores
     /// C.LBU  rd' = zero_extend(mem8\[rs1' + uimm])  uimm ∈ {0,1,2,3}
     CLbu { rd: Reg, rs1: Reg, uimm: u8 },
@@ -30,21 +74,28 @@ pub enum Rv32ZcbInstruction<Reg> {
     /// C.ZEXT.B  rd' = rd' & 0xff
     CZextB { rd: Reg },
     /// C.SEXT.B  rd' = sext(rd'\[7:0])  (requires Zbb)
+    #[instruction(if = [Rv32ZbbInstruction])]
     CSextB { rd: Reg },
     /// C.ZEXT.H  rd' = rd' & 0xffff  (requires Zbb)
+    #[instruction(if = [Rv32ZbbInstruction])]
     CZextH { rd: Reg },
     /// C.SEXT.H  rd' = sext(rd'\[15:0])  (requires Zbb)
+    #[instruction(if = [Rv32ZbbInstruction])]
     CSextH { rd: Reg },
     /// C.NOT  rd' = ~rd'
     CNot { rd: Reg },
 
     // Q01 binary
     /// C.MUL  rd' = (rd' * rs2')\[31:0]  (requires M or Zmmul)
+    #[instruction(
+        if = [Rv32MInstruction],
+        if = [Rv32ZmmulInstruction]
+    )]
     CMul { rd: Reg, rs2: Reg },
 }
 
 #[instruction]
-impl<Reg> const Instruction for Rv32ZcbInstruction<Reg>
+impl<Reg> const Instruction for Rv32ZcbOnlyInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
@@ -170,9 +221,9 @@ where
 }
 
 #[instruction]
-impl<Reg> fmt::Display for Rv32ZcbInstruction<Reg>
+impl<Reg> fmt::Display for Rv32ZcbOnlyInstruction<Reg>
 where
-    Reg: fmt::Display,
+    Reg: fmt::Display + Copy,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb/tests.rs
@@ -1,7 +1,7 @@
 #![expect(clippy::identity_op, reason = "Test readability")]
 
 use crate::instructions::Instruction;
-use crate::instructions::rv32::zce::zcb::Rv32ZcbInstruction;
+use crate::instructions::rv32::zce::zcb::Rv32ZcbOnlyInstruction;
 use crate::registers::general_purpose::Reg;
 
 /// Build a Q00 Zcb load/store: funct3=100, sub=bits\[12:10].
@@ -39,10 +39,10 @@ const fn make_zcb_q01(rd_rs1p: u16, funct2b: u16, rs2_sub: u16) -> u16 {
 fn test_clbu_all_uimm_values() {
     for (bit6, bit5, expected_uimm) in [(0, 0, 0), (1, 0, 1), (0, 1, 2), (1, 1, 3)] {
         let inst = make_zcb_q00(0b000, 0, bit6, bit5, 0);
-        let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+        let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcbInstruction::CLbu {
+            Rv32ZcbOnlyInstruction::CLbu {
                 rd: Reg::S0,
                 rs1: Reg::S0,
                 uimm: expected_uimm,
@@ -55,10 +55,10 @@ fn test_clbu_all_uimm_values() {
 #[test]
 fn test_clbu_all_prime_regs() {
     let inst = make_zcb_q00(0b000, 7, 0, 0, 6);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CLbu {
+        Rv32ZcbOnlyInstruction::CLbu {
             rd: Reg::A4,
             rs1: Reg::A5,
             uimm: 0,
@@ -72,10 +72,10 @@ fn test_clbu_all_prime_regs() {
 #[test]
 fn test_clhu_uimm0() {
     let inst = make_zcb_q00(0b001, 0, 0, 0, 0);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CLhu {
+        Rv32ZcbOnlyInstruction::CLhu {
             rd: Reg::S0,
             rs1: Reg::S0,
             uimm: 0,
@@ -87,10 +87,10 @@ fn test_clhu_uimm0() {
 #[test]
 fn test_clhu_uimm2() {
     let inst = make_zcb_q00(0b001, 0, 0, 1, 0);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CLhu {
+        Rv32ZcbOnlyInstruction::CLhu {
             rd: Reg::S0,
             rs1: Reg::S0,
             uimm: 2,
@@ -102,10 +102,10 @@ fn test_clhu_uimm2() {
 #[test]
 fn test_clh_uimm0() {
     let inst = make_zcb_q00(0b001, 0, 1, 0, 0);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CLh {
+        Rv32ZcbOnlyInstruction::CLh {
             rd: Reg::S0,
             rs1: Reg::S0,
             uimm: 0,
@@ -117,10 +117,10 @@ fn test_clh_uimm0() {
 #[test]
 fn test_clh_uimm2() {
     let inst = make_zcb_q00(0b001, 0, 1, 1, 0);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CLh {
+        Rv32ZcbOnlyInstruction::CLh {
             rd: Reg::S0,
             rs1: Reg::S0,
             uimm: 2,
@@ -134,10 +134,10 @@ fn test_clh_uimm2() {
 #[test]
 fn test_csb_uimm0() {
     let inst = make_zcb_q00(0b010, 0, 0, 0, 0);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CSb {
+        Rv32ZcbOnlyInstruction::CSb {
             rs1: Reg::S0,
             rs2: Reg::S0,
             uimm: 0
@@ -148,10 +148,10 @@ fn test_csb_uimm0() {
 #[test]
 fn test_csb_uimm3() {
     let inst = make_zcb_q00(0b010, 0, 1, 1, 1);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CSb {
+        Rv32ZcbOnlyInstruction::CSb {
             rs1: Reg::S0,
             rs2: Reg::S1,
             uimm: 3
@@ -164,10 +164,10 @@ fn test_csb_uimm3() {
 #[test]
 fn test_csh_uimm0() {
     let inst = make_zcb_q00(0b011, 0, 0, 0, 0);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CSh {
+        Rv32ZcbOnlyInstruction::CSh {
             rs1: Reg::S0,
             rs2: Reg::S0,
             uimm: 0
@@ -178,10 +178,10 @@ fn test_csh_uimm0() {
 #[test]
 fn test_csh_uimm2() {
     let inst = make_zcb_q00(0b011, 0, 0, 1, 1);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CSh {
+        Rv32ZcbOnlyInstruction::CSh {
             rs1: Reg::S0,
             rs2: Reg::S1,
             uimm: 2
@@ -192,7 +192,7 @@ fn test_csh_uimm2() {
 #[test]
 fn test_csh_funct1_1_reserved() {
     let inst = make_zcb_q00(0b011, 0, 1, 0, 0);
-    assert!(Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
 }
 
 // Unary ops - funct2b=0b11
@@ -200,10 +200,10 @@ fn test_csh_funct1_1_reserved() {
 #[test]
 fn test_czext_b() {
     let inst = make_zcb_q01(0, 0b11, 0b000);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CZextB {
+        Rv32ZcbOnlyInstruction::CZextB {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -214,10 +214,10 @@ fn test_czext_b() {
 #[test]
 fn test_csext_b() {
     let inst = make_zcb_q01(0, 0b11, 0b001);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CSextB {
+        Rv32ZcbOnlyInstruction::CSextB {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -228,10 +228,10 @@ fn test_csext_b() {
 #[test]
 fn test_czext_h() {
     let inst = make_zcb_q01(0, 0b11, 0b010);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CZextH {
+        Rv32ZcbOnlyInstruction::CZextH {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -242,10 +242,10 @@ fn test_czext_h() {
 #[test]
 fn test_csext_h() {
     let inst = make_zcb_q01(0, 0b11, 0b011);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CSextH {
+        Rv32ZcbOnlyInstruction::CSextH {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -258,7 +258,7 @@ fn test_csext_h() {
 fn test_czext_w_absent_in_rv32() {
     let inst = make_zcb_q01(0, 0b11, 0b100);
     assert!(
-        Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none(),
+        Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none(),
         "C.ZEXT.W should not exist in RV32"
     );
 }
@@ -266,10 +266,10 @@ fn test_czext_w_absent_in_rv32() {
 #[test]
 fn test_cnot() {
     let inst = make_zcb_q01(0, 0b11, 0b101);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CNot {
+        Rv32ZcbOnlyInstruction::CNot {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -280,13 +280,13 @@ fn test_cnot() {
 #[test]
 fn test_unary_reserved_sub_110() {
     let inst = make_zcb_q01(0, 0b11, 0b110);
-    assert!(Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
 }
 
 #[test]
 fn test_unary_reserved_sub_111() {
     let inst = make_zcb_q01(0, 0b11, 0b111);
-    assert!(Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
 }
 
 #[test]
@@ -294,8 +294,8 @@ fn test_unary_all_prime_regs() {
     // Check all 8 prime registers decode correctly for C.NOT.
     for r in 0..8 {
         let inst = make_zcb_q01(r, 0b11, 0b101);
-        let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
-        assert!(matches!(decoded, Rv32ZcbInstruction::CNot { .. }));
+        let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+        assert!(matches!(decoded, Rv32ZcbOnlyInstruction::CNot { .. }));
     }
 }
 
@@ -305,10 +305,10 @@ fn test_unary_all_prime_regs() {
 fn test_cmul() {
     // c.mul s0, s1: rd'=0(x8), rs2'=1(x9) => 0x9c45
     let inst = make_zcb_q01(0, 0b10, 0b001);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CMul {
+        Rv32ZcbOnlyInstruction::CMul {
             rd: Reg::S0,
             rs2: Reg::S1,
             rs1: Reg::Zero,
@@ -319,10 +319,10 @@ fn test_cmul() {
 #[test]
 fn test_cmul_same_reg() {
     let inst = make_zcb_q01(0, 0b10, 0b000);
-    let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcbInstruction::CMul {
+        Rv32ZcbOnlyInstruction::CMul {
             rd: Reg::S0,
             rs2: Reg::S0,
             rs1: Reg::Zero,
@@ -335,8 +335,8 @@ fn test_cmul_all_prime_reg_pairs() {
     for rd in 0..8 {
         for rs2 in 0..8 {
             let inst = make_zcb_q01(rd, 0b10, rs2);
-            let decoded = Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
-            assert!(matches!(decoded, Rv32ZcbInstruction::CMul { .. }));
+            let decoded = Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).unwrap();
+            assert!(matches!(decoded, Rv32ZcbOnlyInstruction::CMul { .. }));
         }
     }
 }
@@ -346,13 +346,13 @@ fn test_cmul_all_prime_reg_pairs() {
 #[test]
 fn test_reserved_funct2b_00() {
     let inst = make_zcb_q01(0, 0b00, 0);
-    assert!(Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
 }
 
 #[test]
 fn test_reserved_funct2b_01() {
     let inst = make_zcb_q01(0, 0b01, 0);
-    assert!(Rv32ZcbInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
 }
 
 // Non-Zcb quadrants return None
@@ -360,11 +360,11 @@ fn test_reserved_funct2b_01() {
 #[test]
 fn test_non_zcb_q10_returns_none() {
     let inst = (0b000 << 13u8) | (1 << 12u8) | (10 << 7u8) | (3 << 2u8) | 0b10;
-    assert!(Rv32ZcbInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_zca_q01_funct3_000_returns_none() {
     let inst = (0b000 << 13u8) | (0 << 12u8) | (10 << 7u8) | (5 << 2u8) | 0b01;
-    assert!(Rv32ZcbInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcbOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
@@ -4,6 +4,8 @@
 mod tests;
 
 use crate::instructions::Instruction;
+use crate::instructions::rv32::c::zca::Rv32ZcaInstruction;
+use crate::instructions::utils::I24;
 use crate::registers::general_purpose::{EReg, Reg, Register};
 use ab_riscv_macros::instruction;
 use core::fmt;
@@ -242,9 +244,50 @@ impl<Reg> fmt::Display for ZcmpUrlist<Reg> {
 }
 
 /// Zcmp compressed instruction set
+#[instruction(
+    inherit = [Rv32ZcaInstruction, Rv32ZcmpOnlyInstruction],
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rv32ZcmpInstruction<Reg> {}
+
+#[instruction]
+impl<Reg> const Instruction for Rv32ZcmpInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        None
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u16>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u16>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32ZcmpInstruction<Reg>
+where
+    Reg: Register,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {}
+    }
+}
+
+/// Instruction that contains isolated Zcmp instructions without inheriting Zca for testing purposes
 #[instruction]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Rv32ZcmpInstruction<Reg> {
+#[doc(hidden)]
+pub enum Rv32ZcmpOnlyInstruction<Reg> {
     /// CM.PUSH - push reg_list, decrement sp by `stack_adj`
     ///
     /// `stack_adj = urlist.stack_adj_base() + spimm * 16` from the encoding.
@@ -280,7 +323,7 @@ pub enum Rv32ZcmpInstruction<Reg> {
 }
 
 #[instruction]
-impl<Reg> const Instruction for Rv32ZcmpInstruction<Reg>
+impl<Reg> const Instruction for Rv32ZcmpOnlyInstruction<Reg>
 where
     Reg: [const] ZcmpRegister<Type = u32>,
 {
@@ -372,7 +415,7 @@ where
 }
 
 #[instruction]
-impl<Reg> fmt::Display for Rv32ZcmpInstruction<Reg>
+impl<Reg> fmt::Display for Rv32ZcmpOnlyInstruction<Reg>
 where
     Reg: Register,
 {

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp/tests.rs
@@ -1,7 +1,7 @@
 #![expect(clippy::identity_op, reason = "Test readability")]
 
 use crate::instructions::Instruction;
-use crate::instructions::rv32::zce::zcmp::{Rv32ZcmpInstruction, ZcmpUrlist};
+use crate::instructions::rv32::zce::zcmp::{Rv32ZcmpOnlyInstruction, ZcmpUrlist};
 use crate::registers::general_purpose::{EReg, Reg};
 
 /// Build a Zcmp push/pop instruction word.
@@ -53,10 +53,10 @@ fn expected_stack_adj(urlist_raw: u8, spimm: u8) -> u8 {
 fn test_cm_push_ra_only() {
     // urlist=4 = {ra}, spimm=0 -> stack_adj = 16 + 0 = 16
     let inst = make_push_pop(OP_PUSH, 4, 0);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmPush {
+        Rv32ZcmpOnlyInstruction::CmPush {
             urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
             stack_adj: 16,
             rs1: Reg::Zero,
@@ -69,10 +69,10 @@ fn test_cm_push_ra_only() {
 fn test_cm_push_ra_s0_s11() {
     // urlist=15 = {ra, s0-s11}, spimm=3 -> stack_adj = 64 + 48 = 112
     let inst = make_push_pop(OP_PUSH, 15, 3);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmPush {
+        Rv32ZcmpOnlyInstruction::CmPush {
             urlist: ZcmpUrlist::try_from_raw(15).unwrap(),
             stack_adj: 112,
             rs1: Reg::Zero,
@@ -85,10 +85,10 @@ fn test_cm_push_ra_s0_s11() {
 fn test_cm_push_all_valid_urlists() {
     for urlist in 4u16..=15 {
         let inst = make_push_pop(OP_PUSH, urlist, 0);
-        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+        let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmPush {
+            Rv32ZcmpOnlyInstruction::CmPush {
                 urlist: ZcmpUrlist::try_from_raw(urlist as u8).unwrap(),
                 stack_adj: expected_stack_adj(urlist as u8, 0),
                 rs1: Reg::Zero,
@@ -105,7 +105,7 @@ fn test_cm_push_reserved_urlist() {
     for urlist in 0u16..4 {
         let inst = make_push_pop(OP_PUSH, urlist, 0);
         assert!(
-            Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none(),
+            Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none(),
             "urlist={urlist} should be reserved"
         );
     }
@@ -125,10 +125,10 @@ fn test_cm_push_binutils_reference_encodings() {
         (0xb8fe, 15, 112),
     ];
     for &(raw, urlist_raw, stack_adj) in cases {
-        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmPush {
+            Rv32ZcmpOnlyInstruction::CmPush {
                 urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
                 stack_adj,
                 rs1: Reg::Zero,
@@ -145,10 +145,10 @@ fn test_cm_push_binutils_reference_encodings() {
 fn test_cm_pop_basic() {
     // urlist=5 = {ra, s0}, spimm=1 -> stack_adj = 16 + 16 = 32
     let inst = make_push_pop(OP_POP, 5, 1);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmPop {
+        Rv32ZcmpOnlyInstruction::CmPop {
             urlist: ZcmpUrlist::try_from_raw(5).unwrap(),
             stack_adj: 32,
             rs1: Reg::Zero,
@@ -161,10 +161,10 @@ fn test_cm_pop_basic() {
 fn test_cm_pop_ra_s0_s9() {
     // urlist=14 = {ra, s0-s9}, spimm=2 -> stack_adj = 48 + 32 = 80
     let inst = make_push_pop(OP_POP, 14, 2);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmPop {
+        Rv32ZcmpOnlyInstruction::CmPop {
             urlist: ZcmpUrlist::try_from_raw(14).unwrap(),
             stack_adj: 80,
             rs1: Reg::Zero,
@@ -178,10 +178,10 @@ fn test_cm_pop_ra_s0_s9() {
 fn test_cm_pop_binutils_reference_encodings() {
     let cases = &[(0xba56u32, 5, 32), (0xbaea, 14, 80)];
     for &(raw, urlist_raw, stack_adj) in cases {
-        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmPop {
+            Rv32ZcmpOnlyInstruction::CmPop {
                 urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
                 stack_adj,
                 rs1: Reg::Zero,
@@ -198,10 +198,10 @@ fn test_cm_pop_binutils_reference_encodings() {
 fn test_cm_popretz_basic() {
     // urlist=4 = {ra}, spimm=0 -> stack_adj = 16
     let inst = make_push_pop(OP_POPRETZ, 4, 0);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmPopretz {
+        Rv32ZcmpOnlyInstruction::CmPopretz {
             urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
             stack_adj: 16,
             rs1: Reg::Zero,
@@ -213,10 +213,10 @@ fn test_cm_popretz_basic() {
 /// Reference encoding anchored to binutils MATCH_CM_POPRETZ=0xbc02.
 #[test]
 fn test_cm_popretz_binutils_reference_encodings() {
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(0xbc42).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(0xbc42).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmPopretz {
+        Rv32ZcmpOnlyInstruction::CmPopretz {
             urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
             stack_adj: 16,
             rs1: Reg::Zero,
@@ -231,10 +231,10 @@ fn test_cm_popretz_binutils_reference_encodings() {
 fn test_cm_popret_basic() {
     // urlist=6 = {ra, s0-s1}, spimm=0 -> stack_adj = 16
     let inst = make_push_pop(OP_POPRET, 6, 0);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmPopret {
+        Rv32ZcmpOnlyInstruction::CmPopret {
             urlist: ZcmpUrlist::try_from_raw(6).unwrap(),
             stack_adj: 16,
             rs1: Reg::Zero,
@@ -250,10 +250,10 @@ fn test_cm_popret_all_spimm_values() {
     let expected_adjs = [32, 48, 64, 80];
     for (spimm, &expected) in expected_adjs.iter().enumerate() {
         let inst = make_push_pop(OP_POPRET, 8, spimm as u16);
-        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+        let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmPopret {
+            Rv32ZcmpOnlyInstruction::CmPopret {
                 urlist: ZcmpUrlist::try_from_raw(8).unwrap(),
                 stack_adj: expected,
                 rs1: Reg::Zero,
@@ -277,10 +277,10 @@ fn test_cm_popret_binutils_reference_encodings() {
         (0xbe8e, 8, 80),
     ];
     for &(raw, urlist_raw, stack_adj) in cases {
-        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmPopret {
+            Rv32ZcmpOnlyInstruction::CmPopret {
                 urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
                 stack_adj,
                 rs1: Reg::Zero,
@@ -300,22 +300,24 @@ fn test_push_pop_op_sel_distinct_variants() {
     let spimm = 0u16;
 
     assert!(matches!(
-        Rv32ZcmpInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_PUSH, urlist, spimm)).unwrap(),
-        Rv32ZcmpInstruction::CmPush { .. }
-    ));
-    assert!(matches!(
-        Rv32ZcmpInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POP, urlist, spimm)).unwrap(),
-        Rv32ZcmpInstruction::CmPop { .. }
-    ));
-    assert!(matches!(
-        Rv32ZcmpInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POPRETZ, urlist, spimm))
+        Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_PUSH, urlist, spimm))
             .unwrap(),
-        Rv32ZcmpInstruction::CmPopretz { .. }
+        Rv32ZcmpOnlyInstruction::CmPush { .. }
     ));
     assert!(matches!(
-        Rv32ZcmpInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POPRET, urlist, spimm))
+        Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POP, urlist, spimm))
             .unwrap(),
-        Rv32ZcmpInstruction::CmPopret { .. }
+        Rv32ZcmpOnlyInstruction::CmPop { .. }
+    ));
+    assert!(matches!(
+        Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POPRETZ, urlist, spimm))
+            .unwrap(),
+        Rv32ZcmpOnlyInstruction::CmPopretz { .. }
+    ));
+    assert!(matches!(
+        Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(make_push_pop(OP_POPRET, urlist, spimm))
+            .unwrap(),
+        Rv32ZcmpOnlyInstruction::CmPopret { .. }
     ));
 }
 
@@ -325,10 +327,10 @@ fn test_push_pop_op_sel_distinct_variants() {
 fn test_cm_mva01s_s0_s1() {
     // r1s field=0 -> s0(x8), r2s field=1 -> s1(x9)
     let inst = make_mv_pair(MV_FUNCT2_MVA01S, 0, 1);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmMva01s {
+        Rv32ZcmpOnlyInstruction::CmMva01s {
             rs1: Reg::S0,
             rs2: Reg::S1,
         }
@@ -339,10 +341,10 @@ fn test_cm_mva01s_s0_s1() {
 fn test_cm_mva01s_same_reg() {
     // r1s == r2s is allowed for CM.MVA01S
     let inst = make_mv_pair(MV_FUNCT2_MVA01S, 2, 2);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmMva01s {
+        Rv32ZcmpOnlyInstruction::CmMva01s {
             rs1: Reg::S2,
             rs2: Reg::S2,
         }
@@ -364,8 +366,8 @@ fn test_cm_mva01s_all_s_regs() {
     ];
     for (field, &expected) in expected_regs.iter().enumerate() {
         let inst = make_mv_pair(MV_FUNCT2_MVA01S, field as u16, 0);
-        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
-        if let Rv32ZcmpInstruction::CmMva01s { rs1, .. } = decoded {
+        let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+        if let Rv32ZcmpOnlyInstruction::CmMva01s { rs1, .. } = decoded {
             assert_eq!(rs1, expected, "field={field}");
         } else {
             panic!("wrong variant for field={field}");
@@ -388,10 +390,10 @@ fn test_cm_mva01s_binutils_reference_encodings() {
         (0xaefa, Reg::S5, Reg::S6),
     ];
     for &(raw, r1s, r2s) in cases {
-        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmMva01s { rs1: r1s, rs2: r2s },
+            Rv32ZcmpOnlyInstruction::CmMva01s { rs1: r1s, rs2: r2s },
             "raw={raw:#06x}"
         );
     }
@@ -403,10 +405,10 @@ fn test_cm_mva01s_binutils_reference_encodings() {
 fn test_cm_mvsa01_distinct_regs() {
     // r1s=s0, r2s=s2 (distinct)
     let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 2);
-    let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).unwrap();
+    let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv32ZcmpInstruction::CmMvsa01 {
+        Rv32ZcmpOnlyInstruction::CmMvsa01 {
             rs1: Reg::S0,
             rs2: Reg::S2,
         }
@@ -417,7 +419,7 @@ fn test_cm_mvsa01_distinct_regs() {
 fn test_cm_mvsa01_reserved_same_reg() {
     // r1s == r2s is reserved for CM.MVSA01; decoder must return None
     let inst = make_mv_pair(MV_FUNCT2_MVSA01, 3, 3);
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 /// Reference encodings from the binutils gas test suite (zcmp-mv.d).
@@ -434,10 +436,10 @@ fn test_cm_mvsa01_binutils_reference_encodings() {
         (0xaeba, Reg::S5, Reg::S6),
     ];
     for &(raw, r1s, r2s) in cases {
-        let decoded = Rv32ZcmpInstruction::<Reg<u32>>::try_decode(raw).unwrap();
+        let decoded = Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv32ZcmpInstruction::CmMvsa01 { rs1: r1s, rs2: r2s },
+            Rv32ZcmpOnlyInstruction::CmMvsa01 { rs1: r1s, rs2: r2s },
             "raw={raw:#06x}"
         );
     }
@@ -447,14 +449,14 @@ fn test_cm_mvsa01_binutils_reference_encodings() {
 fn test_cm_mv_reserved_funct2_00() {
     // funct2[6:5]=00 is reserved for the mv-pair family
     let inst = make_mv_pair(0b00, 0, 1);
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_cm_mv_reserved_funct2_10() {
     // funct2[6:5]=10 is reserved for the mv-pair family
     let inst = make_mv_pair(0b10, 0, 1);
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
@@ -462,7 +464,7 @@ fn test_cm_mv_reserved_bit10_zero() {
     // funct2_12_11=01 with bit 10 = 0 is not a defined Zcmp encoding
     // (funct6 must be 101_011 for mv-pair)
     let inst: u16 = (0b101 << 13u8) | (0b01 << 11u8) | (0b11 << 5u8) | 0b10;
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(u32::from(inst)).is_none());
 }
 
 // Wrong quadrant / funct3
@@ -471,21 +473,21 @@ fn test_cm_mv_reserved_bit10_zero() {
 fn test_non_zcmp_q00_returns_none() {
     // Quadrant 00 is not Zcmp
     let inst = (0b101 << 13u8) | 0b00;
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_non_zcmp_q01_returns_none() {
     // Quadrant 01 is not Zcmp
     let inst = (0b101 << 13u8) | 0b01;
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_non_zcmp_funct3_mismatch() {
     // Q10 funct3=100 (not 101) -> not Zcmp
     let inst = (0b100 << 13u8) | (0b11 << 11u8) | (0b00 << 9u8) | (4 << 4u8) | 0b10;
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 // Reserved funct2_12_11 values
@@ -494,14 +496,14 @@ fn test_non_zcmp_funct3_mismatch() {
 fn test_reserved_funct2_00_returns_none() {
     // funct2_12_11=0b00 is not defined by Zcmp
     let inst = (0b101 << 13u8) | (0b00 << 11u8) | 0b10;
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_reserved_funct2_10_returns_none() {
     // funct2_12_11=0b10 is not defined by Zcmp
     let inst = (0b101 << 13u8) | (0b10 << 11u8) | 0b10;
-    assert!(Rv32ZcmpInstruction::<Reg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<Reg<u32>>::try_decode(inst).is_none());
 }
 
 // ZcmpUrlist::stack_adj_base (RV32)
@@ -584,14 +586,14 @@ fn test_rve_urlist_max_is_ra_s0_s1() {
 fn test_rve_push_reserved_urlist() {
     // urlist=7 names s2(x18) which does not exist in RVE
     let inst = make_push_pop(OP_PUSH, 7, 0);
-    assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<EReg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_rve_mva01s_accessible_regs() {
     // Under RVE only s0(field=0) and s1(field=1) are accessible
     let inst = make_mv_pair(MV_FUNCT2_MVA01S, 0, 1);
-    assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_some());
+    assert!(Rv32ZcmpOnlyInstruction::<EReg<u32>>::try_decode(inst).is_some());
 }
 
 #[test]
@@ -599,14 +601,14 @@ fn test_rve_mva01s_inaccessible_reg_returns_none() {
     // field=2 maps to s2(x18) which does not exist in RVE;
     // corresponds to r1sc > 1 in the spec reserved() pseudocode
     let inst = make_mv_pair(MV_FUNCT2_MVA01S, 2, 0);
-    assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<EReg<u32>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_rve_mvsa01_accessible_regs() {
     // Under RVE, s0 and s1 are distinct and accessible
     let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 1);
-    assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_some());
+    assert!(Rv32ZcmpOnlyInstruction::<EReg<u32>>::try_decode(inst).is_some());
 }
 
 #[test]
@@ -614,5 +616,5 @@ fn test_rve_mvsa01_inaccessible_reg_returns_none() {
     // field=2 maps to s2(x18) which does not exist in RVE;
     // corresponds to r2sc > 1 in the spec reserved() pseudocode
     let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 2);
-    assert!(Rv32ZcmpInstruction::<EReg<u32>>::try_decode(inst).is_none());
+    assert!(Rv32ZcmpOnlyInstruction::<EReg<u32>>::try_decode(inst).is_none());
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb.rs
@@ -4,6 +4,8 @@
 mod tests;
 
 use crate::instructions::Instruction;
+use crate::instructions::rv64::c::zca::Rv64ZcaInstruction;
+use crate::instructions::utils::I24;
 use crate::registers::general_purpose::Register;
 use ab_riscv_macros::instruction;
 use core::fmt;
@@ -11,9 +13,51 @@ use core::fmt;
 /// RISC-V RV64 Zcb compressed instruction set.
 ///
 /// All register operands are prime-field (x8–x15) registers.
+#[instruction(
+    inherit = [Rv64ZcaInstruction, Rv64ZcbOnlyInstruction],
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rv64ZcbInstruction<Reg> {}
+
+#[instruction]
+impl<Reg> const Instruction for Rv64ZcbInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        None
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u16>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u16>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64ZcbInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {}
+    }
+}
+
+/// Instruction that contains isolated Zcb instructions without inheriting Zca for testing purposes
 #[instruction]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Rv64ZcbInstruction<Reg> {
+#[rustfmt::skip]
+#[doc(hidden)]
+pub enum Rv64ZcbOnlyInstruction<Reg> {
     // Q00 loads / stores
     /// C.LBU  rd' = zero_extend(mem8\[rs1' + uimm])  uimm ∈ {0,1,2,3}
     CLbu { rd: Reg, rs1: Reg, uimm: u8 },
@@ -30,23 +74,31 @@ pub enum Rv64ZcbInstruction<Reg> {
     /// C.ZEXT.B  rd' = rd' & 0xff
     CZextB { rd: Reg },
     /// C.SEXT.B  rd' = sext(rd'\[7:0])  (requires Zbb)
+    #[instruction(if = [Rv64ZbbInstruction])]
     CSextB { rd: Reg },
     /// C.ZEXT.H  rd' = rd' & 0xffff  (requires Zbb)
+    #[instruction(if = [Rv64ZbbInstruction])]
     CZextH { rd: Reg },
     /// C.SEXT.H  rd' = sext(rd'\[15:0])  (requires Zbb)
+    #[instruction(if = [Rv64ZbbInstruction])]
     CSextH { rd: Reg },
     /// C.ZEXT.W  rd' = rd' & 0xffff_ffff  (requires Zba)
+    #[instruction(if = [Rv64ZbaInstruction])]
     CZextW { rd: Reg },
     /// C.NOT  rd' = ~rd'
     CNot { rd: Reg },
 
     // Q01 binary
     /// C.MUL  rd' = (rd' * rs2')\[XLEN-1:0]  (requires M or Zmmul)
+    #[instruction(
+        if = [Rv64MInstruction],
+        if = [Rv64ZmmulInstruction]
+    )]
     CMul { rd: Reg, rs2: Reg },
 }
 
 #[instruction]
-impl<Reg> const Instruction for Rv64ZcbInstruction<Reg>
+impl<Reg> const Instruction for Rv64ZcbOnlyInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
@@ -174,9 +226,9 @@ where
 }
 
 #[instruction]
-impl<Reg> fmt::Display for Rv64ZcbInstruction<Reg>
+impl<Reg> fmt::Display for Rv64ZcbOnlyInstruction<Reg>
 where
-    Reg: fmt::Display,
+    Reg: fmt::Display + Copy,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb/tests.rs
@@ -1,7 +1,7 @@
 #![expect(clippy::identity_op, reason = "Test readability")]
 
 use crate::instructions::Instruction;
-use crate::instructions::rv64::zce::zcb::Rv64ZcbInstruction;
+use crate::instructions::rv64::zce::zcb::Rv64ZcbOnlyInstruction;
 use crate::registers::general_purpose::Reg;
 
 /// Build a Q00 Zcb load/store: funct3=100, sub=bits\[12:10].
@@ -39,10 +39,10 @@ const fn make_zcb_q01(rd_rs1p: u16, funct2b: u16, rs2_sub: u16) -> u16 {
 fn test_clbu_all_uimm_values() {
     for (bit6, bit5, expected_uimm) in [(0, 0, 0), (1, 0, 1), (0, 1, 2), (1, 1, 3)] {
         let inst = make_zcb_q00(0b000, 0, bit6, bit5, 0);
-        let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+        let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcbInstruction::CLbu {
+            Rv64ZcbOnlyInstruction::CLbu {
                 rd: Reg::S0,
                 rs1: Reg::S0,
                 uimm: expected_uimm,
@@ -55,10 +55,10 @@ fn test_clbu_all_uimm_values() {
 #[test]
 fn test_clbu_all_prime_regs() {
     let inst = make_zcb_q00(0b000, 7, 0, 0, 6);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CLbu {
+        Rv64ZcbOnlyInstruction::CLbu {
             rd: Reg::A4,
             rs1: Reg::A5,
             uimm: 0,
@@ -72,10 +72,10 @@ fn test_clbu_all_prime_regs() {
 #[test]
 fn test_clhu_uimm0() {
     let inst = make_zcb_q00(0b001, 0, 0, 0, 0);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CLhu {
+        Rv64ZcbOnlyInstruction::CLhu {
             rd: Reg::S0,
             rs1: Reg::S0,
             uimm: 0,
@@ -87,10 +87,10 @@ fn test_clhu_uimm0() {
 #[test]
 fn test_clhu_uimm2() {
     let inst = make_zcb_q00(0b001, 0, 0, 1, 0);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CLhu {
+        Rv64ZcbOnlyInstruction::CLhu {
             rd: Reg::S0,
             rs1: Reg::S0,
             uimm: 2,
@@ -104,10 +104,10 @@ fn test_clhu_uimm2() {
 #[test]
 fn test_clh_uimm0() {
     let inst = make_zcb_q00(0b001, 0, 1, 0, 0);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CLh {
+        Rv64ZcbOnlyInstruction::CLh {
             rd: Reg::S0,
             rs1: Reg::S0,
             uimm: 0,
@@ -119,10 +119,10 @@ fn test_clh_uimm0() {
 #[test]
 fn test_clh_uimm2() {
     let inst = make_zcb_q00(0b001, 0, 1, 1, 0);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CLh {
+        Rv64ZcbOnlyInstruction::CLh {
             rd: Reg::S0,
             rs1: Reg::S0,
             uimm: 2,
@@ -136,10 +136,10 @@ fn test_clh_uimm2() {
 #[test]
 fn test_csb_uimm0() {
     let inst = make_zcb_q00(0b010, 0, 0, 0, 0);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CSb {
+        Rv64ZcbOnlyInstruction::CSb {
             rs1: Reg::S0,
             rs2: Reg::S0,
             uimm: 0
@@ -150,10 +150,10 @@ fn test_csb_uimm0() {
 #[test]
 fn test_csb_uimm3() {
     let inst = make_zcb_q00(0b010, 0, 1, 1, 1);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CSb {
+        Rv64ZcbOnlyInstruction::CSb {
             rs1: Reg::S0,
             rs2: Reg::S1,
             uimm: 3
@@ -166,10 +166,10 @@ fn test_csb_uimm3() {
 #[test]
 fn test_csh_uimm0() {
     let inst = make_zcb_q00(0b011, 0, 0, 0, 0);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CSh {
+        Rv64ZcbOnlyInstruction::CSh {
             rs1: Reg::S0,
             rs2: Reg::S0,
             uimm: 0
@@ -180,10 +180,10 @@ fn test_csh_uimm0() {
 #[test]
 fn test_csh_uimm2() {
     let inst = make_zcb_q00(0b011, 0, 0, 1, 1);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CSh {
+        Rv64ZcbOnlyInstruction::CSh {
             rs1: Reg::S0,
             rs2: Reg::S1,
             uimm: 2
@@ -194,7 +194,7 @@ fn test_csh_uimm2() {
 #[test]
 fn test_csh_reserved_funct1_1() {
     let inst = make_zcb_q00(0b011, 0, 1, 0, 0);
-    assert!(Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
 }
 
 // Unary ops - funct2b=0b11
@@ -202,10 +202,10 @@ fn test_csh_reserved_funct1_1() {
 #[test]
 fn test_czext_b() {
     let inst = make_zcb_q01(0, 0b11, 0b000);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CZextB {
+        Rv64ZcbOnlyInstruction::CZextB {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -216,10 +216,10 @@ fn test_czext_b() {
 #[test]
 fn test_csext_b() {
     let inst = make_zcb_q01(0, 0b11, 0b001);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CSextB {
+        Rv64ZcbOnlyInstruction::CSextB {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -230,10 +230,10 @@ fn test_csext_b() {
 #[test]
 fn test_czext_h() {
     let inst = make_zcb_q01(0, 0b11, 0b010);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CZextH {
+        Rv64ZcbOnlyInstruction::CZextH {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -244,10 +244,10 @@ fn test_czext_h() {
 #[test]
 fn test_csext_h() {
     let inst = make_zcb_q01(0, 0b11, 0b011);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CSextH {
+        Rv64ZcbOnlyInstruction::CSextH {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -258,10 +258,10 @@ fn test_csext_h() {
 #[test]
 fn test_czext_w() {
     let inst = make_zcb_q01(0, 0b11, 0b100);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CZextW {
+        Rv64ZcbOnlyInstruction::CZextW {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -272,10 +272,10 @@ fn test_czext_w() {
 #[test]
 fn test_cnot() {
     let inst = make_zcb_q01(0, 0b11, 0b101);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CNot {
+        Rv64ZcbOnlyInstruction::CNot {
             rd: Reg::S0,
             rs1: Reg::Zero,
             rs2: Reg::Zero,
@@ -286,13 +286,13 @@ fn test_cnot() {
 #[test]
 fn test_unary_reserved_sub_110() {
     let inst = make_zcb_q01(0, 0b11, 0b110);
-    assert!(Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
 }
 
 #[test]
 fn test_unary_reserved_sub_111() {
     let inst = make_zcb_q01(0, 0b11, 0b111);
-    assert!(Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
 }
 
 #[test]
@@ -300,8 +300,8 @@ fn test_unary_all_prime_regs() {
     // Check all 8 prime registers decode correctly for C.NOT.
     for r in 0..8 {
         let inst = make_zcb_q01(r, 0b11, 0b101);
-        let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
-        assert!(matches!(decoded, Rv64ZcbInstruction::CNot { .. }));
+        let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+        assert!(matches!(decoded, Rv64ZcbOnlyInstruction::CNot { .. }));
     }
 }
 
@@ -310,10 +310,10 @@ fn test_unary_all_prime_regs() {
 #[test]
 fn test_cmul() {
     let inst = make_zcb_q01(0, 0b10, 0b001);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CMul {
+        Rv64ZcbOnlyInstruction::CMul {
             rd: Reg::S0,
             rs2: Reg::S1,
             rs1: Reg::Zero,
@@ -324,10 +324,10 @@ fn test_cmul() {
 #[test]
 fn test_cmul_same_reg() {
     let inst = make_zcb_q01(0, 0b10, 0b000);
-    let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+    let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcbInstruction::CMul {
+        Rv64ZcbOnlyInstruction::CMul {
             rd: Reg::S0,
             rs2: Reg::S0,
             rs1: Reg::Zero,
@@ -340,8 +340,8 @@ fn test_cmul_all_prime_reg_pairs() {
     for rd in 0..8 {
         for rs2 in 0..8 {
             let inst = make_zcb_q01(rd, 0b10, rs2);
-            let decoded = Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
-            assert!(matches!(decoded, Rv64ZcbInstruction::CMul { .. }));
+            let decoded = Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).unwrap();
+            assert!(matches!(decoded, Rv64ZcbOnlyInstruction::CMul { .. }));
         }
     }
 }
@@ -351,13 +351,13 @@ fn test_cmul_all_prime_reg_pairs() {
 #[test]
 fn test_reserved_funct2b_00() {
     let inst = make_zcb_q01(0, 0b00, 0);
-    assert!(Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
 }
 
 #[test]
 fn test_reserved_funct2b_01() {
     let inst = make_zcb_q01(0, 0b01, 0);
-    assert!(Rv64ZcbInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
 }
 
 // Non-Zcb quadrants return None
@@ -365,11 +365,11 @@ fn test_reserved_funct2b_01() {
 #[test]
 fn test_non_zcb_q10_returns_none() {
     let inst = (0b000 << 13u8) | (1 << 12u8) | (10 << 7u8) | (3 << 2u8) | 0b10;
-    assert!(Rv64ZcbInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_zca_q01_funct3_000_returns_none() {
     let inst = (0b000 << 13u8) | (0 << 12u8) | (10 << 7u8) | (5 << 2u8) | 0b01;
-    assert!(Rv64ZcbInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcbOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
@@ -5,14 +5,57 @@ mod tests;
 
 use crate::instructions::Instruction;
 use crate::instructions::rv32::zce::zcmp::{ZcmpRegister, ZcmpUrlist};
+use crate::instructions::rv64::c::zca::Rv64ZcaInstruction;
+use crate::instructions::utils::I24;
 use crate::registers::general_purpose::Register;
 use ab_riscv_macros::instruction;
 use core::fmt;
 
 /// Zcmp compressed instruction set
+#[instruction(
+    inherit = [Rv64ZcaInstruction, Rv64ZcmpOnlyInstruction],
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rv64ZcmpInstruction<Reg> {}
+
+#[instruction]
+impl<Reg> const Instruction for Rv64ZcmpInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        None
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u16>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u16>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64ZcmpInstruction<Reg>
+where
+    Reg: Register,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {}
+    }
+}
+
+/// Instruction that contains isolated Zcmp instructions without inheriting Zca for testing purposes
 #[instruction]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Rv64ZcmpInstruction<Reg> {
+#[doc(hidden)]
+pub enum Rv64ZcmpOnlyInstruction<Reg> {
     /// CM.PUSH - push reg_list, decrement sp by `stack_adj`
     ///
     /// `stack_adj = urlist.stack_adj_base() + spimm * 16` from the encoding.
@@ -48,7 +91,7 @@ pub enum Rv64ZcmpInstruction<Reg> {
 }
 
 #[instruction]
-impl<Reg> const Instruction for Rv64ZcmpInstruction<Reg>
+impl<Reg> const Instruction for Rv64ZcmpOnlyInstruction<Reg>
 where
     Reg: [const] ZcmpRegister<Type = u64>,
 {
@@ -140,7 +183,7 @@ where
 }
 
 #[instruction]
-impl<Reg> fmt::Display for Rv64ZcmpInstruction<Reg>
+impl<Reg> fmt::Display for Rv64ZcmpOnlyInstruction<Reg>
 where
     Reg: Register,
 {

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp/tests.rs
@@ -1,7 +1,7 @@
 #![expect(clippy::identity_op, reason = "Test readability")]
 
 use crate::instructions::Instruction;
-use crate::instructions::rv64::zce::zcmp::{Rv64ZcmpInstruction, ZcmpUrlist};
+use crate::instructions::rv64::zce::zcmp::{Rv64ZcmpOnlyInstruction, ZcmpUrlist};
 use crate::registers::general_purpose::{EReg, Reg};
 
 /// Build a Zcmp push/pop instruction word.
@@ -53,10 +53,10 @@ fn expected_stack_adj(urlist_raw: u8, spimm: u8) -> u8 {
 fn test_cm_push_ra_only() {
     // urlist=4 = {ra}, spimm=0 -> stack_adj = 16 + 0 = 16
     let inst = make_push_pop(OP_PUSH, 4, 0);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmPush {
+        Rv64ZcmpOnlyInstruction::CmPush {
             urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
             stack_adj: 16,
             rs1: Reg::Zero,
@@ -69,10 +69,10 @@ fn test_cm_push_ra_only() {
 fn test_cm_push_ra_s0_s11() {
     // urlist=15 = {ra, s0-s11}, spimm=3 -> stack_adj = 112 + 48 = 160
     let inst = make_push_pop(OP_PUSH, 15, 3);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmPush {
+        Rv64ZcmpOnlyInstruction::CmPush {
             urlist: ZcmpUrlist::try_from_raw(15).unwrap(),
             stack_adj: 160,
             rs1: Reg::Zero,
@@ -85,10 +85,10 @@ fn test_cm_push_ra_s0_s11() {
 fn test_cm_push_all_valid_urlists() {
     for urlist in 4u16..=15 {
         let inst = make_push_pop(OP_PUSH, urlist, 0);
-        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+        let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmPush {
+            Rv64ZcmpOnlyInstruction::CmPush {
                 urlist: ZcmpUrlist::try_from_raw(urlist as u8).unwrap(),
                 stack_adj: expected_stack_adj(urlist as u8, 0),
                 rs1: Reg::Zero,
@@ -105,7 +105,7 @@ fn test_cm_push_reserved_urlist() {
     for urlist in 0u16..4 {
         let inst = make_push_pop(OP_PUSH, urlist, 0);
         assert!(
-            Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none(),
+            Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none(),
             "urlist={urlist} should be reserved"
         );
     }
@@ -125,10 +125,10 @@ fn test_cm_push_binutils_reference_encodings() {
         (0xb8fe, 15, 160),
     ];
     for &(raw, urlist_raw, stack_adj) in cases {
-        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmPush {
+            Rv64ZcmpOnlyInstruction::CmPush {
                 urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
                 stack_adj,
                 rs1: Reg::Zero,
@@ -145,10 +145,10 @@ fn test_cm_push_binutils_reference_encodings() {
 fn test_cm_pop_basic() {
     // urlist=5 = {ra, s0}, spimm=1 -> stack_adj = 16 + 16 = 32
     let inst = make_push_pop(OP_POP, 5, 1);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmPop {
+        Rv64ZcmpOnlyInstruction::CmPop {
             urlist: ZcmpUrlist::try_from_raw(5).unwrap(),
             stack_adj: 32,
             rs1: Reg::Zero,
@@ -161,10 +161,10 @@ fn test_cm_pop_basic() {
 fn test_cm_pop_ra_s0_s9() {
     // urlist=14 = {ra, s0-s9}, spimm=2 -> stack_adj = 96 + 32 = 128
     let inst = make_push_pop(OP_POP, 14, 2);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmPop {
+        Rv64ZcmpOnlyInstruction::CmPop {
             urlist: ZcmpUrlist::try_from_raw(14).unwrap(),
             stack_adj: 128,
             rs1: Reg::Zero,
@@ -178,10 +178,10 @@ fn test_cm_pop_ra_s0_s9() {
 fn test_cm_pop_binutils_reference_encodings() {
     let cases = &[(0xba56u32, 5, 32), (0xbaea, 14, 128)];
     for &(raw, urlist_raw, stack_adj) in cases {
-        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmPop {
+            Rv64ZcmpOnlyInstruction::CmPop {
                 urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
                 stack_adj,
                 rs1: Reg::Zero,
@@ -198,10 +198,10 @@ fn test_cm_pop_binutils_reference_encodings() {
 fn test_cm_popretz_basic() {
     // urlist=4 = {ra}, spimm=0 -> stack_adj = 16
     let inst = make_push_pop(OP_POPRETZ, 4, 0);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmPopretz {
+        Rv64ZcmpOnlyInstruction::CmPopretz {
             urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
             stack_adj: 16,
             rs1: Reg::Zero,
@@ -213,10 +213,10 @@ fn test_cm_popretz_basic() {
 /// Reference encoding anchored to binutils MATCH_CM_POPRETZ=0xbc02.
 #[test]
 fn test_cm_popretz_binutils_reference_encodings() {
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(0xbc42).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(0xbc42).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmPopretz {
+        Rv64ZcmpOnlyInstruction::CmPopretz {
             urlist: ZcmpUrlist::try_from_raw(4).unwrap(),
             stack_adj: 16,
             rs1: Reg::Zero,
@@ -231,10 +231,10 @@ fn test_cm_popretz_binutils_reference_encodings() {
 fn test_cm_popret_basic() {
     // urlist=6 = {ra, s0-s1}, spimm=0 -> stack_adj = 32
     let inst = make_push_pop(OP_POPRET, 6, 0);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmPopret {
+        Rv64ZcmpOnlyInstruction::CmPopret {
             urlist: ZcmpUrlist::try_from_raw(6).unwrap(),
             stack_adj: 32,
             rs1: Reg::Zero,
@@ -250,10 +250,10 @@ fn test_cm_popret_all_spimm_values() {
     let expected_adjs = [48, 64, 80, 96];
     for (spimm, &expected) in expected_adjs.iter().enumerate() {
         let inst = make_push_pop(OP_POPRET, 8, spimm as u16);
-        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+        let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmPopret {
+            Rv64ZcmpOnlyInstruction::CmPopret {
                 urlist: ZcmpUrlist::try_from_raw(8).unwrap(),
                 stack_adj: expected,
                 rs1: Reg::Zero,
@@ -277,10 +277,10 @@ fn test_cm_popret_binutils_reference_encodings() {
         (0xbe8e, 8, 96),
     ];
     for &(raw, urlist_raw, stack_adj) in cases {
-        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmPopret {
+            Rv64ZcmpOnlyInstruction::CmPopret {
                 urlist: ZcmpUrlist::try_from_raw(urlist_raw).unwrap(),
                 stack_adj,
                 rs1: Reg::Zero,
@@ -300,22 +300,24 @@ fn test_push_pop_op_sel_distinct_variants() {
     let spimm = 0u16;
 
     assert!(matches!(
-        Rv64ZcmpInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_PUSH, urlist, spimm)).unwrap(),
-        Rv64ZcmpInstruction::CmPush { .. }
-    ));
-    assert!(matches!(
-        Rv64ZcmpInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POP, urlist, spimm)).unwrap(),
-        Rv64ZcmpInstruction::CmPop { .. }
-    ));
-    assert!(matches!(
-        Rv64ZcmpInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POPRETZ, urlist, spimm))
+        Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_PUSH, urlist, spimm))
             .unwrap(),
-        Rv64ZcmpInstruction::CmPopretz { .. }
+        Rv64ZcmpOnlyInstruction::CmPush { .. }
     ));
     assert!(matches!(
-        Rv64ZcmpInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POPRET, urlist, spimm))
+        Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POP, urlist, spimm))
             .unwrap(),
-        Rv64ZcmpInstruction::CmPopret { .. }
+        Rv64ZcmpOnlyInstruction::CmPop { .. }
+    ));
+    assert!(matches!(
+        Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POPRETZ, urlist, spimm))
+            .unwrap(),
+        Rv64ZcmpOnlyInstruction::CmPopretz { .. }
+    ));
+    assert!(matches!(
+        Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(make_push_pop(OP_POPRET, urlist, spimm))
+            .unwrap(),
+        Rv64ZcmpOnlyInstruction::CmPopret { .. }
     ));
 }
 
@@ -325,10 +327,10 @@ fn test_push_pop_op_sel_distinct_variants() {
 fn test_cm_mva01s_s0_s1() {
     // r1s field=0 -> s0(x8), r2s field=1 -> s1(x9)
     let inst = make_mv_pair(MV_FUNCT2_MVA01S, 0, 1);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmMva01s {
+        Rv64ZcmpOnlyInstruction::CmMva01s {
             rs1: Reg::S0,
             rs2: Reg::S1,
         }
@@ -339,10 +341,10 @@ fn test_cm_mva01s_s0_s1() {
 fn test_cm_mva01s_same_reg() {
     // r1s == r2s is allowed for CM.MVA01S
     let inst = make_mv_pair(MV_FUNCT2_MVA01S, 2, 2);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmMva01s {
+        Rv64ZcmpOnlyInstruction::CmMva01s {
             rs1: Reg::S2,
             rs2: Reg::S2,
         }
@@ -364,8 +366,8 @@ fn test_cm_mva01s_all_s_regs() {
     ];
     for (field, &expected) in expected_regs.iter().enumerate() {
         let inst = make_mv_pair(MV_FUNCT2_MVA01S, field as u16, 0);
-        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
-        if let Rv64ZcmpInstruction::CmMva01s { rs1, .. } = decoded {
+        let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+        if let Rv64ZcmpOnlyInstruction::CmMva01s { rs1, .. } = decoded {
             assert_eq!(rs1, expected, "field={field}");
         } else {
             panic!("wrong variant for field={field}");
@@ -388,10 +390,10 @@ fn test_cm_mva01s_binutils_reference_encodings() {
         (0xaefa, Reg::S5, Reg::S6),
     ];
     for &(raw, r1s, r2s) in cases {
-        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmMva01s { rs1: r1s, rs2: r2s },
+            Rv64ZcmpOnlyInstruction::CmMva01s { rs1: r1s, rs2: r2s },
             "raw={raw:#06x}"
         );
     }
@@ -403,10 +405,10 @@ fn test_cm_mva01s_binutils_reference_encodings() {
 fn test_cm_mvsa01_distinct_regs() {
     // r1s=s0, r2s=s2 (distinct)
     let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 2);
-    let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(
         decoded,
-        Rv64ZcmpInstruction::CmMvsa01 {
+        Rv64ZcmpOnlyInstruction::CmMvsa01 {
             rs1: Reg::S0,
             rs2: Reg::S2,
         }
@@ -417,7 +419,7 @@ fn test_cm_mvsa01_distinct_regs() {
 fn test_cm_mvsa01_reserved_same_reg() {
     // r1s == r2s is reserved for CM.MVSA01; decoder must return None
     let inst = make_mv_pair(MV_FUNCT2_MVSA01, 3, 3);
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 /// Reference encodings from the binutils gas test suite (zcmp-mv.d).
@@ -434,10 +436,10 @@ fn test_cm_mvsa01_binutils_reference_encodings() {
         (0xaeba, Reg::S5, Reg::S6),
     ];
     for &(raw, r1s, r2s) in cases {
-        let decoded = Rv64ZcmpInstruction::<Reg<u64>>::try_decode(raw).unwrap();
+        let decoded = Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(raw).unwrap();
         assert_eq!(
             decoded,
-            Rv64ZcmpInstruction::CmMvsa01 { rs1: r1s, rs2: r2s },
+            Rv64ZcmpOnlyInstruction::CmMvsa01 { rs1: r1s, rs2: r2s },
             "raw={raw:#06x}"
         );
     }
@@ -447,14 +449,14 @@ fn test_cm_mvsa01_binutils_reference_encodings() {
 fn test_cm_mv_reserved_funct2_00() {
     // funct2[6:5]=00 is reserved for the mv-pair family
     let inst = make_mv_pair(0b00, 0, 1);
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_cm_mv_reserved_funct2_10() {
     // funct2[6:5]=10 is reserved for the mv-pair family
     let inst = make_mv_pair(0b10, 0, 1);
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
@@ -462,7 +464,7 @@ fn test_cm_mv_reserved_bit10_zero() {
     // funct2_12_11=01 with bit 10 = 0 is not a defined Zcmp encoding
     // (funct6 must be 101_011 for mv-pair)
     let inst: u16 = (0b101 << 13u8) | (0b01 << 11u8) | (0b11 << 5u8) | 0b10;
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(u32::from(inst)).is_none());
 }
 
 // Wrong quadrant / funct3
@@ -471,21 +473,21 @@ fn test_cm_mv_reserved_bit10_zero() {
 fn test_non_zcmp_q00_returns_none() {
     // Quadrant 00 is not Zcmp
     let inst = (0b101 << 13u8) | 0b00;
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_non_zcmp_q01_returns_none() {
     // Quadrant 01 is not Zcmp
     let inst = (0b101 << 13u8) | 0b01;
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_non_zcmp_funct3_mismatch() {
     // Q10 funct3=100 (not 101) -> not Zcmp
     let inst = (0b100 << 13u8) | (0b11 << 11u8) | (0b00 << 9u8) | (4 << 4u8) | 0b10;
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 // Reserved funct2_12_11 values
@@ -494,14 +496,14 @@ fn test_non_zcmp_funct3_mismatch() {
 fn test_reserved_funct2_00_returns_none() {
     // funct2_12_11=0b00 is not defined by Zcmp
     let inst = (0b101 << 13u8) | (0b00 << 11u8) | 0b10;
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_reserved_funct2_10_returns_none() {
     // funct2_12_11=0b10 is not defined by Zcmp
     let inst = (0b101 << 13u8) | (0b10 << 11u8) | 0b10;
-    assert!(Rv64ZcmpInstruction::<Reg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<Reg<u64>>::try_decode(inst).is_none());
 }
 
 // ZcmpUrlist::stack_adj_base (RV64)
@@ -584,14 +586,14 @@ fn test_rve_urlist_max_is_ra_s0_s1() {
 fn test_rve_push_reserved_urlist() {
     // urlist=7 names s2(x18) which does not exist in RVE
     let inst = make_push_pop(OP_PUSH, 7, 0);
-    assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<EReg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_rve_mva01s_accessible_regs() {
     // Under RVE only s0(field=0) and s1(field=1) are accessible
     let inst = make_mv_pair(MV_FUNCT2_MVA01S, 0, 1);
-    assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_some());
+    assert!(Rv64ZcmpOnlyInstruction::<EReg<u64>>::try_decode(inst).is_some());
 }
 
 #[test]
@@ -599,14 +601,14 @@ fn test_rve_mva01s_inaccessible_reg_returns_none() {
     // field=2 maps to s2(x18) which does not exist in RVE;
     // corresponds to r1sc > 1 in the spec reserved() pseudocode
     let inst = make_mv_pair(MV_FUNCT2_MVA01S, 2, 0);
-    assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<EReg<u64>>::try_decode(inst).is_none());
 }
 
 #[test]
 fn test_rve_mvsa01_accessible_regs() {
     // Under RVE, s0 and s1 are distinct and accessible
     let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 1);
-    assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_some());
+    assert!(Rv64ZcmpOnlyInstruction::<EReg<u64>>::try_decode(inst).is_some());
 }
 
 #[test]
@@ -614,5 +616,5 @@ fn test_rve_mvsa01_inaccessible_reg_returns_none() {
     // field=2 maps to s2(x18) which does not exist in RVE;
     // corresponds to r2sc > 1 in the spec reserved() pseudocode
     let inst = make_mv_pair(MV_FUNCT2_MVSA01, 0, 2);
-    assert!(Rv64ZcmpInstruction::<EReg<u64>>::try_decode(inst).is_none());
+    assert!(Rv64ZcmpOnlyInstruction::<EReg<u64>>::try_decode(inst).is_none());
 }

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -10,8 +10,10 @@ pub use crate::instructions::rv32::b::zbs::Rv32ZbsInstruction;
 pub use crate::instructions::rv32::c::zca::Rv32ZcaInstruction;
 pub use crate::instructions::rv32::m::Rv32MInstruction;
 pub use crate::instructions::rv32::m::zmmul::Rv32ZmmulInstruction;
-pub use crate::instructions::rv32::zce::zcb::Rv32ZcbInstruction;
-pub use crate::instructions::rv32::zce::zcmp::{Rv32ZcmpInstruction, ZcmpRegister, ZcmpUrlist};
+pub use crate::instructions::rv32::zce::zcb::{Rv32ZcbInstruction, Rv32ZcbOnlyInstruction};
+pub use crate::instructions::rv32::zce::zcmp::{
+    Rv32ZcmpInstruction, Rv32ZcmpOnlyInstruction, ZcmpRegister, ZcmpUrlist,
+};
 pub use crate::instructions::rv32::zk::zbkb::Rv32ZbkbInstruction;
 pub use crate::instructions::rv32::zk::zbkc::Rv32ZbkcInstruction;
 pub use crate::instructions::rv32::zk::zbkx::Rv32ZbkxInstruction;
@@ -28,8 +30,8 @@ pub use crate::instructions::rv64::b::zbs::Rv64ZbsInstruction;
 pub use crate::instructions::rv64::c::zca::Rv64ZcaInstruction;
 pub use crate::instructions::rv64::m::Rv64MInstruction;
 pub use crate::instructions::rv64::m::zmmul::Rv64ZmmulInstruction;
-pub use crate::instructions::rv64::zce::zcb::Rv64ZcbInstruction;
-pub use crate::instructions::rv64::zce::zcmp::Rv64ZcmpInstruction;
+pub use crate::instructions::rv64::zce::zcb::{Rv64ZcbInstruction, Rv64ZcbOnlyInstruction};
+pub use crate::instructions::rv64::zce::zcmp::{Rv64ZcmpInstruction, Rv64ZcmpOnlyInstruction};
 pub use crate::instructions::rv64::zk::zbkb::Rv64ZbkbInstruction;
 pub use crate::instructions::rv64::zk::zbkc::Rv64ZbkcInstruction;
 pub use crate::instructions::rv64::zk::zbkx::Rv64ZbkxInstruction;


### PR DESCRIPTION
This is a substantial refactoring that introduces support for `#[instruction(if = [..])]` on both instruction enum and specific variants.

These `if` conditions allow modeling things like `Zcf` part of `C` extension only being available when `F` extension is also available or `Zcb`'s `c.sext.b` only present when `Zbb` extension is also available.

Dependencies that were previously missing are now added to instructions.

The only thing missing in terms of specification modeling that is missing right now that I see is conflicts (`Zcmp` can't be used at the same time as `Zcd`). Since none of the extensions so far have conflicts this is fine, but it will be necessary to add in the future.

The code is a bit messy and will require cleanup in the follow-up PR, the goal was to make it work for now.