### PR TITLE
ACT4 vector tests fixes (part 1)

### DIFF
--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/sail.json
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/sail.json
@@ -279,7 +279,7 @@
       // Zve64x, Zve64f, and Zve64d require `elen_exp` >= 6,
       // and V requires `elen_exp` >= 6 and `vlen_exp` >= 7.
       "support_level": "Integer",
-      "vlen_exp": 9,
+      "vlen_exp": 10,
       "elen_exp": 6,
       "vl_use_ceil": false
     },

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/sail.json
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/sail.json
@@ -279,7 +279,7 @@
       // Zve64x, Zve64f, and Zve64d require `elen_exp` >= 6,
       // and V requires `elen_exp` >= 6 and `vlen_exp` >= 7.
       "support_level": "Integer",
-      "vlen_exp": 9,
+      "vlen_exp": 10,
       "elen_exp": 6,
       "vl_use_ceil": false
     },

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -17,6 +17,7 @@ pub use crate::rv64::zk::zkn::zkne::rv64_zkne_helpers;
 pub use crate::rv64::zk::zkn::zknh::rv64_zknh_helpers;
 pub use crate::v::vector_registers::*;
 pub use crate::v::zve64x::arith::zve64x_arith_helpers;
+pub use crate::v::zve64x::carry::zve64x_carry_helpers;
 pub use crate::v::zve64x::config::zve64x_config_helpers;
 pub use crate::v::zve64x::fixed_point::zve64x_fixed_point_helpers;
 pub use crate::v::zve64x::load::zve64x_load_helpers;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -21,7 +21,7 @@ const TRAP_ADDRESS: u64 = 0;
 /// Zve64x element width
 const ZVE64X_ELEN: u32 = 64;
 /// VLEN in bits for the test vector register file
-const TEST_VLEN: u32 = 128;
+const TEST_VLEN: u32 = 256;
 /// VLEN in bytes
 const TEST_VLENB: usize = (TEST_VLEN / u8::BITS) as usize;
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x.rs
@@ -1,6 +1,7 @@
 //! Zve64x extension
 
 pub mod arith;
+pub mod carry;
 pub mod config;
 pub mod fixed_point;
 pub mod load;
@@ -14,6 +15,7 @@ pub mod zve64x_helpers;
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::arith::zve64x_arith_helpers;
+use crate::v::zve64x::carry::zve64x_carry_helpers;
 use crate::v::zve64x::config::zve64x_config_helpers;
 use crate::v::zve64x::fixed_point::zve64x_fixed_point_helpers;
 use crate::v::zve64x::load::zve64x_load_helpers;

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith.rs
@@ -86,7 +86,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -137,7 +137,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -183,7 +183,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -236,7 +236,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -286,7 +286,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -337,7 +337,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -384,7 +384,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -436,7 +436,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -486,7 +486,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -532,7 +532,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -584,7 +584,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -634,7 +634,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -680,7 +680,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -732,7 +732,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -782,7 +782,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -828,7 +828,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -880,7 +880,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -931,7 +931,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -977,7 +977,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1030,7 +1030,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1085,7 +1085,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1135,7 +1135,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1187,7 +1187,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1241,7 +1241,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1291,7 +1291,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1346,7 +1346,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1399,7 +1399,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1453,7 +1453,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1511,7 +1511,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1571,7 +1571,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1624,7 +1624,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1678,7 +1678,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1736,7 +1736,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
@@ -61,7 +61,7 @@ fn set_vreg(
 }
 
 /// Read a full vector register as bytes
-fn get_vreg(state: &TestInterpreterState<Zve64xArithInstruction<Reg<u64>>>, reg: VReg) -> [u8; 16] {
+fn get_vreg(state: &TestInterpreterState<Zve64xArithInstruction<Reg<u64>>>, reg: VReg) -> [u8; 32] {
     state.ext_state.read_vreg()[usize::from(reg.bits())]
 }
 
@@ -73,7 +73,7 @@ fn read_elem(
     sew: Vsew,
 ) -> u64 {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -91,7 +91,7 @@ fn write_elem(
     value: u64,
 ) {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -109,14 +109,14 @@ fn mask_bit(
     (byte >> (i % u8::BITS)) & 1 != 0
 }
 
-// With TEST_VLEN=128, VLENB=16:
-//   E8/M1  -> VLMAX=16, 1 reg,  16 elems/reg
-//   E16/M1 -> VLMAX=8,  1 reg,  8 elems/reg
-//   E32/M1 -> VLMAX=4,  1 reg,  4 elems/reg
-//   E64/M1 -> VLMAX=2,  1 reg,  2 elems/reg
-//   E8/M2  -> VLMAX=32, 2 regs, 16 elems/reg
-//   E32/M2 -> VLMAX=8,  2 regs, 4 elems/reg
-//   E64/Mf2-> VLMAX=1,  1 reg,  2 elems/reg (but VLMAX=1)
+// With TEST_VLEN=256, VLENB=32:
+//   E8/M1  -> VLMAX=32, 1 reg,  32 elems/reg
+//   E16/M1 -> VLMAX=16, 1 reg,  16 elems/reg
+//   E32/M1 -> VLMAX=8,  1 reg,  8 elems/reg
+//   E64/M1 -> VLMAX=4,  1 reg,  4 elems/reg
+//   E8/M2  -> VLMAX=64, 2 regs, 32 elems/reg
+//   E32/M2 -> VLMAX=16, 2 regs, 8 elems/reg
+//   E64/Mf2-> VLMAX=2,  1 reg,  4 elems/reg
 
 // vadd
 
@@ -224,9 +224,9 @@ fn vadd_vi_e16_m1_negative_imm() {
 
 #[test]
 fn vadd_vv_e8_m2_spans_two_regs() {
-    // VLMAX=32: elements 0..15 in v2, 16..31 in v3
-    let mut state = setup(32, Vsew::E8, Vlmul::M2);
-    for i in 0..32usize {
+    // VLMAX=64: elements 0..31 in v2, 32..63 in v3 (32 E8 elems per VLENB=32 register)
+    let mut state = setup(64, Vsew::E8, Vlmul::M2);
+    for i in 0..64usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E8, i as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E8, 1);
     }
@@ -242,7 +242,7 @@ fn vadd_vv_e8_m2_spans_two_regs() {
         },
     )
     .unwrap();
-    for i in 0..32usize {
+    for i in 0..64usize {
         assert_eq!(
             read_elem(&state, VReg::V6, i, Vsew::E8),
             i as u64 + 1,
@@ -751,7 +751,7 @@ fn vmseq_vv_e8_m1_writes_mask_bits() {
         );
     }
     // Pre-fill vd (v4) with all-ones so we can detect undisturbed bits above vl
-    set_vreg(&mut state, VReg::V4, &[0xFF; 16]);
+    set_vreg(&mut state, VReg::V4, &[0xFF; 32]);
     exec(
         &mut state,
         Zve64xArithInstruction::VmseqVv {
@@ -773,8 +773,8 @@ fn vmseq_vv_e8_m1_writes_mask_bits() {
     assert!(!mask_bit(&state, VReg::V4, 5));
     assert!(mask_bit(&state, VReg::V4, 6));
     assert!(!mask_bit(&state, VReg::V4, 7));
-    // Bits above vl (8..127) must remain undisturbed (all-ones from pre-fill)
-    for i in 8..128usize {
+    // Bits above vl (8..VLEN) must remain undisturbed (all-ones from pre-fill)
+    for i in 8..256usize {
         assert_eq!(
             (state.ext_state.read_vreg()[usize::from(VReg::V4.bits())][i / u8::BITS as usize]
                 >> (i % u8::BITS as usize))

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry.rs
@@ -1,0 +1,765 @@
+//! Zve64x carry/borrow arithmetic instructions
+
+#[cfg(test)]
+mod tests;
+pub mod zve64x_carry_helpers;
+
+use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::zve64x::zve64x_helpers;
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::fmt;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+impl<Reg> ExecutableInstructionOperands for Zve64xCarryInstruction<Reg> where Reg: Register {}
+
+#[instruction_execution]
+impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Zve64xCarryInstruction<Reg>
+where
+    Reg: Register,
+{
+}
+
+#[instruction_execution]
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Zve64xCarryInstruction<Reg>
+where
+    Reg: Register,
+    Regs: RegisterFile<Reg>,
+    ExtState: VectorRegistersExt<Reg, CustomError>,
+    [(); ExtState::ELEN as usize]:,
+    [(); ExtState::VLEN as usize]:,
+    [(); ExtState::VLENB as usize]:,
+    Memory: VirtualMemory,
+    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    CustomError: fmt::Debug,
+{
+    #[inline(always)]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value: _,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> Result<
+        ControlFlow<(), (Self::Reg, <Self::Reg as Register>::Type)>,
+        ExecutionError<Reg::Type, CustomError>,
+    > {
+        match self {
+            // vadc: add with carry-in from v0, data result
+            Self::VadcVvm { vd, vs2, vs1 } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
+                )?;
+                // vd must not be v0: v0 holds carry-in
+                if vd == VReg::V0 {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                // SAFETY: alignments checked above; vd != v0 checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Vreg(vs1.bits()),
+                        true,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VadcVxm { vd, vs2, rs1: _ } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                if vd == VReg::V0 {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = rs1_value.as_u64();
+                // SAFETY: alignments checked above; vd != v0 checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        true,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VadcVim { vd, vs2, imm } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                if vd == VReg::V0 {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = i64::from(imm).cast_unsigned();
+                // SAFETY: alignments checked above; vd != v0 checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        true,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            // vmadc: add and write carry-out mask
+            Self::VmadcVvm { vd, vs2, vs1 } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Vreg(vs1.bits()),
+                        true,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VmadcVxm { vd, vs2, rs1: _ } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = rs1_value.as_u64();
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        true,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VmadcVim { vd, vs2, imm } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = i64::from(imm).cast_unsigned();
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        true,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VmadcVv { vd, vs2, vs1 } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Vreg(vs1.bits()),
+                        false,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VmadcVx { vd, vs2, rs1: _ } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = rs1_value.as_u64();
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        false,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VmadcVi { vd, vs2, imm } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = i64::from(imm).cast_unsigned();
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_add_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        false,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            // vsbc: subtract with borrow-in from v0, data result
+            Self::VsbcVvm { vd, vs2, vs1 } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
+                )?;
+                if vd == VReg::V0 {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                // SAFETY: alignments checked above; vd != v0 checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_sub::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Vreg(vs1.bits()),
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VsbcVxm { vd, vs2, rs1: _ } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                if vd == VReg::V0 {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = rs1_value.as_u64();
+                // SAFETY: alignments checked above; vd != v0 checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_sub::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            // vmsbc: subtract and write borrow-out mask
+            Self::VmsbcVvm { vd, vs2, vs1 } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_sub_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Vreg(vs1.bits()),
+                        true,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VmsbcVxm { vd, vs2, rs1: _ } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = rs1_value.as_u64();
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_sub_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        true,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VmsbcVv { vd, vs2, vs1 } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs1,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_sub_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Vreg(vs1.bits()),
+                        false,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+
+            Self::VmsbcVx { vd, vs2, rs1: _ } => {
+                if !ext_state.vector_instructions_allowed() {
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                let vtype = ext_state
+                    .vtype()
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
+                    })?;
+                let group_regs = vtype.vlmul().register_count();
+                zve64x_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    program_counter,
+                    vs2,
+                    group_regs,
+                )?;
+                zve64x_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs2,
+                    group_regs,
+                )?;
+                let sew = vtype.vsew();
+                let vl = ext_state.vl();
+                let vstart = u32::from(ext_state.vstart());
+                let scalar = rs1_value.as_u64();
+                // SAFETY: alignments and overlap checked above
+                unsafe {
+                    zve64x_carry_helpers::execute_carry_sub_mask::<Reg, _, _>(
+                        ext_state,
+                        vd,
+                        vs2,
+                        zve64x_carry_helpers::OpSrc::Scalar(scalar),
+                        false,
+                        vl,
+                        vstart,
+                        sew,
+                    );
+                }
+            }
+        }
+
+        Ok(ControlFlow::Continue(Default::default()))
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/tests.rs
@@ -1,0 +1,767 @@
+use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
+use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
+use crate::{
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands,
+};
+use ab_riscv_primitives::prelude::*;
+
+fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
+}
+
+fn setup(
+    vl: u32,
+    vsew: Vsew,
+    vlmul: Vlmul,
+) -> TestInterpreterState<Zve64xCarryInstruction<Reg<u64>>> {
+    let mut state = initialize_state([]);
+    state.ext_state.init_vector_csrs();
+    let vtype = Vtype::from_raw::<Reg<u64>>(encode_vtype(vsew, vlmul)).unwrap();
+    state.ext_state.set_vtype(Some(vtype));
+    state.ext_state.set_vl(vl);
+    state.ext_state.set_vstart(0);
+    state
+}
+
+fn exec(
+    state: &mut TestInterpreterState<Zve64xCarryInstruction<Reg<u64>>>,
+    instr: Zve64xCarryInstruction<Reg<u64>>,
+) -> Result<(), ExecutionError<u64>> {
+    let Rs1Rs2Operands { rs1, rs2 } = instr.get_rs1_rs2_operands();
+    let rs1rs2_values = Rs1Rs2OperandValues {
+        rs1_value: state.regs.read(rs1),
+        rs2_value: state.regs.read(rs2),
+    };
+    instr
+        .execute(
+            rs1rs2_values,
+            &mut state.regs,
+            &mut state.ext_state,
+            &mut state.memory,
+            &mut state.instruction_fetcher,
+            &mut state.system_instruction_handler,
+        )
+        .map(|_| ())
+}
+
+fn write_elem(
+    state: &mut TestInterpreterState<Zve64xCarryInstruction<Reg<u64>>>,
+    base_reg: VReg,
+    elem_i: usize,
+    sew: Vsew,
+    value: u64,
+) {
+    let sew_bytes = usize::from(sew.bytes());
+    let elems_per_reg = 32 / sew_bytes;
+    let reg_off = elem_i / elems_per_reg;
+    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let buf = value.to_le_bytes();
+    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+}
+
+fn read_elem(
+    state: &TestInterpreterState<Zve64xCarryInstruction<Reg<u64>>>,
+    base_reg: VReg,
+    elem_i: usize,
+    sew: Vsew,
+) -> u64 {
+    let sew_bytes = usize::from(sew.bytes());
+    let elems_per_reg = 32 / sew_bytes;
+    let reg_off = elem_i / elems_per_reg;
+    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let mut buf = [0u8; 8];
+    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
+    u64::from_le_bytes(buf)
+}
+
+/// Set mask bit `i` in register `reg`
+fn set_mask_bit(
+    state: &mut TestInterpreterState<Zve64xCarryInstruction<Reg<u64>>>,
+    reg: VReg,
+    i: u32,
+    value: bool,
+) {
+    let byte = &mut state.ext_state.write_vreg()[usize::from(reg.bits())][(i / u8::BITS) as usize];
+    if value {
+        *byte |= 1 << (i % u8::BITS);
+    } else {
+        *byte &= !(1 << (i % u8::BITS));
+    }
+}
+
+fn read_mask_bit(
+    state: &TestInterpreterState<Zve64xCarryInstruction<Reg<u64>>>,
+    reg: VReg,
+    i: u32,
+) -> bool {
+    let byte = state.ext_state.read_vreg()[usize::from(reg.bits())][(i / u8::BITS) as usize];
+    (byte >> (i % u8::BITS)) & 1 != 0
+}
+
+// vadc.vvm
+
+#[test]
+fn vadc_vvm_no_carry() {
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    // v0 = all zeros (no carry-in)
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E32, 10);
+        write_elem(&mut state, VReg::V1, i, Vsew::E32, 5);
+    }
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    for i in 0..4usize {
+        assert_eq!(read_elem(&state, VReg::V4, i, Vsew::E32), 15, "elem {i}");
+    }
+    assert_eq!(state.ext_state.vs_dirty_count(), 1);
+    assert_eq!(state.ext_state.vstart(), 0);
+}
+
+#[test]
+fn vadc_vvm_with_carry_propagates() {
+    // For each element: vs2=0xFF, vs1=0x00, carry-in=1 → result=0x100 → wraps to 0x00
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E8, 0xFF);
+        write_elem(&mut state, VReg::V1, i, Vsew::E8, 0x00);
+        // Set carry-in bit i in v0
+        set_mask_bit(&mut state, VReg::V0, i as u32, true);
+    }
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    for i in 0..4usize {
+        // 0xFF + 0x00 + 1 = 0x100 → truncated to E8 = 0x00
+        assert_eq!(read_elem(&state, VReg::V4, i, Vsew::E8), 0x00, "elem {i}");
+    }
+}
+
+#[test]
+fn vadc_vvm_mixed_carry_bits() {
+    // Alternating carry: elements 0,2 have carry=1; elements 1,3 have carry=0
+    let mut state = setup(4, Vsew::E16, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E16, 100);
+        write_elem(&mut state, VReg::V1, i, Vsew::E16, 1);
+    }
+    set_mask_bit(&mut state, VReg::V0, 0, true);
+    set_mask_bit(&mut state, VReg::V0, 1, false);
+    set_mask_bit(&mut state, VReg::V0, 2, true);
+    set_mask_bit(&mut state, VReg::V0, 3, false);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // carry=1: 100+1+1=102; carry=0: 100+1+0=101
+    assert_eq!(read_elem(&state, VReg::V4, 0, Vsew::E16), 102);
+    assert_eq!(read_elem(&state, VReg::V4, 1, Vsew::E16), 101);
+    assert_eq!(read_elem(&state, VReg::V4, 2, Vsew::E16), 102);
+    assert_eq!(read_elem(&state, VReg::V4, 3, Vsew::E16), 101);
+}
+
+#[test]
+fn vadc_vxm_with_scalar_and_carry() {
+    let mut state = setup(2, Vsew::E64, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E64, u64::MAX);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E64, 5);
+    state.regs.write(Reg::A0, 0u64);
+    set_mask_bit(&mut state, VReg::V0, 0, true);
+    set_mask_bit(&mut state, VReg::V0, 1, false);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVxm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // u64::MAX + 0 + 1 = wraps to 0
+    assert_eq!(read_elem(&state, VReg::V4, 0, Vsew::E64), 0);
+    // 5 + 0 + 0 = 5
+    assert_eq!(read_elem(&state, VReg::V4, 1, Vsew::E64), 5);
+}
+
+#[test]
+fn vadc_vim_sign_extended_imm() {
+    let mut state = setup(2, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E16, 0x0001);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E16, 0x0001);
+    // imm = -1 (sign-extended): 0xFFFF + 0x0001 + carry
+    set_mask_bit(&mut state, VReg::V0, 0, false);
+    set_mask_bit(&mut state, VReg::V0, 1, true);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVim {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            imm: -1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // 0x0001 + 0xFFFF + 0 = 0x10000 → truncated to E16 = 0x0000
+    assert_eq!(read_elem(&state, VReg::V4, 0, Vsew::E16), 0x0000);
+    // 0x0001 + 0xFFFF + 1 = 0x10001 → truncated to E16 = 0x0001
+    assert_eq!(read_elem(&state, VReg::V4, 1, Vsew::E16), 0x0001);
+}
+
+// vmadc: carry-out mask
+
+#[test]
+fn vmadc_vvm_carry_out_when_overflow() {
+    // Element 0: 0xFF + 0x01 + carry=0 → 0x100, carry-out=1
+    // Element 1: 0x01 + 0x01 + carry=0 → 0x02, carry-out=0
+    // Element 2: 0xFE + 0x01 + carry=1 → 0x100, carry-out=1
+    // Element 3: 0x01 + 0x00 + carry=1 → 0x02, carry-out=0
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0xFF);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E8, 0x01);
+    write_elem(&mut state, VReg::V2, 2, Vsew::E8, 0xFE);
+    write_elem(&mut state, VReg::V2, 3, Vsew::E8, 0x01);
+    write_elem(&mut state, VReg::V1, 0, Vsew::E8, 0x01);
+    write_elem(&mut state, VReg::V1, 1, Vsew::E8, 0x01);
+    write_elem(&mut state, VReg::V1, 2, Vsew::E8, 0x01);
+    write_elem(&mut state, VReg::V1, 3, Vsew::E8, 0x00);
+    set_mask_bit(&mut state, VReg::V0, 0, false);
+    set_mask_bit(&mut state, VReg::V0, 1, false);
+    set_mask_bit(&mut state, VReg::V0, 2, true);
+    set_mask_bit(&mut state, VReg::V0, 3, true);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+    assert!(!read_mask_bit(&state, VReg::V4, 1));
+    assert!(read_mask_bit(&state, VReg::V4, 2));
+    assert!(!read_mask_bit(&state, VReg::V4, 3));
+    assert_eq!(state.ext_state.vs_dirty_count(), 1);
+    assert_eq!(state.ext_state.vstart(), 0);
+}
+
+#[test]
+fn vmadc_vv_no_carry_in_overflow_check() {
+    // Without carry-in: 0xFF + 0x01 = 0x100 → carry-out=1
+    let mut state = setup(2, Vsew::E8, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0xFF);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E8, 0x10);
+    write_elem(&mut state, VReg::V1, 0, Vsew::E8, 0x01);
+    write_elem(&mut state, VReg::V1, 1, Vsew::E8, 0x10);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmadcVv {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // 0xFF + 0x01 = overflow → carry-out=1
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+    // 0x10 + 0x10 = 0x20 → no overflow
+    assert!(!read_mask_bit(&state, VReg::V4, 1));
+}
+
+#[test]
+fn vmadc_vv_e64_carry_out() {
+    let mut state = setup(1, Vsew::E64, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E64, u64::MAX);
+    write_elem(&mut state, VReg::V1, 0, Vsew::E64, 1);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmadcVv {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+}
+
+#[test]
+fn vmadc_vx_no_carry_scalar() {
+    let mut state = setup(3, Vsew::E32, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E32, 0xFFFF_FFFF);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E32, 0x7FFF_FFFF);
+    write_elem(&mut state, VReg::V2, 2, Vsew::E32, 0);
+    state.regs.write(Reg::A0, 1u64);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmadcVx {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+    assert!(!read_mask_bit(&state, VReg::V4, 1));
+    assert!(!read_mask_bit(&state, VReg::V4, 2));
+}
+
+#[test]
+fn vmadc_vi_no_carry_imm() {
+    let mut state = setup(2, Vsew::E8, Vlmul::M1);
+    // imm=1: 0xFF+1=overflow, 0x00+1=no overflow
+    write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0xFF);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E8, 0x00);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmadcVi {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            imm: 1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+    assert!(!read_mask_bit(&state, VReg::V4, 1));
+}
+
+// vsbc
+
+#[test]
+fn vsbc_vvm_no_borrow() {
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E32, 100);
+        write_elem(&mut state, VReg::V1, i, Vsew::E32, 10);
+    }
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VsbcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    for i in 0..4usize {
+        assert_eq!(read_elem(&state, VReg::V4, i, Vsew::E32), 90, "elem {i}");
+    }
+    assert_eq!(state.ext_state.vs_dirty_count(), 1);
+    assert_eq!(state.ext_state.vstart(), 0);
+}
+
+#[test]
+fn vsbc_vvm_with_borrow_propagates() {
+    // vs2=0, vs1=0, borrow-in=1 → 0 - 0 - 1 = -1 = 0xFFFFFFFF (E32)
+    let mut state = setup(2, Vsew::E32, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E32, 0);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E32, 10);
+    write_elem(&mut state, VReg::V1, 0, Vsew::E32, 0);
+    write_elem(&mut state, VReg::V1, 1, Vsew::E32, 3);
+    set_mask_bit(&mut state, VReg::V0, 0, true);
+    set_mask_bit(&mut state, VReg::V0, 1, false);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VsbcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V4, 0, Vsew::E32), 0xFFFF_FFFF);
+    assert_eq!(read_elem(&state, VReg::V4, 1, Vsew::E32), 7);
+}
+
+#[test]
+fn vsbc_vxm_basic() {
+    let mut state = setup(3, Vsew::E16, Vlmul::M1);
+    for i in 0..3usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E16, 50);
+    }
+    state.regs.write(Reg::A0, 20u64);
+    set_mask_bit(&mut state, VReg::V0, 0, false);
+    set_mask_bit(&mut state, VReg::V0, 1, true);
+    set_mask_bit(&mut state, VReg::V0, 2, false);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VsbcVxm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V4, 0, Vsew::E16), 30);
+    assert_eq!(read_elem(&state, VReg::V4, 1, Vsew::E16), 29);
+    assert_eq!(read_elem(&state, VReg::V4, 2, Vsew::E16), 30);
+}
+
+// vmsbc
+
+#[test]
+fn vmsbc_vvm_borrow_out() {
+    // vs2=5, vs1=10, borrow-in=0 → underflow → borrow-out=1
+    // vs2=10, vs1=5, borrow-in=0 → no underflow → borrow-out=0
+    // vs2=5, vs1=4, borrow-in=1 → 5 - 4 - 1 = 0 → no underflow → borrow-out=0
+    // vs2=5, vs1=5, borrow-in=1 → 5 - 5 - 1 = -1 → underflow → borrow-out=1
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E32, 5);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E32, 10);
+    write_elem(&mut state, VReg::V2, 2, Vsew::E32, 5);
+    write_elem(&mut state, VReg::V2, 3, Vsew::E32, 5);
+    write_elem(&mut state, VReg::V1, 0, Vsew::E32, 10);
+    write_elem(&mut state, VReg::V1, 1, Vsew::E32, 5);
+    write_elem(&mut state, VReg::V1, 2, Vsew::E32, 4);
+    write_elem(&mut state, VReg::V1, 3, Vsew::E32, 5);
+    set_mask_bit(&mut state, VReg::V0, 0, false);
+    set_mask_bit(&mut state, VReg::V0, 1, false);
+    set_mask_bit(&mut state, VReg::V0, 2, true);
+    set_mask_bit(&mut state, VReg::V0, 3, true);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmsbcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+    assert!(!read_mask_bit(&state, VReg::V4, 1));
+    assert!(!read_mask_bit(&state, VReg::V4, 2));
+    assert!(read_mask_bit(&state, VReg::V4, 3));
+    assert_eq!(state.ext_state.vs_dirty_count(), 1);
+    assert_eq!(state.ext_state.vstart(), 0);
+}
+
+#[test]
+fn vmsbc_vv_no_borrow_in() {
+    // No borrow-in: just check unsigned underflow
+    let mut state = setup(2, Vsew::E8, Vlmul::M1);
+    // 3 - 5: underflow
+    write_elem(&mut state, VReg::V2, 0, Vsew::E8, 3);
+    // 5 - 3: no underflow
+    write_elem(&mut state, VReg::V2, 1, Vsew::E8, 5);
+    write_elem(&mut state, VReg::V1, 0, Vsew::E8, 5);
+    write_elem(&mut state, VReg::V1, 1, Vsew::E8, 3);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmsbcVv {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+    assert!(!read_mask_bit(&state, VReg::V4, 1));
+}
+
+#[test]
+fn vmsbc_vxm_e64_exact_boundary() {
+    // 0 - 1 - borrow_in=0: underflow, borrow-out=1
+    // MAX - MAX - borrow_in=0: no underflow, borrow-out=0
+    let mut state = setup(2, Vsew::E64, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E64, 0);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E64, u64::MAX);
+    state.regs.write(Reg::A0, u64::MAX);
+    set_mask_bit(&mut state, VReg::V0, 0, false);
+    set_mask_bit(&mut state, VReg::V0, 1, false);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmsbcVxm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // 0 < u64::MAX → underflow
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+    // u64::MAX == u64::MAX → no underflow
+    assert!(!read_mask_bit(&state, VReg::V4, 1));
+}
+
+#[test]
+fn vmsbc_vx_no_borrow() {
+    let mut state = setup(3, Vsew::E32, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E32, 0);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E32, 10);
+    write_elem(&mut state, VReg::V2, 2, Vsew::E32, 0xFFFF_FFFF);
+    state.regs.write(Reg::A0, 1u64);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VmsbcVx {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // 0 < 1 → underflow
+    assert!(read_mask_bit(&state, VReg::V4, 0));
+    // 10 >= 1 → no underflow
+    assert!(!read_mask_bit(&state, VReg::V4, 1));
+    // 0xFFFF_FFFF >= 1 → no underflow
+    assert!(!read_mask_bit(&state, VReg::V4, 2));
+}
+
+// Error paths
+
+#[test]
+fn error_vadc_vd_is_v0() {
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vs1: VReg::V4,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+#[test]
+fn error_vsbc_vd_is_v0() {
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        Zve64xCarryInstruction::VsbcVvm {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vs1: VReg::V4,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+#[test]
+fn error_vector_not_allowed() {
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    state.ext_state.set_vector_allowed(false);
+    let result = exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+#[test]
+fn error_vill_vtype() {
+    let mut state = initialize_state([]);
+    state.ext_state.init_vector_csrs();
+    state.ext_state.set_vtype(None);
+    state.ext_state.set_vl(0);
+    let result = exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+#[test]
+fn error_vmadc_vd_overlaps_vs2_lmul_gt_1() {
+    let mut state = setup(8, Vsew::E32, Vlmul::M2);
+    let result = exec(
+        &mut state,
+        Zve64xCarryInstruction::VmadcVvm {
+            vd: VReg::V3,
+            vs2: VReg::V2,
+            vs1: VReg::V6,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+#[test]
+fn error_vadc_vs2_misaligned_m2() {
+    let mut state = setup(4, Vsew::E32, Vlmul::M2);
+    let result = exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V3,
+            vs1: VReg::V6,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+// vstart partial execution
+
+#[test]
+fn vadc_vstart_skips_elements() {
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E32, 10);
+        write_elem(&mut state, VReg::V1, i, Vsew::E32, 1);
+        write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xDEAD);
+    }
+    state.ext_state.set_vstart(2);
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V4, 0, Vsew::E32), 0xDEAD);
+    assert_eq!(read_elem(&state, VReg::V4, 1, Vsew::E32), 0xDEAD);
+    assert_eq!(read_elem(&state, VReg::V4, 2, Vsew::E32), 11);
+    assert_eq!(read_elem(&state, VReg::V4, 3, Vsew::E32), 11);
+    assert_eq!(state.ext_state.vstart(), 0);
+}
+
+// vl=0
+
+#[test]
+fn vadc_vl_zero_no_writes() {
+    let mut state = setup(0, Vsew::E32, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xBEEF);
+    }
+    exec(
+        &mut state,
+        Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    for i in 0..4usize {
+        assert_eq!(
+            read_elem(&state, VReg::V4, i, Vsew::E32),
+            0xBEEF,
+            "elem {i}"
+        );
+    }
+    assert_eq!(state.ext_state.vs_dirty_count(), 1);
+}
+
+// Cross-SEW correctness
+
+#[test]
+fn vadc_wraps_at_sew_boundary() {
+    for (vsew, max) in [
+        (Vsew::E8, 0xFFu64),
+        (Vsew::E16, 0xFFFF),
+        (Vsew::E32, 0xFFFF_FFFF),
+        (Vsew::E64, u64::MAX),
+    ] {
+        let mut state = setup(1, vsew, Vlmul::M1);
+        write_elem(&mut state, VReg::V2, 0, vsew, max);
+        write_elem(&mut state, VReg::V1, 0, vsew, 0);
+        set_mask_bit(&mut state, VReg::V0, 0, true);
+        exec(
+            &mut state,
+            Zve64xCarryInstruction::VadcVvm {
+                vd: VReg::V4,
+                vs2: VReg::V2,
+                vs1: VReg::V1,
+                rs1: Reg::Zero,
+                rs2: Reg::Zero,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            read_elem(&state, VReg::V4, 0, vsew),
+            0,
+            "SEW={vsew:?}: MAX+carry should wrap to 0"
+        );
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/zve64x_carry_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/zve64x_carry_helpers.rs
@@ -1,0 +1,299 @@
+//! Opaque helpers for Zve64x extension
+
+use crate::v::vector_registers::VectorRegistersExt;
+pub use crate::v::zve64x::arith::zve64x_arith_helpers::{
+    OpSrc, check_mask_dest_no_overlap, check_vreg_group_alignment,
+};
+use crate::v::zve64x::arith::zve64x_arith_helpers::{
+    read_element_u64, sew_mask, write_element_u64, write_mask_bit,
+};
+use crate::v::zve64x::load::zve64x_load_helpers::mask_bit;
+use ab_riscv_primitives::prelude::*;
+use core::fmt;
+
+/// Read a single mask bit from vector register `v0` at element index `i`.
+///
+/// Used to retrieve the per-element carry-in or borrow-in for vadc/vsbc.
+///
+/// # Safety
+/// `i / 8 < VLENB` must hold, guaranteed when `i < vl <= VLEN`.
+#[inline(always)]
+pub(in super::super) unsafe fn carry_bit<const VLENB: usize>(
+    vreg: &[[u8; VLENB]; 32],
+    i: u32,
+) -> u64 {
+    // SAFETY: `vreg[0]` is always valid; v0 is register index 0
+    let v0 = unsafe { vreg.get_unchecked(0) };
+    u64::from(mask_bit(v0, i))
+}
+
+/// Execute an element-wise add-with-carry over `vstart..vl`, writing SEW-wide data results into
+/// `vd`.
+///
+/// Carry-in for each element is read from `v0[i]` when `with_carry` is true. All elements in
+/// `vstart..vl` are processed unconditionally (no execution mask).
+///
+/// # Safety
+/// - `vd.bits() % group_regs == 0` and `vd.bits() + group_regs <= 32`
+/// - `vs2.bits() % group_regs == 0` and `vs2.bits() + group_regs <= 32`
+/// - `src` register satisfies the same alignment (verified by caller)
+/// - `vd.bits() != 0` (vd must not overlap v0, which holds the carry-in)
+/// - `vl <= group_regs * VLENB / sew_bytes`
+#[inline(always)]
+#[expect(clippy::too_many_arguments, reason = "Internal API")]
+#[doc(hidden)]
+pub unsafe fn execute_carry_add<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
+    vd: VReg,
+    vs2: VReg,
+    src: OpSrc,
+    with_carry: bool,
+    vl: u32,
+    vstart: u32,
+    sew: Vsew,
+) where
+    Reg: Register,
+    ExtState: VectorRegistersExt<Reg, CustomError>,
+    [(); ExtState::ELEN as usize]:,
+    [(); ExtState::VLEN as usize]:,
+    [(); ExtState::VLENB as usize]:,
+    CustomError: fmt::Debug,
+{
+    let vd_base = vd.bits();
+    let vs2_base = vs2.bits();
+
+    for i in vstart..vl {
+        // SAFETY: `vs2_base % group_regs == 0` and `vs2_base + group_regs <= 32` (caller
+        // precondition); `i < vl <= group_regs * elems_per_reg`, so
+        // `vs2_base + i / elems_per_reg < vs2_base + group_regs <= 32`
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let b = match src {
+            OpSrc::Vreg(vs1_base) => {
+                // SAFETY: caller verified that the vs1 register group satisfies the same alignment
+                // constraint as vs2; the index argument is identical, so the same bound holds:
+                // `vs1_base + i / elems_per_reg < 32`
+                unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs1_base), i, sew) }
+            }
+            OpSrc::Scalar(val) => val,
+        };
+        let c = if with_carry {
+            // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
+            unsafe { carry_bit(ext_state.read_vreg(), i) }
+        } else {
+            0
+        };
+
+        // Wrap naturally: write_element_u64 writes only the low sew_bytes
+        let result = a.wrapping_add(b).wrapping_add(c);
+        // SAFETY: `vd_base % group_regs == 0` and `vd_base + group_regs <= 32` (caller
+        // precondition); `i < vl <= group_regs * elems_per_reg`, so
+        // `vd_base + i / elems_per_reg < vd_base + group_regs <= 32`
+        unsafe {
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
+        }
+    }
+
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
+}
+
+/// Execute an element-wise subtract-with-borrow over `vstart..vl`, writing SEW-wide data results
+/// into `vd`.
+///
+/// Borrow-in for each element is read from `v0[i]` (always true for vsbc). All elements in
+/// `vstart..vl` are processed unconditionally.
+///
+/// # Safety
+/// Same as [`execute_carry_add()`].
+#[inline(always)]
+#[doc(hidden)]
+pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
+    vd: VReg,
+    vs2: VReg,
+    src: OpSrc,
+    vl: u32,
+    vstart: u32,
+    sew: Vsew,
+) where
+    Reg: Register,
+    ExtState: VectorRegistersExt<Reg, CustomError>,
+    [(); ExtState::ELEN as usize]:,
+    [(); ExtState::VLEN as usize]:,
+    [(); ExtState::VLENB as usize]:,
+    CustomError: fmt::Debug,
+{
+    let vd_base = vd.bits();
+    let vs2_base = vs2.bits();
+
+    for i in vstart..vl {
+        // SAFETY: `vs2_base % group_regs == 0` and `vs2_base + group_regs <= 32` (caller
+        // precondition); `i < vl <= group_regs * elems_per_reg`, so
+        // `vs2_base + i / elems_per_reg < vs2_base + group_regs <= 32`
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let b = match &src {
+            OpSrc::Vreg(vs1_base) => {
+                // SAFETY: caller verified that the vs1 register group satisfies the same alignment
+                // constraint as vs2; the index argument is identical, so the same bound holds:
+                // `vs1_base + i / elems_per_reg < 32`
+                unsafe { read_element_u64(ext_state.read_vreg(), usize::from(*vs1_base), i, sew) }
+            }
+            OpSrc::Scalar(val) => *val,
+        };
+        // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
+        let borrow = unsafe { carry_bit(ext_state.read_vreg(), i) };
+
+        let result = a.wrapping_sub(b).wrapping_sub(borrow);
+        // SAFETY: `vd_base % group_regs == 0` and `vd_base + group_regs <= 32` (caller
+        // precondition); `i < vl <= group_regs * elems_per_reg`, so
+        // `vd_base + i / elems_per_reg < vd_base + group_regs <= 32`
+        unsafe {
+            write_element_u64(ext_state.write_vreg(), vd_base, i, sew, result);
+        }
+    }
+
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
+}
+
+/// Execute an element-wise add-with-carry over `vstart..vl`, writing the carry-out as a single mask
+/// bit per element into `vd`.
+///
+/// When `with_carry` is true, carry-in for element `i` is read from `v0[i]`. When false, carry-in
+/// is treated as zero.
+///
+/// All elements are processed unconditionally (no execution mask).
+///
+/// Tail mask bits (indices `>= vl`) are left undisturbed per spec §5.3.
+///
+/// # Safety
+/// - `vs2.bits() % group_regs == 0` and `vs2.bits() + group_regs <= 32`
+/// - `src` register satisfies the same alignment
+/// - `vl <= group_regs * VLENB / sew_bytes` and `vl <= VLEN`
+/// - vd overlap constraints checked by caller
+#[inline(always)]
+#[expect(clippy::too_many_arguments, reason = "Internal API")]
+#[doc(hidden)]
+pub unsafe fn execute_carry_add_mask<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
+    vd: VReg,
+    vs2: VReg,
+    src: OpSrc,
+    with_carry: bool,
+    vl: u32,
+    vstart: u32,
+    sew: Vsew,
+) where
+    Reg: Register,
+    ExtState: VectorRegistersExt<Reg, CustomError>,
+    [(); ExtState::ELEN as usize]:,
+    [(); ExtState::VLEN as usize]:,
+    [(); ExtState::VLENB as usize]:,
+    CustomError: fmt::Debug,
+{
+    let vs2_base = vs2.bits();
+    let mask = sew_mask(sew);
+
+    for i in vstart..vl {
+        // SAFETY: `vs2_base % group_regs == 0` and `vs2_base + group_regs <= 32` (caller
+        // precondition); `i < vl <= group_regs * elems_per_reg`, so
+        // `vs2_base + i / elems_per_reg < vs2_base + group_regs <= 32`
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let b = match src {
+            OpSrc::Vreg(vs1_base) => {
+                // SAFETY: caller verified that the vs1 register group satisfies the same alignment
+                // constraint as vs2; the index argument is identical, so the same bound holds:
+                // `vs1_base + i / elems_per_reg < 32`
+                unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs1_base), i, sew) }
+            }
+            OpSrc::Scalar(val) => val,
+        };
+        let c = if with_carry {
+            // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
+            unsafe { carry_bit(ext_state.read_vreg(), i) }
+        } else {
+            0
+        };
+
+        // Use u128 to capture the carry-out bit beyond SEW
+        let sum = u128::from(a & mask) + u128::from(b & mask) + u128::from(c);
+        let carry_out = (sum >> sew.bits()) & 1 != 0;
+
+        // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
+        unsafe {
+            write_mask_bit(ext_state.write_vreg(), vd, i, carry_out);
+        }
+    }
+
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
+}
+
+/// Execute an element-wise subtract-with-borrow over `vstart..vl`, writing the borrow-out as a
+/// single mask bit per element into `vd`.
+///
+/// When `with_borrow` is true, borrow-in for element `i` is read from `v0[i]`. When false,
+/// borrow-in is treated as zero.
+///
+/// Borrow-out is 1 when the subtraction underflows unsigned:
+/// `borrow_out = (b + borrow_in) > a` (compared as SEW-wide unsigned values).
+///
+/// # Safety
+/// Same as [`execute_carry_add_mask()`].
+#[inline(always)]
+#[expect(clippy::too_many_arguments, reason = "Internal API")]
+#[doc(hidden)]
+pub unsafe fn execute_carry_sub_mask<Reg, ExtState, CustomError>(
+    ext_state: &mut ExtState,
+    vd: VReg,
+    vs2: VReg,
+    src: OpSrc,
+    with_borrow: bool,
+    vl: u32,
+    vstart: u32,
+    sew: Vsew,
+) where
+    Reg: Register,
+    ExtState: VectorRegistersExt<Reg, CustomError>,
+    [(); ExtState::ELEN as usize]:,
+    [(); ExtState::VLEN as usize]:,
+    [(); ExtState::VLENB as usize]:,
+    CustomError: fmt::Debug,
+{
+    let vs2_base = vs2.bits();
+    let mask = sew_mask(sew);
+
+    for i in vstart..vl {
+        // SAFETY: `vs2_base % group_regs == 0` and `vs2_base + group_regs <= 32` (caller
+        // precondition); `i < vl <= group_regs * elems_per_reg`, so
+        // `vs2_base + i / elems_per_reg < vs2_base + group_regs <= 32`
+        let a = unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs2_base), i, sew) };
+        let b = match src {
+            OpSrc::Vreg(vs1_base) => {
+                // SAFETY: caller verified that the vs1 register group satisfies the same alignment
+                // constraint as vs2; the index argument is identical, so the same bound holds:
+                // `vs1_base + i / elems_per_reg < 32`
+                unsafe { read_element_u64(ext_state.read_vreg(), usize::from(vs1_base), i, sew) }
+            }
+            OpSrc::Scalar(val) => val,
+        };
+        let borrow_in = if with_borrow {
+            // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
+            unsafe { carry_bit(ext_state.read_vreg(), i) }
+        } else {
+            0
+        };
+
+        let a_m = u128::from(a & mask);
+        let rhs = u128::from(b & mask) + u128::from(borrow_in);
+        let borrow_out = a_m < rhs;
+
+        // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
+        unsafe {
+            write_mask_bit(ext_state.write_vreg(), vd, i, borrow_out);
+        }
+    }
+
+    ext_state.mark_vs_dirty();
+    ext_state.reset_vstart();
+}

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/tests.rs
@@ -16,14 +16,14 @@ fn encode_vtype(vsew: Vsew, vlmul: Vlmul, vta: bool, vma: bool) -> u16 {
     val
 }
 
-// VLMAX for TEST_VLEN=128:
-//   e8,m1  -> 128/8   = 16
-//   e16,m1 -> 128/16  = 8
-//   e32,m1 -> 128/32  = 4
-//   e64,m1 -> 128/64  = 2
-//   e8,m2  -> 256/8   = 32
-//   e8,m8  -> 1024/8  = 128
-//   e32,mf2-> 64/32   = 2
+// VLMAX for TEST_VLEN=256:
+//   e8,m1  -> 256/8    = 32
+//   e16,m1 -> 256/16   = 16
+//   e32,m1 -> 256/32   = 8
+//   e64,m1 -> 256/64   = 4
+//   e8,m2  -> 512/8    = 64
+//   e8,m8  -> 2048/8   = 256
+//   e32,mf2-> 128/32   = 4
 //   e8,mf8 -> 16/8    = 2
 
 // vsetvli basic tests
@@ -31,7 +31,7 @@ fn encode_vtype(vsew: Vsew, vlmul: Vlmul, vta: bool, vma: bool) -> u16 {
 #[test]
 fn vsetvli_sets_vl_and_rd_from_avl() {
     let vtypei = encode_vtype(Vsew::E32, Vlmul::M1, false, false);
-    // VLMAX = 128/32 = 4, AVL = 3 < VLMAX -> vl = 3
+    // VLMAX = 256/32 = 8, AVL = 3 < VLMAX -> vl = 3
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -54,7 +54,7 @@ fn vsetvli_sets_vl_and_rd_from_avl() {
 #[test]
 fn vsetvli_avl_exceeds_vlmax_caps_to_vlmax() {
     let vtypei = encode_vtype(Vsew::E32, Vlmul::M1, false, false);
-    // VLMAX = 4, AVL = 100 -> vl = 4
+    // VLMAX = 8, AVL = 100 -> vl = 8
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -66,8 +66,8 @@ fn vsetvli_avl_exceeds_vlmax_caps_to_vlmax() {
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.regs.read(Reg::A0), 4);
-    assert_eq!(state.ext_state.vl(), 4);
+    assert_eq!(state.regs.read(Reg::A0), 8);
+    assert_eq!(state.ext_state.vl(), 8);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn vsetvli_avl_zero_gives_vl_zero() {
 #[test]
 fn vsetvli_avl_equals_vlmax() {
     let vtypei = encode_vtype(Vsew::E8, Vlmul::M1, false, false);
-    // VLMAX = 128/8 = 16
+    // VLMAX = 256/8 = 32
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -100,12 +100,12 @@ fn vsetvli_avl_equals_vlmax() {
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_vector_csrs();
-    state.regs.write(Reg::A1, 16);
+    state.regs.write(Reg::A1, 32);
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.regs.read(Reg::A0), 16);
-    assert_eq!(state.ext_state.vl(), 16);
+    assert_eq!(state.regs.read(Reg::A0), 32);
+    assert_eq!(state.ext_state.vl(), 32);
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn vsetvli_rd_x0_discards_result() {
 #[test]
 fn vsetvli_e8_m8_gives_max_vlmax() {
     let vtypei = encode_vtype(Vsew::E8, Vlmul::M8, false, false);
-    // VLMAX = (128*8)/8 = 128
+    // VLMAX = (256*8)/8 = 256
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -141,18 +141,18 @@ fn vsetvli_e8_m8_gives_max_vlmax() {
         rs2: Reg::Zero,
     }]);
     state.ext_state.init_vector_csrs();
-    state.regs.write(Reg::A1, 200);
+    state.regs.write(Reg::A1, 300);
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.regs.read(Reg::A0), 128);
-    assert_eq!(state.ext_state.vl(), 128);
+    assert_eq!(state.regs.read(Reg::A0), 256);
+    assert_eq!(state.ext_state.vl(), 256);
 }
 
 #[test]
 fn vsetvli_e64_m1() {
     let vtypei = encode_vtype(Vsew::E64, Vlmul::M1, false, false);
-    // VLMAX = 128/64 = 2
+    // VLMAX = 256/64 = 4
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -173,7 +173,7 @@ fn vsetvli_e64_m1() {
 #[test]
 fn vsetvli_e32_mf2() {
     let vtypei = encode_vtype(Vsew::E32, Vlmul::Mf2, false, false);
-    // VLMAX = 128 / (32*2) = 2
+    // VLMAX = 256 / (32*2) = 4
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -185,14 +185,14 @@ fn vsetvli_e32_mf2() {
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.regs.read(Reg::A0), 2);
-    assert_eq!(state.ext_state.vl(), 2);
+    assert_eq!(state.regs.read(Reg::A0), 4);
+    assert_eq!(state.ext_state.vl(), 4);
 }
 
 #[test]
 fn vsetvli_e8_mf8() {
     let vtypei = encode_vtype(Vsew::E8, Vlmul::Mf8, false, false);
-    // VLMAX = 128 / (8*8) = 2
+    // VLMAX = 256 / (8*8) = 4
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -294,7 +294,7 @@ fn vsetvli_reserved_vlmul_sets_vill() {
 
 #[test]
 fn vsetvli_vlmax_zero_sets_vill() {
-    // e64 with mf8: VLMAX = 128/(64*8) = 0 -> unsupported
+    // e64 with mf8: VLMAX = 256/(64*8) = 0 -> unsupported
     let vtypei = encode_vtype(Vsew::E64, Vlmul::Mf8, false, false);
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
@@ -336,7 +336,7 @@ fn vsetvli_reserved_upper_bits_set_vill() {
 #[test]
 fn vsetvli_rs1_x0_rd_nonzero_sets_vlmax() {
     let vtypei = encode_vtype(Vsew::E32, Vlmul::M1, false, false);
-    // VLMAX = 128/32 = 4
+    // VLMAX = 256/32 = 8
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::Zero,
@@ -347,14 +347,14 @@ fn vsetvli_rs1_x0_rd_nonzero_sets_vlmax() {
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.regs.read(Reg::A0), 4);
-    assert_eq!(state.ext_state.vl(), 4);
+    assert_eq!(state.regs.read(Reg::A0), 8);
+    assert_eq!(state.ext_state.vl(), 8);
 }
 
 #[test]
 fn vsetvli_rs1_x0_rd_nonzero_e8_m8_gives_full_vlmax() {
     let vtypei = encode_vtype(Vsew::E8, Vlmul::M8, false, false);
-    // VLMAX = (128*8)/8 = 128
+    // VLMAX = (256*8)/8 = 256
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::Zero,
@@ -365,8 +365,8 @@ fn vsetvli_rs1_x0_rd_nonzero_e8_m8_gives_full_vlmax() {
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.regs.read(Reg::A0), 128);
-    assert_eq!(state.ext_state.vl(), 128);
+    assert_eq!(state.regs.read(Reg::A0), 256);
+    assert_eq!(state.ext_state.vl(), 256);
 }
 
 #[test]
@@ -472,7 +472,7 @@ fn vsetivli_avl_zero() {
 #[test]
 fn vsetivli_max_immediate() {
     let vtypei = encode_vtype(Vsew::E32, Vlmul::M1, false, false);
-    // VLMAX = 4, uimm = 31 > VLMAX -> vl = 4
+    // VLMAX = 8, uimm = 31 > VLMAX -> vl = 8
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetivli {
         rd: Reg::A0,
         uimm: 31,
@@ -484,14 +484,14 @@ fn vsetivli_max_immediate() {
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.regs.read(Reg::A0), 4);
-    assert_eq!(state.ext_state.vl(), 4);
+    assert_eq!(state.regs.read(Reg::A0), 8);
+    assert_eq!(state.ext_state.vl(), 8);
 }
 
 #[test]
 fn vsetivli_avl_within_vlmax() {
     let vtypei = encode_vtype(Vsew::E8, Vlmul::M8, false, false);
-    // VLMAX = 128, uimm = 20 -> vl = 20
+    // VLMAX = 256, uimm = 20 -> vl = 20
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetivli {
         rd: Reg::A0,
         uimm: 20,
@@ -530,7 +530,7 @@ fn vsetivli_unsupported_sets_vill() {
 #[test]
 fn vsetivli_with_ta_ma() {
     let vtypei = encode_vtype(Vsew::E16, Vlmul::M4, true, true);
-    // VLMAX = (128*4)/16 = 32, uimm = 10
+    // VLMAX = (256*4)/16 = 64, uimm = 10
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetivli {
         rd: Reg::A0,
         uimm: 10,
@@ -576,7 +576,7 @@ fn vsetvl_basic() {
 #[test]
 fn vsetvl_rs1_x0_rd_nonzero() {
     let vtype_raw = u64::from(encode_vtype(Vsew::E64, Vlmul::M1, false, false));
-    // VLMAX = 128/64 = 2
+    // VLMAX = 256/64 = 4
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvl {
         rd: Reg::A0,
         rs1: Reg::Zero,
@@ -587,8 +587,8 @@ fn vsetvl_rs1_x0_rd_nonzero() {
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.regs.read(Reg::A0), 2);
-    assert_eq!(state.ext_state.vl(), 2);
+    assert_eq!(state.regs.read(Reg::A0), 4);
+    assert_eq!(state.ext_state.vl(), 4);
 }
 
 #[test]
@@ -634,7 +634,7 @@ fn vsetvl_high_bits_in_rs2_sets_vill() {
 fn vsetvl_context_restore_preserves_vtype() {
     // vsetvl is used for context restore; ensure the full round-trip works
     let vtype_raw = u64::from(encode_vtype(Vsew::E16, Vlmul::M4, true, false));
-    // VLMAX = (128*4)/16 = 32
+    // VLMAX = (256*4)/16 = 64
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvl {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -1017,7 +1017,7 @@ fn sequential_vsetvli_overrides_previous() {
     execute(&mut state).unwrap();
 
     // Second instruction should have taken effect
-    // VLMAX = (128*2)/8 = 32, AVL = 10 -> vl = 10
+    // VLMAX = (256*2)/8 = 64, AVL = 10 -> vl = 10
     assert_eq!(state.ext_state.vl(), 10);
     assert_eq!(state.regs.read(Reg::A2), 10);
     let vtype = state.ext_state.vtype().unwrap();
@@ -1061,7 +1061,7 @@ fn vsetvli_after_vill_recovers() {
 #[test]
 fn vsetivli_followed_by_vsetvl_x0_x0() {
     let mut state = initialize_state([
-        // Set e16,m1 with AVL=5 -> vl=5, VLMAX=8
+        // Set e16,m1 with AVL=5 -> vl=5, VLMAX=16
         Zve64xConfigInstruction::Vsetivli {
             rd: Reg::A0,
             uimm: 5,
@@ -1069,7 +1069,7 @@ fn vsetivli_followed_by_vsetvl_x0_x0() {
             rs1: Reg::Zero,
             rs2: Reg::Zero,
         },
-        // Change to ta,ma but keep same SEW/LMUL (same VLMAX=8)
+        // Change to ta,ma but keep same SEW/LMUL (same VLMAX=16)
         Zve64xConfigInstruction::Vsetvli {
             rd: Reg::Zero,
             rs1: Reg::Zero,
@@ -1094,7 +1094,7 @@ fn vsetivli_followed_by_vsetvl_x0_x0() {
 #[test]
 fn vsetvli_large_avl_in_register() {
     let vtypei = encode_vtype(Vsew::E32, Vlmul::M1, false, false);
-    // VLMAX = 4, AVL = u64::MAX -> vl = 4
+    // VLMAX = 8, AVL = u64::MAX -> vl = 8
     let mut state = initialize_state([Zve64xConfigInstruction::Vsetvli {
         rd: Reg::A0,
         rs1: Reg::A1,
@@ -1106,8 +1106,8 @@ fn vsetvli_large_avl_in_register() {
 
     execute(&mut state).unwrap();
 
-    assert_eq!(state.ext_state.vl(), 4);
-    assert_eq!(state.regs.read(Reg::A0), 4);
+    assert_eq!(state.ext_state.vl(), 8);
+    assert_eq!(state.regs.read(Reg::A0), 8);
 }
 
 #[test]

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
@@ -1464,7 +1464,8 @@ where
                 zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
-                    group_regs,
+                    vtype.vlmul(),
+                    sew,
                 )?;
                 // vs1 is a normal SEW-wide source for the shift amount
                 zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
@@ -1526,7 +1527,8 @@ where
                 zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
-                    group_regs,
+                    vtype.vlmul(),
+                    sew,
                 )?;
                 if !vm && vd.bits() == 0 {
                     return Err(ExecutionError::IllegalInstruction {
@@ -1578,7 +1580,8 @@ where
                 zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
-                    group_regs,
+                    vtype.vlmul(),
+                    sew,
                 )?;
                 if !vm && vd.bits() == 0 {
                     return Err(ExecutionError::IllegalInstruction {
@@ -1631,7 +1634,8 @@ where
                 zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
-                    group_regs,
+                    vtype.vlmul(),
+                    sew,
                 )?;
                 zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
                     program_counter,
@@ -1692,7 +1696,8 @@ where
                 zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
-                    group_regs,
+                    vtype.vlmul(),
+                    sew,
                 )?;
                 if !vm && vd.bits() == 0 {
                     return Err(ExecutionError::IllegalInstruction {
@@ -1744,7 +1749,8 @@ where
                 zve64x_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
-                    group_regs,
+                    vtype.vlmul(),
+                    sew,
                 )?;
                 if !vm && vd.bits() == 0 {
                     return Err(ExecutionError::IllegalInstruction {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
@@ -71,22 +71,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -128,17 +128,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -176,17 +176,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -227,22 +227,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -284,17 +284,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -332,17 +332,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -382,22 +382,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -439,17 +439,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -488,22 +488,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -545,17 +545,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -594,22 +594,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -651,17 +651,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -700,22 +700,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -757,17 +757,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -806,22 +806,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -863,17 +863,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -912,22 +912,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -969,17 +969,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1018,22 +1018,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1075,17 +1075,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1124,22 +1124,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1185,17 +1185,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1236,17 +1236,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1289,22 +1289,22 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1348,17 +1348,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1398,17 +1398,17 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1455,7 +1455,7 @@ where
                     sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -1468,12 +1468,12 @@ where
                     sew,
                 )?;
                 // vs1 is a normal SEW-wide source for the shift amount
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1519,7 +1519,7 @@ where
                     sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -1530,7 +1530,7 @@ where
                     vtype.vlmul(),
                     sew,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1572,7 +1572,7 @@ where
                     sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -1583,7 +1583,7 @@ where
                     vtype.vlmul(),
                     sew,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1626,7 +1626,7 @@ where
                     sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -1637,12 +1637,12 @@ where
                     vtype.vlmul(),
                     sew,
                 )?;
-                zve64x_fixed_point_helpers::check_vs::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1688,7 +1688,7 @@ where
                     sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -1699,7 +1699,7 @@ where
                     vtype.vlmul(),
                     sew,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1741,7 +1741,7 @@ where
                     sew,
                 )?;
                 let group_regs = vtype.vlmul().register_count();
-                zve64x_fixed_point_helpers::check_vd::<Reg, _, _, _>(
+                zve64x_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -1752,7 +1752,7 @@ where
                     vtype.vlmul(),
                     sew,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
@@ -2084,6 +2084,78 @@ fn vnclipu_vs2_misaligned_m1_faults() {
 }
 
 #[test]
+fn vnclip_wi_mf2_odd_vs2_ok() {
+    // Regression: `vnclip.wi v15, v13, 4`.
+    // With fractional LMUL the source EMUL = 2*LMUL <= 1, so vs2 occupies a single register with no
+    // alignment constraint; an odd-numbered vs2 (V13) must be accepted. The previous check used
+    // 2*register_count() = 2 and wrongly rejected it.
+    let mut state = setup(1, Vsew::E8, Vlmul::Mf2);
+    // 256 (as i16) >> 4 = 16, fits in i8, no rounding/saturation
+    write_wide_elem(&mut state, VReg::V13, 0, Vsew::E8, 0x0100);
+    exec(
+        &mut state,
+        Zve64xFixedPointInstruction::VnclipWi {
+            vd: VReg::V15,
+            vs2: VReg::V13,
+            imm: 4,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        sign_extend(read_elem(&state, VReg::V15, 0, Vsew::E8), Vsew::E8),
+        16
+    );
+    assert!(!vxsat(&state));
+}
+
+#[test]
+fn vnclipu_wi_mf4_odd_vs2_ok() {
+    // Same fractional-LMUL alignment relaxation for the unsigned variant: Mf4 -> source EMUL = 1/2,
+    // so a single, arbitrarily-aligned source register is legal.
+    let mut state = setup(1, Vsew::E8, Vlmul::Mf4);
+    write_wide_elem(&mut state, VReg::V7, 0, Vsew::E8, 0x00F0);
+    exec(
+        &mut state,
+        Zve64xFixedPointInstruction::VnclipuWi {
+            vd: VReg::V9,
+            vs2: VReg::V7,
+            imm: 4,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // 0xF0 >> 4 = 0x0F
+    assert_eq!(read_elem(&state, VReg::V9, 0, Vsew::E8), 0x0F);
+    assert!(!vxsat(&state));
+}
+
+#[test]
+fn vnclip_vs2_misaligned_m2_faults() {
+    // M2: source EMUL = 4, so vs2 must be aligned to 4; V2 is not.
+    let mut state = setup(1, Vsew::E8, Vlmul::M2);
+    let result = exec(
+        &mut state,
+        Zve64xFixedPointInstruction::VnclipWi {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            imm: 0,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+#[test]
 fn vsaddu_aligned_m4_ok() {
     // M4: group_regs=4; vd=V4 (divisible by 4), vs2=V8, vs1=V12 -> all valid
     let mut state = setup(1, Vsew::E8, Vlmul::M4);

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
@@ -66,7 +66,7 @@ fn write_elem(
     value: u64,
 ) {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -81,7 +81,7 @@ fn read_elem(
     sew: Vsew,
 ) -> u64 {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -99,7 +99,7 @@ fn write_wide_elem(
     value: u64,
 ) {
     let wide_bytes = usize::from(sew.bytes()) * 2;
-    let elems_per_reg = 16 / wide_bytes;
+    let elems_per_reg = 32 / wide_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * wide_bytes;
     let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::v::vector_registers::VectorRegistersExt;
 pub use crate::v::zve64x::arith::zve64x_arith_helpers::{
-    OpSrc, check_vreg_group_alignment as check_vd, check_vreg_group_alignment as check_vs, sew_mask,
+    OpSrc, check_vreg_group_alignment, sew_mask,
 };
 use crate::v::zve64x::arith::zve64x_arith_helpers::{
     read_element_u64, sign_extend, write_element_u64,

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
@@ -563,28 +563,48 @@ where
     Ok(())
 }
 
-/// Check that `vs2` for a narrowing instruction is aligned to `2 * group_regs` and fits in [0,32).
+/// Check that the double-width source `vs2` of a narrowing instruction is aligned to its register
+/// group and fits in `[0, 32)`.
+///
+/// The source operand has `EEW = 2*SEW`, so its `EMUL = 2*LMUL`. Per v-spec §5.2 the group must be
+/// aligned to `EMUL` registers, and `EMUL` outside the legal range `[1/8, 8]` (e.g. `LMUL=8`, which
+/// would need `EMUL=16`) is reserved. Unlike `2 * register_count()`, this correctly yields a single
+/// register with no alignment constraint for fractional `LMUL` (where `2*LMUL <= 1`).
+///
+/// `sew` is the destination (narrow) SEW; it must be at most 32 (see [`check_narrowing_sew()`]).
 #[inline(always)]
 #[doc(hidden)]
 pub fn check_vs2_narrowing_alignment<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vs2: VReg,
-    group_regs: u8,
+    vlmul: Vlmul,
+    sew: Vsew,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    // Per v-spec §5.2: narrowing requires EMUL_src = 2*LMUL <= 8.
-    // LMUL=8 with a narrowing instruction is reserved.
-    if group_regs > 4 {
-        return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
-        });
-    }
-    let double_group = group_regs * 2;
+    // Source EEW is double the destination SEW. SEW=64 is rejected earlier by
+    // `check_narrowing_sew`.
+    let wide_eew = match sew {
+        Vsew::E8 => Eew::E16,
+        Vsew::E16 => Eew::E32,
+        Vsew::E32 => Eew::E64,
+        Vsew::E64 => {
+            return Err(ExecutionError::IllegalInstruction {
+                address: program_counter.old_pc(INSTRUCTION_SIZE),
+            });
+        }
+    };
+    // `EMUL = 2*LMUL`; `None` when reserved (e.g. LMUL=8 -> EMUL=16).
+    let wide_group =
+        vlmul
+            .data_register_count(wide_eew, sew)
+            .ok_or(ExecutionError::IllegalInstruction {
+                address: program_counter.old_pc(INSTRUCTION_SIZE),
+            })?;
     let vs2_idx = vs2.bits();
-    if !vs2_idx.is_multiple_of(double_group) || vs2_idx + double_group > 32 {
+    if !vs2_idx.is_multiple_of(wide_group) || vs2_idx + wide_group > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -337,7 +337,18 @@ where
                     vs2,
                     index_group_regs,
                 )?;
-                if zve64x_load_helpers::groups_overlap(vd, data_group_regs, vs2, index_group_regs) {
+                // Non-segment indexed loads permit `vd`/`vs2` overlap under the general
+                // EEW-relative overlap rule (e.g. when the data and index EEW match); only
+                // disallowed overlaps are reserved.
+                if !zve64x_load_helpers::indexed_load_overlap_allowed(
+                    vd,
+                    data_group_regs,
+                    vs2,
+                    index_group_regs,
+                    index_eew,
+                    vtype.vsew(),
+                    vtype.vlmul(),
+                ) {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -354,7 +365,10 @@ where
                 //   `data_group_regs = LMUL`, so VLMAX = LMUL * VLEN / SEW, which bounds `vl`
                 // - `vl <= index_group_regs * VLENB / index_eew.bytes()`: `index_group_regs` is
                 //   EMUL_index defined so this VLMAX_index equals the architectural VLMAX
-                // - no overlap between data and index groups: checked above
+                // - `vd`/`vs2` overlap (if any) satisfies the general EEW overlap rule, checked
+                //   above; the in-order element loop reads index element `i` before writing data
+                //   element `i`, and that rule guarantees a data write never clobbers an index
+                //   element that has not yet been consumed
                 // - mask overlap: checked above via `groups_overlap`
                 unsafe {
                     zve64x_load_helpers::execute_indexed_load(
@@ -410,7 +424,17 @@ where
                     vs2,
                     index_group_regs,
                 )?;
-                if zve64x_load_helpers::groups_overlap(vd, data_group_regs, vs2, index_group_regs) {
+                // Non-segment indexed loads permit `vd`/`vs2` overlap under the general
+                // EEW-relative overlap rule; see the `Vluxei` arm for details.
+                if !zve64x_load_helpers::indexed_load_overlap_allowed(
+                    vd,
+                    data_group_regs,
+                    vs2,
+                    index_group_regs,
+                    index_eew,
+                    vtype.vsew(),
+                    vtype.vlmul(),
+                ) {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
@@ -7,11 +7,11 @@ use crate::{
 use ab_riscv_primitives::prelude::*;
 use core::array;
 
-// With TEST_VLEN=128 and TEST_VLENB=16, the VLMAX values are:
-//   E8/M1=16, E16/M1=8, E32/M1=4, E64/M1=2
-//   E8/M2=32, E16/M2=16, E32/M2=8, E64/M2=4
-//   E8/M4=64, E32/M4=16
-//   E8/Mf2=8, E16/Mf2=4
+// With TEST_VLEN=256 and TEST_VLENB=32, the VLMAX values are:
+//   E8/M1=32, E16/M1=16, E32/M1=8, E64/M1=4
+//   E8/M2=64, E16/M2=32, E32/M2=16, E64/M2=8
+//   E8/M4=128, E32/M4=32
+//   E8/Mf2=16, E16/Mf2=8
 
 /// Initialize the state with vector CSRs and a given vtype configuration
 fn setup(
@@ -57,7 +57,7 @@ fn vreg_byte(
 fn vreg_bytes(
     state: &TestInterpreterState<Zve64xLoadInstruction<Reg<u64>>>,
     reg: VReg,
-) -> [u8; 16] {
+) -> [u8; 32] {
     state.ext_state.read_vreg()[usize::from(reg.bits())]
 }
 
@@ -100,7 +100,7 @@ fn exec_one(
 fn vlr_single_register_loads_vlenb_bytes() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
-    let data = array::from_fn::<_, 16, _>(|i| i as u8);
+    let data = array::from_fn::<_, 32, _>(|i| i as u8);
     write_mem(&mut state, TEST_BASE_ADDR, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -124,7 +124,7 @@ fn vlr_single_register_loads_vlenb_bytes() {
 fn vlr_two_registers_loads_two_vlenb_blocks() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
-    let data = array::from_fn::<_, 32, _>(|i| i as u8);
+    let data = array::from_fn::<_, 64, _>(|i| i as u8);
     write_mem(&mut state, TEST_BASE_ADDR, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -140,15 +140,15 @@ fn vlr_two_registers_loads_two_vlenb_blocks() {
     )
     .unwrap();
 
-    assert_eq!(&vreg_bytes(&state, VReg::V2), &data[..16]);
-    assert_eq!(&vreg_bytes(&state, VReg::V3), &data[16..]);
+    assert_eq!(&vreg_bytes(&state, VReg::V2), &data[..32]);
+    assert_eq!(&vreg_bytes(&state, VReg::V3), &data[32..]);
 }
 
 #[test]
 fn vlr_four_registers() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
-    let data = array::from_fn::<_, 64, _>(|i| i as u8);
+    let data = array::from_fn::<_, 128, _>(|i| i as u8);
     write_mem(&mut state, TEST_BASE_ADDR, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -165,7 +165,7 @@ fn vlr_four_registers() {
     .unwrap();
 
     for i in 0u8..4 {
-        let expected: [u8; 16] = data[i as usize * 16..(i as usize + 1) * 16]
+        let expected: [u8; 32] = data[i as usize * 32..(i as usize + 1) * 32]
             .try_into()
             .unwrap();
         let reg = VReg::from_bits(4 + i).unwrap();
@@ -179,7 +179,7 @@ fn vlr_ignores_vtype_and_vl() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
     // vtype remains vill (default after init_vector_csrs)
-    let data = [0xABu8; 16];
+    let data = [0xABu8; 32];
     write_mem(&mut state, TEST_BASE_ADDR, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -203,7 +203,7 @@ fn vlr_resets_vstart_on_success() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
     state.ext_state.set_vstart(7);
-    let data = [0u8; 16];
+    let data = [0u8; 32];
     write_mem(&mut state, TEST_BASE_ADDR, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -314,7 +314,7 @@ fn vlm_vl_8_loads_exactly_1_byte() {
 #[test]
 fn vlm_vl_0_loads_no_bytes_and_leaves_dst_unchanged() {
     let mut state = setup(0, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V5, &[0xABu8; 16]);
+    set_vreg(&mut state, VReg::V5, &[0xABu8; 32]);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
     exec_one(
@@ -328,7 +328,7 @@ fn vlm_vl_0_loads_no_bytes_and_leaves_dst_unchanged() {
     .unwrap();
 
     // Nothing written; destination unchanged
-    assert_eq!(vreg_bytes(&state, VReg::V5), [0xABu8; 16]);
+    assert_eq!(vreg_bytes(&state, VReg::V5), [0xABu8; 32]);
 }
 
 #[test]
@@ -375,7 +375,7 @@ fn vlm_vector_not_allowed_is_illegal() {
 
 #[test]
 fn vle_e8_loads_vl_bytes_sequentially() {
-    // E8/M1: VLMAX=16, vl=4
+    // E8/M1: VLMAX=32, vl=4
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     let data = [10u8, 20, 30, 40];
     write_mem(&mut state, TEST_BASE_ADDR, &data);
@@ -403,7 +403,7 @@ fn vle_e8_loads_vl_bytes_sequentially() {
 
 #[test]
 fn vle_e32_loads_vl_words_sequentially() {
-    // E32/M1: VLMAX=4, vl=3
+    // E32/M1: VLMAX=8, vl=3
     let mut state = setup(3, Vsew::E32, Vlmul::M1);
     let data = array::from_fn::<_, 12, _>(|i| i as u8);
     write_mem(&mut state, TEST_BASE_ADDR, &data);
@@ -431,7 +431,7 @@ fn vle_e32_loads_vl_words_sequentially() {
 
 #[test]
 fn vle_e64_loads_vl_doublewords() {
-    // E64/M1: VLMAX=2, vl=2
+    // E64/M1: VLMAX=4, vl=2
     let mut state = setup(2, Vsew::E64, Vlmul::M1);
     let val0 = 0x0102_0304_0506_0708_u64;
     let val1 = 0xDEAD_BEEF_CAFE_BABE_u64;
@@ -458,7 +458,7 @@ fn vle_e64_loads_vl_doublewords() {
 #[test]
 fn vle_vl_0_does_not_write_any_elements() {
     let mut state = setup(0, Vsew::E32, Vlmul::M1);
-    set_vreg(&mut state, VReg::V7, &[0xFFu8; 16]);
+    set_vreg(&mut state, VReg::V7, &[0xFFu8; 32]);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
     exec_one(
@@ -474,7 +474,7 @@ fn vle_vl_0_does_not_write_any_elements() {
     .unwrap();
 
     // Tail is undisturbed when vl=0
-    assert_eq!(vreg_bytes(&state, VReg::V7), [0xFFu8; 16]);
+    assert_eq!(vreg_bytes(&state, VReg::V7), [0xFFu8; 32]);
     assert_eq!(state.ext_state.vs_dirty_count(), 1);
 }
 
@@ -1917,9 +1917,9 @@ fn mark_vs_dirty_not_called_on_illegal_instruction_error() {
 
 #[test]
 fn vle_e8_all_elements_across_register_boundary_m2() {
-    // E8/M2: VLMAX=32, vl=20, group spans V2 and V3
-    let mut state = setup(20, Vsew::E8, Vlmul::M2);
-    let data = array::from_fn::<_, 20, _>(|i| i as u8 + 1);
+    // E8/M2: VLMAX=64, vl=40, group spans V2 and V3 (32 E8 elems per VLENB=32 register)
+    let mut state = setup(40, Vsew::E8, Vlmul::M2);
+    let data = array::from_fn::<_, 40, _>(|i| i as u8 + 1);
     write_mem(&mut state, TEST_BASE_ADDR, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -1935,18 +1935,18 @@ fn vle_e8_all_elements_across_register_boundary_m2() {
     )
     .unwrap();
 
-    // Elements 0-15 in V2, elements 16-19 in V3
-    for i in 0..16usize {
+    // Elements 0-31 in V2, elements 32-39 in V3
+    for i in 0..32usize {
         assert_eq!(vreg_byte(&state, VReg::V2, i), (i + 1) as u8, "V2[{i}]");
     }
-    for i in 0..4usize {
-        assert_eq!(vreg_byte(&state, VReg::V3, i), (17 + i) as u8, "V3[{i}]");
+    for i in 0..8usize {
+        assert_eq!(vreg_byte(&state, VReg::V3, i), (33 + i) as u8, "V3[{i}]");
     }
 }
 
 #[test]
 fn vle_e16_loads_half_words() {
-    // E16/M1: VLMAX=8, vl=3
+    // E16/M1: VLMAX=16, vl=3
     let mut state = setup(3, Vsew::E16, Vlmul::M1);
     let vals = [0x0102_u16, 0x0304, 0x0506];
     let data = vals.map(u16::to_le_bytes);
@@ -1975,9 +1975,9 @@ fn vle_e16_loads_half_words() {
 
 #[test]
 fn vle_vl_equals_vlmax_loads_all_elements() {
-    // E8/M1: VLMAX=16, vl=16 (maximum)
-    let mut state = setup(16, Vsew::E8, Vlmul::M1);
-    let data = array::from_fn::<_, 16, _>(|i| i as u8);
+    // E8/M1: VLMAX=32, vl=32 (maximum)
+    let mut state = setup(32, Vsew::E8, Vlmul::M1);
+    let data = array::from_fn::<_, 32, _>(|i| i as u8);
     write_mem(&mut state, TEST_BASE_ADDR, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -2000,7 +2000,7 @@ fn vle_vl_equals_vlmax_loads_all_elements() {
 
 #[test]
 fn vle_fractional_lmul_mf2_e8() {
-    // E8/Mf2: VLMAX = VLEN/(SEW*2) = 128/(8*2) = 8; group_regs=1
+    // E8/Mf2: VLMAX = VLEN/(SEW*2) = 256/(8*2) = 16; group_regs=1
     let mut state = setup(4, Vsew::E8, Vlmul::Mf2);
     write_mem(&mut state, TEST_BASE_ADDR, &[5u8, 6, 7, 8]);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
@@ -2169,7 +2169,7 @@ fn vle_fault_at_first_element_does_not_mark_vs_dirty() {
 fn vlr_eight_registers() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
-    let data = array::from_fn::<_, 128, _>(|i| i as u8);
+    let data = array::from_fn::<_, 256, _>(|i| i as u8);
     write_mem(&mut state, TEST_BASE_ADDR, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -2187,7 +2187,7 @@ fn vlr_eight_registers() {
 
     for r in 0u8..8 {
         let reg = VReg::from_bits(r).unwrap();
-        let expected: [u8; 16] = data[r as usize * 16..(r as usize + 1) * 16]
+        let expected: [u8; 32] = data[r as usize * 32..(r as usize + 1) * 32]
             .try_into()
             .unwrap();
         assert_eq!(vreg_bytes(&state, reg), expected, "register v{r}");

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
@@ -1050,11 +1050,29 @@ fn vluxei_index_eew_smaller_than_data_eew() {
 }
 
 #[test]
-fn vluxei_vd_vs2_overlap_is_illegal() {
-    // data_group_regs=1 (LMUL=M1), index_group_regs=1 (EMUL_index=1 for E32/E32/M1)
+fn vluxei_vd_vs2_overlap_equal_eew_is_legal() {
+    // Non-segment indexed loads permit vd/vs2 overlap when the data EEW equals the index EEW.
+    // This is the `vluxei32.v v16, (s2), v16` shape that the certification suite exercises.
+    // SEW=E32/M1: data EEW=E32 (1 reg), index EEW=E32 (EMUL=1, 1 reg); vd == vs2 == V3.
     let mut state = setup(2, Vsew::E32, Vlmul::M1);
 
-    let err = exec_one(
+    let data_base = TEST_BASE_ADDR;
+    state.memory.write::<u32>(data_base, 0x1111_1111).unwrap();
+    state
+        .memory
+        .write::<u32>(data_base + 4, 0x2222_2222)
+        .unwrap();
+
+    // V3 holds the indices [4, 0] as u32 LE; the load overwrites V3 with the gathered data.
+    // Element i's index is consumed before element i's data is written, so the in-place overlap
+    // is well-defined.
+    let mut idx = [0u8; 16];
+    idx[0..4].copy_from_slice(&4u32.to_le_bytes());
+    idx[4..8].copy_from_slice(&0u32.to_le_bytes());
+    set_vreg(&mut state, VReg::V3, &idx);
+    state.regs.write(Reg::A0, data_base);
+
+    exec_one(
         &mut state,
         Zve64xLoadInstruction::Vluxei {
             vd: VReg::V3,
@@ -1065,8 +1083,191 @@ fn vluxei_vd_vs2_overlap_is_illegal() {
             rs2: Reg::Zero,
         },
     )
+    .unwrap();
+
+    let reg = vreg_bytes(&state, VReg::V3);
+    assert_eq!(
+        u32::from_le_bytes(reg[0..4].try_into().unwrap()),
+        0x2222_2222,
+        "elem0 at offset 4"
+    );
+    assert_eq!(
+        u32::from_le_bytes(reg[4..8].try_into().unwrap()),
+        0x1111_1111,
+        "elem1 at offset 0"
+    );
+}
+
+#[test]
+fn vluxei_vd_vs2_overlap_smaller_data_eew_is_legal() {
+    // Data EEW smaller than index EEW: overlap is legal when the data group starts at the index
+    // base register (lowest-numbered part of the source group).
+    // SEW=E16/M1: data EEW=E16 (1 reg). Index EEW=E32: EMUL=(32/16)*1=2 -> 2 regs (V4,V5).
+    // vd == vs2 == V4, so the data group is the lowest register of the index group.
+    let mut state = setup(2, Vsew::E16, Vlmul::M1);
+
+    let data_base = TEST_BASE_ADDR;
+    state.memory.write::<u16>(data_base, 0x1111).unwrap();
+    state.memory.write::<u16>(data_base + 2, 0x2222).unwrap();
+
+    // Two u32 indices [2, 0] occupying V4 bytes [0..8].
+    let mut idx = [0u8; 16];
+    idx[0..4].copy_from_slice(&2u32.to_le_bytes());
+    idx[4..8].copy_from_slice(&0u32.to_le_bytes());
+    set_vreg(&mut state, VReg::V4, &idx);
+    state.regs.write(Reg::A0, data_base);
+
+    exec_one(
+        &mut state,
+        Zve64xLoadInstruction::Vluxei {
+            vd: VReg::V4,
+            rs1: Reg::A0,
+            vs2: VReg::V4,
+            vm: true,
+            eew: Eew::E32,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+
+    let reg = vreg_bytes(&state, VReg::V4);
+    assert_eq!(
+        u16::from_le_bytes(reg[0..2].try_into().unwrap()),
+        0x2222,
+        "elem0 at offset 2"
+    );
+    assert_eq!(
+        u16::from_le_bytes(reg[2..4].try_into().unwrap()),
+        0x1111,
+        "elem1 at offset 0"
+    );
+}
+
+#[test]
+fn vluxei_vd_vs2_overlap_larger_data_eew_top_aligned_is_legal() {
+    // Data EEW larger than index EEW: overlap is legal when the index group occupies the
+    // highest-numbered part of the data group and the index EMUL is at least one register.
+    // SEW=E32/M2: data EEW=E32 (2 regs, V4..V5). Index EEW=E16: EMUL=(16/32)*2=1 -> 1 reg.
+    // vs2 == V5 sits at the top of the data group [V4, V6).
+    let mut state = setup(2, Vsew::E32, Vlmul::M2);
+
+    let data_base = TEST_BASE_ADDR;
+    state.memory.write::<u32>(data_base, 0xAAAA_AAAA).unwrap();
+    state
+        .memory
+        .write::<u32>(data_base + 4, 0xBBBB_BBBB)
+        .unwrap();
+
+    // Two u16 indices [4, 0] in V5 bytes [0..4].
+    let mut idx = [0u8; 16];
+    idx[0..2].copy_from_slice(&4u16.to_le_bytes());
+    idx[2..4].copy_from_slice(&0u16.to_le_bytes());
+    set_vreg(&mut state, VReg::V5, &idx);
+    state.regs.write(Reg::A0, data_base);
+
+    exec_one(
+        &mut state,
+        Zve64xLoadInstruction::Vluxei {
+            vd: VReg::V4,
+            rs1: Reg::A0,
+            vs2: VReg::V5,
+            vm: true,
+            eew: Eew::E16,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+
+    let reg = vreg_bytes(&state, VReg::V4);
+    assert_eq!(
+        u32::from_le_bytes(reg[0..4].try_into().unwrap()),
+        0xBBBB_BBBB,
+        "elem0 at offset 4"
+    );
+    assert_eq!(
+        u32::from_le_bytes(reg[4..8].try_into().unwrap()),
+        0xAAAA_AAAA,
+        "elem1 at offset 0"
+    );
+}
+
+#[test]
+fn vluxei_vd_vs2_overlap_larger_data_eew_not_top_is_illegal() {
+    // Data EEW larger than index EEW but the overlap is NOT in the highest-numbered part of the
+    // data group: reserved encoding.
+    // SEW=E32/M2: data EEW=E32 (2 regs, V4..V5). Index EEW=E16: EMUL=1 -> 1 reg.
+    // vd == vs2 == V4, so the index group overlaps the *lowest* register of the data group.
+    let mut state = setup(2, Vsew::E32, Vlmul::M2);
+
+    let err = exec_one(
+        &mut state,
+        Zve64xLoadInstruction::Vluxei {
+            vd: VReg::V4,
+            rs1: Reg::A0,
+            vs2: VReg::V4,
+            vm: true,
+            eew: Eew::E16,
+            rs2: Reg::Zero,
+        },
+    )
     .unwrap_err();
     assert!(matches!(err, ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn vluxei_vd_vs2_overlap_larger_data_eew_fractional_index_is_illegal() {
+    // Data EEW larger than index EEW with a fractional index EMUL (< 1 register): reserved, even
+    // though both groups are clamped to a single register and appear to "end" together.
+    // SEW=E64/M1: data EEW=E64 (1 reg). Index EEW=E32: EMUL=(32/64)*1=1/2 -> clamped to 1 reg.
+    // vd == vs2 == V2.
+    let mut state = setup(2, Vsew::E64, Vlmul::M1);
+
+    let err = exec_one(
+        &mut state,
+        Zve64xLoadInstruction::Vluxei {
+            vd: VReg::V2,
+            rs1: Reg::A0,
+            vs2: VReg::V2,
+            vm: true,
+            eew: Eew::E32,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn vluxei_vd_vs2_no_overlap_is_legal() {
+    // Disjoint data and index groups are always permitted regardless of EEW.
+    // SEW=E32/M1: data EEW=E32 (1 reg), index EEW=E32 (1 reg); vd=V1, vs2=V4.
+    let mut state = setup(2, Vsew::E32, Vlmul::M1);
+
+    let data_base = TEST_BASE_ADDR;
+    state.memory.write::<u32>(data_base, 0xCAFE_BABE).unwrap();
+    let mut idx = [0u8; 16];
+    idx[0..4].copy_from_slice(&0u32.to_le_bytes());
+    idx[4..8].copy_from_slice(&0u32.to_le_bytes());
+    set_vreg(&mut state, VReg::V4, &idx);
+    state.regs.write(Reg::A0, data_base);
+
+    exec_one(
+        &mut state,
+        Zve64xLoadInstruction::Vluxei {
+            vd: VReg::V1,
+            rs1: Reg::A0,
+            vs2: VReg::V4,
+            vm: true,
+            eew: Eew::E32,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        u32::from_le_bytes(vreg_bytes(&state, VReg::V1)[0..4].try_into().unwrap()),
+        0xCAFE_BABE
+    );
 }
 
 #[test]

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
@@ -4,6 +4,7 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, ProgramCounter, VirtualMemory, VirtualMemoryError};
 use ab_riscv_primitives::prelude::*;
+use core::cmp::Ordering;
 use core::fmt;
 
 #[doc(hidden)]
@@ -60,6 +61,62 @@ pub(in super::super) unsafe fn snapshot_mask<const VLENB: usize>(
 pub fn groups_overlap(a: VReg, a_regs: u8, b: VReg, b_regs: u8) -> bool {
     let (a, b) = (a.bits(), b.bits());
     a < b + b_regs && b < a + a_regs
+}
+
+/// Return whether a *non-segment* indexed load's data destination group
+/// `[vd, vd + data_regs)` may legally overlap its index source group `[vs2, vs2 + index_regs)`.
+///
+/// The data EEW equals `sew` (indexed loads take their data width from `vtype.vsew()`) with
+/// `EMUL = LMUL`, whereas the index group has EEW `index_eew` and `EMUL = (index_eew / sew) *
+/// LMUL`. Because the two groups can have different EEW, the general vector register overlap
+/// constraint applies: a destination group may overlap a source group only when one of the
+/// following holds:
+///
+/// - the EEWs are equal (the groups coincide); or
+/// - the destination EEW is smaller and the overlap is in the lowest-numbered part of the source
+///   group, i.e. the destination starts at the source's base register (`vd == vs2`); or
+/// - the destination EEW is larger, the source EMUL is at least one register, and the overlap is in
+///   the highest-numbered part of the destination group, i.e. both groups end at the same register
+///   (`vd + data_regs == vs2 + index_regs`).
+///
+/// Groups that do not overlap at all are always permitted. Any other overlap is reserved.
+///
+/// Unlike indexed *segment* loads (which forbid any `vd`/`vs2` overlap to remain restartable),
+/// these relaxed rules are what allow encodings such as `vluxei32.v v16, (s2), v16` when the data
+/// and index EEW match.
+#[inline(always)]
+#[doc(hidden)]
+pub fn indexed_load_overlap_allowed(
+    vd: VReg,
+    data_regs: u8,
+    vs2: VReg,
+    index_regs: u8,
+    index_eew: Eew,
+    sew: Vsew,
+    vlmul: Vlmul,
+) -> bool {
+    if !groups_overlap(vd, data_regs, vs2, index_regs) {
+        return true;
+    }
+
+    match sew.bytes().cmp(&index_eew.bytes()) {
+        // Equal EEW: the two groups coincide, overlap is permitted.
+        Ordering::Equal => true,
+        // Smaller data EEW: overlap must be in the lowest-numbered part of the index group, which
+        // (given both groups are alignment-checked) means the data group starts at the index base.
+        Ordering::Less => vd == vs2,
+        // Larger data EEW: overlap must be in the highest-numbered part of the data group, and the
+        // index EMUL must be at least one full register. `index_regs` alone cannot distinguish a
+        // whole-register EMUL from a fractional one clamped to a single register, so the EMUL is
+        // recomputed here as `(index_eew / sew) * LMUL >= 1`.
+        Ordering::Greater => {
+            let (lmul_num, lmul_den) = vlmul.as_fraction();
+            let index_emul_at_least_one = u16::from(index_eew.bits()) * u16::from(lmul_num)
+                >= u16::from(sew.bits()) * u16::from(lmul_den);
+            let (vd, vs2) = (vd.bits(), vs2.bits());
+            index_emul_at_least_one && vd + data_regs == vs2 + index_regs
+        }
+    }
 }
 
 /// Check that `vd` is aligned to `group_regs` and that the group fits within `[0, 32)`.

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
@@ -59,9 +59,11 @@ where
     > {
         match self {
             // Mask-register logical instructions (§16.1).
-            // These operate on the full VLENB bytes regardless of vtype/vl, but still require
-            // vtype to be valid (vill=0). Any vector instruction must be rejected when vill is
-            // set, regardless of whether it uses SEW or vl.
+            // These compute the body elements [vstart, vl); prestart bits [0, vstart) are
+            // undisturbed and the tail (past vl) is tail-agnostic (realised here as
+            // undisturbed). They still require vtype to be valid (vill=0); any vector
+            // instruction must be rejected when vill is set, regardless of whether it uses
+            // SEW or vl.
             Self::Vmandn { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
@@ -73,15 +75,20 @@ where
                     .ok_or(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
-                // SAFETY: all VReg values are valid indices < 32; snapshot-before-write
-                // inside the helper means vd may overlap vs2 or vs1 safely.
+                let vl = ext_state.vl();
+                let vstart = ext_state.vstart();
+                // SAFETY: all VReg values are valid indices < 32; `vl <= VLEN` and
+                // `vstart <= vl` are architectural invariants; snapshot-before-write inside
+                // the helper means vd may overlap vs2 or vs1 safely.
                 unsafe {
                     zve64x_mask_helpers::execute_mask_logical_op(
                         ext_state,
                         vd,
                         vs2,
                         vs1,
-                        |a, b| a & !b,
+                        vl,
+                        vstart,
+                        |a, b| a && !b,
                     );
                 }
             }
@@ -96,6 +103,8 @@ where
                     .ok_or(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
+                let vl = ext_state.vl();
+                let vstart = ext_state.vstart();
                 // SAFETY: see `Vmandn`
                 unsafe {
                     zve64x_mask_helpers::execute_mask_logical_op(
@@ -103,6 +112,8 @@ where
                         vd,
                         vs2,
                         vs1,
+                        vl,
+                        vstart,
                         |a, b| a & b,
                     );
                 }
@@ -118,6 +129,8 @@ where
                     .ok_or(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
+                let vl = ext_state.vl();
+                let vstart = ext_state.vstart();
                 // SAFETY: see `Vmandn`
                 unsafe {
                     zve64x_mask_helpers::execute_mask_logical_op(
@@ -125,6 +138,8 @@ where
                         vd,
                         vs2,
                         vs1,
+                        vl,
+                        vstart,
                         |a, b| a | b,
                     );
                 }
@@ -140,6 +155,8 @@ where
                     .ok_or(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
+                let vl = ext_state.vl();
+                let vstart = ext_state.vstart();
                 // SAFETY: see `Vmandn`
                 unsafe {
                     zve64x_mask_helpers::execute_mask_logical_op(
@@ -147,6 +164,8 @@ where
                         vd,
                         vs2,
                         vs1,
+                        vl,
+                        vstart,
                         |a, b| a ^ b,
                     );
                 }
@@ -162,6 +181,8 @@ where
                     .ok_or(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
+                let vl = ext_state.vl();
+                let vstart = ext_state.vstart();
                 // SAFETY: see `Vmandn`
                 unsafe {
                     zve64x_mask_helpers::execute_mask_logical_op(
@@ -169,7 +190,9 @@ where
                         vd,
                         vs2,
                         vs1,
-                        |a, b| a | !b,
+                        vl,
+                        vstart,
+                        |a, b| a || !b,
                     );
                 }
             }
@@ -184,6 +207,8 @@ where
                     .ok_or(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
+                let vl = ext_state.vl();
+                let vstart = ext_state.vstart();
                 // SAFETY: see `Vmandn`
                 unsafe {
                     zve64x_mask_helpers::execute_mask_logical_op(
@@ -191,6 +216,8 @@ where
                         vd,
                         vs2,
                         vs1,
+                        vl,
+                        vstart,
                         |a, b| !(a & b),
                     );
                 }
@@ -206,6 +233,8 @@ where
                     .ok_or(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
+                let vl = ext_state.vl();
+                let vstart = ext_state.vstart();
                 // SAFETY: see `Vmandn`
                 unsafe {
                     zve64x_mask_helpers::execute_mask_logical_op(
@@ -213,6 +242,8 @@ where
                         vd,
                         vs2,
                         vs1,
+                        vl,
+                        vstart,
                         |a, b| !(a | b),
                     );
                 }
@@ -228,6 +259,8 @@ where
                     .ok_or(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
+                let vl = ext_state.vl();
+                let vstart = ext_state.vstart();
                 // SAFETY: see `Vmandn`
                 unsafe {
                     zve64x_mask_helpers::execute_mask_logical_op(
@@ -235,6 +268,8 @@ where
                         vd,
                         vs2,
                         vs1,
+                        vl,
+                        vstart,
                         |a, b| !(a ^ b),
                     );
                 }
@@ -253,7 +288,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let vl = ext_state.vl();
-                let vstart = u32::from(ext_state.vstart());
+                let vstart = ext_state.vstart();
                 // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`; `vstart <= vl`
                 // by spec invariant.
                 unsafe {
@@ -273,7 +308,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let vl = ext_state.vl();
-                let vstart = u32::from(ext_state.vstart());
+                let vstart = ext_state.vstart();
                 // SAFETY: same as `Vcpop`
                 unsafe {
                     zve64x_mask_helpers::execute_vfirst(regs, ext_state, rd, vs2, vm, vl, vstart);
@@ -468,7 +503,7 @@ where
                 }
                 let sew = vtype.vsew();
                 let vl = ext_state.vl();
-                let vstart = u32::from(ext_state.vstart());
+                let vstart = ext_state.vstart();
                 // SAFETY: vd alignment checked above; `vm=false` implies `vd != v0` checked above;
                 // `vl <= VLMAX = group_regs * VLENB / sew_bytes`, all element indices valid.
                 unsafe {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
@@ -300,12 +300,12 @@ where
                     });
                 }
                 // Per spec §16.4: vd must not overlap vs2
-                if vd.bits() == vs2.bits() {
+                if vd == vs2 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -337,12 +337,12 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if vd.bits() == vs2.bits() {
+                if vd == vs2 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -373,12 +373,12 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if vd.bits() == vs2.bits() {
+                if vd == vs2 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -427,7 +427,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -461,7 +461,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
@@ -391,8 +391,10 @@ where
             }
             // viota.m (§16.8): write prefix popcount of vs2 bits as SEW-wide elements into vd.
             // Constraints: vd must not overlap vs2 or v0 (when masked); vd alignment per LMUL;
-            // vstart must be zero (mandatory trap per spec §16.8); SEW must be wide enough
-            // to represent VLMAX-1.
+            // vstart must be zero (mandatory trap per spec §16.8). There is no SEW-width
+            // constraint: if SEW is too narrow to hold the prefix count the result simply wraps
+            // (truncates to SEW), matching the spec's "integer operations wrap around on overflow"
+            // rule rather than raising an exception.
             Self::Viota { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
@@ -431,17 +433,9 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let sew_bits = u32::from(sew.bits());
-                let vlmax = vtype.vlmul().vlmax(ExtState::VLEN, sew_bits);
-                if u64::from(vlmax).unbounded_shr(sew_bits) != 0 {
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
-                    });
-                }
                 let vl = ext_state.vl();
                 // SAFETY: vd alignment checked above; vd group does not overlap vs2 checked above;
                 // `vm=false` implies `vd != v0` checked above; vstart == 0 checked above;
-                // SEW wide enough to hold VLMAX-1 checked above;
                 // `vl <= VLMAX = group_regs * VLENB / sew_bytes`, all element indices valid.
                 unsafe {
                     zve64x_mask_helpers::execute_viota(ext_state, vd, vs2, vm, vl, sew);

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
@@ -1436,8 +1436,17 @@ fn viota_misaligned_vd_illegal() {
     ));
 }
 
+/// viota.m never raises an illegal-instruction exception because of a narrow SEW. Per spec §16.8
+/// the result simply wraps (truncates to SEW) if it does not fit, matching the general "integer
+/// operations wrap around on overflow" rule. This exercises the widest element width to confirm
+/// the prefix count is written correctly and the instruction is accepted.
+///
+/// The previously-removed implementation rejected any configuration where `VLMAX >= 2^SEW`, which
+/// wrongly trapped legal instructions such as `viota.m` at `E8/M2` on `VLEN=1024` (`VLMAX=256`,
+/// whose maximum result `255` fits in 8 bits). That `VLEN=1024` boundary is covered by the ACT4
+/// differential runner; the unit harness uses `VLEN=128`, where `VLMAX` never reaches `2^SEW`.
 #[test]
-fn viota_sew64_does_not_overflow_width_check() {
+fn viota_e64_m1_no_width_trap() {
     let mut state = setup(2, Vsew::E64, Vlmul::M1);
     let mut vs2 = [0u8; 16];
     vs2[0] = 0b11;
@@ -1455,6 +1464,34 @@ fn viota_sew64_does_not_overflow_width_check() {
     .unwrap();
     assert_eq!(read_elem(&state, VReg::V4, 0, Vsew::E64), 0);
     assert_eq!(read_elem(&state, VReg::V4, 1, Vsew::E64), 1);
+}
+
+/// viota.m at the largest VLMAX the harness supports (`E8/M8` -> `VLMAX=128`, an 8-register
+/// group). All mask bits are set so the prefix count climbs to 127, exercising writes across the
+/// whole register group and confirming no width-based trap fires for an in-range count.
+#[test]
+fn viota_e8_m8_max_vlmax() {
+    let mut state = setup(128, Vsew::E8, Vlmul::M8);
+    set_vreg(&mut state, VReg::V8, [0xFF; 16]);
+    exec(
+        &mut state,
+        Zve64xMaskInstruction::Viota {
+            vd: VReg::V16,
+            vs2: VReg::V8,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // Element i counts the set bits strictly before i; with every bit set that is just i.
+    for i in 0..128usize {
+        assert_eq!(
+            read_elem(&state, VReg::V16, i, Vsew::E8),
+            i as u64,
+            "elem {i}"
+        );
+    }
 }
 
 // vid
@@ -1902,7 +1939,7 @@ fn all_instructions_mark_vs_dirty_and_reset_vstart() {
             "instruction {idx}: vstart reset"
         );
     }
-    // Instructions that trap on vstart != 0 per spec (§16.4, §16.8) — checked with vstart=0
+    // Instructions that trap on vstart != 0 per spec (§16.4, §16.8) - checked with vstart=0
     let vstart_must_be_zero: &[Zve64xMaskInstruction<Reg<u64>>] = &[
         Zve64xMaskInstruction::Vmsbf {
             vd: VReg::V4,

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
@@ -95,10 +95,11 @@ fn mask_bit(
 }
 
 // mask-logical
-
+// E8/M8 gives VLMAX=256, so the whole 32-byte mask register is body and the per-byte
+// assertions below exercise every bit of the logical operation.
 #[test]
 fn vmand_basic() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     // vs2 = 0b10101010, vs1 = 0b11001100
     set_vreg(&mut state, VReg::V2, [0xAA; 32]);
     set_vreg(&mut state, VReg::V1, [0xCC; 32]);
@@ -121,7 +122,7 @@ fn vmand_basic() {
 
 #[test]
 fn vmor_basic() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     set_vreg(&mut state, VReg::V2, [0xAA; 32]);
     set_vreg(&mut state, VReg::V1, [0x55; 32]);
     exec(
@@ -141,7 +142,7 @@ fn vmor_basic() {
 
 #[test]
 fn vmxor_basic() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     set_vreg(&mut state, VReg::V2, [0xF0; 32]);
     set_vreg(&mut state, VReg::V1, [0xFF; 32]);
     exec(
@@ -161,7 +162,7 @@ fn vmxor_basic() {
 
 #[test]
 fn vmandn_basic() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     // vmandn: vd = vs2 AND NOT vs1
     set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     set_vreg(&mut state, VReg::V1, [0x0F; 32]);
@@ -182,7 +183,7 @@ fn vmandn_basic() {
 
 #[test]
 fn vmorn_basic() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     // vmorn: vd = vs2 OR NOT vs1
     set_vreg(&mut state, VReg::V2, [0x00; 32]);
     set_vreg(&mut state, VReg::V1, [0x0F; 32]);
@@ -203,7 +204,7 @@ fn vmorn_basic() {
 
 #[test]
 fn vmnand_basic() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     // vmnand: vd = NOT(vs2 AND vs1)
     set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     set_vreg(&mut state, VReg::V1, [0xFF; 32]);
@@ -224,7 +225,7 @@ fn vmnand_basic() {
 
 #[test]
 fn vmnor_basic() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     // vmnor: vd = NOT(vs2 OR vs1)
     set_vreg(&mut state, VReg::V2, [0x00; 32]);
     set_vreg(&mut state, VReg::V1, [0x00; 32]);
@@ -245,7 +246,7 @@ fn vmnor_basic() {
 
 #[test]
 fn vmxnor_basic() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     // vmxnor: vd = NOT(vs2 XOR vs1)
     set_vreg(&mut state, VReg::V2, [0xAA; 32]);
     set_vreg(&mut state, VReg::V1, [0xAA; 32]);
@@ -264,13 +265,15 @@ fn vmxnor_basic() {
     assert_eq!(get_vreg(&state, VReg::V4), [0xFF; 32]);
 }
 
-/// Mask-logical ops operate on full VLENB bytes regardless of vl.
-/// Even with vl=0 the full register is processed.
+/// Mask-logical ops compute only the body [0, vl); bits at or past vl are tail-agnostic and
+/// left undisturbed here. This is the core property the certification suite checks.
 #[test]
-fn vmand_operates_on_full_register_regardless_of_vl() {
-    let mut state = setup(0, Vsew::E8, Vlmul::M1);
+fn vmand_respects_vl_tail_undisturbed() {
+    let mut state = setup(8, Vsew::E8, Vlmul::M1);
     set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     set_vreg(&mut state, VReg::V1, [0xAA; 32]);
+    // Pre-set vd so undisturbed tail bytes are detectable
+    set_vreg(&mut state, VReg::V4, [0x33; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmand {
@@ -282,14 +285,106 @@ fn vmand_operates_on_full_register_regardless_of_vl() {
         },
     )
     .unwrap();
-    // All VLENB (32) bytes processed: 0xFF & 0xAA = 0xAA
-    assert_eq!(get_vreg(&state, VReg::V4), [0xAA; 32]);
+    // Body is the first 8 mask bits = byte 0: 0xFF & 0xAA = 0xAA
+    assert_eq!(get_vreg(&state, VReg::V4)[0], 0xAA);
+    // Bytes 1..32 are past vl: undisturbed
+    for b in 1..32usize {
+        assert_eq!(get_vreg(&state, VReg::V4)[b], 0x33, "tail byte {b}");
+    }
+}
+
+/// Mask-logical ops honor vstart: prestart bits [0, vstart) are undisturbed.
+#[test]
+fn vmand_respects_vstart_prestart_undisturbed() {
+    let mut state = setup(8, Vsew::E8, Vlmul::M1);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V1, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V4, [0x00; 32]);
+    state.ext_state.set_vstart(4);
+    exec(
+        &mut state,
+        Zve64xMaskInstruction::Vmand {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // Bits 0..4 prestart: undisturbed (0)
+    for i in 0..4 {
+        assert!(!mask_bit(&state, VReg::V4, i), "prestart bit {i}");
+    }
+    // Bits 4..8 body: 0xFF & 0xFF = 1
+    for i in 4..8 {
+        assert!(mask_bit(&state, VReg::V4, i), "body bit {i}");
+    }
+    assert_eq!(state.ext_state.vstart(), 0);
+}
+
+/// With vl=0, mask-logical ops write nothing; vd is undisturbed but VS is still marked dirty.
+#[test]
+fn vmand_vl_zero_undisturbed() {
+    let mut state = setup(0, Vsew::E8, Vlmul::M1);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V1, [0xAA; 32]);
+    set_vreg(&mut state, VReg::V4, [0x5C; 32]);
+    exec(
+        &mut state,
+        Zve64xMaskInstruction::Vmand {
+            vd: VReg::V4,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(get_vreg(&state, VReg::V4), [0x5C; 32]);
+    assert_eq!(state.ext_state.vs_dirty_count(), 1);
+}
+
+/// Regression for the Vx16-vmand.mm certification failure. The cert uses SEW=16, LMUL=1/4,
+/// which with VLEN=256 yields VLMAX=4, so vl=4. The same effective body [0, 4) is reproduced
+/// here with E16/M1, vl=4 (no dependence on the fractional-LMUL enum). The old implementation
+/// applied the logical op across the whole physical register, corrupting the tail-agnostic
+/// bytes that the certification signature compares as undisturbed; the body bits stayed
+/// correct, so only the tail check tripped.
+#[test]
+fn vmand_cert_regression_tail_undisturbed() {
+    let mut state = setup(4, Vsew::E16, Vlmul::M1);
+    // In the cert flow vd == vs2 (v13); mirror that overlap here.
+    set_vreg(&mut state, VReg::V13, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V11, [0x0F; 32]);
+    let before = get_vreg(&state, VReg::V13);
+    exec(
+        &mut state,
+        Zve64xMaskInstruction::Vmand {
+            vd: VReg::V13,
+            vs2: VReg::V13,
+            vs1: VReg::V11,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // Body bits 0..4: 0xFF & 0x0F = 1
+    for i in 0..4u32 {
+        assert!(mask_bit(&state, VReg::V13, i), "body bit {i}");
+    }
+    let after = get_vreg(&state, VReg::V13);
+    // Every bit at or past vl=4 is undisturbed: high nibble of byte 0 plus all higher bytes.
+    assert_eq!(after[0] & 0xF0, before[0] & 0xF0, "tail of byte 0");
+    for b in 1..32usize {
+        assert_eq!(after[b], before[b], "tail byte {b}");
+    }
 }
 
 /// vd may overlap vs2 for mask-logical ops
 #[test]
 fn vmand_vd_overlaps_vs2() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     set_vreg(&mut state, VReg::V1, [0x0F; 32]);
     // vd = vs2
@@ -310,7 +405,7 @@ fn vmand_vd_overlaps_vs2() {
 /// vd may overlap vs1 for mask-logical ops
 #[test]
 fn vmand_vd_overlaps_vs1() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     set_vreg(&mut state, VReg::V1, [0x0F; 32]);
     // vd = vs1
@@ -331,7 +426,7 @@ fn vmand_vd_overlaps_vs1() {
 /// vd may be v0 for mask-logical ops (they are always unmasked)
 #[test]
 fn vmand_vd_is_v0() {
-    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
     set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     set_vreg(&mut state, VReg::V1, [0xAA; 32]);
     exec(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
@@ -6,11 +6,12 @@ use crate::{
 };
 use ab_riscv_primitives::prelude::*;
 
-// With TEST_VLEN=128, VLENB=16:
-//   E8/M1 -> VLMAX=16, 1 reg
-//   E16/M1 -> VLMAX=8, 1 reg
-//   E32/M1 -> VLMAX=4, 1 reg
-//   E64/M1 -> VLMAX=2, 1 reg
+// With TEST_VLEN=256, VLENB=32:
+//   E8/M1 -> VLMAX=32, 1 reg
+//   E16/M1 -> VLMAX=16, 1 reg
+//   E32/M1 -> VLMAX=8, 1 reg
+//   E64/M1 -> VLMAX=4, 1 reg
+//   E8/M8 -> VLMAX=256, 8 regs
 
 // helpers
 
@@ -54,14 +55,14 @@ fn exec(
         .map(|_| ())
 }
 
-fn get_vreg(state: &TestInterpreterState<Zve64xMaskInstruction<Reg<u64>>>, reg: VReg) -> [u8; 16] {
+fn get_vreg(state: &TestInterpreterState<Zve64xMaskInstruction<Reg<u64>>>, reg: VReg) -> [u8; 32] {
     state.ext_state.read_vreg()[usize::from(reg.bits())]
 }
 
 fn set_vreg(
     state: &mut TestInterpreterState<Zve64xMaskInstruction<Reg<u64>>>,
     reg: VReg,
-    data: [u8; 16],
+    data: [u8; 32],
 ) {
     state.ext_state.write_vreg()[usize::from(reg.bits())] = data;
 }
@@ -74,7 +75,7 @@ fn read_elem(
     sew: Vsew,
 ) -> u64 {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -99,8 +100,8 @@ fn mask_bit(
 fn vmand_basic() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // vs2 = 0b10101010, vs1 = 0b11001100
-    set_vreg(&mut state, VReg::V2, [0xAA; 16]);
-    set_vreg(&mut state, VReg::V1, [0xCC; 16]);
+    set_vreg(&mut state, VReg::V2, [0xAA; 32]);
+    set_vreg(&mut state, VReg::V1, [0xCC; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmand {
@@ -113,7 +114,7 @@ fn vmand_basic() {
     )
     .unwrap();
     // 0xAA & 0xCC = 0x88
-    assert_eq!(get_vreg(&state, VReg::V4), [0x88; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0x88; 32]);
     assert_eq!(state.ext_state.vs_dirty_count(), 1);
     assert_eq!(state.ext_state.vstart(), 0);
 }
@@ -121,8 +122,8 @@ fn vmand_basic() {
 #[test]
 fn vmor_basic() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xAA; 16]);
-    set_vreg(&mut state, VReg::V1, [0x55; 16]);
+    set_vreg(&mut state, VReg::V2, [0xAA; 32]);
+    set_vreg(&mut state, VReg::V1, [0x55; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmor {
@@ -135,14 +136,14 @@ fn vmor_basic() {
     )
     .unwrap();
     // 0xAA | 0x55 = 0xFF
-    assert_eq!(get_vreg(&state, VReg::V4), [0xFF; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0xFF; 32]);
 }
 
 #[test]
 fn vmxor_basic() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xF0; 16]);
-    set_vreg(&mut state, VReg::V1, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xF0; 32]);
+    set_vreg(&mut state, VReg::V1, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmxor {
@@ -155,15 +156,15 @@ fn vmxor_basic() {
     )
     .unwrap();
     // 0xF0 ^ 0xFF = 0x0F
-    assert_eq!(get_vreg(&state, VReg::V4), [0x0F; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0x0F; 32]);
 }
 
 #[test]
 fn vmandn_basic() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // vmandn: vd = vs2 AND NOT vs1
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
-    set_vreg(&mut state, VReg::V1, [0x0F; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V1, [0x0F; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmandn {
@@ -176,15 +177,15 @@ fn vmandn_basic() {
     )
     .unwrap();
     // 0xFF & !0x0F = 0xF0
-    assert_eq!(get_vreg(&state, VReg::V4), [0xF0; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0xF0; 32]);
 }
 
 #[test]
 fn vmorn_basic() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // vmorn: vd = vs2 OR NOT vs1
-    set_vreg(&mut state, VReg::V2, [0x00; 16]);
-    set_vreg(&mut state, VReg::V1, [0x0F; 16]);
+    set_vreg(&mut state, VReg::V2, [0x00; 32]);
+    set_vreg(&mut state, VReg::V1, [0x0F; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmorn {
@@ -197,15 +198,15 @@ fn vmorn_basic() {
     )
     .unwrap();
     // 0x00 | !0x0F = 0xF0
-    assert_eq!(get_vreg(&state, VReg::V4), [0xF0; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0xF0; 32]);
 }
 
 #[test]
 fn vmnand_basic() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // vmnand: vd = NOT(vs2 AND vs1)
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
-    set_vreg(&mut state, VReg::V1, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V1, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmnand {
@@ -218,15 +219,15 @@ fn vmnand_basic() {
     )
     .unwrap();
     // NOT(0xFF & 0xFF) = 0x00
-    assert_eq!(get_vreg(&state, VReg::V4), [0x00; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0x00; 32]);
 }
 
 #[test]
 fn vmnor_basic() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // vmnor: vd = NOT(vs2 OR vs1)
-    set_vreg(&mut state, VReg::V2, [0x00; 16]);
-    set_vreg(&mut state, VReg::V1, [0x00; 16]);
+    set_vreg(&mut state, VReg::V2, [0x00; 32]);
+    set_vreg(&mut state, VReg::V1, [0x00; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmnor {
@@ -239,15 +240,15 @@ fn vmnor_basic() {
     )
     .unwrap();
     // NOT(0x00 | 0x00) = 0xFF
-    assert_eq!(get_vreg(&state, VReg::V4), [0xFF; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0xFF; 32]);
 }
 
 #[test]
 fn vmxnor_basic() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // vmxnor: vd = NOT(vs2 XOR vs1)
-    set_vreg(&mut state, VReg::V2, [0xAA; 16]);
-    set_vreg(&mut state, VReg::V1, [0xAA; 16]);
+    set_vreg(&mut state, VReg::V2, [0xAA; 32]);
+    set_vreg(&mut state, VReg::V1, [0xAA; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmxnor {
@@ -260,7 +261,7 @@ fn vmxnor_basic() {
     )
     .unwrap();
     // NOT(0xAA ^ 0xAA) = NOT(0x00) = 0xFF
-    assert_eq!(get_vreg(&state, VReg::V4), [0xFF; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0xFF; 32]);
 }
 
 /// Mask-logical ops operate on full VLENB bytes regardless of vl.
@@ -268,8 +269,8 @@ fn vmxnor_basic() {
 #[test]
 fn vmand_operates_on_full_register_regardless_of_vl() {
     let mut state = setup(0, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
-    set_vreg(&mut state, VReg::V1, [0xAA; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V1, [0xAA; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmand {
@@ -281,16 +282,16 @@ fn vmand_operates_on_full_register_regardless_of_vl() {
         },
     )
     .unwrap();
-    // All 16 bytes processed: 0xFF & 0xAA = 0xAA
-    assert_eq!(get_vreg(&state, VReg::V4), [0xAA; 16]);
+    // All VLENB (32) bytes processed: 0xFF & 0xAA = 0xAA
+    assert_eq!(get_vreg(&state, VReg::V4), [0xAA; 32]);
 }
 
 /// vd may overlap vs2 for mask-logical ops
 #[test]
 fn vmand_vd_overlaps_vs2() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
-    set_vreg(&mut state, VReg::V1, [0x0F; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V1, [0x0F; 32]);
     // vd = vs2
     exec(
         &mut state,
@@ -303,15 +304,15 @@ fn vmand_vd_overlaps_vs2() {
         },
     )
     .unwrap();
-    assert_eq!(get_vreg(&state, VReg::V2), [0x0F; 16]);
+    assert_eq!(get_vreg(&state, VReg::V2), [0x0F; 32]);
 }
 
 /// vd may overlap vs1 for mask-logical ops
 #[test]
 fn vmand_vd_overlaps_vs1() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
-    set_vreg(&mut state, VReg::V1, [0x0F; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V1, [0x0F; 32]);
     // vd = vs1
     exec(
         &mut state,
@@ -324,15 +325,15 @@ fn vmand_vd_overlaps_vs1() {
         },
     )
     .unwrap();
-    assert_eq!(get_vreg(&state, VReg::V1), [0x0F; 16]);
+    assert_eq!(get_vreg(&state, VReg::V1), [0x0F; 32]);
 }
 
 /// vd may be v0 for mask-logical ops (they are always unmasked)
 #[test]
 fn vmand_vd_is_v0() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
-    set_vreg(&mut state, VReg::V1, [0xAA; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V1, [0xAA; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmand {
@@ -344,7 +345,7 @@ fn vmand_vd_is_v0() {
         },
     )
     .unwrap();
-    assert_eq!(get_vreg(&state, VReg::V0), [0xAA; 16]);
+    assert_eq!(get_vreg(&state, VReg::V0), [0xAA; 32]);
 }
 
 /// Mask-logical ops require vector instructions to be allowed
@@ -374,7 +375,7 @@ fn vmand_vector_not_allowed() {
 #[test]
 fn vcpop_all_set_unmasked() {
     let mut state = setup(16, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vcpop {
@@ -395,7 +396,7 @@ fn vcpop_all_set_unmasked() {
 #[test]
 fn vcpop_all_clear() {
     let mut state = setup(16, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0x00; 16]);
+    set_vreg(&mut state, VReg::V2, [0x00; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vcpop {
@@ -415,7 +416,7 @@ fn vcpop_all_clear() {
 fn vcpop_respects_vl() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // All bits set, but only 4 elements active
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vcpop {
@@ -435,12 +436,15 @@ fn vcpop_respects_vl() {
 fn vcpop_masked() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // vs2: bits 0,1,2,3,4,5,6,7 all set
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     // mask v0: only elements 0,2,4,6 active (alternating, low nibble = 0b01010101 = 0x55)
     set_vreg(
         &mut state,
         VReg::V0,
-        [0x55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [
+            0x55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ],
     );
     exec(
         &mut state,
@@ -461,7 +465,7 @@ fn vcpop_masked() {
 #[test]
 fn vcpop_vstart_skips_early_elements() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     state.ext_state.set_vstart(4);
     exec(
         &mut state,
@@ -525,7 +529,7 @@ fn vcpop_vector_not_allowed() {
 fn vcpop_sparse_bits() {
     let mut state = setup(16, Vsew::E8, Vlmul::M1);
     // Set exactly bits 0, 3, 7, 11, 15 - one per byte boundary cluster
-    let mut data = [0u8; 16];
+    let mut data = [0u8; 32];
     // Byte 0: bits 0,3,7 -> 0b1000_1001 = 0x89
     data[0] = 0x89;
     // Byte 1: bits 8+3=11 -> 0b0000_1000 = 0x08
@@ -554,7 +558,7 @@ fn vcpop_sparse_bits() {
 fn vfirst_basic() {
     let mut state = setup(16, Vsew::E8, Vlmul::M1);
     // First set bit at position 3
-    let mut data = [0u8; 16];
+    let mut data = [0u8; 32];
     data[0] = 0b0000_1000;
     set_vreg(&mut state, VReg::V2, data);
     exec(
@@ -577,7 +581,7 @@ fn vfirst_basic() {
 #[test]
 fn vfirst_no_set_bit_returns_minus_one() {
     let mut state = setup(16, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0x00; 16]);
+    set_vreg(&mut state, VReg::V2, [0x00; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vfirst {
@@ -597,7 +601,7 @@ fn vfirst_no_set_bit_returns_minus_one() {
 #[test]
 fn vfirst_bit_zero() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vfirst {
@@ -617,7 +621,7 @@ fn vfirst_bit_zero() {
 fn vfirst_respects_vl() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // Only bit 5 set - beyond vl=4
-    let mut data = [0u8; 16];
+    let mut data = [0u8; 32];
     data[0] = 0b0010_0000;
     set_vreg(&mut state, VReg::V2, data);
     exec(
@@ -639,11 +643,11 @@ fn vfirst_respects_vl() {
 fn vfirst_masked_skips_inactive() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // vs2: bit 0 set, bit 4 set
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0b0001_0001;
     set_vreg(&mut state, VReg::V2, vs2);
     // Mask: elements 2,3,4,5,6,7 active (bits 2-7 = 0b11111100 = 0xFC)
-    let mut mask = [0u8; 16];
+    let mut mask = [0u8; 32];
     mask[0] = 0xFC;
     set_vreg(&mut state, VReg::V0, mask);
     exec(
@@ -666,7 +670,7 @@ fn vfirst_masked_skips_inactive() {
 fn vfirst_vstart_skips_early() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // Bits 1 and 5 set
-    let mut data = [0u8; 16];
+    let mut data = [0u8; 32];
     data[0] = 0b0010_0010;
     set_vreg(&mut state, VReg::V2, data);
     state.ext_state.set_vstart(3);
@@ -692,7 +696,7 @@ fn vfirst_vstart_skips_early() {
 fn vmsbf_first_at_position_3() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // First set bit at position 3
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0b0000_1000;
     set_vreg(&mut state, VReg::V2, vs2);
     exec(
@@ -721,7 +725,7 @@ fn vmsbf_first_at_position_3() {
 #[test]
 fn vmsbf_no_set_bit() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0x00; 16]);
+    set_vreg(&mut state, VReg::V2, [0x00; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmsbf {
@@ -742,7 +746,7 @@ fn vmsbf_no_set_bit() {
 #[test]
 fn vmsbf_first_at_position_zero() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0x01;
     set_vreg(&mut state, VReg::V2, vs2);
     exec(
@@ -766,13 +770,13 @@ fn vmsbf_first_at_position_zero() {
 fn vmsbf_masked_inactive_undisturbed() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // First set bit in vs2 at position 4
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0b0001_0000;
     set_vreg(&mut state, VReg::V2, vs2);
     // Pre-set vd to all-ones so we can detect undisturbed bits
-    set_vreg(&mut state, VReg::V4, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V4, [0xFF; 32]);
     // Mask: elements 2,3,4,5,6,7 active (bits 2-7 = 0xFC)
-    let mut mask = [0u8; 16];
+    let mut mask = [0u8; 32];
     mask[0] = 0xFC;
     set_vreg(&mut state, VReg::V0, mask);
     exec(
@@ -886,7 +890,7 @@ fn vmsbf_nonzero_vstart_illegal() {
 fn vmsof_first_at_position_3() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // Set bits at positions 3 and 6
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0b0100_1000;
     set_vreg(&mut state, VReg::V2, vs2);
     exec(
@@ -912,8 +916,8 @@ fn vmsof_first_at_position_3() {
 #[test]
 fn vmsof_no_set_bit() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0x00; 16]);
-    set_vreg(&mut state, VReg::V4, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0x00; 32]);
+    set_vreg(&mut state, VReg::V4, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmsof {
@@ -975,13 +979,13 @@ fn vmsof_vd_eq_v0_masked_illegal() {
 fn vmsof_masked_inactive_undisturbed() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // First set bit in vs2 at position 2
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0b0000_0100;
     set_vreg(&mut state, VReg::V2, vs2);
     // vd pre-set to all-ones
-    set_vreg(&mut state, VReg::V4, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V4, [0xFF; 32]);
     // Mask: elements 2..8 active (bits 2-7 = 0xFC)
-    let mut mask = [0u8; 16];
+    let mut mask = [0u8; 32];
     mask[0] = 0xFC;
     set_vreg(&mut state, VReg::V0, mask);
     exec(
@@ -1034,7 +1038,7 @@ fn vmsof_nonzero_vstart_illegal() {
 fn vmsif_first_at_position_3() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // First set bit at position 3
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0b0000_1000;
     set_vreg(&mut state, VReg::V2, vs2);
     exec(
@@ -1063,7 +1067,7 @@ fn vmsif_first_at_position_3() {
 #[test]
 fn vmsif_no_set_bit() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0x00; 16]);
+    set_vreg(&mut state, VReg::V2, [0x00; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmsif {
@@ -1084,7 +1088,7 @@ fn vmsif_no_set_bit() {
 #[test]
 fn vmsif_first_at_position_zero() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0x01;
     set_vreg(&mut state, VReg::V2, vs2);
     exec(
@@ -1176,7 +1180,7 @@ fn vmsbf_vmsof_vmsif_relationship() {
     let k = 5u32;
     let vl = 8u32;
 
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[(k / u8::BITS) as usize] |= 1 << (k % u8::BITS);
 
     for i in 0..vl {
@@ -1250,7 +1254,7 @@ fn vmsbf_vmsof_vmsif_relationship() {
 fn viota_basic_e8_m1() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // vs2 bits: 0=1, 1=0, 2=1, 3=0, 4=1, 5=0, 6=0, 7=0 -> byte = 0b00010101 = 0x15
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0x15;
     set_vreg(&mut state, VReg::V2, vs2);
     exec(
@@ -1286,7 +1290,7 @@ fn viota_basic_e8_m1() {
 fn viota_e32_m1() {
     let mut state = setup(4, Vsew::E32, Vlmul::M1);
     // vs2: bits 1 and 2 set -> byte = 0b00000110 = 0x06
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0x06;
     set_vreg(&mut state, VReg::V2, vs2);
     exec(
@@ -1314,13 +1318,13 @@ fn viota_e32_m1() {
 fn viota_inactive_vs2_bits_treated_as_zero() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // vs2: all bits set
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     // Execution mask: only elements 4..8 active (bits 4-7 = 0xF0)
-    let mut mask = [0u8; 16];
+    let mut mask = [0u8; 32];
     mask[0] = 0xF0;
     set_vreg(&mut state, VReg::V0, mask);
     // Pre-set vd to a sentinel so we can confirm inactive elements are undisturbed
-    set_vreg(&mut state, VReg::V4, [0xAB; 16]);
+    set_vreg(&mut state, VReg::V4, [0xAB; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Viota {
@@ -1441,14 +1445,12 @@ fn viota_misaligned_vd_illegal() {
 /// operations wrap around on overflow" rule. This exercises the widest element width to confirm
 /// the prefix count is written correctly and the instruction is accepted.
 ///
-/// The previously-removed implementation rejected any configuration where `VLMAX >= 2^SEW`, which
-/// wrongly trapped legal instructions such as `viota.m` at `E8/M2` on `VLEN=1024` (`VLMAX=256`,
-/// whose maximum result `255` fits in 8 bits). That `VLEN=1024` boundary is covered by the ACT4
-/// differential runner; the unit harness uses `VLEN=128`, where `VLMAX` never reaches `2^SEW`.
+/// The exact `VLMAX == 2^SEW` boundary that the removed check got wrong is covered by
+/// [`viota_e8_m8_vlmax_256_boundary()`].
 #[test]
 fn viota_e64_m1_no_width_trap() {
     let mut state = setup(2, Vsew::E64, Vlmul::M1);
-    let mut vs2 = [0u8; 16];
+    let mut vs2 = [0u8; 32];
     vs2[0] = 0b11;
     set_vreg(&mut state, VReg::V2, vs2);
     exec(
@@ -1466,13 +1468,17 @@ fn viota_e64_m1_no_width_trap() {
     assert_eq!(read_elem(&state, VReg::V4, 1, Vsew::E64), 1);
 }
 
-/// viota.m at the largest VLMAX the harness supports (`E8/M8` -> `VLMAX=128`, an 8-register
-/// group). All mask bits are set so the prefix count climbs to 127, exercising writes across the
-/// whole register group and confirming no width-based trap fires for an in-range count.
+/// Regression test for the removed SEW-width trap. At `E8/M8` with `TEST_VLEN=256` the maximum
+/// vector length is `VLMAX = 8 * 256 / 8 = 256`, i.e. `VLMAX == 2^SEW` for `SEW=8`. The largest
+/// prefix count `viota.m` writes is `VLMAX - 1 = 255`, which fits exactly in an 8-bit element, so
+/// the instruction is legal. The removed check rejected this (`256 >> 8 == 1`) and wrongly trapped
+/// it - exactly the failure seen for `viota.m` on the ACT4 runner. With every mask bit set and
+/// active, element `i` must equal `i` across the full 8-register destination group.
 #[test]
-fn viota_e8_m8_max_vlmax() {
-    let mut state = setup(128, Vsew::E8, Vlmul::M8);
-    set_vreg(&mut state, VReg::V8, [0xFF; 16]);
+fn viota_e8_m8_vlmax_256_boundary() {
+    let mut state = setup(256, Vsew::E8, Vlmul::M8);
+    // A single mask register holds VLEN bits; with VLENB=32 that is all 256 elements.
+    set_vreg(&mut state, VReg::V8, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Viota {
@@ -1484,8 +1490,9 @@ fn viota_e8_m8_max_vlmax() {
         },
     )
     .unwrap();
-    // Element i counts the set bits strictly before i; with every bit set that is just i.
-    for i in 0..128usize {
+    // Element i counts the set bits strictly before i; with every bit set that is just i. The
+    // largest, 255, exercises the boundary where the old width check would have trapped.
+    for i in 0..256usize {
         assert_eq!(
             read_elem(&state, VReg::V16, i, Vsew::E8),
             i as u64,
@@ -1590,7 +1597,7 @@ fn vid_e64_m1() {
 fn vid_respects_vl() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // Pre-set entire vd register to sentinel value
-    set_vreg(&mut state, VReg::V4, [0xEE; 16]);
+    set_vreg(&mut state, VReg::V4, [0xEE; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vid {
@@ -1620,9 +1627,9 @@ fn vid_respects_vl() {
 fn vid_masked_inactive_undisturbed() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // Pre-set vd to sentinel
-    set_vreg(&mut state, VReg::V4, [0xBE; 16]);
+    set_vreg(&mut state, VReg::V4, [0xBE; 32]);
     // Mask: only even elements active (bits 0,2,4,6 = 0b01010101 = 0x55)
-    let mut mask = [0u8; 16];
+    let mut mask = [0u8; 32];
     mask[0] = 0x55;
     set_vreg(&mut state, VReg::V0, mask);
     exec(
@@ -1695,7 +1702,7 @@ fn vid_misaligned_vd_illegal() {
 #[test]
 fn vid_vstart_undisturbed_below() {
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V4, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V4, [0xFF; 32]);
     state.ext_state.set_vstart(4);
     exec(
         &mut state,
@@ -1767,7 +1774,7 @@ fn vid_vector_not_allowed() {
 #[test]
 fn vcpop_vl_zero() {
     let mut state = setup(0, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vcpop {
@@ -1786,7 +1793,7 @@ fn vcpop_vl_zero() {
 #[test]
 fn vfirst_vl_zero() {
     let mut state = setup(0, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vfirst {
@@ -1805,8 +1812,8 @@ fn vfirst_vl_zero() {
 #[test]
 fn vmsbf_vl_zero() {
     let mut state = setup(0, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V2, [0xFF; 16]);
-    set_vreg(&mut state, VReg::V4, [0xAB; 16]);
+    set_vreg(&mut state, VReg::V2, [0xFF; 32]);
+    set_vreg(&mut state, VReg::V4, [0xAB; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vmsbf {
@@ -1818,14 +1825,14 @@ fn vmsbf_vl_zero() {
         },
     )
     .unwrap();
-    assert_eq!(get_vreg(&state, VReg::V4), [0xAB; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0xAB; 32]);
 }
 
 /// With vl=0, vid writes nothing and vd is untouched
 #[test]
 fn vid_vl_zero() {
     let mut state = setup(0, Vsew::E8, Vlmul::M1);
-    set_vreg(&mut state, VReg::V4, [0xCD; 16]);
+    set_vreg(&mut state, VReg::V4, [0xCD; 32]);
     exec(
         &mut state,
         Zve64xMaskInstruction::Vid {
@@ -1836,7 +1843,7 @@ fn vid_vl_zero() {
         },
     )
     .unwrap();
-    assert_eq!(get_vreg(&state, VReg::V4), [0xCD; 16]);
+    assert_eq!(get_vreg(&state, VReg::V4), [0xCD; 32]);
 }
 
 // vs_dirty and vstart invariants

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
@@ -317,13 +317,15 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
 /// treated as zero for the prefix sum. Inactive destination elements follow the mask-agnostic
 /// policy (here implemented as undisturbed, which is a permitted realisation).
 ///
+/// If SEW is too narrow to hold the prefix count, the value wraps (truncates to SEW) via
+/// [`write_element_u64()`]; the spec does not raise an exception for this case.
+///
 /// The caller must reject `vstart != 0` before invocation (spec §16.8 mandatory trap).
 ///
 /// # Safety
 /// - `vd` does not overlap `vs2` (checked by caller)
 /// - `vm=false` implies `vd != v0` (checked by caller)
 /// - `vd.bits() % group_regs == 0` and `vd.bits() + group_regs <= 32` (checked by caller)
-/// - SEW wide enough to hold VLMAX-1 (checked by caller)
 /// - `vl <= VLMAX`; `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
@@ -7,14 +7,17 @@ use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
-/// Execute a mask-register logical operation on the full `VLENB`-byte mask registers.
+/// Execute a mask-register logical operation (§16.1).
 ///
-/// Operates on the entire register width independent of `vl` or `vtype`, per spec §16.1.
-/// `op` receives `(vs2_byte: u8, vs1_byte: u8) -> u8`.
+/// Computes the result for the body elements `[vstart, vl)` only. Prestart bits `[0, vstart)`
+/// are left undisturbed, and tail bits `[vl, VLEN)` follow the tail-agnostic policy, realised
+/// here as undisturbed (a permitted agnostic implementation and the one the reference model
+/// produces). `op` receives `(vs2_bit: bool, vs1_bit: bool) -> bool`.
 ///
 /// # Safety
-/// `vd`, `vs2`, and `vs1` are valid register indices (guaranteed by `VReg` type).
-/// The operation snaps both sources before writing, so `vd` may safely overlap either source.
+/// `vd`, `vs2`, and `vs1` are valid register indices (guaranteed by `VReg`).
+/// `vl <= VLEN`, so `(vl - 1) / 8 < VLENB`; `vstart <= vl` by the architectural invariant.
+/// The operation snapshots both sources before writing, so `vd` may safely overlap either source.
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
@@ -22,6 +25,8 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
     vd: VReg,
     vs2: VReg,
     vs1: VReg,
+    vl: u32,
+    vstart: u16,
     op: F,
 ) where
     Reg: Register,
@@ -30,29 +35,22 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
     [(); ExtState::VLEN as usize]:,
     [(); ExtState::VLENB as usize]:,
     CustomError: fmt::Debug,
-    F: Fn(u8, u8) -> u8,
+    F: Fn(bool, bool) -> bool,
 {
     // Snapshot both sources before writing to handle vd overlapping vs2 or vs1
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
     let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     // SAFETY: `vs1.bits() < 32`; `VReg` values are always in `0..32`
     let vs1_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs1.bits())) };
-    // SAFETY: `vd.bits() < 32`; `VReg` values are always in `0..32`
-    let vd_reg = unsafe {
-        ext_state
-            .write_vreg()
-            .get_unchecked_mut(usize::from(vd.bits()))
-    };
-    for byte_i in 0..ExtState::VLENB as usize {
-        // SAFETY: `byte_i < VLENB` because the loop bound is `ExtState::VLENB`, and
-        // `vs2_snap` / `vs1_snap` are `[u8; VLENB]` arrays
-        let a = unsafe { *vs2_snap.get_unchecked(byte_i) };
-        // SAFETY: `byte_i < VLENB` because the loop bound is `ExtState::VLENB`, and
-        // `vs2_snap` / `vs1_snap` are `[u8; VLENB]` arrays
-        let b = unsafe { *vs1_snap.get_unchecked(byte_i) };
-        // SAFETY: `byte_i < VLENB` because the loop bound is `ExtState::VLENB`, and
-        // `vd_reg` points to a `[u8; VLENB]` register row
-        *unsafe { vd_reg.get_unchecked_mut(byte_i) } = op(a, b);
+    // Body elements [vstart, vl): compute the logical operation bit-by-bit. Prestart bits
+    // [0, vstart) and tail bits [vl, VLEN) are left undisturbed.
+    for i in u32::from(vstart)..vl {
+        let a = mask_bit(&vs2_snap, i);
+        let b = mask_bit(&vs1_snap, i);
+        // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
+        unsafe {
+            write_mask_bit(ext_state.write_vreg(), vd, i, op(a, b));
+        }
     }
     ext_state.mark_vs_dirty();
     ext_state.reset_vstart();
@@ -75,7 +73,7 @@ pub unsafe fn execute_vcpop<Reg, Regs, ExtState, CustomError>(
     vs2: VReg,
     vm: bool,
     vl: u32,
-    vstart: u32,
+    vstart: u16,
 ) where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -90,7 +88,7 @@ pub unsafe fn execute_vcpop<Reg, Regs, ExtState, CustomError>(
     // SAFETY: `vs2` is a valid VReg index (< 32)
     let vs2_reg = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
     let mut count = 0u32;
-    for i in vstart..vl {
+    for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
@@ -121,7 +119,7 @@ pub unsafe fn execute_vfirst<Reg, Regs, ExtState, CustomError>(
     vs2: VReg,
     vm: bool,
     vl: u32,
-    vstart: u32,
+    vstart: u16,
 ) where
     Reg: Register,
     Regs: RegisterFile<Reg>,
@@ -138,7 +136,7 @@ pub unsafe fn execute_vfirst<Reg, Regs, ExtState, CustomError>(
     // -1 encoded as all-ones for the register width; `Into<u64>` on XLEN-wide type then back
     let not_found = u64::MAX;
     let mut result = not_found;
-    for i in vstart..vl {
+    for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
@@ -385,7 +383,7 @@ pub unsafe fn execute_vid<Reg, ExtState, CustomError>(
     vd: VReg,
     vm: bool,
     vl: u32,
-    vstart: u32,
+    vstart: u16,
     sew: Vsew,
 ) where
     Reg: Register,
@@ -397,7 +395,7 @@ pub unsafe fn execute_vid<Reg, ExtState, CustomError>(
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
-    for i in vstart..vl {
+    for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
@@ -86,7 +86,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -136,7 +136,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -194,7 +194,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -249,7 +249,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -306,7 +306,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -361,7 +361,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -418,7 +418,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -474,7 +474,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -528,7 +528,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -584,7 +584,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -641,7 +641,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -691,7 +691,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -743,7 +743,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -803,7 +803,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -864,7 +864,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -914,7 +914,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -979,7 +979,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1058,7 +1058,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1131,7 +1131,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1211,7 +1211,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1286,7 +1286,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1366,7 +1366,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1430,7 +1430,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1481,7 +1481,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1533,7 +1533,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1584,7 +1584,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1636,7 +1636,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1687,7 +1687,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1740,7 +1740,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1791,7 +1791,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1856,7 +1856,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1935,7 +1935,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -2008,7 +2008,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -2088,7 +2088,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -2162,7 +2162,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -2242,7 +2242,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -2320,7 +2320,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
@@ -2270,13 +2270,13 @@ where
                         vl,
                         vstart,
                         sew,
-                        // vwmaccsu.vx: vd[i] = vd[i] + sext(vs2[i]) * zext(rs1)
-                        // Helper passes (acc, scalar_as_a, vs2_as_b, sew): a=rs1 (unsigned), b=vs2
-                        // (signed)
+                        // vwmaccsu.vx: vd[i] = vd[i] + sext(rs1) * zext(vs2[i])
+                        // Helper passes (acc, scalar_as_a, vs2_as_b, sew): a=rs1 (signed),
+                        // b=vs2 (unsigned)
                         |acc, a, b, sew| {
-                            let ua = a & zve64x_muldiv_helpers::sew_mask(sew);
-                            let sb = zve64x_muldiv_helpers::sign_extend(b, sew);
-                            acc.wrapping_add(sb.cast_unsigned().wrapping_mul(ua))
+                            let sa = zve64x_muldiv_helpers::sign_extend(a, sew);
+                            let ub = b & zve64x_muldiv_helpers::sew_mask(sew);
+                            acc.wrapping_add(sa.cast_unsigned().wrapping_mul(ub))
                         },
                     );
                 }
@@ -2348,13 +2348,13 @@ where
                         vl,
                         vstart,
                         sew,
-                        // vwmaccus.vx: vd[i] = vd[i] + sext(rs1) * zext(vs2[i])
-                        // Helper passes (acc, scalar_as_a, vs2_as_b, sew): a=rs1 (signed), b=vs2
-                        // (unsigned)
+                        // vwmaccus.vx: vd[i] = vd[i] + zext(rs1) * sext(vs2[i])
+                        // Helper passes (acc, scalar_as_a, vs2_as_b, sew): a=rs1 (unsigned),
+                        // b=vs2 (signed)
                         |acc, a, b, sew| {
-                            let sa = zve64x_muldiv_helpers::sign_extend(a, sew);
-                            let ub = b & zve64x_muldiv_helpers::sew_mask(sew);
-                            acc.wrapping_add(sa.cast_unsigned().wrapping_mul(ub))
+                            let ua = a & zve64x_muldiv_helpers::sew_mask(sew);
+                            let sb = zve64x_muldiv_helpers::sign_extend(b, sew);
+                            acc.wrapping_add(sb.cast_unsigned().wrapping_mul(ua))
                         },
                     );
                 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
@@ -7,15 +7,15 @@ use crate::{
 };
 use ab_riscv_primitives::prelude::*;
 
-// With TEST_VLEN=128, VLENB=16:
-//   E8/M1  -> VLMAX=16, 1 reg
-//   E16/M1 -> VLMAX=8,  1 reg
-//   E32/M1 -> VLMAX=4,  1 reg
-//   E64/M1 -> VLMAX=2,  1 reg
-//   E8/M2  -> VLMAX=32, 2 regs
-//   E16/M2 -> VLMAX=16, 2 regs
-//   E32/M2 -> VLMAX=8,  2 regs (vd for widening E16 uses 2 regs)
-//   E8/M4  -> VLMAX=64, 4 regs (vd for widening E32 uses 4 regs - but VLMAX=4 at E32/M1)
+// With TEST_VLEN=256, VLENB=32:
+//   E8/M1  -> VLMAX=32, 1 reg
+//   E16/M1 -> VLMAX=16, 1 reg
+//   E32/M1 -> VLMAX=8,  1 reg
+//   E64/M1 -> VLMAX=4,  1 reg
+//   E8/M2  -> VLMAX=64, 2 regs
+//   E16/M2 -> VLMAX=32, 2 regs
+//   E32/M2 -> VLMAX=16, 2 regs (vd for widening E16 uses 2 regs)
+//   E8/M4  -> VLMAX=128, 4 regs (vd for widening E32 uses 4 regs - but VLMAX=8 at E32/M1)
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3u8)
@@ -64,7 +64,7 @@ fn read_elem(
     sew: Vsew,
 ) -> u64 {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -97,7 +97,7 @@ fn write_elem(
     value: u64,
 ) {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -995,9 +995,9 @@ fn vwmulu_m8_is_illegal() {
 
 #[test]
 fn vwmulu_mf2_e8_correct_result() {
-    // LMUL=Mf2, SEW=E8: VLMAX = VLEN/2 / 8 = 128/2/8 = 8 elements
+    // LMUL=Mf2, SEW=E8: VLMAX = VLEN/2 / 8 = 256/2/8 = 16 elements
     // EMUL = 2 * (1/2) = 1, so vd occupies 1 register (same as vs2/vs1)
-    // With VLENB=16: 8 E8 elements fit in half a register, so VLMAX=8
+    // With VLENB=32: 16 E8 elements fit in half a register, so VLMAX=16
     let mut state = setup(4, Vsew::E8, Vlmul::Mf2);
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E8, (i + 1) as u64 * 10);
@@ -1632,7 +1632,7 @@ fn vwmacc_vv_e8_signed() {
 
 #[test]
 fn vwmacc_mf2_e16_basic() {
-    // LMUL=Mf2, SEW=E16: VLMAX = 128/2/16 = 4 elements
+    // LMUL=Mf2, SEW=E16: VLMAX = 256/2/16 = 8 elements
     // EMUL_dest = 1, so vd is 1 register wide at E32 (2*SEW)
     let mut state = setup(4, Vsew::E16, Vlmul::Mf2);
     for i in 0..4usize {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
@@ -845,13 +845,6 @@ fn vrem_vv_e32_signed_overflow_returns_zero() {
 #[test]
 fn vrem_vx_e8() {
     let mut state = setup(1, Vsew::E8, Vlmul::M1);
-    // -128 % -1 = 0
-    // i8::MIN
-    write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0x80);
-    // sign-extends as -1 in the vx scalar path? No - scalar is treated as unsigned for vrem
-    state.regs.write(Reg::A0, 0xFFu64);
-    // Actually for vrem.vx, the scalar is the divisor and is sign-extended from XLEN.
-    // rs1 = 0xFF00...FF (if we write 0xFF it is zero-extended) - let's use a simpler case.
     // -127 % 7: -127 = 0x81 as i8, result = -127 % 7 = -1
     write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0x81);
     state.regs.write(Reg::A0, 7u64);
@@ -1700,21 +1693,20 @@ fn vwmaccsu_vv_e8() {
     assert_eq!(read_wide_elem(&state, VReg::V8, 1, Vsew::E8), 400u64);
 }
 
-// vwmaccus
+// vwmaccus.vx: vd[i] = vd[i] + zext(rs1) * sext(vs2[i])
+// rs1 is UNSIGNED, vs2 is SIGNED.
 
 #[test]
 fn vwmaccus_vx_e8() {
-    // vwmaccus.vx: vd[i] = vd[i] + sext(rs1) * zext(vs2[i])
-    // rs1 is SIGNED, vs2 is UNSIGNED.
     let mut state = setup(2, Vsew::E8, Vlmul::M1);
     write_wide_elem(&mut state, VReg::V8, 0, Vsew::E8, 0);
     write_wide_elem(&mut state, VReg::V8, 1, Vsew::E8, 0);
-    // vs2=255 (unsigned)
+    // vs2=-1 (signed)
     write_elem(&mut state, VReg::V4, 0, Vsew::E8, 0xFF);
-    // vs2=50 (unsigned)
+    // vs2=50 (signed positive)
     write_elem(&mut state, VReg::V4, 1, Vsew::E8, 50);
-    // rs1 low 8 bits = 0xFF, sign-extends to -1
-    state.regs.write(Reg::A0, 0xFFu64);
+    // rs1=255 (unsigned)
+    state.regs.write(Reg::A0, 255u64);
     exec(
         &mut state,
         Zve64xMulDivInstruction::VwmaccusVx {
@@ -1726,28 +1718,29 @@ fn vwmaccus_vx_e8() {
         },
     )
     .unwrap();
-    // 0 + (-1) * 255 = -255 as i16
+    // 0 + zext(255) * sext(-1) = 255 * (-1) = -255 as i16
     assert_eq!(
         read_wide_elem(&state, VReg::V8, 0, Vsew::E8) as i16,
         -255i16
     );
-    // 0 + (-1) * 50 = -50
-    assert_eq!(read_wide_elem(&state, VReg::V8, 1, Vsew::E8) as i16, -50i16);
+    // 0 + zext(255) * sext(50) = 255 * 50 = 12750
+    assert_eq!(read_wide_elem(&state, VReg::V8, 1, Vsew::E8), 12750u64);
 }
+
+// vwmaccsu.vx: vd[i] = vd[i] + sext(rs1) * zext(vs2[i])
+// rs1 is SIGNED, vs2 is UNSIGNED.
 
 #[test]
 fn vwmaccsu_vx_e8() {
-    // vwmaccsu.vx: vd[i] = vd[i] + sext(vs2[i]) * zext(rs1)
-    // vs2 is SIGNED, rs1 is UNSIGNED.
     let mut state = setup(2, Vsew::E8, Vlmul::M1);
     write_wide_elem(&mut state, VReg::V8, 0, Vsew::E8, 0);
     write_wide_elem(&mut state, VReg::V8, 1, Vsew::E8, 0);
-    // vs2=-1 (signed)
-    write_elem(&mut state, VReg::V4, 0, Vsew::E8, 0xFF);
-    // vs2=2 (signed)
-    write_elem(&mut state, VReg::V4, 1, Vsew::E8, 2);
-    // rs1=200 (unsigned)
-    state.regs.write(Reg::A0, 200u64);
+    // vs2=200 (unsigned)
+    write_elem(&mut state, VReg::V4, 0, Vsew::E8, 200);
+    // vs2=50 (unsigned)
+    write_elem(&mut state, VReg::V4, 1, Vsew::E8, 50);
+    // rs1=0xFF stored in register; sign-extends from SEW (8 bits) to -1 signed
+    state.regs.write(Reg::A0, 0xFFu64);
     exec(
         &mut state,
         Zve64xMulDivInstruction::VwmaccsuVx {
@@ -1759,13 +1752,13 @@ fn vwmaccsu_vx_e8() {
         },
     )
     .unwrap();
-    // 0 + (-1) * 200 = -200 as i16
+    // 0 + sext(0xFF=-1) * zext(200) = -1 * 200 = -200 as i16
     assert_eq!(
         read_wide_elem(&state, VReg::V8, 0, Vsew::E8) as i16,
         -200i16
     );
-    // 0 + 2 * 200 = 400
-    assert_eq!(read_wide_elem(&state, VReg::V8, 1, Vsew::E8), 400u64);
+    // 0 + sext(0xFF=-1) * zext(50) = -1 * 50 = -50 as i16
+    assert_eq!(read_wide_elem(&state, VReg::V8, 1, Vsew::E8) as i16, -50i16);
 }
 
 // common error paths

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
@@ -1092,9 +1092,16 @@ fn vwmulu_m1_overlap_uses_2_dest_regs() {
 }
 
 #[test]
-fn vwmulu_m1_vs2_in_upper_dest_reg_is_illegal() {
-    // With M1, vd=V4 occupies V4+V5. vs2=V5 overlaps with upper half of vd -> illegal.
+fn vwmulu_m1_vs2_in_upper_dest_reg_is_legal() {
+    // With M1, vd=V4 occupies V4+V5 (source EMUL=1). vs2=V5 occupies exactly the
+    // highest-numbered register of the destination group, which the RISC-V "V" spec §5.2
+    // permits for widening instructions. With vl=4 the wide results land entirely in V4, so the
+    // V5 source is not clobbered before it is read.
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V5, i, Vsew::E8, (i + 1) as u64);
+        write_elem(&mut state, VReg::V2, i, Vsew::E8, 2);
+    }
     let result = exec(
         &mut state,
         Zve64xMulDivInstruction::VwmuluVv {
@@ -1106,10 +1113,109 @@ fn vwmulu_m1_vs2_in_upper_dest_reg_is_illegal() {
             rs2: Reg::Zero,
         },
     );
+    assert!(result.is_ok());
+    for i in 0..4usize {
+        assert_eq!(
+            read_wide_elem(&state, VReg::V4, i, Vsew::E8),
+            (i + 1) as u64 * 2,
+            "elem {i}"
+        );
+    }
+}
+
+#[test]
+fn vwmulu_m1_vs1_in_upper_dest_reg_is_legal() {
+    // Same legal top-overlap as above, but for vs1 (the second source operand). This mirrors the
+    // `vwmul.vv v10, v7, v11` case: vd=V10 occupies V10+V11 and vs1=V11 is the highest-numbered
+    // register of the destination group.
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V7, i, Vsew::E8, (i + 1) as u64);
+        write_elem(&mut state, VReg::V11, i, Vsew::E8, 3);
+    }
+    let result = exec(
+        &mut state,
+        Zve64xMulDivInstruction::VwmuluVv {
+            vd: VReg::V10,
+            vs2: VReg::V7,
+            vs1: VReg::V11,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(result.is_ok());
+    for i in 0..4usize {
+        assert_eq!(
+            read_wide_elem(&state, VReg::V10, i, Vsew::E8),
+            (i + 1) as u64 * 3,
+            "elem {i}"
+        );
+    }
+}
+
+#[test]
+fn vwmulu_m1_vs2_in_lower_dest_reg_is_illegal() {
+    // With M1, vd=V4 occupies V4+V5. vs2=V4 overlaps the *lowest*-numbered register of the
+    // destination group, which is not the permitted highest-numbered overlap -> illegal.
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        Zve64xMulDivInstruction::VwmuluVv {
+            vd: VReg::V4,
+            vs2: VReg::V4,
+            vs1: VReg::V2,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
     assert!(matches!(
         result,
         Err(ExecutionError::IllegalInstruction { .. })
     ));
+}
+
+#[test]
+fn vwmulu_m2_lower_half_overlap_is_illegal() {
+    // With M2, vd=V8 occupies V8..V12 (4 regs) and a source occupies 2 regs. The only legal
+    // overlap is the top half (V10+V11). vs1=V8 occupies the lowest-numbered half of the
+    // destination group, which is not the permitted highest-numbered overlap -> illegal.
+    let mut state = setup(4, Vsew::E8, Vlmul::M2);
+    let result = exec(
+        &mut state,
+        Zve64xMulDivInstruction::VwmuluVv {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            vs1: VReg::V8,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+#[test]
+fn vwmulu_m2_top_half_overlap_is_legal() {
+    // With M2, vd=V8 occupies V8..V12. vs1=V10 occupies exactly the top half (V10+V11) of the
+    // destination group -> legal per spec §5.2.
+    let mut state = setup(4, Vsew::E8, Vlmul::M2);
+    let result = exec(
+        &mut state,
+        Zve64xMulDivInstruction::VwmuluVv {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            vs1: VReg::V10,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(result.is_ok());
 }
 
 // vwmul (signed widening)

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
@@ -42,11 +42,24 @@ pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<u8> {
     Some(if d > 1 { 1 } else { n })
 }
 
-/// Check that a narrower source register group does not overlap the wider destination group.
+/// Check that a narrower source register group does not *illegally* overlap the wider destination
+/// group of a widening instruction.
 ///
 /// For widening instructions `vd` occupies `dest_group_regs` registers (which is
 /// [`widening_dest_register_count()`] of the source LMUL); `vs` occupies `src_group_regs`.
-/// The spec prohibits any overlap between them.
+///
+/// Per the RISC-V "V" spec §5.2, because the destination EEW (`2*SEW`) is greater than the source
+/// EEW (`SEW`), the source group *may* overlap the destination group, but only when both of the
+/// following hold:
+/// - the source EMUL is at least 1, and
+/// - the overlap is in the highest-numbered part of the destination register group, i.e. the source
+///   occupies exactly the top `src_group_regs` registers of the destination group.
+///
+/// When the source EMUL is at least 1, `dest_group_regs == 2 * src_group_regs`, so
+/// `dest_group_regs > src_group_regs` is an equivalent test for "source EMUL >= 1": a fractional
+/// source EMUL (`< 1`) yields `dest_group_regs == src_group_regs == 1`, in which case no overlap is
+/// ever legal. Any overlap that is not the legal "source in the highest-numbered part" form is
+/// rejected as an illegal instruction.
 #[inline(always)]
 #[doc(hidden)]
 pub fn check_no_widening_overlap<Reg, Memory, PC, CustomError>(
@@ -64,13 +77,19 @@ where
     let vd_end = vd_start + dest_group_regs;
     let vs_start = vs.bits();
     let vs_end = vs_start + src_group_regs;
-    // Overlap when the intervals intersect
-    if vs_start < vd_end && vd_start < vs_end {
-        return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
-        });
+    // Disjoint register groups are always fine
+    if vs_start >= vd_end || vd_start >= vs_end {
+        return Ok(());
     }
-    Ok(())
+    // The groups overlap. This is legal only when the source EMUL is at least 1
+    // (`dest_group_regs > src_group_regs`) and the source occupies exactly the highest-numbered
+    // part of the destination group (`vs_start == vd_end - src_group_regs`).
+    if dest_group_regs > src_group_regs && vs_start == vd_end - src_group_regs {
+        return Ok(());
+    }
+    Err(ExecutionError::IllegalInstruction {
+        address: program_counter.old_pc(INSTRUCTION_SIZE),
+    })
 }
 
 /// Write a 2*SEW-wide element into the widened destination register group at element index

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
@@ -158,7 +158,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -204,7 +204,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -250,7 +250,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -291,7 +291,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -345,7 +345,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -392,7 +392,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -450,7 +450,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -502,7 +502,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -549,7 +549,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -622,7 +622,7 @@ where
                     vs1,
                     index_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
@@ -6,16 +6,16 @@ use crate::{
 };
 use ab_riscv_primitives::prelude::*;
 
-// With TEST_VLEN=128, VLENB=16:
-//   E8/M1   -> VLMAX=16, 1 reg,  16 elems/reg
-//   E16/M1  -> VLMAX=8,  1 reg,  8 elems/reg
-//   E32/M1  -> VLMAX=4,  1 reg,  4 elems/reg
-//   E64/M1  -> VLMAX=2,  1 reg,  2 elems/reg
-//   E8/M2   -> VLMAX=32, 2 regs, 16 elems/reg
-//   E16/M2  -> VLMAX=16, 2 regs, 8 elems/reg
-//   E32/M2  -> VLMAX=8,  2 regs, 4 elems/reg
-//   E64/M2  -> VLMAX=4,  2 regs, 2 elems/reg
-//   E64/Mf2 -> VLMAX=1,  1 reg,  2 elems/reg  (VLMAX=1)
+// With TEST_VLEN=256, VLENB=32:
+//   E8/M1   -> VLMAX=32, 1 reg,  32 elems/reg
+//   E16/M1  -> VLMAX=16, 1 reg,  16 elems/reg
+//   E32/M1  -> VLMAX=8,  1 reg,  8 elems/reg
+//   E64/M1  -> VLMAX=4,  1 reg,  4 elems/reg
+//   E8/M2   -> VLMAX=64, 2 regs, 32 elems/reg
+//   E16/M2  -> VLMAX=32, 2 regs, 16 elems/reg
+//   E32/M2  -> VLMAX=16, 2 regs, 8 elems/reg
+//   E64/M2  -> VLMAX=8,  2 regs, 4 elems/reg
+//   E64/Mf2 -> VLMAX=2,  1 reg,  4 elems/reg
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
@@ -64,7 +64,7 @@ fn read_elem(
     sew: Vsew,
 ) -> u64 {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -81,7 +81,7 @@ fn write_elem(
     value: u64,
 ) {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -100,7 +100,7 @@ fn set_vreg_bytes(
 fn get_vreg_bytes(
     state: &crate::rv64::test_utils::TestInterpreterState<Zve64xPermInstruction<Reg<u64>>>,
     reg: VReg,
-) -> [u8; 16] {
+) -> [u8; 32] {
     state.ext_state.read_vreg()[usize::from(reg.bits())]
 }
 
@@ -2060,7 +2060,8 @@ fn vmerge_variants_reset_vstart_and_mark_dirty() {
 
 #[test]
 fn vmv_v_x_m2_e32_broadcasts_across_group() {
-    let mut state = setup(8, Vsew::E32, Vlmul::M2);
+    // E32/M2: VLMAX=16, vl=16 spans V4 and V5 (8 E32 elems per VLENB=32 register)
+    let mut state = setup(16, Vsew::E32, Vlmul::M2);
     state.regs.write(Reg::A0, 0xCAFEu64);
     exec(
         &mut state,
@@ -2073,7 +2074,7 @@ fn vmv_v_x_m2_e32_broadcasts_across_group() {
         },
     )
     .unwrap();
-    for i in 0..8usize {
+    for i in 0..16usize {
         assert_eq!(
             read_elem(&state, VReg::V4, i, Vsew::E32),
             0xCAFE,
@@ -2084,14 +2085,16 @@ fn vmv_v_x_m2_e32_broadcasts_across_group() {
 
 #[test]
 fn vmerge_vxm_m2_e32_blends_across_group() {
-    let mut state = setup(8, Vsew::E32, Vlmul::M2);
-    for i in 0..8usize {
+    // E32/M2: VLMAX=16, vl=16 spans V4 and V5 (8 E32 elems per VLENB=32 register)
+    let mut state = setup(16, Vsew::E32, Vlmul::M2);
+    for i in 0..16usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, (i * 100) as u64);
     }
     state.regs.write(Reg::A0, 777u64);
-    // Set mask bits 0, 2, 4, 6.
+    // Set even mask bits across both bytes: elements 0,2,..,14 active.
     state.ext_state.write_vreg()[0].fill(0);
     state.ext_state.write_vreg()[0][0] = 0b0101_0101;
+    state.ext_state.write_vreg()[0][1] = 0b0101_0101;
     exec(
         &mut state,
         Zve64xPermInstruction::VmergeVxm {
@@ -2103,7 +2106,7 @@ fn vmerge_vxm_m2_e32_blends_across_group() {
         },
     )
     .unwrap();
-    for i in 0..8usize {
+    for i in 0..16usize {
         let expected = if i % 2 == 0 { 777 } else { (i * 100) as u64 };
         assert_eq!(
             read_elem(&state, VReg::V4, i, Vsew::E32),
@@ -2314,7 +2317,10 @@ fn vcompress_vm_vstart_zero_normal_operation() {
 #[test]
 fn vmv1r_v_copies_single_register() {
     let mut state = setup(4, Vsew::E32, Vlmul::M1);
-    let src: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    let src: [u8; 32] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+    ];
     state.ext_state.write_vreg()[usize::from(VReg::V2.bits())] = src;
     set_vreg_bytes(&mut state, VReg::V4, 0xCC);
     exec(
@@ -2346,7 +2352,7 @@ fn vmv1r_v_src_eq_dst_nop() {
         },
     )
     .unwrap();
-    assert_eq!(get_vreg_bytes(&state, VReg::V2), [0xAB; 16]);
+    assert_eq!(get_vreg_bytes(&state, VReg::V2), [0xAB; 32]);
 }
 
 #[test]
@@ -2367,8 +2373,8 @@ fn vmv2r_v_copies_two_registers() {
         },
     )
     .unwrap();
-    assert_eq!(get_vreg_bytes(&state, VReg::V4), [0x11; 16]);
-    assert_eq!(get_vreg_bytes(&state, VReg::V5), [0x22; 16]);
+    assert_eq!(get_vreg_bytes(&state, VReg::V4), [0x11; 32]);
+    assert_eq!(get_vreg_bytes(&state, VReg::V5), [0x22; 32]);
 }
 
 #[test]
@@ -2432,7 +2438,7 @@ fn vmv4r_v_copies_four_registers() {
     for k in 0u8..4 {
         assert_eq!(
             get_vreg_bytes(&state, VReg::from_bits(VReg::V12.bits() + k).unwrap()),
-            [k + 1; 16],
+            [k + 1; 32],
             "reg offset {k}"
         );
     }
@@ -2503,7 +2509,7 @@ fn vmv8r_v_copies_eight_registers() {
     for k in 0u8..8 {
         assert_eq!(
             get_vreg_bytes(&state, VReg::from_bits(VReg::V16.bits() + k).unwrap()),
-            [k + 10; 16],
+            [k + 10; 32],
             "reg offset {k}"
         );
     }
@@ -2560,7 +2566,7 @@ fn vmvr_does_not_require_valid_vtype() {
         },
     )
     .unwrap();
-    assert_eq!(get_vreg_bytes(&state, VReg::V4), [0xAB; 16]);
+    assert_eq!(get_vreg_bytes(&state, VReg::V4), [0xAB; 32]);
 }
 
 // Multi-register group (LMUL > 1) tests
@@ -3318,7 +3324,7 @@ fn vl_zero_leaves_vd_undisturbed_rgather() {
 
 #[test]
 fn vslideup_mf2_e64_offset_ge_vlmax_no_write() {
-    // Mf2/E64: VLMAX = VLEN/(8*2) = 128/(8*2) = 1.
+    // Mf2/E64: VLMAX = VLEN/(64*2) = 256/128 = 2; this test pins vl=1.
     let mut state = setup(1, Vsew::E64, Vlmul::Mf2);
     write_elem(&mut state, VReg::V2, 0, Vsew::E64, 0xABCD);
     write_elem(&mut state, VReg::V4, 0, Vsew::E64, 0xDEAD);

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
@@ -53,7 +53,7 @@ fn read_elem(
     sew: Vsew,
 ) -> u64 {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -70,7 +70,7 @@ fn write_elem(
     value: u64,
 ) {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -285,9 +285,9 @@ fn vredsum_all_masked_out_writes_vs1_zero() {
 
 #[test]
 fn vredsum_m2_uses_group() {
-    // LMUL=2, E8: VLMAX=32; vs2 spans v2-v3
-    let mut state = setup(32, Vsew::E8, Vlmul::M2);
-    for i in 0..32usize {
+    // LMUL=2, E8: VLMAX=64; vs2 spans v2-v3 (32 E8 elems per VLENB=32 register)
+    let mut state = setup(64, Vsew::E8, Vlmul::M2);
+    for i in 0..64usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E8, 1);
     }
     write_elem(&mut state, VReg::V1, 0, Vsew::E8, 0);
@@ -303,7 +303,7 @@ fn vredsum_m2_uses_group() {
         },
     )
     .unwrap();
-    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E8), 32u64 & 0xff);
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E8), 64u64 & 0xff);
 }
 
 // vredand

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
@@ -7,11 +7,11 @@ use crate::{
 use ab_riscv_primitives::prelude::*;
 use core::array;
 
-// With TEST_VLEN=128 and TEST_VLENB=16:
-//   E8/M1  VLMAX=16, E16/M1 VLMAX=8, E32/M1 VLMAX=4, E64/M1 VLMAX=2
-//   E8/M2  VLMAX=32, E16/M2 VLMAX=16
-//   E8/M4  VLMAX=64
-//   E8/Mf2 VLMAX=8,  E16/Mf2 VLMAX=4
+// With TEST_VLEN=256 and TEST_VLENB=32:
+//   E8/M1  VLMAX=32, E16/M1 VLMAX=16, E32/M1 VLMAX=8, E64/M1 VLMAX=4
+//   E8/M2  VLMAX=64, E16/M2 VLMAX=32
+//   E8/M4  VLMAX=128
+//   E8/Mf2 VLMAX=16, E16/Mf2 VLMAX=8
 
 fn setup(
     vl: u32,
@@ -104,8 +104,8 @@ fn vsr_single_register_stores_vlenb_bytes() {
 fn vsr_two_registers_stores_two_vlenb_blocks() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
-    let data0 = array::from_fn::<_, 16, _>(|i| i as u8);
-    let data1 = array::from_fn::<_, 16, _>(|i| i as u8 + 16);
+    let data0 = array::from_fn::<_, 32, _>(|i| i as u8);
+    let data1 = array::from_fn::<_, 32, _>(|i| i as u8 + 32);
     set_vreg(&mut state, VReg::V2, &data0);
     set_vreg(&mut state, VReg::V3, &data1);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
@@ -121,8 +121,8 @@ fn vsr_two_registers_stores_two_vlenb_blocks() {
     )
     .unwrap();
 
-    assert_eq!(read_mem_bytes::<16>(&state, TEST_BASE_ADDR), &data0);
-    assert_eq!(read_mem_bytes::<16>(&state, TEST_BASE_ADDR + 16), &data1);
+    assert_eq!(read_mem_bytes::<32>(&state, TEST_BASE_ADDR), &data0);
+    assert_eq!(read_mem_bytes::<32>(&state, TEST_BASE_ADDR + 32), &data1);
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn vsr_four_registers_stores_four_vlenb_blocks() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
     for i in 0u8..4 {
-        let data = array::from_fn::<_, 16, _>(|j| i * 16 + j as u8);
+        let data = array::from_fn::<_, 32, _>(|j| i * 32 + j as u8);
         set_vreg(&mut state, VReg::from_bits(4 + i).unwrap(), &data);
     }
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
@@ -147,9 +147,9 @@ fn vsr_four_registers_stores_four_vlenb_blocks() {
     .unwrap();
 
     for i in 0u8..4 {
-        let expected = array::from_fn::<_, 16, _>(|j| i * 16 + j as u8);
+        let expected = array::from_fn::<_, 32, _>(|j| i * 32 + j as u8);
         assert_eq!(
-            read_mem_bytes::<16>(&state, TEST_BASE_ADDR + u64::from(i) * 16),
+            read_mem_bytes::<32>(&state, TEST_BASE_ADDR + u64::from(i) * 32),
             &expected
         );
     }
@@ -160,7 +160,7 @@ fn vsr_eight_registers_stores_eight_vlenb_blocks() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
     for i in 0u8..8 {
-        let data = array::from_fn::<_, 16, _>(|j| i * 16 + j as u8);
+        let data = array::from_fn::<_, 32, _>(|j| i * 32 + j as u8);
         set_vreg(&mut state, VReg::from_bits(8 + i).unwrap(), &data);
     }
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
@@ -177,9 +177,9 @@ fn vsr_eight_registers_stores_eight_vlenb_blocks() {
     .unwrap();
 
     for i in 0u8..8 {
-        let expected = array::from_fn::<_, 16, _>(|j| i * 16 + j as u8);
+        let expected = array::from_fn::<_, 32, _>(|j| i * 32 + j as u8);
         assert_eq!(
-            read_mem_bytes::<16>(&state, TEST_BASE_ADDR + u64::from(i) * 16),
+            read_mem_bytes::<32>(&state, TEST_BASE_ADDR + u64::from(i) * 32),
             &expected
         );
     }
@@ -322,16 +322,16 @@ fn vsr_vstart_at_or_past_evl_writes_nothing() {
 fn vsr_nreg2_vstart_spans_register_boundary() {
     let mut state = initialize_state([]);
     state.ext_state.init_vector_csrs();
-    let d0 = array::from_fn::<_, 16, _>(|i| i as u8);
-    let d1 = array::from_fn::<_, 16, _>(|i| i as u8 + 16);
+    let d0 = array::from_fn::<_, 32, _>(|i| i as u8);
+    let d1 = array::from_fn::<_, 32, _>(|i| i as u8 + 32);
     set_vreg(&mut state, VReg::V2, &d0);
     set_vreg(&mut state, VReg::V3, &d1);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
-    for i in 0u64..32 {
+    for i in 0u64..64 {
         state.memory.write::<u8>(TEST_BASE_ADDR + i, 0xEE).unwrap();
     }
-    // Start mid-second register (byte 20: v3, in-reg offset 4)
-    state.ext_state.set_vstart(20);
+    // Start mid-second register (byte 36: v3, in-reg offset 4)
+    state.ext_state.set_vstart(36);
 
     exec_one(
         &mut state,
@@ -344,15 +344,15 @@ fn vsr_nreg2_vstart_spans_register_boundary() {
     )
     .unwrap();
 
-    for i in 0u64..20 {
+    for i in 0u64..36 {
         assert_eq!(state.memory.read::<u8>(TEST_BASE_ADDR + i).unwrap(), 0xEE);
     }
-    // Bytes 20..32 correspond to v3 bytes 4..16, which equal (byte as u8) + 16
-    for i in 20u64..32 {
-        let in_reg = (i - 16) as u8;
+    // Bytes 36..64 correspond to v3 bytes 4..32, which equal (byte - 32) as u8 + 32
+    for i in 36u64..64 {
+        let in_reg = (i - 32) as u8;
         assert_eq!(
             state.memory.read::<u8>(TEST_BASE_ADDR + i).unwrap(),
-            in_reg + 16
+            in_reg + 32
         );
     }
     assert_eq!(state.ext_state.vstart(), 0);
@@ -362,7 +362,7 @@ fn vsr_nreg2_vstart_spans_register_boundary() {
 
 #[test]
 fn vsm_stores_ceil_vl_over_8_bytes() {
-    // E8/M1: VLMAX=16. Set vl=9 -> ceil(9/8)=2 bytes written.
+    // E8/M1: VLMAX=32. Set vl=9 -> ceil(9/8)=2 bytes written.
     let mut state = setup(9, Vsew::E8, Vlmul::M1);
     // v1 mask register: byte0=0xFF, byte1=0x01
     let mask = [
@@ -526,9 +526,9 @@ fn vsm_vstart_past_evl_writes_nothing() {
 
 #[test]
 fn vse_e8_m1_stores_all_elements() {
-    // VLMAX=16, store all 16 elements
-    let mut state = setup(16, Vsew::E8, Vlmul::M1);
-    let data = array::from_fn::<_, 16, _>(|i| i as u8 + 1);
+    // VLMAX=32, store all 32 elements
+    let mut state = setup(32, Vsew::E8, Vlmul::M1);
+    let data = array::from_fn::<_, 32, _>(|i| i as u8 + 1);
     set_vreg(&mut state, VReg::V4, &data);
     state.regs.write(Reg::A0, TEST_BASE_ADDR);
 
@@ -544,14 +544,14 @@ fn vse_e8_m1_stores_all_elements() {
     )
     .unwrap();
 
-    assert_eq!(read_mem_bytes::<16>(&state, TEST_BASE_ADDR), &data);
+    assert_eq!(read_mem_bytes::<32>(&state, TEST_BASE_ADDR), &data);
     assert_eq!(state.ext_state.vs_dirty_count(), 0);
     assert_eq!(state.ext_state.vstart(), 0);
 }
 
 #[test]
 fn vse_e32_m1_stores_partial_vl() {
-    // VLMAX=4, use vl=3
+    // VLMAX=8, use vl=3
     let mut state = setup(3, Vsew::E32, Vlmul::M1);
     // Pack three u32 values into v0: [1, 2, 3, 0]
     let mut vreg = [0u8; 16];
@@ -590,7 +590,7 @@ fn vse_e32_m1_stores_partial_vl() {
 
 #[test]
 fn vse_e64_m1_stores_two_elements() {
-    // VLMAX=2
+    // E64/M1: VLMAX=4, vl=2
     let mut state = setup(2, Vsew::E64, Vlmul::M1);
     let mut vreg = [0u8; 16];
     vreg[0..8].copy_from_slice(&0x0102_0304_0506_0708_u64.to_le_bytes());
@@ -622,7 +622,7 @@ fn vse_e64_m1_stores_two_elements() {
 
 #[test]
 fn vse_masked_skips_inactive_elements() {
-    // E8/M1 VLMAX=16, vl=8, use first byte of v0 as mask
+    // E8/M1 VLMAX=32, vl=8, use first byte of v0 as mask
     let mut state = setup(8, Vsew::E8, Vlmul::M1);
     // mask: bits 0,2,4,6 set -> elements 0,2,4,6 active
     let mut mask = [0u8; 16];
@@ -781,7 +781,7 @@ fn vse_vector_not_allowed_returns_illegal_instruction() {
 
 #[test]
 fn vsse_positive_stride_stores_with_gap() {
-    // E32/M1 VLMAX=4, vl=3, stride=8 (two u32 gaps)
+    // E32/M1 VLMAX=8, vl=3, stride=8 (two u32 gaps)
     let mut state = setup(3, Vsew::E32, Vlmul::M1);
     let mut vreg = [0u8; 16];
     vreg[0..4].copy_from_slice(&10u32.to_le_bytes());
@@ -878,7 +878,7 @@ fn vsse_negative_stride_stores_in_reverse() {
 
 #[test]
 fn vsse_masked_skips_inactive_elements() {
-    // E64/M1 VLMAX=2, vl=2, stride=16; mask bit 0 set, bit 1 clear
+    // E64/M1 VLMAX=4, vl=2, stride=16; mask bit 0 set, bit 1 clear
     let mut state = setup(2, Vsew::E64, Vlmul::M1);
     let mut mask = [0u8; 16];
     mask[0] = 0b0000_0001;
@@ -922,7 +922,7 @@ fn vsse_masked_skips_inactive_elements() {
 
 #[test]
 fn vsuxei_e32_data_e32_index_stores_at_indexed_addresses() {
-    // SEW=E32/M1: VLMAX=4, vl=3
+    // SEW=E32/M1: VLMAX=8, vl=3
     // index EEW=E32; EMUL_index = (32/32)*1 = 1 -> also M1
     let mut state = setup(3, Vsew::E32, Vlmul::M1);
     // Data register v2: [100, 200, 300]
@@ -966,7 +966,7 @@ fn vsuxei_e32_data_e32_index_stores_at_indexed_addresses() {
 
 #[test]
 fn vsoxei_e64_data_e64_index_stores_at_indexed_addresses() {
-    // SEW=E64/M1: VLMAX=2, vl=2; index EEW=E64 -> EMUL=1
+    // SEW=E64/M1: VLMAX=4, vl=2; index EEW=E64 -> EMUL=1
     let mut state = setup(2, Vsew::E64, Vlmul::M1);
     let mut data_reg = [0u8; 16];
     data_reg[0..8].copy_from_slice(&0xDEAD_BEEF_DEAD_BEEF_u64.to_le_bytes());
@@ -1004,7 +1004,7 @@ fn vsoxei_e64_data_e64_index_stores_at_indexed_addresses() {
 
 #[test]
 fn vsuxei_e8_index_scatter_e8_data() {
-    // SEW=E8/M1: VLMAX=16, vl=4; index EEW=E8 -> EMUL=1
+    // SEW=E8/M1: VLMAX=32, vl=4; index EEW=E8 -> EMUL=1
     // Scatter four bytes to arbitrary offsets
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     let mut data_reg = [0u8; 16];
@@ -1129,7 +1129,7 @@ fn vsuxei_misaligned_data_register_returns_illegal() {
 
 #[test]
 fn vsseg_nf2_e8_m1_stores_two_fields_interleaved() {
-    // nf=2, SEW=E8/M1 VLMAX=16, vl=4
+    // nf=2, SEW=E8/M1 VLMAX=32, vl=4
     // Field 0 in v2, field 1 in v3
     // Memory layout per element: [f0, f1], stride=nf*eew_bytes=2
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
@@ -1169,7 +1169,7 @@ fn vsseg_nf2_e8_m1_stores_two_fields_interleaved() {
 
 #[test]
 fn vsseg_nf3_e32_m1_stores_three_fields_per_element() {
-    // nf=3, SEW=E32/M1 VLMAX=4, vl=2
+    // nf=3, SEW=E32/M1 VLMAX=8, vl=2
     // segment stride = 3 * 4 = 12 bytes per element
     let mut state = setup(2, Vsew::E32, Vlmul::M1);
     for (f, base_val) in [(VReg::V0, 1u32), (VReg::V1, 2u32), (VReg::V2, 3u32)] {
@@ -1314,7 +1314,7 @@ fn vssseg_nf2_e32_m1_stride_16_stores_correctly() {
 
 #[test]
 fn vsuxseg_nf2_e32_index_e32_data_stores_segments_at_indexed_addresses() {
-    // nf=2, SEW=E32/M1 VLMAX=4, vl=2; index EEW=E32
+    // nf=2, SEW=E32/M1 VLMAX=8, vl=2; index EEW=E32
     // vs3=V2 (f0), vs3+1=V3 (f1); vs2=V6 (indices)
     let mut state = setup(2, Vsew::E32, Vlmul::M1);
     let mut f0 = [0u8; 16];
@@ -1356,7 +1356,7 @@ fn vsuxseg_nf2_e32_index_e32_data_stores_segments_at_indexed_addresses() {
 
 #[test]
 fn vsoxseg_nf2_e64_index_e64_data_stores_in_element_order() {
-    // nf=2, SEW=E64/M1 VLMAX=2, vl=2; index EEW=E64
+    // nf=2, SEW=E64/M1 VLMAX=4, vl=2; index EEW=E64
     let mut state = setup(2, Vsew::E64, Vlmul::M1);
     let mut f0 = [0u8; 16];
     f0[0..8].copy_from_slice(&0xAAAA_AAAA_AAAA_AAAA_u64.to_le_bytes());

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow.rs
@@ -107,7 +107,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -179,7 +179,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -253,7 +253,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -325,7 +325,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -403,7 +403,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -475,7 +475,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -548,7 +548,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -620,7 +620,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -698,7 +698,7 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -766,7 +766,7 @@ where
                     vd,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -838,7 +838,7 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -905,7 +905,7 @@ where
                     vd,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -981,7 +981,7 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1048,7 +1048,7 @@ where
                     vd,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1120,7 +1120,7 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1187,7 +1187,7 @@ where
                     vd,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1261,7 +1261,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1328,7 +1328,7 @@ where
                     vs2,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1391,7 +1391,7 @@ where
                     vs2,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1458,7 +1458,7 @@ where
                     vs1,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1525,7 +1525,7 @@ where
                     vs2,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1588,7 +1588,7 @@ where
                     vs2,
                     wide_group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1644,7 +1644,7 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1691,7 +1691,7 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1738,7 +1738,7 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1784,7 +1784,7 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1830,7 +1830,7 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -1876,7 +1876,7 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && vd.bits() == 0 {
+                if !vm && vd == VReg::V0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
@@ -53,7 +53,7 @@ fn read_elem(
     sew: Vsew,
 ) -> u64 {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -70,7 +70,7 @@ fn write_elem(
     value: u64,
 ) {
     let sew_bytes = usize::from(sew.bytes());
-    let elems_per_reg = 16 / sew_bytes;
+    let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
     let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
@@ -87,12 +87,12 @@ fn write_mask(state: &mut TestInterpreterState<Zve64xWidenNarrowInstruction<Reg<
         }
     }
 }
-// With TEST_VLEN=128, VLENB=16:
+// With TEST_VLEN=256, VLENB=32:
 // Widening from SEW produces 2*SEW destination.
-// E8/M1 -> narrow VLMAX=16; wide dest uses M2 (2 regs, E16)
-// E16/M1 -> narrow VLMAX=8; wide dest uses M2 (2 regs, E32)
-// E32/M1 -> narrow VLMAX=4; wide dest uses M2 (2 regs, E64)
-// E8/M2 -> narrow VLMAX=32; wide dest uses M4 (4 regs, E16)
+// E8/M1 -> narrow VLMAX=32; wide dest uses M2 (2 regs, E16)
+// E16/M1 -> narrow VLMAX=16; wide dest uses M2 (2 regs, E32)
+// E32/M1 -> narrow VLMAX=8; wide dest uses M2 (2 regs, E64)
+// E8/M2 -> narrow VLMAX=64; wide dest uses M4 (4 regs, E16)
 // Narrowing from 2*SEW to SEW:
 // vl set to narrow VLMAX; vs2 is a wide group
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
@@ -1842,3 +1842,227 @@ fn vwaddu_wv_vd_aliases_vs2_legal() {
         );
     }
 }
+
+// Widening destination overlapping the highest-numbered part of a narrow source
+
+#[test]
+fn vwsubu_wv_e32_m1_vd_aliases_vs1_high_part_legal() {
+    // Spec §5.2: a widening destination (EEW=2*SEW) may overlap a narrow source (EEW=SEW) when the
+    // source EMUL >= 1 and the overlap is in the highest-numbered part of the destination group.
+    // vwsubu.wv v2, v14, v3: vd={v2,v3} (E64,M2), vs2={v14,v15} (E64,M2 wide), vs1=v3 (E32,M1)
+    // which aliases the high register of the destination group.
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V14, i, Vsew::E64, 0x1_0000_0000u64);
+    }
+    // Narrow source lives in v3, the high register of the {v2,v3} destination group.
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V3, i, Vsew::E32, (i as u64) + 1);
+    }
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubuWv {
+            vd: VReg::V2,
+            vs2: VReg::V14,
+            vs1: VReg::V3,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // Each source element i is read before the destination element i overwrites it (elements are
+    // processed in increasing order), so the aliasing produces correct results.
+    for i in 0..4usize {
+        assert_eq!(
+            read_elem(&state, VReg::V2, i, Vsew::E64),
+            0x1_0000_0000u64 - (i as u64 + 1),
+            "elem {i}"
+        );
+    }
+}
+
+#[test]
+fn vwadd_wv_e8_m2_vs1_high_part_overlap_legal() {
+    // LMUL=2: narrow group=2 regs, wide dest=4 regs. vd={v8,v9,v10,v11}; vs1={v10,v11} occupies the
+    // highest-numbered part of the destination, which is legal.
+    let mut state = setup(4, Vsew::E8, Vlmul::M2);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V16, i, Vsew::E16, 0u64);
+        write_elem(&mut state, VReg::V10, i, Vsew::E8, 5u64);
+    }
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwaddWv {
+            vd: VReg::V8,
+            vs2: VReg::V16,
+            vs1: VReg::V10,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    for i in 0..4usize {
+        // 0 + sext(5) = 5
+        assert_eq!(read_elem(&state, VReg::V8, i, Vsew::E16), 5u64, "elem {i}");
+    }
+}
+
+#[test]
+fn vwaddu_vv_vd_aliases_vs1_high_part_legal() {
+    // The highest-part overlap is also permitted for the .vv form. vd={v2,v3}; vs1=v3 aliases the
+    // high register of the destination, vs2=v6 is disjoint.
+    let mut state = setup(4, Vsew::E16, Vlmul::M1);
+    for i in 0..4usize {
+        write_elem(&mut state, VReg::V6, i, Vsew::E16, 1000u64);
+        write_elem(&mut state, VReg::V3, i, Vsew::E16, 7u64);
+    }
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwadduVv {
+            vd: VReg::V2,
+            vs2: VReg::V6,
+            vs1: VReg::V3,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    for i in 0..4usize {
+        assert_eq!(
+            read_elem(&state, VReg::V2, i, Vsew::E32),
+            1007u64,
+            "elem {i}"
+        );
+    }
+}
+
+#[test]
+fn vwsubu_wv_e32_m1_vd_overlaps_vs1_low_part_illegal() {
+    // vs1=v2 aliases the *low* register of the {v2,v3} destination group, which is not the
+    // highest-numbered part and is therefore illegal.
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubuWv {
+            vd: VReg::V2,
+            vs2: VReg::V14,
+            vs1: VReg::V2,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+// Extension destination overlapping the highest-numbered part of a narrow source
+
+#[test]
+fn vsext_vf2_e16_m2_vs2_high_part_overlap_legal() {
+    // Spec §5.2: an extension destination (EEW=SEW) may overlap a narrow source (EEW=SEW/factor)
+    // when the source EMUL >= 1 and the overlap is in the highest-numbered part of the destination
+    // group. vsext.vf2 v28, v29: vd={v28,v29} (E16,M2), vs2=v29 (E8, EMUL=1) which aliases the high
+    // register of the destination group. This is the exact case that previously failed.
+    let mut state = setup(16, Vsew::E16, Vlmul::M2);
+    // Narrow E8 source elements live in v29, the high register of the {v28,v29} destination group.
+    // High bit is set so sign-extension is exercised: byte 0x80+i -> i16 (i - 128).
+    for i in 0..16usize {
+        write_elem(&mut state, VReg::V29, i, Vsew::E8, 0x80 + i as u64);
+    }
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VsextVf2 {
+            vd: VReg::V28,
+            vs2: VReg::V29,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // Each narrow source element is read before the wide destination element overwrites it
+    // (elements are processed in increasing order), so the aliasing produces correct results.
+    for i in 0..16usize {
+        assert_eq!(
+            read_elem(&state, VReg::V28, i, Vsew::E16),
+            0xff80 + i as u64,
+            "elem {i}"
+        );
+    }
+}
+
+#[test]
+fn vzext_vf4_e32_m8_vs2_high_part_overlap_legal() {
+    // Spec §5.2 example: with LMUL=8, vzext.vf4 v0, v6 is legal. vd={v0..v7} (E32,M8), vs2={v6,v7}
+    // (E8, EMUL=2) aliases the two highest registers of the destination group.
+    let mut state = setup(32, Vsew::E32, Vlmul::M8);
+    for i in 0..32usize {
+        write_elem(&mut state, VReg::V6, i, Vsew::E8, 0xabu64);
+    }
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VzextVf4 {
+            vd: VReg::V0,
+            vs2: VReg::V6,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    for i in 0..32usize {
+        assert_eq!(
+            read_elem(&state, VReg::V0, i, Vsew::E32),
+            0xabu64,
+            "elem {i}"
+        );
+    }
+}
+
+#[test]
+fn vsext_vf2_e16_m2_vs2_low_part_overlap_illegal() {
+    // vs2=v28 aliases the *low* register of the {v28,v29} destination group, which is not the
+    // highest-numbered part and is therefore illegal.
+    let mut state = setup(16, Vsew::E16, Vlmul::M2);
+    let result = exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VsextVf2 {
+            vd: VReg::V28,
+            vs2: VReg::V28,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}
+
+#[test]
+fn vzext_vf4_e32_m8_vs2_non_high_part_overlap_illegal() {
+    // Spec §5.2 example: with LMUL=8, a source of v0/v2/v4 for vzext.vf4 v0, ... is illegal because
+    // it does not occupy the highest-numbered part of the destination group.
+    let mut state = setup(32, Vsew::E32, Vlmul::M8);
+    let result = exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VzextVf4 {
+            vd: VReg::V0,
+            vs2: VReg::V4,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert!(matches!(
+        result,
+        Err(ExecutionError::IllegalInstruction { .. })
+    ));
+}

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
@@ -87,6 +87,7 @@ fn write_mask(state: &mut TestInterpreterState<Zve64xWidenNarrowInstruction<Reg<
         }
     }
 }
+
 // With TEST_VLEN=256, VLENB=32:
 // Widening from SEW produces 2*SEW destination.
 // E8/M1 -> narrow VLMAX=32; wide dest uses M2 (2 regs, E16)
@@ -203,9 +204,9 @@ fn vwaddu_vx_e8_m1_zero_extends_scalar() {
 }
 
 #[test]
-fn vwaddu_vx_e8_m1_scalar_not_truncated_to_sew() {
-    // Per spec §11.2, the rs1 scalar is the full XLEN value zero-extended to 2*SEW
-    // (NOT truncated to SEW). With rs1=0x1ff and SEW=8, the operand is 0x1ff, not 0xff.
+fn vwaddu_vx_e8_m1_scalar_truncated_to_sew() {
+    // The scalar operand participates as a SEW-width zero-extended value; bits above SEW are
+    // discarded before widening. With rs1=0x1ff and SEW=8: 0x1ff & 0xff = 0xff.
     let mut state = setup(2, Vsew::E8, Vlmul::M1);
     write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0x01);
     write_elem(&mut state, VReg::V2, 1, Vsew::E8, 0x00);
@@ -221,8 +222,51 @@ fn vwaddu_vx_e8_m1_scalar_not_truncated_to_sew() {
         },
     )
     .unwrap();
-    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0x200u64);
-    assert_eq!(read_elem(&state, VReg::V8, 1, Vsew::E16), 0x1ffu64);
+    // 0x01 + 0xff = 0x100; 0x00 + 0xff = 0xff
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0x100u64);
+    assert_eq!(read_elem(&state, VReg::V8, 1, Vsew::E16), 0xffu64);
+}
+
+#[test]
+fn vwaddu_vx_e16_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_ffff with SEW=16: truncated to 0xffff; 0x0001 + 0xffff = 0x1_0000
+    let mut state = setup(2, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E16, 0x0001);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E16, 0x0000);
+    state.regs.write(Reg::A0, 0x1_ffffu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwadduVx {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E32), 0x1_0000u64);
+    assert_eq!(read_elem(&state, VReg::V8, 1, Vsew::E32), 0xffffu64);
+}
+
+#[test]
+fn vwaddu_vx_e32_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_ffff_ffff with SEW=32: truncated to 0xffff_ffff; 0x01 + 0xffff_ffff = 0x1_0000_0000
+    let mut state = setup(1, Vsew::E32, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E32, 0x01);
+    state.regs.write(Reg::A0, 0x1_ffff_ffffu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwadduVx {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E64), 0x1_0000_0000u64);
 }
 
 // vwadd.vv
@@ -279,10 +323,11 @@ fn vwadd_vv_e32_m1_sign_extends() {
 
 #[test]
 fn vwadd_vx_e16_m1_sign_extends_scalar() {
-    // rs1 is treated as sign-extended; a negative 64-bit scalar is the right treatment
+    // rs1 is treated as sign-extended from SEW bits; u64::MAX masked to 16 bits = 0xffff = -1 as
+    // i16
     let mut state = setup(2, Vsew::E16, Vlmul::M1);
     write_elem(&mut state, VReg::V2, 0, Vsew::E16, 0x8000);
-    // scalar = -1 in 64 bits = 0xffff_ffff_ffff_ffff (sign-extended)
+    // scalar = u64::MAX; truncated to SEW=16 bits = 0xffff = -1 as i16
     state.regs.write(Reg::A1, u64::MAX);
     exec(
         &mut state,
@@ -295,15 +340,15 @@ fn vwadd_vx_e16_m1_sign_extends_scalar() {
         },
     )
     .unwrap();
-    // sext(0x8000 as i16) = -32768 as i64 = 0xffff_ffff_ffff_8000
-    // + scalar (-1) = 0xffff_ffff_ffff_7fff
+    // sext(0x8000 as i16) = -32768; scalar sext(0xffff as i16) = -1; -32768 + (-1) = -32769 =
+    // 0xffff_7fff
     assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E32), 0xffff_7fffu64);
 }
 
 #[test]
-fn vwadd_vx_e8_m1_scalar_sign_extended_from_xlen_not_sew() {
-    // rs1=0x1ff as i64 is +511 (sign-extended from XLEN, not from SEW).
-    // element 0x01 sext to i16 = 1; 1 + 511 = 512 = 0x0200.
+fn vwadd_vx_e8_m1_scalar_truncated_to_sew() {
+    // Scalar is first truncated to SEW bits, then sign-extended. rs1=0x1ff with SEW=8:
+    // 0x1ff & 0xff = 0xff = -1 as i8; sext to i16 = -1. element 0x01 sext=1; 1+(-1)=0.
     let mut state = setup(1, Vsew::E8, Vlmul::M1);
     write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0x01);
     state.regs.write(Reg::A0, 0x1ffu64);
@@ -318,12 +363,13 @@ fn vwadd_vx_e8_m1_scalar_sign_extended_from_xlen_not_sew() {
         },
     )
     .unwrap();
-    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0x0200u64);
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0u64);
 }
 
 #[test]
 fn vwadd_vx_e8_m1_negative_xlen_scalar() {
-    // rs1 = u64::MAX = -1 signed. 0x01 sext = 1. 1 + (-1) = 0.
+    // rs1 = u64::MAX = -1 signed; truncated to SEW=8 bits: 0xff = -1 as i8; sext = -1.
+    // 0x01 sext = 1. 1 + (-1) = 0.
     let mut state = setup(1, Vsew::E8, Vlmul::M1);
     write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0x01);
     state.regs.write(Reg::A0, u64::MAX);
@@ -339,6 +385,47 @@ fn vwadd_vx_e8_m1_negative_xlen_scalar() {
     )
     .unwrap();
     assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0u64);
+}
+
+#[test]
+fn vwadd_vx_e8_m1_positive_scalar_fits_in_sew() {
+    // rs1=0x7f=127 which fits in i8. sext(0x7f as i8) = 127. 0x01 sext=1. 1+127=128=0x0080.
+    let mut state = setup(1, Vsew::E8, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0x01);
+    state.regs.write(Reg::A0, 0x7fu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwaddVx {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0x0080u64);
+}
+
+#[test]
+fn vwadd_vx_e16_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_8000 with SEW=16: 0x1_8000 & 0xffff = 0x8000 = -32768 as i16.
+    // sext to i32 = -32768. vs2[0]=0x0001 sext=1. 1+(-32768) = -32767 = 0xffff_8001.
+    let mut state = setup(1, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E16, 0x0001);
+    state.regs.write(Reg::A0, 0x1_8000u64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwaddVx {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E32), 0xffff_8001u64);
 }
 
 // vwsubu.vv
@@ -362,6 +449,53 @@ fn vwsubu_vv_e8_m1_zero_extends() {
     )
     .unwrap();
     assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0xffffu64);
+}
+
+// vwsubu.vx
+
+#[test]
+fn vwsubu_vx_e8_m1_scalar_truncated_to_sew() {
+    // rs1=0x1ff with SEW=8: truncated to 0xff. vs2[0]=0x01 zero-ext=0x0001.
+    // 0x0001 - 0x00ff wraps in u16 = 0xff02.
+    let mut state = setup(2, Vsew::E8, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0x01);
+    write_elem(&mut state, VReg::V2, 1, Vsew::E8, 0xff);
+    state.regs.write(Reg::A0, 0x1ffu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubuVx {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    // 0x0001 - 0x00ff = 0xff02 (wraps)
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0xff02u64);
+    // 0x00ff - 0x00ff = 0
+    assert_eq!(read_elem(&state, VReg::V8, 1, Vsew::E16), 0u64);
+}
+
+#[test]
+fn vwsubu_vx_e16_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_0001 with SEW=16: truncated to 0x0001. vs2[0]=0x8000. 0x8000 - 0x0001 = 0x7fff.
+    let mut state = setup(1, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E16, 0x8000);
+    state.regs.write(Reg::A0, 0x1_0001u64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubuVx {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E32), 0x7fffu64);
 }
 
 // vwsub.vv
@@ -388,10 +522,12 @@ fn vwsub_vv_e8_m1_sign_extends() {
     assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 0xffffu64);
 }
 
+// vwsub.vx
+
 #[test]
 fn vwsub_vx_e32_m1_sign_extends() {
-    // sext(0x8000_0000 as i32) = -2147483648i64; scalar = -1
-    // result = -2147483648 - (-1) = -2147483647
+    // sext(0x8000_0000 as i32) = -2147483648i64; scalar u64::MAX truncated to SEW=32 = 0xffff_ffff
+    // = -1 result = -2147483648 - (-1) = -2147483647
     let mut state = setup(1, Vsew::E32, Vlmul::M1);
     write_elem(&mut state, VReg::V2, 0, Vsew::E32, 0x8000_0000);
     state.regs.write(Reg::A0, u64::MAX);
@@ -413,15 +549,55 @@ fn vwsub_vx_e32_m1_sign_extends() {
     );
 }
 
+#[test]
+fn vwsub_vx_e8_m1_scalar_truncated_to_sew() {
+    // rs1=0x1ff with SEW=8: 0x1ff & 0xff = 0xff = -1 as i8; sext = -1.
+    // vs2[0]=0x01 sext=1. 1 - (-1) = 2.
+    let mut state = setup(1, Vsew::E8, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E8, 0x01);
+    state.regs.write(Reg::A0, 0x1ffu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubVx {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E16), 2u64);
+}
+
+#[test]
+fn vwsub_vx_e16_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_8000 with SEW=16: truncated to 0x8000 = -32768 as i16; sext = -32768.
+    // vs2[0]=0x0001 sext=1. 1 - (-32768) = 32769 = 0x8001.
+    let mut state = setup(1, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V2, 0, Vsew::E16, 0x0001);
+    state.regs.write(Reg::A0, 0x1_8000u64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubVx {
+            vd: VReg::V8,
+            vs2: VReg::V2,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V8, 0, Vsew::E32), 0x8001u64);
+}
+
 // vwaddu.wv
 
 #[test]
 fn vwaddu_wv_e8_m1_wide_plus_narrow() {
     // vs2 holds 2*SEW=E16 values; vs1 holds SEW=E8 (zero-extended)
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
-    // vs2 is the wide group (uses 2 regs for M1 -> M2 dest)
     // vwaddu.wv: vd(E16,M2) = vs2(E16,M2) + zext(vs1(E8,M1))
-    // Use V8 as wide vs2, V4 as narrow vs1, V0 group for vd but v0 conflicts with mask
     // Use V16 as vd(M2), V8 as vs2(M2), V4 as vs1(M1)
     for i in 0..4usize {
         write_elem(&mut state, VReg::V8, i, Vsew::E16, 1000);
@@ -444,6 +620,8 @@ fn vwaddu_wv_e8_m1_wide_plus_narrow() {
         assert_eq!(read_elem(&state, VReg::V16, i, Vsew::E16), 1255, "elem {i}");
     }
 }
+
+// vwaddu.wx
 
 #[test]
 fn vwaddu_wx_e16_m1_wide_plus_scalar() {
@@ -473,9 +651,9 @@ fn vwaddu_wx_e16_m1_wide_plus_scalar() {
 }
 
 #[test]
-fn vwaddu_wx_e8_m1_scalar_not_truncated() {
-    // Wide source = 0x200, scalar = 0x1ff (full XLEN value, zero-extended).
-    // 0x200 + 0x1ff = 0x3ff.
+fn vwaddu_wx_e8_m1_scalar_truncated_to_sew() {
+    // Scalar participates as a SEW-width zero-extended value. rs1=0x1ff with SEW=8:
+    // truncated to 0xff. Wide source=0x200. 0x200 + 0xff = 0x2ff.
     let mut state = setup(1, Vsew::E8, Vlmul::M1);
     write_elem(&mut state, VReg::V8, 0, Vsew::E16, 0x200u64);
     state.regs.write(Reg::A0, 0x1ffu64);
@@ -490,7 +668,27 @@ fn vwaddu_wx_e8_m1_scalar_not_truncated() {
         },
     )
     .unwrap();
-    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E16), 0x3ffu64);
+    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E16), 0x2ffu64);
+}
+
+#[test]
+fn vwaddu_wx_e16_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_ffff with SEW=16: truncated to 0xffff. Wide=0x0001. 0x0001 + 0xffff = 0x1_0000.
+    let mut state = setup(1, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V8, 0, Vsew::E32, 0x0001u64);
+    state.regs.write(Reg::A0, 0x1_ffffu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwadduWx {
+            vd: VReg::V16,
+            vs2: VReg::V8,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E32), 0x1_0000u64);
 }
 
 // vwadd.wv / vwadd.wx
@@ -527,7 +725,8 @@ fn vwadd_wv_e8_m1_sign_extends_narrow() {
 
 #[test]
 fn vwadd_wx_e32_m1_sign_extends_scalar() {
-    // scalar = -1 (u64::MAX), wide source = 0; result = -1 as E64 = 0xffff_ffff_ffff_ffff
+    // scalar = -1 (u64::MAX truncated to SEW=32 = 0xffff_ffff = -1 as i32; sext = -1)
+    // wide source = 0; result = -1 as E64 = 0xffff_ffff_ffff_ffff
     let mut state = setup(1, Vsew::E32, Vlmul::M1);
     write_elem(&mut state, VReg::V8, 0, Vsew::E64, 0u64);
     state.regs.write(Reg::A0, u64::MAX);
@@ -543,6 +742,48 @@ fn vwadd_wx_e32_m1_sign_extends_scalar() {
     )
     .unwrap();
     assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E64), u64::MAX);
+}
+
+#[test]
+fn vwadd_wx_e8_m1_scalar_truncated_to_sew() {
+    // rs1=0x1ff with SEW=8: truncated to 0xff = -1 as i8; sext = -1 as i16 = 0xffff.
+    // Wide source = 0x0000. 0x0000 + 0xffff = 0xffff.
+    let mut state = setup(1, Vsew::E8, Vlmul::M1);
+    write_elem(&mut state, VReg::V8, 0, Vsew::E16, 0u64);
+    state.regs.write(Reg::A0, 0x1ffu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwaddWx {
+            vd: VReg::V16,
+            vs2: VReg::V8,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E16), 0xffffu64);
+}
+
+#[test]
+fn vwadd_wx_e16_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_8000 with SEW=16: truncated to 0x8000 = -32768 as i16; sext = -32768 as i32.
+    // Wide source = 0. 0 + (-32768) = -32768 as u32 = 0xffff_8000.
+    let mut state = setup(1, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V8, 0, Vsew::E32, 0u64);
+    state.regs.write(Reg::A0, 0x1_8000u64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwaddWx {
+            vd: VReg::V16,
+            vs2: VReg::V8,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E32), 0xffff_8000u64);
 }
 
 // vwsubu.wv / vwsubu.wx
@@ -593,6 +834,46 @@ fn vwsubu_wx_e16_m1_scalar() {
     assert_eq!(read_elem(&state, VReg::V16, 1, Vsew::E32), 4u64);
 }
 
+#[test]
+fn vwsubu_wx_e8_m1_scalar_truncated_to_sew() {
+    // rs1=0x1ff with SEW=8: truncated to 0xff. Wide=0x0100. 0x0100 - 0x00ff = 0x0001.
+    let mut state = setup(1, Vsew::E8, Vlmul::M1);
+    write_elem(&mut state, VReg::V8, 0, Vsew::E16, 0x0100u64);
+    state.regs.write(Reg::A0, 0x1ffu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubuWx {
+            vd: VReg::V16,
+            vs2: VReg::V8,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E16), 0x0001u64);
+}
+
+#[test]
+fn vwsubu_wx_e16_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_0001 with SEW=16: truncated to 0x0001. Wide=0x8000. 0x8000 - 0x0001 = 0x7fff.
+    let mut state = setup(1, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V8, 0, Vsew::E32, 0x8000u64);
+    state.regs.write(Reg::A0, 0x1_0001u64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubuWx {
+            vd: VReg::V16,
+            vs2: VReg::V8,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E32), 0x7fffu64);
+}
+
 // vwsub.wv / vwsub.wx
 
 #[test]
@@ -618,7 +899,7 @@ fn vwsub_wv_e8_m1_sign_extends_narrow() {
 
 #[test]
 fn vwsub_wx_e32_m1_sign_extends_scalar() {
-    // wide = 0, scalar = -1 (u64::MAX); 0 - (-1) = 1
+    // wide = 0, scalar u64::MAX truncated to SEW=32 = 0xffff_ffff = -1; 0 - (-1) = 1
     let mut state = setup(1, Vsew::E32, Vlmul::M1);
     write_elem(&mut state, VReg::V8, 0, Vsew::E64, 0u64);
     state.regs.write(Reg::A0, u64::MAX);
@@ -634,6 +915,48 @@ fn vwsub_wx_e32_m1_sign_extends_scalar() {
     )
     .unwrap();
     assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E64), 1u64);
+}
+
+#[test]
+fn vwsub_wx_e8_m1_scalar_truncated_to_sew() {
+    // rs1=0x1ff with SEW=8: truncated to 0xff = -1 as i8; sext = -1.
+    // Wide = 0x0000. 0 - (-1) = 1.
+    let mut state = setup(1, Vsew::E8, Vlmul::M1);
+    write_elem(&mut state, VReg::V8, 0, Vsew::E16, 0u64);
+    state.regs.write(Reg::A0, 0x1ffu64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubWx {
+            vd: VReg::V16,
+            vs2: VReg::V8,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E16), 1u64);
+}
+
+#[test]
+fn vwsub_wx_e16_m1_scalar_truncated_to_sew() {
+    // rs1=0x1_8000 with SEW=16: truncated to 0x8000 = -32768 as i16; sext = -32768.
+    // Wide = 0. 0 - (-32768) = 32768 = 0x8000.
+    let mut state = setup(1, Vsew::E16, Vlmul::M1);
+    write_elem(&mut state, VReg::V8, 0, Vsew::E32, 0u64);
+    state.regs.write(Reg::A0, 0x1_8000u64);
+    exec(
+        &mut state,
+        Zve64xWidenNarrowInstruction::VwsubWx {
+            vd: VReg::V16,
+            vs2: VReg::V8,
+            rs1: Reg::A0,
+            vm: true,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(read_elem(&state, VReg::V16, 0, Vsew::E32), 0x8000u64);
 }
 
 // vnsrl.wv / vnsrl.wx / vnsrl.wi
@@ -1968,7 +2291,7 @@ fn vsext_vf2_e16_m2_vs2_high_part_overlap_legal() {
     // Spec §5.2: an extension destination (EEW=SEW) may overlap a narrow source (EEW=SEW/factor)
     // when the source EMUL >= 1 and the overlap is in the highest-numbered part of the destination
     // group. vsext.vf2 v28, v29: vd={v28,v29} (E16,M2), vs2=v29 (E8, EMUL=1) which aliases the high
-    // register of the destination group. This is the exact case that previously failed.
+    // register of the destination group.
     let mut state = setup(16, Vsew::E16, Vlmul::M2);
     // Narrow E8 source elements live in v29, the high register of the {v28,v29} destination group.
     // High bit is set so sign-extension is exercised: byte 0x80+i -> i16 (i - 128).

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
@@ -275,6 +275,57 @@ pub fn sign_extend_bits(val: u64, bits: u32) -> i64 {
     (val.cast_signed() << shift) >> shift
 }
 
+/// Interpret a scalar operand as an unsigned SEW-wide value.
+///
+/// RVV widening scalar instructions (.vx/.wx) conceptually use a scalar
+/// operand whose width matches the current SEW, not the full XLEN width.
+///
+/// For example on RV64:
+///
+/// SEW=8:
+///     val = 0x0000_0000_0000_01ff
+///     result = 0x0000_0000_0000_00ff
+///
+/// SEW=16:
+///     val = 0x0000_0000_0000_01ff
+///     result = 0x0000_0000_0000_01ff
+///
+/// SEW=32:
+///     val = 0xffff_ffff_1234_5678
+///     result = 0x0000_0000_1234_5678
+///
+/// This helper performs that SEW-width truncation without sign extension.
+#[inline(always)]
+fn scalar_unsigned_for_sew(val: u64, sew_bits: u32) -> u64 {
+    val & (u64::MAX >> (u64::BITS - sew_bits))
+}
+
+/// Interpret a scalar operand as a signed SEW-wide value.
+///
+/// The scalar is first truncated to SEW bits, then sign-extended back to
+/// 64 bits.
+///
+/// For example on RV64:
+///
+/// SEW=8:
+///     val = 0x0000_0000_0000_00ff
+///     result = 0xffff_ffff_ffff_ffff (-1)
+///
+/// SEW=8:
+///     val = 0x0000_0000_0000_007f
+///     result = 0x0000_0000_0000_007f (+127)
+///
+/// SEW=16:
+///     val = 0x0000_0000_0000_ffff
+///     result = 0xffff_ffff_ffff_ffff (-1)
+///
+/// This matches the signed widening behavior required by instructions such
+/// as vwadd.vx and vwsub.vx.
+#[inline(always)]
+fn scalar_signed_for_sew(val: u64, sew_bits: u32) -> u64 {
+    sign_extend_bits(val, sew_bits).cast_unsigned()
+}
+
 /// Execute a widening integer add/subtract.
 ///
 /// Each source element is SEW-wide; the destination element is 2×SEW-wide.
@@ -350,7 +401,13 @@ pub unsafe fn execute_widen_op<Reg, ExtState, CustomError, F>(
                     sign_extend_bits(raw_b, sew_bits).cast_unsigned()
                 }
             }
-            OpSrc::Scalar(val) => *val,
+            OpSrc::Scalar(val) => {
+                if zero_extend_b {
+                    scalar_unsigned_for_sew(*val, sew_bits)
+                } else {
+                    scalar_signed_for_sew(*val, sew_bits)
+                }
+            }
         };
         let result = op(wide_a, wide_b);
         // SAFETY: `vd` aligned to `2*group_regs`; `i < vl <= group_regs * (VLENB / sew_bytes)`
@@ -435,7 +492,13 @@ pub unsafe fn execute_widen_w_op<Reg, ExtState, CustomError, F>(
                     sign_extend_bits(raw_b, sew_bits).cast_unsigned()
                 }
             }
-            OpSrc::Scalar(val) => *val,
+            OpSrc::Scalar(val) => {
+                if zero_extend_b {
+                    scalar_unsigned_for_sew(*val, sew_bits)
+                } else {
+                    scalar_signed_for_sew(*val, sew_bits)
+                }
+            }
         };
         let result = op(wide_a, wide_b);
         // SAFETY: same as `execute_widen_op` for vd

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
@@ -30,8 +30,14 @@ where
     Ok(())
 }
 
-/// Check that an extension source `vs2` is aligned to `src_group_regs`, fits in `[0,32)`, and
-/// does not overlap `vd` (which occupies `group_regs` registers).
+/// Check that an extension source `vs2` is aligned to `src_group_regs`, fits in `[0,32)`, and only
+/// overlaps `vd` (which occupies `group_regs` registers) in a manner permitted by the spec.
+///
+/// Per the vector spec §5.2, the destination EEW (SEW) of an extension is greater than the source
+/// EEW (SEW/factor), so the destination may overlap the source only when the source EMUL is at
+/// least 1 and the overlap is in the highest-numbered part of the destination register group (e.g.
+/// `vzext.vf4 v0, v6` with LMUL=8, where the narrow source `{v6,v7}` aliases the high registers of
+/// the wide `{v0..v7}` destination). Any other overlap is illegal.
 #[inline(always)]
 #[doc(hidden)]
 pub fn check_vs_ext_alignment<Reg, Memory, PC, CustomError>(
@@ -51,8 +57,9 @@ where
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
-    // vd and vs2 must not overlap
-    if ranges_overlap(vd.bits(), group_regs, vs2_idx, src_group_regs) {
+    // The wide destination (group_regs) may overlap the narrow source (src_group_regs) only in the
+    // highest-numbered part of the destination group, and only when the source EMUL >= 1.
+    if widen_src_overlap_illegal(vd.bits(), group_regs, vs2_idx, src_group_regs) {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
@@ -60,11 +67,18 @@ where
     Ok(())
 }
 
-/// Check that a widening destination `vd` is aligned to `wide_group_regs`, does not overlap the
-/// `group_regs` registers starting at `vs_a` or `vs_b`, and fits within `[0, 32)`.
+/// Check that a widening destination `vd` is aligned to `wide_group_regs`, fits within `[0, 32)`,
+/// and only overlaps the `group_regs`-register narrow source(s) starting at `vs_a`/`vs_b` in a
+/// manner permitted by the spec.
 ///
 /// `wide_group_regs` is the pre-computed register count for the wide EMUL (2*LMUL), obtained via
 /// `Vlmul::index_register_count(wide_eew, sew)`. `group_regs` is the narrow LMUL register count.
+///
+/// Per the vector spec §5.2, a destination whose EEW (2*SEW) is greater than a source's EEW (SEW)
+/// may overlap that source only when the source EMUL is at least 1 and the overlap is in the
+/// highest-numbered part of the destination register group (e.g. `vwsubu.wv v2, v14, v3` with
+/// LMUL=1, where the narrow `v3` aliases the high register of the wide `{v2, v3}` destination).
+/// Any other overlap is illegal.
 #[inline(always)]
 #[doc(hidden)]
 pub fn check_vd_widen_alignment<Reg, Memory, PC, CustomError>(
@@ -85,21 +99,37 @@ where
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
-    let va_idx = vs_a.bits();
-    if ranges_overlap(vd_idx, wide_group_regs, va_idx, group_regs) {
+    if widen_src_overlap_illegal(vd_idx, wide_group_regs, vs_a.bits(), group_regs) {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
-    if let Some(vs_b) = vs_b_opt {
-        let vb_idx = vs_b.bits();
-        if ranges_overlap(vd_idx, wide_group_regs, vb_idx, group_regs) {
-            return Err(ExecutionError::IllegalInstruction {
-                address: program_counter.old_pc(INSTRUCTION_SIZE),
-            });
-        }
+    if let Some(vs_b) = vs_b_opt
+        && widen_src_overlap_illegal(vd_idx, wide_group_regs, vs_b.bits(), group_regs)
+    {
+        return Err(ExecutionError::IllegalInstruction {
+            address: program_counter.old_pc(INSTRUCTION_SIZE),
+        });
     }
     Ok(())
+}
+
+/// Returns `true` when a narrow source group of `group_regs` registers starting at `vs_idx`
+/// overlaps the wide destination group (`wide_group_regs` registers starting at `vd_idx`) in a way
+/// that is *not* permitted by the spec.
+///
+/// Overlap is only legal when the source EMUL is at least 1 - which, on widening, is exactly when
+/// the destination register count strictly exceeds the narrow source count (for fractional LMUL
+/// both counts collapse to 1) - and the source occupies the highest-numbered registers of the
+/// destination group.
+#[inline(always)]
+fn widen_src_overlap_illegal(vd_idx: u8, wide_group_regs: u8, vs_idx: u8, group_regs: u8) -> bool {
+    if !ranges_overlap(vd_idx, wide_group_regs, vs_idx, group_regs) {
+        return false;
+    }
+    let high_part_overlap =
+        wide_group_regs > group_regs && vs_idx == vd_idx + wide_group_regs - group_regs;
+    !high_part_overlap
 }
 
 /// Check that a widening source `vs2` that is already 2×SEW wide is aligned to `wide_group_regs`

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
@@ -80,6 +80,9 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
                         pat_struct.fields = mem::take(&mut pat_struct.fields)
                             .into_iter()
                             .filter_map(|field| {
+                                // TODO: Ensure all fields correspond to those in the enum
+                                //  definition, right now this silently accepts non-existing ignored
+                                //  fields
                                 if let Pat::Wild(_) = &*field.pat {
                                     return None;
                                 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/utils/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/utils/tests.rs
@@ -121,7 +121,7 @@ fn i24_negative_one_stored_as_all_ff() {
 
 #[test]
 fn i24_sign_extension_positive_boundary() {
-    // 0x7FFFFF is max positive; 0x800000 would be the sign bit — must not be stored
+    // 0x7FFFFF is max positive; 0x800000 would be the sign bit - must not be stored
     let v = 0x007F_FFFF_i32;
     let recovered = I24::from_i32(v).to_i32();
     assert_eq!(recovered, v);

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x.rs
@@ -3,6 +3,8 @@
 #[doc(hidden)]
 pub mod arith;
 #[doc(hidden)]
+pub mod carry;
+#[doc(hidden)]
 pub mod config;
 #[doc(hidden)]
 pub mod fixed_point;
@@ -24,6 +26,7 @@ pub mod widen_narrow;
 use crate::instructions::Instruction;
 use crate::instructions::v::Eew;
 use crate::instructions::v::zve64x::arith::Zve64xArithInstruction;
+use crate::instructions::v::zve64x::carry::Zve64xCarryInstruction;
 use crate::instructions::v::zve64x::config::Zve64xConfigInstruction;
 use crate::instructions::v::zve64x::fixed_point::Zve64xFixedPointInstruction;
 use crate::instructions::v::zve64x::load::Zve64xLoadInstruction;
@@ -46,6 +49,7 @@ use core::fmt;
         Zve64xLoadInstruction,
         Zve64xStoreInstruction,
         Zve64xArithInstruction,
+        Zve64xCarryInstruction,
         Zve64xMulDivInstruction,
         Zve64xWidenNarrowInstruction,
         Zve64xFixedPointInstruction,

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/carry.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/carry.rs
@@ -1,0 +1,177 @@
+//! Zve64x carry/borrow arithmetic instructions
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use crate::registers::vector::VReg;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V Zve64x carry/borrow arithmetic instruction.
+///
+/// All use the OP-V major opcode (0b101_0111) with OPIVV/OPIVX/OPIVI funct3.
+/// The `vm` encoding bit selects carry/borrow-in source or signals no carry:
+///
+/// - vadc:  funct6=0b010000, vm=0 (carry-in from v0, always)
+/// - vmadc: funct6=0b010001, vm=0 (carry-in from v0) or vm=1 (no carry-in)
+/// - vsbc:  funct6=0b010010, vm=0 (borrow-in from v0, always)
+/// - vmsbc: funct6=0b010011, vm=0 (borrow-in from v0) or vm=1 (no borrow-in)
+///
+/// vadc/vsbc produce SEW-wide data results written to vd.
+/// vmadc/vmsbc produce one mask bit per element (carry-out/borrow-out) written to vd.
+#[instruction]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[rustfmt::skip]
+#[doc(hidden)]
+pub enum Zve64xCarryInstruction<Reg> {
+    // vadc: add with carry-in from v0, write SEW-wide result to vd (data register)
+
+    /// `vadc.vvm vd, vs2, vs1, v0`
+    VadcVvm { vd: VReg, vs2: VReg, vs1: VReg },
+    /// `vadc.vxm vd, vs2, rs1, v0`
+    VadcVxm { vd: VReg, vs2: VReg, rs1: Reg },
+    /// `vadc.vim vd, vs2, imm, v0`
+    VadcVim { vd: VReg, vs2: VReg, imm: i8 },
+
+    // vmadc: add and produce carry-out mask in vd
+    // vm=0: carry-in from v0;  vm=1: no carry-in (treat carry-in as zero)
+
+    /// `vmadc.vvm vd, vs2, vs1, v0` - with carry-in
+    VmadcVvm { vd: VReg, vs2: VReg, vs1: VReg },
+    /// `vmadc.vxm vd, vs2, rs1, v0` - with carry-in
+    VmadcVxm { vd: VReg, vs2: VReg, rs1: Reg },
+    /// `vmadc.vim vd, vs2, imm, v0` - with carry-in
+    VmadcVim { vd: VReg, vs2: VReg, imm: i8 },
+    /// `vmadc.vv vd, vs2, vs1` - no carry-in
+    VmadcVv  { vd: VReg, vs2: VReg, vs1: VReg },
+    /// `vmadc.vx vd, vs2, rs1` - no carry-in
+    VmadcVx  { vd: VReg, vs2: VReg, rs1: Reg },
+    /// `vmadc.vi vd, vs2, imm` - no carry-in
+    VmadcVi  { vd: VReg, vs2: VReg, imm: i8 },
+
+    // vsbc: subtract with borrow-in from v0, write SEW-wide result to vd (data register)
+    // No immediate form in the spec.
+
+    /// `vsbc.vvm vd, vs2, vs1, v0`
+    VsbcVvm  { vd: VReg, vs2: VReg, vs1: VReg },
+    /// `vsbc.vxm vd, vs2, rs1, v0`
+    VsbcVxm  { vd: VReg, vs2: VReg, rs1: Reg },
+
+    // vmsbc: subtract and produce borrow-out mask in vd
+    // vm=0: borrow-in from v0;  vm=1: no borrow-in
+
+    /// `vmsbc.vvm vd, vs2, vs1, v0` - with borrow-in
+    VmsbcVvm { vd: VReg, vs2: VReg, vs1: VReg },
+    /// `vmsbc.vxm vd, vs2, rs1, v0` - with borrow-in
+    VmsbcVxm { vd: VReg, vs2: VReg, rs1: Reg },
+    /// `vmsbc.vv vd, vs2, vs1` - no borrow-in
+    VmsbcVv  { vd: VReg, vs2: VReg, vs1: VReg },
+    /// `vmsbc.vx vd, vs2, rs1` - no borrow-in
+    VmsbcVx  { vd: VReg, vs2: VReg, rs1: Reg },
+}
+
+#[instruction]
+impl<Reg> const Instruction for Zve64xCarryInstruction<Reg>
+where
+    Reg: [const] Register,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+
+        if opcode != 0b101_0111 {
+            None?;
+        }
+
+        let vd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let vs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let vs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let vm = ((instruction >> 25) & 1) as u8;
+        let funct6 = ((instruction >> 26) & 0b11_1111) as u8;
+
+        let vd = VReg::from_bits(vd_bits)?;
+        let vs2 = VReg::from_bits(vs2_bits)?;
+
+        match funct3 {
+            // OPIVV
+            0b000 => {
+                let vs1 = VReg::from_bits(vs1_bits)?;
+                match (funct6, vm) {
+                    (0b01_0000, 0) => Some(Self::VadcVvm { vd, vs2, vs1 }),
+                    (0b01_0001, 0) => Some(Self::VmadcVvm { vd, vs2, vs1 }),
+                    (0b01_0001, 1) => Some(Self::VmadcVv { vd, vs2, vs1 }),
+                    (0b01_0010, 0) => Some(Self::VsbcVvm { vd, vs2, vs1 }),
+                    (0b01_0011, 0) => Some(Self::VmsbcVvm { vd, vs2, vs1 }),
+                    (0b01_0011, 1) => Some(Self::VmsbcVv { vd, vs2, vs1 }),
+                    _ => None,
+                }
+            }
+            // OPIVX
+            0b100 => {
+                let rs1 = Reg::from_bits(vs1_bits)?;
+                match (funct6, vm) {
+                    (0b01_0000, 0) => Some(Self::VadcVxm { vd, vs2, rs1 }),
+                    (0b01_0001, 0) => Some(Self::VmadcVxm { vd, vs2, rs1 }),
+                    (0b01_0001, 1) => Some(Self::VmadcVx { vd, vs2, rs1 }),
+                    (0b01_0010, 0) => Some(Self::VsbcVxm { vd, vs2, rs1 }),
+                    (0b01_0011, 0) => Some(Self::VmsbcVxm { vd, vs2, rs1 }),
+                    (0b01_0011, 1) => Some(Self::VmsbcVx { vd, vs2, rs1 }),
+                    _ => None,
+                }
+            }
+            // OPIVI - only vadc and vmadc have immediate forms; vsbc/vmsbc do not
+            0b011 => {
+                let imm = (vs1_bits << 3).cast_signed() >> 3u8;
+                match (funct6, vm) {
+                    (0b01_0000, 0) => Some(Self::VadcVim { vd, vs2, imm }),
+                    (0b01_0001, 0) => Some(Self::VmadcVim { vd, vs2, imm }),
+                    (0b01_0001, 1) => Some(Self::VmadcVi { vd, vs2, imm }),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Zve64xCarryInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::VadcVvm  { vd, vs2, vs1 } => write!(f, "vadc.vvm {vd}, {vs2}, {vs1}, v0"),
+            Self::VadcVxm  { vd, vs2, rs1 } => write!(f, "vadc.vxm {vd}, {vs2}, {rs1}, v0"),
+            Self::VadcVim  { vd, vs2, imm } => write!(f, "vadc.vim {vd}, {vs2}, {imm}, v0"),
+            Self::VmadcVvm { vd, vs2, vs1 } => write!(f, "vmadc.vvm {vd}, {vs2}, {vs1}, v0"),
+            Self::VmadcVxm { vd, vs2, rs1 } => write!(f, "vmadc.vxm {vd}, {vs2}, {rs1}, v0"),
+            Self::VmadcVim { vd, vs2, imm } => write!(f, "vmadc.vim {vd}, {vs2}, {imm}, v0"),
+            Self::VmadcVv  { vd, vs2, vs1 } => write!(f, "vmadc.vv {vd}, {vs2}, {vs1}"),
+            Self::VmadcVx  { vd, vs2, rs1 } => write!(f, "vmadc.vx {vd}, {vs2}, {rs1}"),
+            Self::VmadcVi  { vd, vs2, imm } => write!(f, "vmadc.vi {vd}, {vs2}, {imm}"),
+            Self::VsbcVvm  { vd, vs2, vs1 } => write!(f, "vsbc.vvm {vd}, {vs2}, {vs1}, v0"),
+            Self::VsbcVxm  { vd, vs2, rs1 } => write!(f, "vsbc.vxm {vd}, {vs2}, {rs1}, v0"),
+            Self::VmsbcVvm { vd, vs2, vs1 } => write!(f, "vmsbc.vvm {vd}, {vs2}, {vs1}, v0"),
+            Self::VmsbcVxm { vd, vs2, rs1 } => write!(f, "vmsbc.vxm {vd}, {vs2}, {rs1}, v0"),
+            Self::VmsbcVv  { vd, vs2, vs1 } => write!(f, "vmsbc.vv {vd}, {vs2}, {vs1}"),
+            Self::VmsbcVx  { vd, vs2, rs1 } => write!(f, "vmsbc.vx {vd}, {vs2}, {rs1}"),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/carry/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/carry/tests.rs
@@ -1,0 +1,429 @@
+extern crate alloc;
+
+use crate::instructions::Instruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::instructions::v::zve64x::carry::Zve64xCarryInstruction;
+use crate::registers::general_purpose::Reg;
+use crate::registers::vector::VReg;
+use alloc::format;
+
+/// Build a carry-class OP-V instruction word.
+///
+/// Format: `funct6[31:26] | vm[25] | vs2[24:20] | vs1[19:15] | funct3[14:12] | vd[11:7] |
+/// opcode[6:0]`
+fn make_vop(funct6: u8, vm: u8, vs2: u8, vs1: u8, funct3: u8, vd: u8) -> u32 {
+    let funct7 = (funct6 << 1u8) | (vm & 1);
+    make_r_type(0b101_0111, vd, funct3, vs1, vs2, funct7)
+}
+
+const OPIVV: u8 = 0b000;
+const OPIVX: u8 = 0b100;
+const OPIVI: u8 = 0b011;
+
+// vadd (funct6=0b00_0000) must NOT decode as any carry instruction - regression guard
+// for the false-positive that triggered this fix.
+
+#[test]
+fn non_carry_funct6_not_decoded() {
+    let inst = make_vop(0b00_0000, 1, 2, 3, OPIVV, 1);
+    assert_eq!(Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst), None);
+}
+
+// False-decode regression: funct6=0b010000, OPIVV with vs1=v17 (0b10001)
+// previously matched vfirst.m in the mask decoder.
+
+#[test]
+fn vadc_vvm_not_falsely_decoded_as_vfirst_m() {
+    // funct6=0b01_0000, vm=0, vs2=v9, vs1=v17 (0b10001), OPIVV, vd=v12
+    let inst = make_vop(0b01_0000, 0, 9, 17, OPIVV, 12);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert!(matches!(
+        decoded,
+        Some(Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V12,
+            vs2: VReg::V9,
+            vs1: VReg::V17,
+            ..
+        })
+    ));
+}
+
+// vadc
+
+#[test]
+fn vadc_vvm_basic() {
+    let inst = make_vop(0b01_0000, 0, 2, 3, OPIVV, 1);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V1,
+            vs2: VReg::V2,
+            vs1: VReg::V3,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vadc_vxm_basic() {
+    let inst = make_vop(0b01_0000, 0, 4, 10, OPIVX, 6);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VadcVxm {
+            vd: VReg::V6,
+            vs2: VReg::V4,
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vadc_vim_positive() {
+    // imm = 5 (0b00101)
+    let inst = make_vop(0b01_0000, 0, 8, 5, OPIVI, 2);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VadcVim {
+            vd: VReg::V2,
+            vs2: VReg::V8,
+            imm: 5,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vadc_vim_negative() {
+    // imm = -1 → 5-bit = 0b11111 = 31
+    let inst = make_vop(0b01_0000, 0, 8, 0b11111, OPIVI, 2);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VadcVim {
+            vd: VReg::V2,
+            vs2: VReg::V8,
+            imm: -1,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+// vadc vm=1 is reserved - must not decode
+
+#[test]
+fn vadc_vvm_vm1_is_reserved() {
+    let inst = make_vop(0b01_0000, 1, 2, 3, OPIVV, 1);
+    assert_eq!(Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst), None);
+}
+
+#[test]
+fn vadc_vxm_vm1_is_reserved() {
+    let inst = make_vop(0b01_0000, 1, 2, 5, OPIVX, 1);
+    assert_eq!(Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst), None);
+}
+
+// vmadc
+
+#[test]
+fn vmadc_vvm_with_carry() {
+    let inst = make_vop(0b01_0001, 0, 4, 5, OPIVV, 3);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmadcVvm {
+            vd: VReg::V3,
+            vs2: VReg::V4,
+            vs1: VReg::V5,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmadc_vv_no_carry() {
+    let inst = make_vop(0b01_0001, 1, 4, 5, OPIVV, 3);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmadcVv {
+            vd: VReg::V3,
+            vs2: VReg::V4,
+            vs1: VReg::V5,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmadc_vxm_with_carry() {
+    let inst = make_vop(0b01_0001, 0, 8, 11, OPIVX, 0);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmadcVxm {
+            vd: VReg::V0,
+            vs2: VReg::V8,
+            rs1: Reg::A1,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmadc_vx_no_carry() {
+    let inst = make_vop(0b01_0001, 1, 8, 11, OPIVX, 0);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmadcVx {
+            vd: VReg::V0,
+            vs2: VReg::V8,
+            rs1: Reg::A1,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmadc_vim_with_carry() {
+    // imm = -16 → 5-bit = 0b10000 = 16
+    let inst = make_vop(0b01_0001, 0, 6, 0b10000, OPIVI, 2);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmadcVim {
+            vd: VReg::V2,
+            vs2: VReg::V6,
+            imm: -16,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmadc_vi_no_carry() {
+    let inst = make_vop(0b01_0001, 1, 6, 7, OPIVI, 2);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmadcVi {
+            vd: VReg::V2,
+            vs2: VReg::V6,
+            imm: 7,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+// vsbc - no immediate form
+
+#[test]
+fn vsbc_vvm_basic() {
+    let inst = make_vop(0b01_0010, 0, 10, 11, OPIVV, 8);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VsbcVvm {
+            vd: VReg::V8,
+            vs2: VReg::V10,
+            vs1: VReg::V11,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vsbc_vxm_basic() {
+    let inst = make_vop(0b01_0010, 0, 12, 5, OPIVX, 16);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VsbcVxm {
+            vd: VReg::V16,
+            vs2: VReg::V12,
+            rs1: Reg::T0,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vsbc_has_no_immediate_form() {
+    let inst = make_vop(0b01_0010, 0, 2, 5, OPIVI, 1);
+    assert_eq!(Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst), None);
+}
+
+#[test]
+fn vsbc_vm1_is_reserved() {
+    let inst = make_vop(0b01_0010, 1, 2, 3, OPIVV, 1);
+    assert_eq!(Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst), None);
+}
+
+// vmsbc
+
+#[test]
+fn vmsbc_vvm_with_borrow() {
+    let inst = make_vop(0b01_0011, 0, 14, 15, OPIVV, 0);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmsbcVvm {
+            vd: VReg::V0,
+            vs2: VReg::V14,
+            vs1: VReg::V15,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmsbc_vv_no_borrow() {
+    let inst = make_vop(0b01_0011, 1, 14, 15, OPIVV, 0);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmsbcVv {
+            vd: VReg::V0,
+            vs2: VReg::V14,
+            vs1: VReg::V15,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmsbc_vxm_with_borrow() {
+    let inst = make_vop(0b01_0011, 0, 16, 10, OPIVX, 0);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmsbcVxm {
+            vd: VReg::V0,
+            vs2: VReg::V16,
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmsbc_vx_no_borrow() {
+    let inst = make_vop(0b01_0011, 1, 16, 10, OPIVX, 0);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VmsbcVx {
+            vd: VReg::V0,
+            vs2: VReg::V16,
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn vmsbc_has_no_immediate_form() {
+    let inst = make_vop(0b01_0011, 0, 2, 5, OPIVI, 1);
+    assert_eq!(Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst), None);
+}
+
+// High register numbers
+
+#[test]
+fn vadc_high_regs() {
+    let inst = make_vop(0b01_0000, 0, 31, 30, OPIVV, 29);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Zve64xCarryInstruction::VadcVvm {
+            vd: VReg::V29,
+            vs2: VReg::V31,
+            vs1: VReg::V30,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+// Wrong opcode
+
+#[test]
+fn wrong_opcode_not_decoded() {
+    let funct7 = 0b01_0000 << 1u8;
+    let inst = make_r_type(0b011_0011, 1, OPIVV, 2, 3, funct7);
+    assert_eq!(Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst), None);
+}
+
+// OPMVV (funct3=0b010) - carry decoder must NOT claim these (mask decoder owns them)
+
+#[test]
+fn opmvv_funct3_not_claimed() {
+    // funct6=0b010000, OPMVV - this is vcpop/vfirst territory
+    let inst = make_vop(0b01_0000, 0, 4, 0b10000, 0b010, 1);
+    assert_eq!(Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst), None);
+}
+
+// Display
+
+#[test]
+fn display_vadc_vvm() {
+    let inst = make_vop(0b01_0000, 0, 2, 3, OPIVV, 1);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(format!("{decoded}"), "vadc.vvm v1, v2, v3, v0");
+}
+
+#[test]
+fn display_vadc_vxm() {
+    let inst = make_vop(0b01_0000, 0, 4, 10, OPIVX, 6);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(format!("{decoded}"), "vadc.vxm v6, v4, a0, v0");
+}
+
+#[test]
+fn display_vadc_vim_negative() {
+    let inst = make_vop(0b01_0000, 0, 8, 0b11111, OPIVI, 2);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(format!("{decoded}"), "vadc.vim v2, v8, -1, v0");
+}
+
+#[test]
+fn display_vmadc_vvm() {
+    let inst = make_vop(0b01_0001, 0, 4, 5, OPIVV, 3);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(format!("{decoded}"), "vmadc.vvm v3, v4, v5, v0");
+}
+
+#[test]
+fn display_vmadc_vv_no_carry() {
+    let inst = make_vop(0b01_0001, 1, 4, 5, OPIVV, 3);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(format!("{decoded}"), "vmadc.vv v3, v4, v5");
+}
+
+#[test]
+fn display_vsbc_vvm() {
+    let inst = make_vop(0b01_0010, 0, 10, 11, OPIVV, 8);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(format!("{decoded}"), "vsbc.vvm v8, v10, v11, v0");
+}
+
+#[test]
+fn display_vmsbc_vv_no_borrow() {
+    let inst = make_vop(0b01_0011, 1, 14, 15, OPIVV, 0);
+    let decoded = Zve64xCarryInstruction::<Reg<u64>>::try_decode(inst).unwrap();
+    assert_eq!(format!("{decoded}"), "vmsbc.vv v0, v14, v15");
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/fixed_point.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/fixed_point.rs
@@ -241,16 +241,16 @@ where
                 _ => None,
             },
 
-            // Fractional multiply - OPMVV / OPMVX
+            // Fractional multiply - OPIVV / OPIVX
             // vsmul: funct6=10_0111
             0b10_0111 => match funct3 {
-                // OPMVV
-                0b010 => {
+                // OPIVV
+                0b000 => {
                     let vs1 = VReg::from_bits(vs1_bits)?;
                     Some(Self::VsmulVv { vd, vs2, vs1, vm })
                 }
-                // OPMVX
-                0b110 => {
+                // OPIVX
+                0b100 => {
                     let rs1 = Reg::from_bits(vs1_bits)?;
                     Some(Self::VsmulVx { vd, vs2, rs1, vm })
                 }
@@ -258,8 +258,8 @@ where
             },
 
             // Scaling shifts - OPIVV / OPIVX / OPIVI
-            // vssrl: funct6=10_1000
-            0b10_1000 => match funct3 {
+            // vssrl: funct6=10_1010
+            0b10_1010 => match funct3 {
                 // OPIVV
                 0b000 => {
                     let vs1 = VReg::from_bits(vs1_bits)?;
@@ -277,8 +277,8 @@ where
                 }
                 _ => None,
             },
-            // vssra: funct6=10_1001
-            0b10_1001 => match funct3 {
+            // vssra: funct6=10_1011
+            0b10_1011 => match funct3 {
                 // OPIVV
                 0b000 => {
                     let vs1 = VReg::from_bits(vs1_bits)?;

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/fixed_point/tests.rs
@@ -393,7 +393,7 @@ fn test_vasub_vx() {
 
 #[test]
 fn test_vsmul_vv() {
-    let inst = make_v_arith(0b10_0111, true, 2, 3, OPMVV, 1);
+    let inst = make_v_arith(0b10_0111, true, 2, 3, OPIVV, 1);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,
@@ -410,7 +410,7 @@ fn test_vsmul_vv() {
 
 #[test]
 fn test_vsmul_vx_masked() {
-    let inst = make_v_arith(0b10_0111, false, 8, 10, OPMVX, 12);
+    let inst = make_v_arith(0b10_0111, false, 8, 10, OPIVX, 12);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,
@@ -424,19 +424,11 @@ fn test_vsmul_vx_masked() {
     );
 }
 
-#[test]
-fn test_vsmul_vi_rejected() {
-    // vsmul has no VI form
-    let inst = make_v_arith(0b10_0111, true, 2, 3, OPIVI, 1);
-    let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
-    assert_eq!(decoded, None);
-}
-
 // Scaling shifts
 
 #[test]
 fn test_vssrl_vv() {
-    let inst = make_v_arith(0b10_1000, true, 2, 3, OPIVV, 1);
+    let inst = make_v_arith(0b10_1010, true, 2, 3, OPIVV, 1);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,
@@ -453,7 +445,7 @@ fn test_vssrl_vv() {
 
 #[test]
 fn test_vssrl_vx() {
-    let inst = make_v_arith(0b10_1000, true, 2, 5, OPIVX, 1);
+    let inst = make_v_arith(0b10_1010, true, 2, 5, OPIVX, 1);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,
@@ -470,7 +462,7 @@ fn test_vssrl_vx() {
 #[test]
 fn test_vssrl_vi() {
     // imm=7 (unsigned shift amount)
-    let inst = make_v_arith(0b10_1000, true, 2, 7, OPIVI, 1);
+    let inst = make_v_arith(0b10_1010, true, 2, 7, OPIVI, 1);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,
@@ -487,7 +479,7 @@ fn test_vssrl_vi() {
 
 #[test]
 fn test_vssra_vv() {
-    let inst = make_v_arith(0b10_1001, true, 2, 3, OPIVV, 1);
+    let inst = make_v_arith(0b10_1011, true, 2, 3, OPIVV, 1);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,
@@ -504,7 +496,7 @@ fn test_vssra_vv() {
 
 #[test]
 fn test_vssra_vx_masked() {
-    let inst = make_v_arith(0b10_1001, false, 8, 10, OPIVX, 12);
+    let inst = make_v_arith(0b10_1011, false, 8, 10, OPIVX, 12);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,
@@ -520,7 +512,7 @@ fn test_vssra_vx_masked() {
 
 #[test]
 fn test_vssra_vi() {
-    let inst = make_v_arith(0b10_1001, true, 4, 31, OPIVI, 8);
+    let inst = make_v_arith(0b10_1011, true, 4, 31, OPIVI, 8);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,
@@ -657,9 +649,24 @@ fn test_unknown_funct6() {
 }
 
 #[test]
-fn test_vsmul_opivv_rejected() {
-    // vsmul uses OPMVV/OPMVX, not OPIVV
-    let inst = make_v_arith(0b10_0111, true, 2, 3, OPIVV, 1);
+fn test_vsmul_vi_rejected() {
+    // vsmul has no VI form
+    let inst = make_v_arith(0b10_0111, true, 2, 3, OPIVI, 1);
+    let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_vsmul_opmvv_rejected() {
+    // vsmul uses OPIVV/OPIVX, not OPMVV/OPMVX
+    let inst = make_v_arith(0b10_0111, true, 2, 3, OPMVV, 1);
+    let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_vsmul_opmvx_rejected() {
+    let inst = make_v_arith(0b10_0111, true, 2, 5, OPMVX, 1);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(decoded, None);
 }
@@ -703,14 +710,14 @@ fn test_display_vaadd_vv() {
 
 #[test]
 fn test_display_vsmul_vx_masked() {
-    let inst = make_v_arith(0b10_0111, false, 8, 10, OPMVX, 12);
+    let inst = make_v_arith(0b10_0111, false, 8, 10, OPIVX, 12);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(format!("{decoded}"), "vsmul.vx v12, v8, a0, v0.t");
 }
 
 #[test]
 fn test_display_vssrl_vi() {
-    let inst = make_v_arith(0b10_1000, true, 2, 7, OPIVI, 1);
+    let inst = make_v_arith(0b10_1010, true, 2, 7, OPIVI, 1);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst).unwrap();
     assert_eq!(format!("{decoded}"), "vssrl.vi v1, v2, 7");
 }
@@ -751,7 +758,7 @@ fn test_vsaddu_vv_high_regs() {
 #[test]
 fn test_vssra_vi_max_shift() {
     // max 5-bit unsigned immediate = 31
-    let inst = make_v_arith(0b10_1001, true, 16, 31, OPIVI, 0);
+    let inst = make_v_arith(0b10_1011, true, 16, 31, OPIVI, 0);
     let decoded = Zve64xFixedPointInstruction::<Reg<u64>>::try_decode(inst);
     assert_eq!(
         decoded,

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -42,6 +42,7 @@ pub use crate::instructions::rv64::zk::zkn::zknh::Rv64ZknhInstruction;
 pub use crate::instructions::utils::{I24, I24WithZeroedBits};
 pub use crate::instructions::v::zve64x::Zve64xInstruction;
 pub use crate::instructions::v::zve64x::arith::Zve64xArithInstruction;
+pub use crate::instructions::v::zve64x::carry::Zve64xCarryInstruction;
 pub use crate::instructions::v::zve64x::config::Zve64xConfigInstruction;
 pub use crate::instructions::v::zve64x::fixed_point::Zve64xFixedPointInstruction;
 pub use crate::instructions::v::zve64x::load::Zve64xLoadInstruction;


### PR DESCRIPTION
This fixes a bunch of things and successfully passes ACT4 tests for RV64I.

There are still failures for RV32I that I'll look into separately.

I also did some small cleanups and there are still many more left to do.