### PR TITLE
ACT4 vector tests fixes (part 2)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           path: *cache-path
           key: *cache-key
-        # Only save on `main` branch, and only from one canonical matrix variant per OS
+        # Only save on `main` branch and only from one canonical matrix variant per OS
         if: github.ref == 'refs/heads/main' && matrix.type == 'features'
 
   cargo-test:
@@ -593,6 +593,15 @@ jobs:
           cache-to: ${{ github.ref == 'refs/heads/main' && format('type=gha,mode=min,scope=act4-build-{0}', runner.arch) || '' }}
           load: true
 
+      - name: Restore cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
+        with:
+          path: &act4-work-cache-path |
+            work
+          key: &act4-work-cache-key act4-work-${{ hashFiles('crates/execution/ab-riscv-act4-runner/res/abundance/**') }}
+          restore-keys: |
+            act4-work-
+
       - name: ACT4 tests
         working-directory: crates/execution/ab-riscv-act4-runner
         run: |
@@ -616,6 +625,14 @@ jobs:
           # And just to make sure, force-disable AES intrinsics and test software implementation
           echo "Running RV64 tests (-aes)"
           RUSTFLAGS="$RUSTFLAGS -C target-feature=-aes" cargo run --release -- rv64 work/abundance-rv64i-max/elfs
+
+      - name: Save cache
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
+        with:
+          path: *act4-work-cache-path
+          key: *act4-work-cache-key
+        # Only save on `main` branch and only from one OS since the contents will be identical for all OSes
+        if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-24.04'
 
   rust-all:
     # Hack for buggy GitHub Actions behavior with skipped checks: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -577,7 +577,7 @@ jobs:
 
       - name: Clone ACT4 repo
         run: |
-          git clone --depth 1 --revision=d33252a6f0de859fe16273a730d068fd7cc7ad8e \
+          git clone --depth 1 --revision=29b50e3d0281d347a5ab94887db8f4e1af93cd30 \
             https://github.com/riscv/riscv-arch-test \
             riscv-arch-test
 
@@ -607,15 +607,15 @@ jobs:
             make
           
           echo "Running RV32 tests"
-          cargo run -- rv32 work/abundance-rv32i-max/elfs
+          cargo run --release -- rv32 work/abundance-rv32i-max/elfs
           
           # Native CPU will use AES intrinsics for Zknd/Zkne implementation
           echo "Running RV64 tests (native)"
-          RUSTFLAGS="$RUSTFLAGS -C target-cpu=native" cargo run -- rv64 work/abundance-rv64i-max/elfs
+          RUSTFLAGS="$RUSTFLAGS -C target-cpu=native" cargo run --release -- rv64 work/abundance-rv64i-max/elfs
           
           # And just to make sure, force-disable AES intrinsics and test software implementation
           echo "Running RV64 tests (-aes)"
-          RUSTFLAGS="$RUSTFLAGS -C target-feature=-aes" cargo run -- rv64 work/abundance-rv64i-max/elfs
+          RUSTFLAGS="$RUSTFLAGS -C target-feature=-aes" cargo run --release -- rv64 work/abundance-rv64i-max/elfs
 
   rust-all:
     # Hack for buggy GitHub Actions behavior with skipped checks: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks

--- a/crates/execution/ab-riscv-act4-runner/res/Dockerfile
+++ b/crates/execution/ab-riscv-act4-runner/res/Dockerfile
@@ -27,7 +27,7 @@ ARG RISCV_TOOLCHAIN_VERSION=2026.05.06
 # Stage 1: build riscv-gnu-toolchain
 #
 # LDFLAGS=-static ensures no shared-lib dependencies survive into the final image.
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS toolchain-builder
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS toolchain-builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG RISCV_TOOLCHAIN_PREFIX
@@ -99,7 +99,7 @@ RUN git clone --depth 1 --branch "${RISCV_TOOLCHAIN_VERSION}" https://github.com
 #
 # HOME=/home/shared is used so all caches (mise, uv, udb, etc.) land in a single directory that is copied to the final
 # image.
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS mise-fetcher
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS mise-fetcher
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -145,7 +145,7 @@ RUN cd /act4 \
 RUN chmod -R 777 /act4 /home/shared
 
 # Stage 3: final runtime image
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS act4-build
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS act4-build
 
 LABEL description="RISC-V Architectural Certification Tests (ACT4) build env"
 LABEL org.opencontainers.image.source="https://github.com/riscv/riscv-arch-test"
@@ -186,9 +186,6 @@ RUN riscv64-unknown-elf-gcc --version \
   && sail_riscv_sim --version \
   && mise --version
 
-# Default user with ID 1000 matching typical desktop installation
-USER ubuntu
-
 WORKDIR /act4
 
 CMD ["/bin/bash"]
@@ -197,3 +194,10 @@ FROM act4-build AS act4
 
 COPY --from=mise-fetcher /act4/.venv /act4/.venv
 COPY --chmod=777 . /act4
+
+# TODO: `make vector-tests` is only needed temporarily before vector tests are enabled by default
+RUN make vector-tests \
+  && chmod -R 777 /act4/.venv
+
+# Default user with ID 1000 matching typical desktop installation
+USER ubuntu

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith.rs
@@ -139,7 +139,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above; scalar source has no register constraints
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -276,7 +276,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -323,7 +323,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // vrsub: result = src - vs2[i]
                 // SAFETY: alignment checked above
                 unsafe {
@@ -460,7 +460,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -596,7 +596,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -732,7 +732,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -1301,7 +1301,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -1405,7 +1405,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -1510,7 +1510,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -1614,7 +1614,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_arith_helpers::execute_arith_op(
@@ -1719,7 +1719,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
@@ -1858,7 +1858,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
@@ -1997,7 +1997,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
@@ -2095,7 +2095,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
@@ -2193,7 +2193,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
@@ -2339,7 +2339,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
@@ -2427,7 +2427,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(
@@ -2515,7 +2515,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: see `VmseqVv`
                 unsafe {
                     zve64x_arith_helpers::execute_compare_op(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry.rs
@@ -134,7 +134,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above; vd != v0 checked above
                 unsafe {
                     zve64x_carry_helpers::execute_carry_add::<Reg, _, _>(
@@ -263,7 +263,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments and overlap checked above
                 unsafe {
                     zve64x_carry_helpers::execute_carry_add_mask::<Reg, _, _>(
@@ -387,7 +387,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments and overlap checked above
                 unsafe {
                     zve64x_carry_helpers::execute_carry_add_mask::<Reg, _, _>(
@@ -513,7 +513,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above; vd != v0 checked above
                 unsafe {
                     zve64x_carry_helpers::execute_carry_sub::<Reg, _, _>(
@@ -599,7 +599,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments and overlap checked above
                 unsafe {
                     zve64x_carry_helpers::execute_carry_sub_mask::<Reg, _, _>(
@@ -685,7 +685,7 @@ where
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments and overlap checked above
                 unsafe {
                     zve64x_carry_helpers::execute_carry_sub_mask::<Reg, _, _>(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point.rs
@@ -140,7 +140,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
@@ -284,7 +284,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
@@ -427,7 +427,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
@@ -525,7 +525,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
@@ -623,7 +623,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
@@ -721,7 +721,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
@@ -819,7 +819,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(
@@ -917,7 +917,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_fixed_point_helpers::execute_fixed_point_op(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -272,8 +272,8 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                // rs2 holds a signed stride; reinterpret the register value as signed.
-                let stride = rs2_value.as_u64().cast_signed();
+                // rs2 holds a signed stride; reinterpret the register value as signed
+                let stride = rs2_value.as_i64();
                 // SAFETY:
                 // - alignment and nf=1 bounds: `check_register_group_alignment` verified `vd %
                 //   group_regs == 0` and `vd + group_regs <= 32`
@@ -597,7 +597,7 @@ where
                     group_regs,
                     nf,
                 )?;
-                let stride = rs2_value.as_u64().cast_signed();
+                let stride = rs2_value.as_i64();
                 // SAFETY:
                 // - alignment and nf-group bounds: `validate_segment_registers` verified `vd %
                 //   group_regs == 0` and `vd + nf * group_regs <= 32`

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv.rs
@@ -138,7 +138,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
@@ -554,7 +554,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
@@ -653,7 +653,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
@@ -757,7 +757,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
@@ -860,7 +860,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_arith_op(
@@ -1395,7 +1395,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_scalar_op(
@@ -1490,7 +1490,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_scalar_op(
@@ -1585,7 +1585,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_scalar_op(
@@ -1681,7 +1681,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment checked above
                 unsafe {
                     zve64x_muldiv_helpers::execute_muladd_scalar_op(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
@@ -105,7 +105,7 @@ where
                 let vstart = ext_state.vstart();
                 // Per spec §16.1: update only when vstart < vl.
                 if u32::from(vstart) < vl {
-                    let scalar = rs1_value.as_u64();
+                    let scalar = rs1_value.as_i64().cast_unsigned();
                     // SAFETY: element 0 always fits.
                     unsafe {
                         zve64x_perm_helpers::write_element_0_u64(
@@ -339,7 +339,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment and no-overlap verified; vl <= VLMAX.
                 unsafe {
                     zve64x_perm_helpers::execute_slide1up(ext_state, vd, vs2, vm, sew, scalar);
@@ -382,7 +382,7 @@ where
                     });
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment verified; vl <= VLMAX; overlap permitted by spec.
                 unsafe {
                     zve64x_perm_helpers::execute_slide1down(ext_state, vd, vs2, vm, sew, scalar);
@@ -705,7 +705,7 @@ where
                     )?;
                 }
                 let sew = vtype.vsew();
-                let scalar = rs1_value.as_u64();
+                let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignment and overlap verified above; vl <= VLMAX.
                 unsafe {
                     zve64x_perm_helpers::execute_merge_scalar(ext_state, vd, vs2, vm, sew, scalar);

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
@@ -212,7 +212,7 @@ where
                     vs3,
                     group_regs,
                 )?;
-                let stride = rs2_value.as_u64().cast_signed();
+                let stride = rs2_value.as_i64();
                 // SAFETY: same preconditions as `Vse`.
                 unsafe {
                     zve64x_store_helpers::execute_strided_store(
@@ -418,7 +418,7 @@ where
                     group_regs,
                     nf,
                 )?;
-                let stride = rs2_value.as_u64().cast_signed();
+                let stride = rs2_value.as_i64();
                 // SAFETY: same as `Vsseg`.
                 unsafe {
                     zve64x_store_helpers::execute_strided_store(

--- a/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
@@ -65,6 +65,9 @@ where
 
     /// Convert to `u64`
     fn as_u64(&self) -> u64;
+
+    /// Convert to `i64` (sign-extended)
+    fn as_i64(&self) -> i64;
 }
 
 impl const RegType for u32 {
@@ -74,6 +77,11 @@ impl const RegType for u32 {
     fn as_u64(&self) -> u64 {
         u64::from(*self)
     }
+
+    #[inline(always)]
+    fn as_i64(&self) -> i64 {
+        i64::from(self.cast_signed())
+    }
 }
 
 impl const RegType for u64 {
@@ -82,6 +90,11 @@ impl const RegType for u64 {
     #[inline(always)]
     fn as_u64(&self) -> u64 {
         *self
+    }
+
+    #[inline(always)]
+    fn as_i64(&self) -> i64 {
+        self.cast_signed()
     }
 }
 


### PR DESCRIPTION
This fixes RV64 issues related to sign extension and enabled ACT4 vector tests in CI :tada: 