### PR TITLE
Optimize vector load/store instruction size

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -166,7 +166,6 @@ where
                     });
                 }
                 // SAFETY:
-                // - 1 <= MAX_NF
                 // - alignment: `check_register_group_alignment` verified `vd % group_regs == 0` and
                 //   `vd + group_regs <= 32`, satisfying both the alignment and nf=1 bounds
                 //   preconditions
@@ -183,7 +182,7 @@ where
                         rs1_value.as_u64(),
                         eew,
                         group_regs,
-                        1,
+                        Nf::N1,
                         false,
                     )?;
                 }
@@ -232,7 +231,7 @@ where
                         rs1_value.as_u64(),
                         eew,
                         group_regs,
-                        1,
+                        Nf::N1,
                         true,
                     )?;
                 }
@@ -290,7 +289,7 @@ where
                         stride,
                         eew,
                         group_regs,
-                        1,
+                        Nf::N1,
                     )?;
                 }
             }
@@ -375,7 +374,7 @@ where
                         vtype.vsew().as_eew(),
                         index_eew,
                         data_group_regs,
-                        1,
+                        Nf::N1,
                     )?;
                 }
             }
@@ -449,7 +448,7 @@ where
                         vtype.vsew().as_eew(),
                         index_eew,
                         data_group_regs,
-                        1,
+                        Nf::N1,
                     )?;
                 }
             }
@@ -458,10 +457,11 @@ where
             Self::Vlseg {
                 vd,
                 rs1: _,
-                vm,
                 eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -485,13 +485,7 @@ where
                     group_regs,
                     nf,
                 )?;
-                if nf > zve64x_load_helpers::MAX_NF {
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
-                    });
-                }
                 // SAFETY:
-                // - `nf <= MAX_NF` checked above
                 // - alignment and nf-group bounds: `validate_segment_registers` verified `vd %
                 //   group_regs == 0` and `vd + nf * group_regs <= 32`
                 // - `vl <= group_regs * VLENB / eew.bytes()`: `group_regs` is the EMUL for this
@@ -517,10 +511,11 @@ where
             Self::Vlsegff {
                 vd,
                 rs1: _,
-                vm,
                 eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -544,11 +539,6 @@ where
                     group_regs,
                     nf,
                 )?;
-                if nf > zve64x_load_helpers::MAX_NF {
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
-                    });
-                }
                 // SAFETY: preconditions identical to `Vlseg`; see that arm for the full argument.
                 unsafe {
                     zve64x_load_helpers::execute_unit_stride_load(
@@ -570,10 +560,11 @@ where
                 vd,
                 rs1: _,
                 rs2: _,
-                vm,
                 eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -625,10 +616,11 @@ where
                 vd,
                 rs1: _,
                 vs2,
-                vm,
                 eew: index_eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -661,7 +653,7 @@ where
                     vs2,
                     index_group_regs,
                 )?;
-                for f in 0..nf {
+                for f in 0..nf.fields_per_segment() {
                     // SAFETY: `vd.bits() + f * data_group_regs < 32` because
                     // `validate_segment_registers` established `vd.bits() + nf * data_group_regs
                     // <= 32` and `f < nf`. The value is in [0, 31], so it is a valid `VReg`
@@ -715,10 +707,11 @@ where
                 vd,
                 rs1: _,
                 vs2,
-                vm,
                 eew: index_eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -748,7 +741,7 @@ where
                     vs2,
                     index_group_regs,
                 )?;
-                for f in 0..nf {
+                for f in 0..nf.fields_per_segment() {
                     // SAFETY: `vd.bits() + f * data_group_regs < 32` because
                     // `validate_segment_registers` established `vd.bits() + nf * data_group_regs
                     // <= 32` and `f < nf`. The value is in [0, 31], so it is a valid `VReg`

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
@@ -1356,9 +1356,8 @@ fn vlseg_nf2_e8_interleaved_fields() {
         Zve64xLoadInstruction::Vlseg {
             vd: VReg::V2,
             rs1: Reg::A0,
-            vm: true,
             eew: Eew::E8,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1395,9 +1394,8 @@ fn vlseg_nf3_e32() {
         Zve64xLoadInstruction::Vlseg {
             vd: VReg::V1,
             rs1: Reg::A0,
-            vm: true,
             eew: Eew::E32,
-            nf: 3,
+            vm_nf: SegVmNf::new(true, Nf::N3),
             rs2: Reg::Zero,
         },
     )
@@ -1429,9 +1427,8 @@ fn vlseg_register_group_overflow_is_illegal() {
         Zve64xLoadInstruction::Vlseg {
             vd: VReg::V30,
             rs1: Reg::A0,
-            vm: true,
             eew: Eew::E8,
-            nf: 8,
+            vm_nf: SegVmNf::new(true, Nf::N8),
             rs2: Reg::Zero,
         },
     )
@@ -1448,9 +1445,8 @@ fn vlseg_masked_vd_at_v0_is_illegal() {
         Zve64xLoadInstruction::Vlseg {
             vd: VReg::V0,
             rs1: Reg::A0,
-            vm: false,
             eew: Eew::E8,
-            nf: 2,
+            vm_nf: SegVmNf::new(false, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1472,9 +1468,8 @@ fn vlsegff_no_fault_loads_all_segments() {
         Zve64xLoadInstruction::Vlsegff {
             vd: VReg::V2,
             rs1: Reg::A0,
-            vm: true,
             eew: Eew::E8,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1505,9 +1500,8 @@ fn vlsegff_fault_at_segment_1_truncates_vl() {
         Zve64xLoadInstruction::Vlsegff {
             vd: VReg::V4,
             rs1: Reg::A0,
-            vm: true,
             eew: Eew::E8,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1554,9 +1548,8 @@ fn vlsseg_nf2_e32_with_stride() {
             vd: VReg::V2,
             rs1: Reg::A0,
             rs2: Reg::A1,
-            vm: true,
             eew: Eew::E32,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
         },
     )
     .unwrap();
@@ -1602,9 +1595,8 @@ fn vlsseg_fault_at_f1_of_i0_marks_vs_dirty_and_sets_vstart() {
             vd: VReg::V2,
             rs1: Reg::A0,
             rs2: Reg::A1,
-            vm: true,
             eew: Eew::E32,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
         },
     )
     .unwrap_err();
@@ -1648,9 +1640,8 @@ fn vlsseg_fault_at_i1_f0_marks_vs_dirty_and_sets_vstart() {
             vd: VReg::V2,
             rs1: Reg::A0,
             rs2: Reg::A1,
-            vm: true,
             eew: Eew::E8,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
         },
     )
     .unwrap_err();
@@ -1698,9 +1689,8 @@ fn vluxseg_nf2_e32_indexed() {
             vd: VReg::V2,
             rs1: Reg::A0,
             vs2: VReg::V8,
-            vm: true,
             eew: Eew::E32,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1740,9 +1730,8 @@ fn vluxseg_field_vs2_overlap_is_illegal() {
             vd: VReg::V2,
             rs1: Reg::A0,
             vs2: VReg::V3,
-            vm: true,
             eew: Eew::E32,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1779,9 +1768,8 @@ fn vloxseg_same_result_as_vluxseg() {
             vd: VReg::V2,
             rs1: Reg::A0,
             vs2: VReg::V6,
-            vm: true,
             eew: Eew::E32,
-            nf: 1,
+            vm_nf: SegVmNf::new(true, Nf::N1),
             rs2: Reg::Zero,
         },
     )

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
@@ -7,9 +7,6 @@ use ab_riscv_primitives::prelude::*;
 use core::cmp::Ordering;
 use core::fmt;
 
-#[doc(hidden)]
-pub const MAX_NF: u8 = 8;
-
 /// Return whether mask bit `i` is set in the mask byte slice.
 ///
 /// Bits are stored LSB-first within each byte: bit `i` is at byte `i / 8`, position `i % 8`.
@@ -154,14 +151,14 @@ pub fn validate_segment_registers<Reg, Memory, PC, CustomError>(
     vd: VReg,
     vm: bool,
     group_regs: u8,
-    nf: u8,
+    nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     let group_regs = u32::from(group_regs);
-    let nf = u32::from(nf);
+    let nf = u32::from(nf.fields_per_segment());
     let vd_idx = u32::from(vd.bits());
     if vd_idx % group_regs != 0 || vd_idx + nf * group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
@@ -270,7 +267,6 @@ fn read_mem_element(
 /// and returns `Ok`. An error at element `0` always propagates.
 ///
 /// # Safety
-/// - `nf <= MAX_NF`
 /// - `vd.bits() % group_regs == 0`
 /// - `vd.bits() + nf * group_regs <= 32`
 /// - `vl <= group_regs * VLENB / eew.bytes()` (all `vl` elements fit within the destination
@@ -288,7 +284,7 @@ pub unsafe fn execute_unit_stride_load<Reg, ExtState, Memory, CustomError>(
     base: u64,
     eew: Eew,
     group_regs: u8,
-    nf: u8,
+    nf: Nf,
     fault_only_first: bool,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -303,7 +299,7 @@ where
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     let elem_bytes = eew.bytes();
-    let segment_stride = u64::from(nf) * u64::from(elem_bytes);
+    let segment_stride = u64::from(nf.fields_per_segment()) * u64::from(elem_bytes);
 
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
@@ -316,23 +312,23 @@ where
         let elem_base = base.wrapping_add(u64::from(i) * segment_stride);
 
         // Read all nf fields into a stack buffer before writing any of them.
-        // This ensures a fault on field f>0 leaves the destination registers
-        // untouched for the faulting element, so only elements with index
-        // new_vl are ever written (fault-only-first semantics).
+        // This ensures a fault on field f>0 leaves the destination registers untouched for the
+        // faulting element, so only elements with index new_vl are ever written (fault-only-first
+        // semantics).
         //
-        // Sized by `MAX_NF * Eew::MAX_BYTES`: the V spec allows at most 8
-        // fields (nf in 1..=8) each is at most 8 bytes (E64), giving 64 bytes.
-        let mut field_buf = [[0u8; usize::from(Eew::MAX_BYTES)]; usize::from(MAX_NF)];
+        // Sized by `Nf::MAX * Eew::MAX_BYTES`: the V spec allows at most 8 fields (nf in 1..=8)
+        // each is at most 8 bytes (E64), giving 64 bytes.
+        let mut field_buf =
+            [[0u8; usize::from(Eew::MAX_BYTES)]; usize::from(Nf::MAX.fields_per_segment())];
 
-        for f in 0..nf {
+        for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
             match read_mem_element(memory, addr, eew) {
                 Ok(data) => {
                     // SAFETY: `f < nf` and the precondition on this function requires
-                    // `nf <= MAX_NF` (the V spec encodes nf in 3 bits giving 1..=8 =
-                    // MAX_NF, and the decoder enforces this before constructing the
-                    // instruction). Therefore, `f as usize < nf as usize <= MAX_NF`,
-                    // which is exactly the length of `field_buf`.
+                    // `nf <= Nf::MAX` (the V spec encodes nf in 3 bits giving 1..=Nf::MAX, and the
+                    // decoder enforces this before constructing the instruction). Therefore, `f as
+                    // usize < nf as usize <= Nf::MAX`, which is exactly the length of `field_buf`.
                     unsafe {
                         *field_buf.get_unchecked_mut(f as usize) = data;
                     }
@@ -356,7 +352,7 @@ where
         }
 
         // All nf fields for element i were read successfully; commit to the register file.
-        for f in 0..nf {
+        for f in 0..nf.fields_per_segment() {
             let field_base_reg = vd.bits() + f * group_regs;
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
             //
@@ -372,8 +368,8 @@ where
             // Therefore, `field_base_reg + i / elems_per_reg
             //            < field_base_reg + group_regs <= 32`.
             //
-            // For `field_buf`: `f < nf <= MAX_NF` (the same argument as in the read loop
-            // above), so `f as usize < MAX_NF = field_buf.len()`.
+            // For `field_buf`: `f < nf <= Nf::MAX` (the same argument as in the read loop
+            // above), so `f as usize < Nf::MAX = field_buf.len()`.
             unsafe {
                 write_group_element(
                     ext_state.write_vreg(),
@@ -413,7 +409,7 @@ pub unsafe fn execute_strided_load<Reg, ExtState, Memory, CustomError>(
     stride: i64,
     eew: Eew,
     group_regs: u8,
-    nf: u8,
+    nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
@@ -438,7 +434,7 @@ where
 
         let elem_base = base.wrapping_add(i64::from(i).wrapping_mul(stride).cast_unsigned());
 
-        for f in 0..nf {
+        for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
             let data = match read_mem_element(memory, addr, eew) {
                 Ok(data) => data,
@@ -502,7 +498,7 @@ pub unsafe fn execute_indexed_load<Reg, ExtState, Memory, CustomError>(
     data_eew: Eew,
     index_eew: Eew,
     data_group_regs: u8,
-    nf: u8,
+    nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
@@ -538,7 +534,7 @@ where
         let elem_addr = base.wrapping_add(offset);
 
         let data_elem_bytes = data_eew.bytes();
-        for f in 0..nf {
+        for f in 0..nf.fields_per_segment() {
             let addr = elem_addr.wrapping_add(u64::from(f) * u64::from(data_elem_bytes));
             let data = match read_mem_element(memory, addr, data_eew) {
                 Ok(data) => data,

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
@@ -180,7 +180,7 @@ where
                         rs1_value.as_u64(),
                         eew,
                         group_regs,
-                        1,
+                        Nf::N1,
                     )?;
                 }
             }
@@ -224,7 +224,7 @@ where
                         stride,
                         eew,
                         group_regs,
-                        1,
+                        Nf::N1,
                     )?;
                 }
             }
@@ -283,7 +283,7 @@ where
                         data_eew,
                         index_eew,
                         data_group_regs,
-                        1,
+                        Nf::N1,
                     )?;
                 }
             }
@@ -337,7 +337,7 @@ where
                         data_eew,
                         index_eew,
                         data_group_regs,
-                        1,
+                        Nf::N1,
                     )?;
                 }
             }
@@ -345,10 +345,11 @@ where
             Self::Vsseg {
                 vs3,
                 rs1: _,
-                vm,
                 eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -393,10 +394,11 @@ where
                 vs3,
                 rs1: _,
                 rs2: _,
-                vm,
                 eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -439,10 +441,11 @@ where
                 vs3,
                 rs1: _,
                 vs2,
-                vm,
                 eew: index_eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -498,10 +501,11 @@ where
                 vs3,
                 rs1: _,
                 vs2,
-                vm,
                 eew: index_eew,
-                nf,
+                vm_nf,
             } => {
+                let vm = vm_nf.vm();
+                let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
@@ -1144,9 +1144,8 @@ fn vsseg_nf2_e8_m1_stores_two_fields_interleaved() {
         Zve64xStoreInstruction::Vsseg {
             vs3: VReg::V2,
             rs1: Reg::A0,
-            vm: true,
             eew: Eew::E8,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1185,9 +1184,8 @@ fn vsseg_nf3_e32_m1_stores_three_fields_per_element() {
         Zve64xStoreInstruction::Vsseg {
             vs3: VReg::V0,
             rs1: Reg::A0,
-            vm: true,
             eew: Eew::E32,
-            nf: 3,
+            vm_nf: SegVmNf::new(true, Nf::N3),
             rs2: Reg::Zero,
         },
     )
@@ -1214,9 +1212,8 @@ fn vsseg_register_group_out_of_bounds_returns_illegal() {
         Zve64xStoreInstruction::Vsseg {
             vs3: VReg::V30,
             rs1: Reg::A0,
-            vm: true,
             eew: Eew::E32,
-            nf: 4,
+            vm_nf: SegVmNf::new(true, Nf::N4),
             rs2: Reg::Zero,
         },
     );
@@ -1246,9 +1243,8 @@ fn vsseg_masked_vs3_equals_v0_is_legal() {
         Zve64xStoreInstruction::Vsseg {
             vs3: VReg::V0,
             rs1: Reg::A0,
-            vm: false,
             eew: Eew::E8,
-            nf: 2,
+            vm_nf: SegVmNf::new(false, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1292,9 +1288,8 @@ fn vssseg_nf2_e32_m1_stride_16_stores_correctly() {
             vs3: VReg::V2,
             rs1: Reg::A0,
             rs2: Reg::A1,
-            vm: true,
             eew: Eew::E32,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
         },
     )
     .unwrap();
@@ -1338,9 +1333,8 @@ fn vsuxseg_nf2_e32_index_e32_data_stores_segments_at_indexed_addresses() {
             vs3: VReg::V2,
             rs1: Reg::A0,
             vs2: VReg::V6,
-            vm: true,
             eew: Eew::E32,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             rs2: Reg::Zero,
         },
     )
@@ -1379,9 +1373,8 @@ fn vsoxseg_nf2_e64_index_e64_data_stores_in_element_order() {
             vs3: VReg::V2,
             rs1: Reg::A0,
             vs2: VReg::V6,
-            vm: true,
             eew: Eew::E64,
-            nf: 2,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             rs2: Reg::Zero,
         },
     )

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
@@ -46,14 +46,14 @@ pub fn validate_segment_store_registers<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vs3: VReg,
     group_regs: u8,
-    nf: u8,
+    nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     check_register_group_alignment::<Reg, _, _, _>(program_counter, vs3, group_regs)?;
-    let total = u32::from(vs3.bits()) + u32::from(nf) * u32::from(group_regs);
+    let total = u32::from(vs3.bits()) + u32::from(nf.fields_per_segment()) * u32::from(group_regs);
     if total > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -86,7 +86,7 @@ pub unsafe fn execute_unit_stride_store<Reg, ExtState, Memory, CustomError>(
     base: u64,
     eew: Eew,
     group_regs: u8,
-    nf: u8,
+    nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
@@ -100,7 +100,7 @@ where
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     let elem_bytes = eew.bytes();
-    let segment_stride = u64::from(nf * elem_bytes);
+    let segment_stride = u64::from(nf.fields_per_segment() * elem_bytes);
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     for i in u32::from(vstart)..vl {
@@ -108,7 +108,7 @@ where
             continue;
         }
         let elem_base = base.wrapping_add(u64::from(i) * segment_stride);
-        for f in 0..nf {
+        for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
             let field_base_reg = vs3.bits() + f * group_regs;
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
@@ -164,7 +164,7 @@ pub unsafe fn execute_strided_store<Reg, ExtState, Memory, CustomError>(
     stride: i64,
     eew: Eew,
     group_regs: u8,
-    nf: u8,
+    nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
@@ -185,7 +185,7 @@ where
             continue;
         }
         let elem_base = base.wrapping_add(i64::from(i).wrapping_mul(stride).cast_unsigned());
-        for f in 0..nf {
+        for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
             let field_base_reg = vs3.bits() + f * group_regs;
             // SAFETY: same argument as `execute_unit_stride_store`; `field_base_reg +
@@ -237,7 +237,7 @@ pub unsafe fn execute_indexed_store<Reg, ExtState, Memory, CustomError>(
     data_eew: Eew,
     index_eew: Eew,
     data_group_regs: u8,
-    nf: u8,
+    nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
@@ -265,7 +265,7 @@ where
         // SAFETY: `index_eew.bytes() <= Eew::MAX_BYTES` always holds.
         let offset = unsafe { index_buf_to_u64(index_buf, index_eew) };
         let elem_base = base.wrapping_add(offset);
-        for f in 0..nf {
+        for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(data_elem_bytes));
             let field_base_reg = vs3.bits() + f * data_group_regs;
             // SAFETY: `i < vl <= data_group_regs * VLENB / data_eew.bytes()` (precondition), so

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x.rs
@@ -29,7 +29,7 @@ use crate::instructions::v::zve64x::arith::Zve64xArithInstruction;
 use crate::instructions::v::zve64x::carry::Zve64xCarryInstruction;
 use crate::instructions::v::zve64x::config::Zve64xConfigInstruction;
 use crate::instructions::v::zve64x::fixed_point::Zve64xFixedPointInstruction;
-use crate::instructions::v::zve64x::load::Zve64xLoadInstruction;
+use crate::instructions::v::zve64x::load::{Nf, SegVmNf, Zve64xLoadInstruction};
 use crate::instructions::v::zve64x::mask::Zve64xMaskInstruction;
 use crate::instructions::v::zve64x::muldiv::Zve64xMulDivInstruction;
 use crate::instructions::v::zve64x::perm::Zve64xPermInstruction;

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/load.rs
@@ -10,6 +10,94 @@ use crate::registers::vector::VReg;
 use ab_riscv_macros::instruction;
 use core::fmt;
 
+/// Number of fields per segment for load/store instructions
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Nf {
+    /// 1 field per segment
+    N1 = 1,
+    /// 2 fields per segment
+    N2 = 2,
+    /// 3 fields per segment
+    N3 = 3,
+    /// 4 fields per segment
+    N4 = 4,
+    /// 5 fields per segment
+    N5 = 5,
+    /// 6 fields per segment
+    N6 = 6,
+    /// 7 fields per segment
+    N7 = 7,
+    /// 8 fields per segment
+    N8 = 8,
+}
+
+impl fmt::Display for Nf {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.fields_per_segment())
+    }
+}
+
+impl Nf {
+    /// Maximum allowed value for `Nf`
+    pub const MAX: Self = Nf::N8;
+
+    /// Create a new instance.
+    ///
+    /// `nf` must be in the range `1..=8` or `None` is returned.
+    #[inline(always)]
+    pub const fn new(nf: u8) -> Option<Self> {
+        match nf {
+            1 => Some(Nf::N1),
+            2 => Some(Nf::N2),
+            3 => Some(Nf::N3),
+            4 => Some(Nf::N4),
+            5 => Some(Nf::N5),
+            6 => Some(Nf::N6),
+            7 => Some(Nf::N7),
+            8 => Some(Nf::N8),
+            _ => None,
+        }
+    }
+
+    /// Returns the number of fields per segment for the load/store instruction.
+    ///
+    /// Always in `1..=8` range.
+    #[inline(always)]
+    pub const fn fields_per_segment(&self) -> u8 {
+        *self as u8
+    }
+}
+
+/// `vm` and `nf` fields for segmented load/store instructions.
+///
+/// This is a more compact representation that fits within a single byte rather than two when
+/// storing these separately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SegVmNf(u8);
+
+impl SegVmNf {
+    /// Create a new instance
+    #[inline(always)]
+    pub const fn new(vm: bool, nf: Nf) -> Self {
+        Self((nf.fields_per_segment() << 1) | u8::from(vm))
+    }
+
+    /// Extracts the `vm` field from the `SegVmNf` representation
+    #[inline(always)]
+    pub const fn vm(&self) -> bool {
+        self.0 & 1 == 1
+    }
+
+    /// Extracts the `nf` field from the `SegVmNf` representation
+    #[inline(always)]
+    pub const fn nf(&self) -> Nf {
+        // SAFETY: Protected internal invariant
+        unsafe { Nf::new(self.0 >> 1).unwrap_unchecked() }
+    }
+}
+
 /// RISC-V Zve64x vector load instruction.
 ///
 /// Encoded under the LOAD-FP major opcode (0x07). All loads use rs1 (GPR) as a base address and vd
@@ -50,23 +138,23 @@ pub enum Zve64xLoadInstruction<Reg> {
     /// Unit-stride segment load: `vlseg{nf}e{eew}.v vd, (rs1), vm`
     ///
     /// mop=00, lumop=00000, nf>0
-    Vlseg { vd: VReg, rs1: Reg, vm: bool, eew: Eew, nf: u8 },
+    Vlseg { vd: VReg, rs1: Reg, eew: Eew, vm_nf: SegVmNf },
     /// Unit-stride fault-only-first segment load: `vlseg{nf}e{eew}ff.v vd, (rs1), vm`
     ///
     /// mop=00, lumop=10000, nf>0
-    Vlsegff { vd: VReg, rs1: Reg, vm: bool, eew: Eew, nf: u8 },
+    Vlsegff { vd: VReg, rs1: Reg, eew: Eew, vm_nf: SegVmNf },
     /// Strided segment load: `vlsseg{nf}e{eew}.v vd, (rs1), rs2, vm`
     ///
     /// mop=10, nf>0
-    Vlsseg { vd: VReg, rs1: Reg, rs2: Reg, vm: bool, eew: Eew, nf: u8 },
+    Vlsseg { vd: VReg, rs1: Reg, rs2: Reg, eew: Eew, vm_nf: SegVmNf },
     /// Indexed-unordered segment load: `vluxseg{nf}ei{eew}.v vd, (rs1), vs2, vm`
     ///
     /// mop=01, nf>0
-    Vluxseg { vd: VReg, rs1: Reg, vs2: VReg, vm: bool, eew: Eew, nf: u8 },
+    Vluxseg { vd: VReg, rs1: Reg, vs2: VReg, eew: Eew, vm_nf: SegVmNf },
     /// Indexed-ordered segment load: `vloxseg{nf}ei{eew}.v vd, (rs1), vs2, vm`
     ///
     /// mop=11, nf>0
-    Vloxseg { vd: VReg, rs1: Reg, vs2: VReg, vm: bool, eew: Eew, nf: u8 },
+    Vloxseg { vd: VReg, rs1: Reg, vs2: VReg, eew: Eew, vm_nf: SegVmNf },
 }
 
 #[instruction]
@@ -119,9 +207,8 @@ where
                             Some(Self::Vlseg {
                                 vd,
                                 rs1,
-                                vm,
                                 eew,
-                                nf: nf_val,
+                                vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                             })
                         }
                     }
@@ -160,9 +247,8 @@ where
                             Some(Self::Vlsegff {
                                 vd,
                                 rs1,
-                                vm,
                                 eew,
-                                nf: nf_val,
+                                vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                             })
                         }
                     }
@@ -186,9 +272,8 @@ where
                         vd,
                         rs1,
                         vs2,
-                        vm,
                         eew,
-                        nf: nf_val,
+                        vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                     })
                 }
             }
@@ -209,9 +294,8 @@ where
                         vd,
                         rs1,
                         rs2,
-                        vm,
                         eew,
-                        nf: nf_val,
+                        vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                     })
                 }
             }
@@ -232,9 +316,8 @@ where
                         vd,
                         rs1,
                         vs2,
-                        vm,
                         eew,
-                        nf: nf_val,
+                        vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                     })
                 }
             }
@@ -268,11 +351,11 @@ where
             Self::Vluxei { vd, rs1, vs2, vm, eew } => write!(f, "vluxei{eew}.v {vd}, ({rs1}), {vs2}{}", mask_suffix(vm)),
             Self::Vloxei { vd, rs1, vs2, vm, eew } => write!(f, "vloxei{eew}.v {vd}, ({rs1}), {vs2}{}", mask_suffix(vm)),
             Self::Vlr { vd, rs1, nreg, eew } => write!(f, "vl{nreg}re{eew}.v {vd}, ({rs1})"),
-            Self::Vlseg { vd, rs1, vm, eew, nf } => write!(f, "vlseg{nf}e{eew}.v {vd}, ({rs1}){}", mask_suffix(vm)),
-            Self::Vlsegff { vd, rs1, vm, eew, nf } => write!(f, "vlseg{nf}e{eew}ff.v {vd}, ({rs1}){}", mask_suffix(vm)),
-            Self::Vlsseg { vd, rs1, rs2, vm, eew, nf } => write!(f, "vlsseg{nf}e{eew}.v {vd}, ({rs1}), {rs2}{}", mask_suffix(vm)),
-            Self::Vluxseg { vd, rs1, vs2, vm, eew, nf } => write!(f, "vluxseg{nf}ei{eew}.v {vd}, ({rs1}), {vs2}{}", mask_suffix(vm)),
-            Self::Vloxseg { vd, rs1, vs2, vm, eew, nf } => write!(f, "vloxseg{nf}ei{eew}.v {vd}, ({rs1}), {vs2}{}", mask_suffix(vm)),
+            Self::Vlseg { vd, rs1, eew, vm_nf } => write!(f, "vlseg{}e{eew}.v {vd}, ({rs1}){}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
+            Self::Vlsegff { vd, rs1, eew, vm_nf } => write!(f, "vlseg{}e{eew}ff.v {vd}, ({rs1}){}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
+            Self::Vlsseg { vd, rs1, rs2, eew, vm_nf } => write!(f, "vlsseg{}e{eew}.v {vd}, ({rs1}), {rs2}{}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
+            Self::Vluxseg { vd, rs1, vs2, eew, vm_nf } => write!(f, "vluxseg{}ei{eew}.v {vd}, ({rs1}), {vs2}{}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
+            Self::Vloxseg { vd, rs1, vs2, eew, vm_nf } => write!(f, "vloxseg{}ei{eew}.v {vd}, ({rs1}), {vs2}{}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
         }
     }
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/load/tests.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use crate::instructions::Instruction;
 use crate::instructions::v::Eew;
-use crate::instructions::v::zve64x::load::Zve64xLoadInstruction;
+use crate::instructions::v::zve64x::load::{Nf, SegVmNf, Zve64xLoadInstruction};
 use crate::registers::general_purpose::Reg;
 use crate::registers::vector::VReg;
 use alloc::format;
@@ -376,9 +376,8 @@ fn test_vlseg2e8() {
         Some(Zve64xLoadInstruction::Vlseg {
             vd: VReg::V4,
             rs1: Reg::A0,
-            vm: true,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             eew: Eew::E8,
-            nf: 2,
             rs2: Reg::Zero,
         })
     );
@@ -394,9 +393,8 @@ fn test_vlseg8e32_masked() {
         Some(Zve64xLoadInstruction::Vlseg {
             vd: VReg::V0,
             rs1: Reg::T0,
-            vm: false,
+            vm_nf: SegVmNf::new(false, Nf::N8),
             eew: Eew::E32,
-            nf: 8,
             rs2: Reg::Zero,
         })
     );
@@ -412,9 +410,8 @@ fn test_vlseg3e16ff() {
         Some(Zve64xLoadInstruction::Vlsegff {
             vd: VReg::V8,
             rs1: Reg::A0,
-            vm: true,
+            vm_nf: SegVmNf::new(true, Nf::N3),
             eew: Eew::E16,
-            nf: 3,
             rs2: Reg::Zero,
         })
     );
@@ -431,9 +428,8 @@ fn test_vlsseg4e64() {
             vd: VReg::V8,
             rs1: Reg::A0,
             rs2: Reg::A1,
-            vm: true,
+            vm_nf: SegVmNf::new(true, Nf::N4),
             eew: Eew::E64,
-            nf: 4,
         })
     );
 }
@@ -449,9 +445,8 @@ fn test_vluxseg2ei32() {
             vd: VReg::V4,
             rs1: Reg::A0,
             vs2: VReg::V8,
-            vm: true,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             eew: Eew::E32,
-            nf: 2,
             rs2: Reg::Zero,
         })
     );
@@ -468,9 +463,8 @@ fn test_vloxseg3ei8() {
             vd: VReg::V4,
             rs1: Reg::A0,
             vs2: VReg::V12,
-            vm: false,
+            vm_nf: SegVmNf::new(false, Nf::N3),
             eew: Eew::E8,
-            nf: 3,
             rs2: Reg::Zero,
         })
     );

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/store.rs
@@ -5,6 +5,7 @@ mod tests;
 
 use crate::instructions::Instruction;
 use crate::instructions::v::Eew;
+use crate::instructions::v::zve64x::load::{Nf, SegVmNf};
 use crate::registers::general_purpose::Register;
 use crate::registers::vector::VReg;
 use ab_riscv_macros::instruction;
@@ -46,19 +47,19 @@ pub enum Zve64xStoreInstruction<Reg> {
     /// Unit-stride segment store: `vsseg{nf}e{eew}.v vs3, (rs1), vm`
     ///
     /// mop=00, sumop=00000, nf>0
-    Vsseg { vs3: VReg, rs1: Reg, vm: bool, eew: Eew, nf: u8 },
+    Vsseg { vs3: VReg, rs1: Reg, eew: Eew, vm_nf: SegVmNf },
     /// Strided segment store: `vssseg{nf}e{eew}.v vs3, (rs1), rs2, vm`
     ///
     /// mop=10, nf>0
-    Vssseg { vs3: VReg, rs1: Reg, rs2: Reg, vm: bool, eew: Eew, nf: u8 },
+    Vssseg { vs3: VReg, rs1: Reg, rs2: Reg, eew: Eew, vm_nf: SegVmNf },
     /// Indexed-unordered segment store: `vsuxseg{nf}ei{eew}.v vs3, (rs1), vs2, vm`
     ///
     /// mop=01, nf>0
-    Vsuxseg { vs3: VReg, rs1: Reg, vs2: VReg, vm: bool, eew: Eew, nf: u8 },
+    Vsuxseg { vs3: VReg, rs1: Reg, vs2: VReg, eew: Eew, vm_nf: SegVmNf },
     /// Indexed-ordered segment store: `vsoxseg{nf}ei{eew}.v vs3, (rs1), vs2, vm`
     ///
     /// mop=11, nf>0
-    Vsoxseg { vs3: VReg, rs1: Reg, vs2: VReg, vm: bool, eew: Eew, nf: u8 },
+    Vsoxseg { vs3: VReg, rs1: Reg, vs2: VReg, eew: Eew, vm_nf: SegVmNf },
 }
 
 #[instruction]
@@ -109,9 +110,8 @@ where
                             Some(Self::Vsseg {
                                 vs3,
                                 rs1,
-                                vm,
+                                vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                                 eew,
-                                nf: nf_val,
                             })
                         }
                     }
@@ -159,9 +159,8 @@ where
                         vs3,
                         rs1,
                         vs2,
-                        vm,
+                        vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                         eew,
-                        nf: nf_val,
                     })
                 }
             }
@@ -182,9 +181,8 @@ where
                         vs3,
                         rs1,
                         rs2,
-                        vm,
+                        vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                         eew,
-                        nf: nf_val,
                     })
                 }
             }
@@ -205,9 +203,8 @@ where
                         vs3,
                         rs1,
                         vs2,
-                        vm,
+                        vm_nf: SegVmNf::new(vm, Nf::new(nf_val)?),
                         eew,
-                        nf: nf_val,
                     })
                 }
             }
@@ -240,10 +237,10 @@ where
             Self::Vsuxei { vs3, rs1, vs2, vm, eew } => write!(f, "vsuxei{eew}.v {vs3}, ({rs1}), {vs2}{}", mask_suffix(vm)),
             Self::Vsoxei { vs3, rs1, vs2, vm, eew } => write!(f, "vsoxei{eew}.v {vs3}, ({rs1}), {vs2}{}", mask_suffix(vm)),
             Self::Vsr { vs3, rs1, nreg } => write!(f, "vs{nreg}r.v {vs3}, ({rs1})"),
-            Self::Vsseg { vs3, rs1, vm, eew, nf } => write!(f, "vsseg{nf}e{eew}.v {vs3}, ({rs1}){}", mask_suffix(vm)),
-            Self::Vssseg { vs3, rs1, rs2, vm, eew, nf } => write!(f, "vssseg{nf}e{eew}.v {vs3}, ({rs1}), {rs2}{}", mask_suffix(vm)),
-            Self::Vsuxseg { vs3, rs1, vs2, vm, eew, nf } => write!(f, "vsuxseg{nf}ei{eew}.v {vs3}, ({rs1}), {vs2}{}", mask_suffix(vm)),
-            Self::Vsoxseg { vs3, rs1, vs2, vm, eew, nf } => write!(f, "vsoxseg{nf}ei{eew}.v {vs3}, ({rs1}), {vs2}{}", mask_suffix(vm)),
+            Self::Vsseg { vs3, rs1, eew, vm_nf } => write!(f, "vsseg{}e{eew}.v {vs3}, ({rs1}){}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
+            Self::Vssseg { vs3, rs1, rs2, eew, vm_nf } => write!(f, "vssseg{}e{eew}.v {vs3}, ({rs1}), {rs2}{}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
+            Self::Vsuxseg { vs3, rs1, vs2, eew, vm_nf } => write!(f, "vsuxseg{}ei{eew}.v {vs3}, ({rs1}), {vs2}{}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
+            Self::Vsoxseg { vs3, rs1, vs2, eew, vm_nf } => write!(f, "vsoxseg{}ei{eew}.v {vs3}, ({rs1}), {vs2}{}", vm_nf.nf(), mask_suffix(&vm_nf.vm())),
         }
     }
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/store/tests.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 
 use crate::instructions::Instruction;
 use crate::instructions::v::Eew;
+use crate::instructions::v::zve64x::load::{Nf, SegVmNf};
 use crate::instructions::v::zve64x::store::Zve64xStoreInstruction;
 use crate::registers::general_purpose::Reg;
 use crate::registers::vector::VReg;
@@ -325,9 +326,8 @@ fn test_vsseg2e8() {
         Some(Zve64xStoreInstruction::Vsseg {
             vs3: VReg::V4,
             rs1: Reg::A0,
-            vm: true,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             eew: Eew::E8,
-            nf: 2,
             rs2: Reg::Zero,
         })
     );
@@ -342,9 +342,8 @@ fn test_vsseg8e32_masked() {
         Some(Zve64xStoreInstruction::Vsseg {
             vs3: VReg::V0,
             rs1: Reg::T0,
-            vm: false,
+            vm_nf: SegVmNf::new(false, Nf::N8),
             eew: Eew::E32,
-            nf: 8,
             rs2: Reg::Zero,
         })
     );
@@ -360,9 +359,8 @@ fn test_vssseg4e64() {
             vs3: VReg::V8,
             rs1: Reg::A0,
             rs2: Reg::A1,
-            vm: true,
+            vm_nf: SegVmNf::new(true, Nf::N4),
             eew: Eew::E64,
-            nf: 4,
         })
     );
 }
@@ -377,9 +375,8 @@ fn test_vsuxseg2ei32() {
             vs3: VReg::V4,
             rs1: Reg::A0,
             vs2: VReg::V8,
-            vm: true,
+            vm_nf: SegVmNf::new(true, Nf::N2),
             eew: Eew::E32,
-            nf: 2,
             rs2: Reg::Zero,
         })
     );
@@ -395,9 +392,8 @@ fn test_vsoxseg3ei8_masked() {
             vs3: VReg::V4,
             rs1: Reg::A0,
             vs2: VReg::V12,
-            vm: false,
+            vm_nf: SegVmNf::new(false, Nf::N3),
             eew: Eew::E8,
-            nf: 3,
             rs2: Reg::Zero,
         })
     );

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -45,7 +45,7 @@ pub use crate::instructions::v::zve64x::arith::Zve64xArithInstruction;
 pub use crate::instructions::v::zve64x::carry::Zve64xCarryInstruction;
 pub use crate::instructions::v::zve64x::config::Zve64xConfigInstruction;
 pub use crate::instructions::v::zve64x::fixed_point::Zve64xFixedPointInstruction;
-pub use crate::instructions::v::zve64x::load::Zve64xLoadInstruction;
+pub use crate::instructions::v::zve64x::load::{Nf, SegVmNf, Zve64xLoadInstruction};
 pub use crate::instructions::v::zve64x::mask::Zve64xMaskInstruction;
 pub use crate::instructions::v::zve64x::muldiv::Zve64xMulDivInstruction;
 pub use crate::instructions::v::zve64x::perm::Zve64xPermInstruction;


### PR DESCRIPTION
It is a little awkward, but improves type safety, allows for more optimizations and reduces vector instruction size with 16-bit discriminant back to 8 bytes instead of 12