### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -606,7 +606,7 @@ jobs:
         working-directory: crates/execution/ab-riscv-act4-runner
         run: |
           echo "Building ELFs"
-          mkdir work
+          mkdir -p work
           docker run --rm \
             -u $(id -u):$(id -g) \
             -v ./work:/act4/work \


### PR DESCRIPTION
Cache restoration makes the directory exist before attempting to create it