### PR TITLE
Check for all possible job statuses

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -638,9 +638,10 @@ jobs:
       - act4
 
     steps:
-      - name: Exit failure
-        if: "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}"
-        run: exit 1
-      - name: Exit success
-        if: "${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}"
-        run: exit 0
+      - name: Job status check
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          for result in $RESULTS; do
+            [[ "$result" == "success" ]] || exit 1
+          done


### PR DESCRIPTION
Looks like `skipped` was not checked before and any possible unknown non-success statuses, which I think is what happened here: https://github.com/nazar-pc/abundance/actions/runs/26595401463/job/78366644414