### PR TITLE
Cleanups

### DIFF
--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
@@ -101,10 +101,10 @@ impl VectorRegisters for AbundanceRv32IMaxExtState
 where
     Self: Csrs<<AbundanceRv32IMaxInstruction as Instruction>::Reg>,
 {
-    fn read_vreg(&self) -> &VectorRegisterFile<{ Self::VLENB as usize }> {
+    fn read_vregs(&self) -> &VectorRegisterFile<{ Self::VLENB as usize }> {
         &self.vregs
     }
-    fn write_vreg(&mut self) -> &mut VectorRegisterFile<{ Self::VLENB as usize }> {
+    fn write_vregs(&mut self) -> &mut VectorRegisterFile<{ Self::VLENB as usize }> {
         &mut self.vregs
     }
     fn vtype(&self) -> Option<Vtype<{ Self::ELEN }, { Self::VLEN }>> {

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
@@ -101,10 +101,10 @@ impl VectorRegisters for AbundanceRv64IMaxExtState
 where
     Self: Csrs<<AbundanceRv64IMaxInstruction as Instruction>::Reg>,
 {
-    fn read_vreg(&self) -> &VectorRegisterFile<{ Self::VLENB as usize }> {
+    fn read_vregs(&self) -> &VectorRegisterFile<{ Self::VLENB as usize }> {
         &self.vregs
     }
-    fn write_vreg(&mut self) -> &mut VectorRegisterFile<{ Self::VLENB as usize }> {
+    fn write_vregs(&mut self) -> &mut VectorRegisterFile<{ Self::VLENB as usize }> {
         &mut self.vregs
     }
     fn vtype(&self) -> Option<Vtype<{ Self::ELEN }, { Self::VLEN }>> {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -378,11 +378,11 @@ where
     [(); Self::ELEN as usize]:,
     [(); Self::VLEN as usize]:,
 {
-    fn read_vreg(&self) -> &VectorRegisterFile<{ Self::VLENB as usize }> {
+    fn read_vregs(&self) -> &VectorRegisterFile<{ Self::VLENB as usize }> {
         &self.vector.vregs
     }
 
-    fn write_vreg(&mut self) -> &mut VectorRegisterFile<{ Self::VLENB as usize }> {
+    fn write_vregs(&mut self) -> &mut VectorRegisterFile<{ Self::VLENB as usize }> {
         &mut self.vector.vregs
     }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
@@ -4,7 +4,6 @@ use crate::v::private::SupportedElenVlen;
 use crate::{Csrs, CustomErrorPlaceholder};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
-use core::ops::{Deref, DerefMut};
 
 /// Alignment wrapper for vector registers
 #[derive(Debug, Clone, Copy)]
@@ -20,19 +19,19 @@ impl<const VLENB: usize> const Default for VectorRegisterFile<VLENB> {
     }
 }
 
-impl<const VLENB: usize> const Deref for VectorRegisterFile<VLENB> {
-    type Target = [[u8; VLENB]; 32];
-
+impl<const VLENB: usize> VectorRegisterFile<VLENB> {
+    /// Get reference to a vector register
     #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub fn get(&self, index: VReg) -> &[u8; VLENB] {
+        // SAFETY: Always in-range
+        unsafe { self.0.get_unchecked(usize::from(index.to_bits())) }
     }
-}
 
-impl<const VLENB: usize> const DerefMut for VectorRegisterFile<VLENB> {
+    /// Get mutable reference to a vector register
     #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    pub fn get_mut(&mut self, index: VReg) -> &mut [u8; VLENB] {
+        // SAFETY: Always in-range
+        unsafe { self.0.get_unchecked_mut(usize::from(index.to_bits())) }
     }
 }
 
@@ -69,10 +68,10 @@ where
     Self: VectorRegistersBase + SupportedElenVlen<{ Self::ELEN }, { Self::VLEN }>,
 {
     /// Read the vector register file
-    fn read_vreg(&self) -> &VectorRegisterFile<{ Self::VLENB as usize }>;
+    fn read_vregs(&self) -> &VectorRegisterFile<{ Self::VLENB as usize }>;
 
     /// Mutable access to the vector register file
-    fn write_vreg(&mut self) -> &mut VectorRegisterFile<{ Self::VLENB as usize }>;
+    fn write_vregs(&mut self) -> &mut VectorRegisterFile<{ Self::VLENB as usize }>;
 
     /// Get the current decoded vtype
     fn vtype(&self) -> Option<Vtype<{ Self::ELEN }, { Self::VLEN }>>;
@@ -83,6 +82,9 @@ where
     /// reads via Zicsr, writes via Zicsr are not allowed).
     fn set_vtype(&mut self, vtype: Option<Vtype<{ Self::ELEN }, { Self::VLEN }>>);
 
+    // TODO: Consider new type for `vl`. It is guaranteed to be `at most u16::MAX + 1`, so can be a
+    //  wrapper around `u16`, which will make things nicer in some places like when iterating over
+    //  `vstart..vl`
     /// Get the current vl
     fn vl(&self) -> u32;
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
@@ -8,7 +8,7 @@ use ab_riscv_primitives::prelude::*;
 
 /// Encode a raw vtype value (vta=false, vma=false)
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3u8)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3u8)
 }
 
 /// Build a fresh state with vector CSRs initialized and vtype/vl configured
@@ -55,14 +55,14 @@ fn set_vreg(
     reg: VReg,
     data: &[u8],
 ) {
-    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.bits())];
+    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())];
     dst.fill(0);
     dst[..data.len()].copy_from_slice(data);
 }
 
 /// Read a full vector register as bytes
 fn get_vreg(state: &TestInterpreterState<Zve64xArithInstruction<Reg<u64>>>, reg: VReg) -> [u8; 32] {
-    state.ext_state.read_vreg()[usize::from(reg.bits())]
+    state.ext_state.read_vreg()[usize::from(reg.to_bits())]
 }
 
 /// Read element `i` from a register group as a u64 (zero-extended), given SEW
@@ -76,7 +76,7 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -94,7 +94,7 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -105,7 +105,7 @@ fn mask_bit(
     reg: VReg,
     i: u32,
 ) -> bool {
-    let byte = state.ext_state.read_vreg()[usize::from(reg.bits())][(i / u8::BITS) as usize];
+    let byte = state.ext_state.read_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
     (byte >> (i % u8::BITS)) & 1 != 0
 }
 
@@ -538,7 +538,7 @@ fn vsrl_vx_e8_does_not_bleed_upper_bits() {
     // Register holds 0xAB in the e8 slot; upper bits of u64 representation must not affect result
     let mut state = setup(1, Vsew::E8, Vlmul::M1);
     // Manually place 0xAB in the byte slot for element 0
-    state.ext_state.write_vreg()[usize::from(VReg::V2.bits())][0] = 0xAB;
+    state.ext_state.write_vreg()[usize::from(VReg::V2.to_bits())][0] = 0xAB;
     state.regs.write(Reg::A0, 1);
     exec(
         &mut state,
@@ -559,8 +559,8 @@ fn vsrl_vx_e8_does_not_bleed_upper_bits() {
 fn vsra_vv_e8_arithmetic_shift() {
     // 0x80 as signed i8 = -128; >> 1 = -64 = 0xC0 (arithmetic)
     let mut state = setup(2, Vsew::E8, Vlmul::M1);
-    state.ext_state.write_vreg()[usize::from(VReg::V2.bits())][0] = 0x80;
-    state.ext_state.write_vreg()[usize::from(VReg::V2.bits())][1] = 0x40;
+    state.ext_state.write_vreg()[usize::from(VReg::V2.to_bits())][0] = 0x80;
+    state.ext_state.write_vreg()[usize::from(VReg::V2.to_bits())][1] = 0x40;
     write_elem(&mut state, VReg::V1, 0, Vsew::E8, 1);
     write_elem(&mut state, VReg::V1, 1, Vsew::E8, 1);
     exec(
@@ -776,7 +776,7 @@ fn vmseq_vv_e8_m1_writes_mask_bits() {
     // Bits above vl (8..VLEN) must remain undisturbed (all-ones from pre-fill)
     for i in 8..256usize {
         assert_eq!(
-            (state.ext_state.read_vreg()[usize::from(VReg::V4.bits())][i / u8::BITS as usize]
+            (state.ext_state.read_vreg()[usize::from(VReg::V4.to_bits())][i / u8::BITS as usize]
                 >> (i % u8::BITS as usize))
                 & 1,
             1,
@@ -968,7 +968,7 @@ fn vmsleu_vi_negative_imm_always_true() {
         write_elem(&mut state, VReg::V2, i, Vsew::E8, i as u64);
     }
     // Pre-clear vd bits so we can confirm they all get set
-    state.ext_state.write_vreg()[usize::from(VReg::V4.bits())][0] = 0x00;
+    state.ext_state.write_vreg()[usize::from(VReg::V4.to_bits())][0] = 0x00;
     exec(
         &mut state,
         Zve64xArithInstruction::VmsleuVi {
@@ -1141,7 +1141,7 @@ fn masked_compare_leaves_inactive_mask_bits_undisturbed() {
         write_elem(&mut state, VReg::V1, i, Vsew::E8, 5);
     }
     // Pre-fill destination bits with known pattern: all 1s
-    state.ext_state.write_vreg()[usize::from(VReg::V4.bits())][0] = 0xFF;
+    state.ext_state.write_vreg()[usize::from(VReg::V4.to_bits())][0] = 0xFF;
     exec(
         &mut state,
         Zve64xArithInstruction::VmseqVv {
@@ -1155,7 +1155,7 @@ fn masked_compare_leaves_inactive_mask_bits_undisturbed() {
     )
     .unwrap();
     // Active elements (0,2): eq -> bit set; inactive (1,3): undisturbed (were 1)
-    let vd = state.ext_state.read_vreg()[usize::from(VReg::V4.bits())][0];
+    let vd = state.ext_state.read_vreg()[usize::from(VReg::V4.to_bits())][0];
     // bits 0,2 active and eq -> 1; bits 1,3 undisturbed from 1
     assert_eq!(vd & 0x0F, 0b1111);
 }
@@ -1234,7 +1234,7 @@ fn vstart_skips_elements_before_vstart_compare() {
         write_elem(&mut state, VReg::V1, i, Vsew::E8, i as u64);
     }
     // Pre-fill vd bits with 0
-    state.ext_state.write_vreg()[usize::from(VReg::V4.bits())][0] = 0x00;
+    state.ext_state.write_vreg()[usize::from(VReg::V4.to_bits())][0] = 0x00;
     state.ext_state.set_vstart(2);
     exec(
         &mut state,
@@ -1249,7 +1249,7 @@ fn vstart_skips_elements_before_vstart_compare() {
     )
     .unwrap();
     // Bits 0,1 undisturbed (0); bits 2,3 written (eq = 1)
-    let vd = state.ext_state.read_vreg()[usize::from(VReg::V4.bits())][0];
+    let vd = state.ext_state.read_vreg()[usize::from(VReg::V4.to_bits())][0];
     assert_eq!(vd & 0x0F, 0b1100);
     assert_eq!(state.ext_state.vstart(), 0);
 }
@@ -1638,7 +1638,7 @@ fn compare_mask_dest_may_overlap_source_at_lmul_1() {
     .unwrap();
     // All 4 elements equal 42 -> low 4 bits set
     assert_eq!(
-        state.ext_state.read_vreg()[usize::from(VReg::V2.bits())][0] & 0x0F,
+        state.ext_state.read_vreg()[usize::from(VReg::V2.to_bits())][0] & 0x0F,
         0x0F
     );
 }
@@ -1664,7 +1664,7 @@ fn compare_mask_dest_outside_source_group_lmul_gt_1_ok() {
     )
     .unwrap();
     assert_eq!(
-        state.ext_state.read_vreg()[usize::from(VReg::V8.bits())][0],
+        state.ext_state.read_vreg()[usize::from(VReg::V8.to_bits())][0],
         0xFF
     );
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/tests.rs
@@ -55,14 +55,14 @@ fn set_vreg(
     reg: VReg,
     data: &[u8],
 ) {
-    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())];
+    let dst = state.ext_state.write_vregs().get_mut(reg);
     dst.fill(0);
     dst[..data.len()].copy_from_slice(data);
 }
 
 /// Read a full vector register as bytes
 fn get_vreg(state: &TestInterpreterState<Zve64xArithInstruction<Reg<u64>>>, reg: VReg) -> [u8; 32] {
-    state.ext_state.read_vreg()[usize::from(reg.to_bits())]
+    *state.ext_state.read_vregs().get(reg)
 }
 
 /// Read element `i` from a register group as a u64 (zero-extended), given SEW
@@ -76,7 +76,10 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -94,7 +97,10 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -105,7 +111,7 @@ fn mask_bit(
     reg: VReg,
     i: u32,
 ) -> bool {
-    let byte = state.ext_state.read_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
+    let byte = state.ext_state.read_vregs().get(reg)[(i / u8::BITS) as usize];
     (byte >> (i % u8::BITS)) & 1 != 0
 }
 
@@ -538,7 +544,7 @@ fn vsrl_vx_e8_does_not_bleed_upper_bits() {
     // Register holds 0xAB in the e8 slot; upper bits of u64 representation must not affect result
     let mut state = setup(1, Vsew::E8, Vlmul::M1);
     // Manually place 0xAB in the byte slot for element 0
-    state.ext_state.write_vreg()[usize::from(VReg::V2.to_bits())][0] = 0xAB;
+    state.ext_state.write_vregs().get_mut(VReg::V2)[0] = 0xAB;
     state.regs.write(Reg::A0, 1);
     exec(
         &mut state,
@@ -559,8 +565,8 @@ fn vsrl_vx_e8_does_not_bleed_upper_bits() {
 fn vsra_vv_e8_arithmetic_shift() {
     // 0x80 as signed i8 = -128; >> 1 = -64 = 0xC0 (arithmetic)
     let mut state = setup(2, Vsew::E8, Vlmul::M1);
-    state.ext_state.write_vreg()[usize::from(VReg::V2.to_bits())][0] = 0x80;
-    state.ext_state.write_vreg()[usize::from(VReg::V2.to_bits())][1] = 0x40;
+    state.ext_state.write_vregs().get_mut(VReg::V2)[0] = 0x80;
+    state.ext_state.write_vregs().get_mut(VReg::V2)[1] = 0x40;
     write_elem(&mut state, VReg::V1, 0, Vsew::E8, 1);
     write_elem(&mut state, VReg::V1, 1, Vsew::E8, 1);
     exec(
@@ -776,7 +782,7 @@ fn vmseq_vv_e8_m1_writes_mask_bits() {
     // Bits above vl (8..VLEN) must remain undisturbed (all-ones from pre-fill)
     for i in 8..256usize {
         assert_eq!(
-            (state.ext_state.read_vreg()[usize::from(VReg::V4.to_bits())][i / u8::BITS as usize]
+            (state.ext_state.read_vregs().get(VReg::V4)[i / u8::BITS as usize]
                 >> (i % u8::BITS as usize))
                 & 1,
             1,
@@ -968,7 +974,7 @@ fn vmsleu_vi_negative_imm_always_true() {
         write_elem(&mut state, VReg::V2, i, Vsew::E8, i as u64);
     }
     // Pre-clear vd bits so we can confirm they all get set
-    state.ext_state.write_vreg()[usize::from(VReg::V4.to_bits())][0] = 0x00;
+    state.ext_state.write_vregs().get_mut(VReg::V4)[0] = 0x00;
     exec(
         &mut state,
         Zve64xArithInstruction::VmsleuVi {
@@ -1100,7 +1106,7 @@ fn masked_arith_leaves_inactive_elements_undisturbed() {
     // vm=false: only active (mask bit set) elements are written; others unchanged
     let mut state = setup(4, Vsew::E32, Vlmul::M1);
     // Mask: bits 0 and 2 active, bits 1 and 3 inactive
-    state.ext_state.write_vreg()[0][0] = 0b0101;
+    state.ext_state.write_vregs().get_mut(VReg::V0)[0] = 0b0101;
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, 10);
         write_elem(&mut state, VReg::V1, i, Vsew::E32, 1);
@@ -1135,13 +1141,13 @@ fn masked_arith_leaves_inactive_elements_undisturbed() {
 fn masked_compare_leaves_inactive_mask_bits_undisturbed() {
     let mut state = setup(4, Vsew::E8, Vlmul::M1);
     // Mask: only bits 0 and 2 active
-    state.ext_state.write_vreg()[0][0] = 0b0101;
+    state.ext_state.write_vregs().get_mut(VReg::V0)[0] = 0b0101;
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E8, 5);
         write_elem(&mut state, VReg::V1, i, Vsew::E8, 5);
     }
     // Pre-fill destination bits with known pattern: all 1s
-    state.ext_state.write_vreg()[usize::from(VReg::V4.to_bits())][0] = 0xFF;
+    state.ext_state.write_vregs().get_mut(VReg::V4)[0] = 0xFF;
     exec(
         &mut state,
         Zve64xArithInstruction::VmseqVv {
@@ -1155,7 +1161,7 @@ fn masked_compare_leaves_inactive_mask_bits_undisturbed() {
     )
     .unwrap();
     // Active elements (0,2): eq -> bit set; inactive (1,3): undisturbed (were 1)
-    let vd = state.ext_state.read_vreg()[usize::from(VReg::V4.to_bits())][0];
+    let vd = state.ext_state.read_vregs().get(VReg::V4)[0];
     // bits 0,2 active and eq -> 1; bits 1,3 undisturbed from 1
     assert_eq!(vd & 0x0F, 0b1111);
 }
@@ -1165,7 +1171,7 @@ fn compare_can_write_to_v0_when_masked() {
     // Per spec, compare destination may be v0 even with masking (vm=false)
     let mut state = setup(2, Vsew::E8, Vlmul::M1);
     // Mask v0 all active
-    state.ext_state.write_vreg()[0][0] = 0xFF;
+    state.ext_state.write_vregs().get_mut(VReg::V0)[0] = 0xFF;
     write_elem(&mut state, VReg::V2, 0, Vsew::E8, 5);
     write_elem(&mut state, VReg::V2, 1, Vsew::E8, 3);
     write_elem(&mut state, VReg::V1, 0, Vsew::E8, 5);
@@ -1234,7 +1240,7 @@ fn vstart_skips_elements_before_vstart_compare() {
         write_elem(&mut state, VReg::V1, i, Vsew::E8, i as u64);
     }
     // Pre-fill vd bits with 0
-    state.ext_state.write_vreg()[usize::from(VReg::V4.to_bits())][0] = 0x00;
+    state.ext_state.write_vregs().get_mut(VReg::V4)[0] = 0x00;
     state.ext_state.set_vstart(2);
     exec(
         &mut state,
@@ -1249,7 +1255,7 @@ fn vstart_skips_elements_before_vstart_compare() {
     )
     .unwrap();
     // Bits 0,1 undisturbed (0); bits 2,3 written (eq = 1)
-    let vd = state.ext_state.read_vreg()[usize::from(VReg::V4.to_bits())][0];
+    let vd = state.ext_state.read_vregs().get(VReg::V4)[0];
     assert_eq!(vd & 0x0F, 0b1100);
     assert_eq!(state.ext_state.vstart(), 0);
 }
@@ -1637,10 +1643,7 @@ fn compare_mask_dest_may_overlap_source_at_lmul_1() {
     )
     .unwrap();
     // All 4 elements equal 42 -> low 4 bits set
-    assert_eq!(
-        state.ext_state.read_vreg()[usize::from(VReg::V2.to_bits())][0] & 0x0F,
-        0x0F
-    );
+    assert_eq!(state.ext_state.read_vregs().get(VReg::V2)[0] & 0x0F, 0x0F);
 }
 
 #[test]
@@ -1663,8 +1666,5 @@ fn compare_mask_dest_outside_source_group_lmul_gt_1_ok() {
         },
     )
     .unwrap();
-    assert_eq!(
-        state.ext_state.read_vreg()[usize::from(VReg::V8.to_bits())][0],
-        0xFF
-    );
+    assert_eq!(state.ext_state.read_vregs().get(VReg::V8)[0], 0xFF);
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/zve64x_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/zve64x_arith_helpers.rs
@@ -19,7 +19,7 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let vreg_idx = vreg.bits();
+    let vreg_idx = vreg.to_bits();
     if !vreg_idx.is_multiple_of(group_regs) || vreg_idx + group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -46,8 +46,8 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     if group_regs > 1 {
-        let vd_idx = vd.bits();
-        let src = src_base.bits();
+        let vd_idx = vd.to_bits();
+        let src = src_base.to_bits();
         if vd_idx >= src && vd_idx < src + group_regs {
             return Err(ExecutionError::IllegalInstruction {
                 address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -79,7 +79,7 @@ pub(in super::super) unsafe fn read_element_u64<const VLENB: usize>(
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * sew_bytes;
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.bits()) + reg_off) };
+    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.to_bits()) + reg_off) };
     // SAFETY: `byte_off + sew_bytes <= VLENB` because `byte_off` is at most
     // `(elems_per_reg - 1) * sew_bytes = VLENB - sew_bytes`
     let src = unsafe { reg.get_unchecked(byte_off..byte_off + sew_bytes) };
@@ -108,7 +108,7 @@ pub(in super::super) unsafe fn write_element_u64<const VLENB: usize>(
     let byte_off = (elem_i as usize % elems_per_reg) * sew_bytes;
     let buf = value.to_le_bytes();
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.bits()) + reg_off) };
+    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.to_bits()) + reg_off) };
     // SAFETY: `byte_off + sew_bytes <= VLENB` - same argument as `read_element_u64`.
     // `sew_bytes <= 8` for all `Vsew` variants.
     let dst = unsafe { reg.get_unchecked_mut(byte_off..byte_off + sew_bytes) };
@@ -136,7 +136,7 @@ pub(in super::super) unsafe fn write_mask_bit<const VLENB: usize>(
     let bit_idx = elem_i % u8::BITS;
     // SAFETY: `byte_idx < VLENB` by the caller's precondition
     let byte = unsafe {
-        vreg.get_unchecked_mut(usize::from(vd.bits()))
+        vreg.get_unchecked_mut(usize::from(vd.to_bits()))
             .get_unchecked_mut(byte_idx)
     };
     if result {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/zve64x_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/zve64x_arith_helpers.rs
@@ -1,6 +1,6 @@
 //! Opaque helpers for Zve64x extension
 
-use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, ProgramCounter};
@@ -69,7 +69,7 @@ where
 /// `base_reg + elem_i / (VLENB / sew_bytes) < 32` must hold.
 #[inline(always)]
 pub(in super::super) unsafe fn read_element_u64<const VLENB: usize>(
-    vreg: &[[u8; VLENB]; 32],
+    vregs: &VectorRegisterFile<VLENB>,
     base_reg: VReg,
     elem_i: u32,
     sew: Vsew,
@@ -79,7 +79,8 @@ pub(in super::super) unsafe fn read_element_u64<const VLENB: usize>(
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * sew_bytes;
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.to_bits()) + reg_off) };
+    let reg = vregs
+        .get(unsafe { VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked() });
     // SAFETY: `byte_off + sew_bytes <= VLENB` because `byte_off` is at most
     // `(elems_per_reg - 1) * sew_bytes = VLENB - sew_bytes`
     let src = unsafe { reg.get_unchecked(byte_off..byte_off + sew_bytes) };
@@ -96,7 +97,7 @@ pub(in super::super) unsafe fn read_element_u64<const VLENB: usize>(
 /// `base_reg + elem_i / (VLENB / sew_bytes) < 32` must hold.
 #[inline(always)]
 pub(in super::super) unsafe fn write_element_u64<const VLENB: usize>(
-    vreg: &mut [[u8; VLENB]; 32],
+    vregs: &mut VectorRegisterFile<VLENB>,
     base_reg: VReg,
     elem_i: u32,
     sew: Vsew,
@@ -108,7 +109,8 @@ pub(in super::super) unsafe fn write_element_u64<const VLENB: usize>(
     let byte_off = (elem_i as usize % elems_per_reg) * sew_bytes;
     let buf = value.to_le_bytes();
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.to_bits()) + reg_off) };
+    let reg = vregs
+        .get_mut(unsafe { VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked() });
     // SAFETY: `byte_off + sew_bytes <= VLENB` - same argument as `read_element_u64`.
     // `sew_bytes <= 8` for all `Vsew` variants.
     let dst = unsafe { reg.get_unchecked_mut(byte_off..byte_off + sew_bytes) };
@@ -127,7 +129,7 @@ pub(in super::super) unsafe fn write_element_u64<const VLENB: usize>(
 /// `elem_i < vl <= VLMAX <= VLEN`.
 #[inline(always)]
 pub(in super::super) unsafe fn write_mask_bit<const VLENB: usize>(
-    vreg: &mut [[u8; VLENB]; 32],
+    vregs: &mut VectorRegisterFile<VLENB>,
     vd: VReg,
     elem_i: u32,
     result: bool,
@@ -135,10 +137,7 @@ pub(in super::super) unsafe fn write_mask_bit<const VLENB: usize>(
     let byte_idx = (elem_i / u8::BITS) as usize;
     let bit_idx = elem_i % u8::BITS;
     // SAFETY: `byte_idx < VLENB` by the caller's precondition
-    let byte = unsafe {
-        vreg.get_unchecked_mut(usize::from(vd.to_bits()))
-            .get_unchecked_mut(byte_idx)
-    };
+    let byte = unsafe { vregs.get_mut(vd).get_unchecked_mut(byte_idx) };
     if result {
         *byte |= 1 << bit_idx;
     } else {
@@ -188,7 +187,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
@@ -197,12 +196,12 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 
         // SAFETY: `vs2 % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
 
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) }
+                unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -212,7 +211,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
         // SAFETY: `vd % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
 
@@ -255,7 +254,7 @@ pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         // When masked, inactive elements in the destination mask register are left undisturbed
@@ -265,12 +264,12 @@ pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
         }
 
         // SAFETY: same argument as in `execute_arith_op`
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
 
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) }
+                unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -279,7 +278,7 @@ pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
 
         // SAFETY: `i < vl <= VLMAX <= VLEN`, so `i / 8 < VLEN / 8 = VLENB`
         unsafe {
-            write_mask_bit(ext_state.write_vreg(), vd, i, result);
+            write_mask_bit(ext_state.write_vregs(), vd, i, result);
         }
     }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/zve64x_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/arith/zve64x_arith_helpers.rs
@@ -158,13 +158,13 @@ pub enum OpSrc {
 /// Execute a single-width element-wise arithmetic operation over `vstart..vl`.
 ///
 /// `op` receives `(vs2_elem: u64, src_elem: u64, sew: Vsew)` and returns the `u64` result (only the
-/// low `sew.bits()` are written back).
+/// low `sew.bits_width()` are written back).
 ///
 /// # Safety
-/// - `vd.bits() % group_regs == 0` and `vd.bits() + group_regs <= 32` (verified by caller)
+/// - `vd.to_bits() % group_regs == 0` and `vd.to_bits() + group_regs <= 32` (verified by caller)
 /// - `src` register (when `OpSrc::Vreg`) satisfies the same alignment (verified by caller)
 /// - `vl <= group_regs * VLENB / sew_bytes` (all `vl` elements fit within the register group)
-/// - When `vm=false`: `vd.bits() != 0` (vd does not overlap v0)
+/// - When `vm=false`: `vd.to_bits() != 0` (vd does not overlap v0)
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
@@ -228,7 +228,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 /// regardless of `vta`. Only bits in `vstart..vl` are written.
 ///
 /// # Safety
-/// - `vs2.bits() % group_regs == 0` and `vs2.bits() + group_regs <= 32` (verified by caller)
+/// - `vs2.to_bits() % group_regs == 0` and `vs2.to_bits() + group_regs <= 32` (verified by caller)
 /// - `src` register (when `OpSrc::Vreg`) satisfies the same alignment (verified by caller)
 /// - `vl <= group_regs * VLENB / sew_bytes`
 /// - `vl <= VLEN` (so every element index fits within the mask register)
@@ -286,7 +286,7 @@ pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
     ext_state.reset_vstart();
 }
 
-/// Sign-extend the low `sew.bits()` of `val` to a full `i64`
+/// Sign-extend the low `sew.bits_width()` of `val` to a full `i64`
 #[inline(always)]
 #[doc(hidden)]
 pub fn sign_extend(val: u64, sew: Vsew) -> i64 {
@@ -294,7 +294,7 @@ pub fn sign_extend(val: u64, sew: Vsew) -> i64 {
     (val.cast_signed() << shift) >> shift
 }
 
-/// Mask off the upper bits of a `u64` to leave only the low `sew.bits()`.
+/// Mask off the upper bits of a `u64` to leave only the low `sew.bits_width()`.
 ///
 /// Used for unsigned arithmetic and comparisons where only the SEW-wide portion is significant. For
 /// SEW = 64 this is a no-op (all bits are significant).

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 use ab_riscv_primitives::prelude::*;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
 }
 
 fn setup(
@@ -56,7 +56,7 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -71,7 +71,7 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -84,7 +84,8 @@ fn set_mask_bit(
     i: u32,
     value: bool,
 ) {
-    let byte = &mut state.ext_state.write_vreg()[usize::from(reg.bits())][(i / u8::BITS) as usize];
+    let byte =
+        &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
     if value {
         *byte |= 1 << (i % u8::BITS);
     } else {
@@ -97,7 +98,7 @@ fn read_mask_bit(
     reg: VReg,
     i: u32,
 ) -> bool {
-    let byte = state.ext_state.read_vreg()[usize::from(reg.bits())][(i / u8::BITS) as usize];
+    let byte = state.ext_state.read_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
     (byte >> (i % u8::BITS)) & 1 != 0
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/tests.rs
@@ -56,7 +56,10 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -71,7 +74,10 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -84,8 +90,7 @@ fn set_mask_bit(
     i: u32,
     value: bool,
 ) {
-    let byte =
-        &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
+    let byte = &mut state.ext_state.write_vregs().get_mut(reg)[(i / u8::BITS) as usize];
     if value {
         *byte |= 1 << (i % u8::BITS);
     } else {
@@ -98,7 +103,7 @@ fn read_mask_bit(
     reg: VReg,
     i: u32,
 ) -> bool {
-    let byte = state.ext_state.read_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
+    let byte = state.ext_state.read_vregs().get(reg)[(i / u8::BITS) as usize];
     (byte >> (i % u8::BITS)) & 1 != 0
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/zve64x_carry_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/zve64x_carry_helpers.rs
@@ -34,10 +34,10 @@ pub(in super::super) unsafe fn carry_bit<const VLENB: usize>(
 /// `vstart..vl` are processed unconditionally (no execution mask).
 ///
 /// # Safety
-/// - `vd.bits() % group_regs == 0` and `vd.bits() + group_regs <= 32`
-/// - `vs2.bits() % group_regs == 0` and `vs2.bits() + group_regs <= 32`
+/// - `vd.to_bits() % group_regs == 0` and `vd.to_bits() + group_regs <= 32`
+/// - `vs2.to_bits() % group_regs == 0` and `vs2.to_bits() + group_regs <= 32`
 /// - `src` register satisfies the same alignment (verified by caller)
-/// - `vd.bits() != 0` (vd must not overlap v0, which holds the carry-in)
+/// - `vd.to_bits() != 0` (vd must not overlap v0, which holds the carry-in)
 /// - `vl <= group_regs * VLENB / sew_bytes`
 #[inline(always)]
 #[doc(hidden)]
@@ -160,7 +160,7 @@ pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
 /// Tail mask bits (indices `>= vl`) are left undisturbed per spec §5.3.
 ///
 /// # Safety
-/// - `vs2.bits() % group_regs == 0` and `vs2.bits() + group_regs <= 32`
+/// - `vs2.to_bits() % group_regs == 0` and `vs2.to_bits() + group_regs <= 32`
 /// - `src` register satisfies the same alignment
 /// - `vl <= group_regs * VLENB / sew_bytes` and `vl <= VLEN`
 /// - vd overlap constraints checked by caller

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/zve64x_carry_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/carry/zve64x_carry_helpers.rs
@@ -1,6 +1,6 @@
 //! Opaque helpers for Zve64x extension
 
-use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zve64x::arith::zve64x_arith_helpers::{
     OpSrc, check_mask_dest_no_overlap, check_vreg_group_alignment,
 };
@@ -11,6 +11,7 @@ use crate::v::zve64x::load::zve64x_load_helpers::mask_bit;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
+// TODO: Safety comment here doesn't make sense
 /// Read a single mask bit from vector register `v0` at element index `i`.
 ///
 /// Used to retrieve the per-element carry-in or borrow-in for vadc/vsbc.
@@ -19,11 +20,10 @@ use core::fmt;
 /// `i / 8 < VLENB` must hold, guaranteed when `i < vl <= VLEN`.
 #[inline(always)]
 pub(in super::super) unsafe fn carry_bit<const VLENB: usize>(
-    vreg: &[[u8; VLENB]; 32],
+    vregs: &VectorRegisterFile<VLENB>,
     i: u32,
 ) -> u64 {
-    // SAFETY: `vreg[0]` is always valid; v0 is register index 0
-    let v0 = unsafe { vreg.get_unchecked(0) };
+    let v0 = vregs.get(VReg::V0);
     u64::from(mask_bit(v0, i))
 }
 
@@ -62,19 +62,19 @@ pub unsafe fn execute_carry_add<Reg, ExtState, CustomError>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds:
                 // `vs1_base + i / elems_per_reg < 32`
-                unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) }
+                unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
         let c = if with_carry {
             // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
-            unsafe { carry_bit(ext_state.read_vreg(), i) }
+            unsafe { carry_bit(ext_state.read_vregs(), i) }
         } else {
             0
         };
@@ -85,7 +85,7 @@ pub unsafe fn execute_carry_add<Reg, ExtState, CustomError>(
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
 
@@ -123,25 +123,25 @@ pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds:
                 // `vs1_base + i / elems_per_reg < 32`
-                unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) }
+                unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
-        let borrow = unsafe { carry_bit(ext_state.read_vreg(), i) };
+        let borrow = unsafe { carry_bit(ext_state.read_vregs(), i) };
 
         let result = a.wrapping_sub(b).wrapping_sub(borrow);
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
 
@@ -189,19 +189,19 @@ pub unsafe fn execute_carry_add_mask<Reg, ExtState, CustomError>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds:
                 // `vs1_base + i / elems_per_reg < 32`
-                unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) }
+                unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
         let c = if with_carry {
             // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
-            unsafe { carry_bit(ext_state.read_vreg(), i) }
+            unsafe { carry_bit(ext_state.read_vregs(), i) }
         } else {
             0
         };
@@ -212,7 +212,7 @@ pub unsafe fn execute_carry_add_mask<Reg, ExtState, CustomError>(
 
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
         unsafe {
-            write_mask_bit(ext_state.write_vreg(), vd, i, carry_out);
+            write_mask_bit(ext_state.write_vregs(), vd, i, carry_out);
         }
     }
 
@@ -256,19 +256,19 @@ pub unsafe fn execute_carry_sub_mask<Reg, ExtState, CustomError>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds:
                 // `vs1_base + i / elems_per_reg < 32`
-                unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) }
+                unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
         let borrow_in = if with_borrow {
             // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
-            unsafe { carry_bit(ext_state.read_vreg(), i) }
+            unsafe { carry_bit(ext_state.read_vregs(), i) }
         } else {
             0
         };
@@ -279,7 +279,7 @@ pub unsafe fn execute_carry_sub_mask<Reg, ExtState, CustomError>(
 
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
         unsafe {
-            write_mask_bit(ext_state.write_vreg(), vd, i, borrow_out);
+            write_mask_bit(ext_state.write_vregs(), vd, i, borrow_out);
         }
     }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/config/tests.rs
@@ -6,7 +6,7 @@ use ab_riscv_primitives::prelude::*;
 /// Encode a vtype immediate from SEW, LMUL, vta, vma fields
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul, vta: bool, vma: bool) -> u16 {
     let mut val = u16::from(vlmul.to_bits());
-    val |= u16::from(vsew.bits()) << 3u8;
+    val |= u16::from(vsew.to_bits()) << 3u8;
     if vta {
         val |= 1 << 6u8;
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
@@ -8,7 +8,7 @@ use crate::{
 use ab_riscv_primitives::prelude::*;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3u8)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3u8)
 }
 
 fn setup(
@@ -69,7 +69,7 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -84,7 +84,7 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -102,7 +102,7 @@ fn write_wide_elem(
     let elems_per_reg = 32 / wide_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * wide_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + wide_bytes].copy_from_slice(&buf[..wide_bytes]);
 }
@@ -113,7 +113,8 @@ fn set_mask_bit(
     i: u32,
     val: bool,
 ) {
-    let byte = &mut state.ext_state.write_vreg()[usize::from(reg.bits())][(i / u8::BITS) as usize];
+    let byte =
+        &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
     if val {
         *byte |= 1 << (i % u8::BITS);
     } else {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/tests.rs
@@ -69,7 +69,10 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -84,7 +87,10 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -102,7 +108,10 @@ fn write_wide_elem(
     let elems_per_reg = 32 / wide_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * wide_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + wide_bytes].copy_from_slice(&buf[..wide_bytes]);
 }
@@ -113,8 +122,7 @@ fn set_mask_bit(
     i: u32,
     val: bool,
 ) {
-    let byte =
-        &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
+    let byte = &mut state.ext_state.write_vregs().get_mut(reg)[(i / u8::BITS) as usize];
     if val {
         *byte |= 1 << (i % u8::BITS);
     } else {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
@@ -474,11 +474,11 @@ pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
 /// bits. The caller must verify this constraint before invoking this function.
 ///
 /// # Safety
-/// - `sew.bits() <= 32` (Zve64x ELEN = 64 constraint for narrowing)
-/// - `vs2.bits() % (2 * group_regs) == 0` and `vs2.bits() + 2 * group_regs <= 32`
-/// - `vd.bits() % group_regs == 0` and `vd.bits() + group_regs <= 32`
+/// - `sew.bits_width() <= 32` (Zve64x ELEN = 64 constraint for narrowing)
+/// - `vs2.to_bits() % (2 * group_regs) == 0` and `vs2.to_bits() + 2 * group_regs <= 32`
+/// - `vd.to_bits() % group_regs == 0` and `vd.to_bits() + group_regs <= 32`
 /// - `vl <= group_regs * VLENB / sew_bytes`
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
@@ -537,7 +537,7 @@ pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
 
 /// Verify that the destination SEW is valid for narrowing (must be at most 32 in Zve64x).
 ///
-/// Returns `Err(IllegalInstruction)` when `sew.bits() > 32`.
+/// Returns `Err(IllegalInstruction)` when `sew.bits_width() > 32`.
 #[inline(always)]
 #[doc(hidden)]
 pub fn check_narrowing_sew<Reg, Memory, PC, CustomError>(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
@@ -1,6 +1,6 @@
 //! Opaque helpers for Zve64x extension
 
-use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zve64x::arith::zve64x_arith_helpers::{
     OpSrc, check_vreg_group_alignment, sew_mask,
 };
@@ -384,7 +384,7 @@ pub fn nclip(vs2_elem: u64, shamt: u32, sew: Vsew, mode: Vxrm, vxsat: &mut bool)
 /// - `base_reg + elem_i / (VLENB / (2*sew_bytes)) < 32`
 #[inline(always)]
 pub unsafe fn read_wide_element_u64<const VLENB: usize>(
-    vreg: &[[u8; VLENB]; 32],
+    vregs: &VectorRegisterFile<VLENB>,
     base_reg: VReg,
     elem_i: u32,
     sew: Vsew,
@@ -394,7 +394,9 @@ pub unsafe fn read_wide_element_u64<const VLENB: usize>(
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * double_sew_bytes;
     // SAFETY: caller guarantees bounds
-    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.to_bits()) + reg_off) };
+    let reg = unsafe {
+        vregs.get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
+    };
     // SAFETY: `byte_off + double_sew_bytes <= VLENB`
     let src = unsafe { reg.get_unchecked(byte_off..byte_off + double_sew_bytes) };
     let mut buf = [0u8; 8];
@@ -434,25 +436,25 @@ pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
     let vstart = ext_state.vstart();
     let vxrm = ext_state.vxrm();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     let mut any_sat = false;
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: alignment and bounds checked by caller
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) }
+                unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
         let result = op(a, b, sew, vxrm, &mut any_sat);
         // SAFETY: alignment and bounds checked by caller
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     if any_sat {
@@ -501,7 +503,7 @@ pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
     let vstart = ext_state.vstart();
     let vxrm = ext_state.vxrm();
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     let mut any_sat = false;
     // Mask shift amount to log2(2*SEW) bits per spec §12.11
     let shamt_mask = u64::from(sew.bits_width() * 2 - 1);
@@ -511,11 +513,11 @@ pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
         }
         // Read 2*SEW-wide source element
         // SAFETY: `vs2` double-width alignment checked by caller
-        let wide_a = unsafe { read_wide_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let wide_a = unsafe { read_wide_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let shamt = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: vs1 SEW-wide alignment checked by caller
-                let raw = unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) };
+                let raw = unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) };
                 (raw & shamt_mask) as u32
             }
             OpSrc::Scalar(val) => (val & shamt_mask) as u32,
@@ -523,7 +525,7 @@ pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
         let result = op(wide_a, shamt, sew, vxrm, &mut any_sat);
         // SAFETY: `vd` alignment checked by caller
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     if any_sat {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/fixed_point/zve64x_fixed_point_helpers.rs
@@ -394,7 +394,7 @@ pub unsafe fn read_wide_element_u64<const VLENB: usize>(
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * double_sew_bytes;
     // SAFETY: caller guarantees bounds
-    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.bits()) + reg_off) };
+    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.to_bits()) + reg_off) };
     // SAFETY: `byte_off + double_sew_bytes <= VLENB`
     let src = unsafe { reg.get_unchecked(byte_off..byte_off + double_sew_bytes) };
     let mut buf = [0u8; 8];
@@ -594,7 +594,7 @@ where
             .ok_or(ExecutionError::IllegalInstruction {
                 address: program_counter.old_pc(INSTRUCTION_SIZE),
             })?;
-    let vs2_idx = vs2.bits();
+    let vs2_idx = vs2.to_bits();
     if !vs2_idx.is_multiple_of(wide_group) || vs2_idx + wide_group > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -66,6 +66,7 @@ where
                 nreg,
                 eew: _,
             } => {
+                let nreg = nreg.num_registers();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -81,7 +81,7 @@ where
                 let vlenb = u64::from(ExtState::VLENB);
                 for reg_off in 0..nreg {
                     // SAFETY: the decoder guarantees nreg in {1,2,4,8} and vd is nreg-aligned
-                    // (checked above), so vd.bits() + nreg - 1 <= 31.
+                    // (checked above), so vd.to_bits() + nreg - 1 <= 31.
                     let reg = unsafe { VReg::from_bits(vd.to_bits() + reg_off).unwrap_unchecked() };
                     let bytes = memory
                         .read_slice(base + u64::from(reg_off) * vlenb, ExtState::VLENB)
@@ -487,7 +487,7 @@ where
                 //   group_regs == 0` and `vd + nf * group_regs <= 32`
                 // - `vl <= group_regs * VLENB / eew.bytes()`: `group_regs` is the EMUL for this
                 //   `eew` and `vtype`, so this VLMAX equals the architectural VLMAX bounding `vl`
-                // - mask overlap with v0: `validate_segment_registers` checked `vd.bits() != 0`
+                // - mask overlap with v0: `validate_segment_registers` checked `vd.to_bits() != 0`
                 //   when `vm=false`, ensuring no field group contains v0
                 unsafe {
                     zve64x_load_helpers::execute_unit_stride_load(
@@ -591,7 +591,7 @@ where
                 //   group_regs == 0` and `vd + nf * group_regs <= 32`
                 // - `vl <= group_regs * VLENB / eew.bytes()`: `group_regs` is EMUL for this `eew`
                 //   and `vtype`
-                // - mask overlap: `validate_segment_registers` checked `vd.bits() != 0` when
+                // - mask overlap: `validate_segment_registers` checked `vd.to_bits() != 0` when
                 //   `vm=false`
                 unsafe {
                     zve64x_load_helpers::execute_strided_load(
@@ -636,7 +636,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 // `validate_segment_registers` is called before the per-field overlap loop so
-                // that `vd.bits() + f * data_group_regs < 32` is established for all `f < nf`,
+                // that `vd.to_bits() + f * data_group_regs < 32` is established for all `f < nf`,
                 // which is required by the `VReg::from_bits` call inside the loop.
                 zve64x_load_helpers::validate_segment_registers::<Reg, _, _, _>(
                     program_counter,
@@ -651,8 +651,8 @@ where
                     index_group_regs,
                 )?;
                 for f in 0..nf.fields_per_segment() {
-                    // SAFETY: `vd.bits() + f * data_group_regs < 32` because
-                    // `validate_segment_registers` established `vd.bits() + nf * data_group_regs
+                    // SAFETY: `vd.to_bits() + f * data_group_regs < 32` because
+                    // `validate_segment_registers` established `vd.to_bits() + nf * data_group_regs
                     // <= 32` and `f < nf`. The value is in [0, 31], so it is a valid `VReg`
                     // encoding.
                     let field_vd = unsafe {
@@ -679,7 +679,7 @@ where
                 //   `data_group_regs = LMUL`, so VLMAX = LMUL * VLEN / SEW bounds `vl`
                 // - `vl <= EMUL_index * VLENB / index_eew.bytes()`: `index_group_regs` (EMUL_index)
                 //   is defined so this VLMAX_index equals the architectural VLMAX
-                // - mask overlap: `validate_segment_registers` checked `vd.bits() != 0` when
+                // - mask overlap: `validate_segment_registers` checked `vd.to_bits() != 0` when
                 //   `vm=false`, and no field group starts at 0 since groups are contiguous from
                 //   `vd` which is nonzero
                 unsafe {
@@ -739,8 +739,8 @@ where
                     index_group_regs,
                 )?;
                 for f in 0..nf.fields_per_segment() {
-                    // SAFETY: `vd.bits() + f * data_group_regs < 32` because
-                    // `validate_segment_registers` established `vd.bits() + nf * data_group_regs
+                    // SAFETY: `vd.to_bits() + f * data_group_regs < 32` because
+                    // `validate_segment_registers` established `vd.to_bits() + nf * data_group_regs
                     // <= 32` and `f < nf`. The value is in [0, 31], so it is a valid `VReg`
                     // encoding.
                     let field_vd = unsafe {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -72,29 +72,26 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if u32::from(vd.to_bits()) % u32::from(nreg) != 0 {
+                if vd.to_bits() % nreg != 0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
                 let base = rs1_value.as_u64();
                 let vlenb = u64::from(ExtState::VLENB);
-                for reg_off in 0..u64::from(nreg) {
-                    let reg_idx = u64::from(vd.to_bits()) + reg_off;
+                for reg_off in 0..nreg {
+                    // SAFETY: the decoder guarantees nreg in {1,2,4,8} and vd is nreg-aligned
+                    // (checked above), so vd.bits() + nreg - 1 <= 31.
+                    let reg = unsafe { VReg::from_bits(vd.to_bits() + reg_off).unwrap_unchecked() };
                     let bytes = memory
-                        .read_slice(base + reg_off * vlenb, ExtState::VLENB)
+                        .read_slice(base + u64::from(reg_off) * vlenb, ExtState::VLENB)
                         .inspect_err(|_error| {
                             if reg_off > 0 {
                                 ext_state.mark_vs_dirty();
                                 ext_state.reset_vstart();
                             }
                         })?;
-                    // SAFETY: `reg_idx < 32` because the decoder guarantees nreg in {1,2,4,8}
-                    // and vd is nreg-aligned (checked above), so vd.bits() + nreg - 1 <= 31.
-                    // `read_slice` returns a slice of exactly `ExtState::VLENB` bytes on success,
-                    // matching `dst`'s length, so `copy_from_slice` cannot panic.
-                    let dst = unsafe { ext_state.write_vreg().get_unchecked_mut(reg_idx as usize) };
-                    dst.copy_from_slice(bytes);
+                    ext_state.write_vregs().get_mut(reg).copy_from_slice(bytes);
                 }
                 ext_state.mark_vs_dirty();
                 ext_state.reset_vstart();
@@ -113,14 +110,13 @@ where
                 if byte_count > 0 {
                     let base = rs1_value.as_u64();
                     let bytes = memory.read_slice(base, byte_count)?;
-                    // SAFETY: `vd.bits() < 32` is guaranteed by the `VReg` type.
-                    // `bytes.len() == byte_count = vl.div_ceil(8) <= VLEN / 8 = VLENB` because
-                    // `vl <= VLMAX <= VLEN`, so `..bytes.len()` is in bounds within the
+                    // SAFETY: `bytes.len() == byte_count = vl.div_ceil(8) <= VLEN / 8 = VLENB`
+                    // because `vl <= VLMAX <= VLEN`, so `..bytes.len()` is in bounds within the
                     // `VLENB`-byte destination register.
                     unsafe {
                         ext_state
-                            .write_vreg()
-                            .get_unchecked_mut(usize::from(vd.to_bits()))
+                            .write_vregs()
+                            .get_mut(vd)
                             .get_unchecked_mut(..bytes.len())
                             .copy_from_slice(bytes);
                     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load.rs
@@ -71,7 +71,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if u32::from(vd.bits()) % u32::from(nreg) != 0 {
+                if u32::from(vd.to_bits()) % u32::from(nreg) != 0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -79,7 +79,7 @@ where
                 let base = rs1_value.as_u64();
                 let vlenb = u64::from(ExtState::VLENB);
                 for reg_off in 0..u64::from(nreg) {
-                    let reg_idx = u64::from(vd.bits()) + reg_off;
+                    let reg_idx = u64::from(vd.to_bits()) + reg_off;
                     let bytes = memory
                         .read_slice(base + reg_off * vlenb, ExtState::VLENB)
                         .inspect_err(|_error| {
@@ -119,7 +119,7 @@ where
                     unsafe {
                         ext_state
                             .write_vreg()
-                            .get_unchecked_mut(usize::from(vd.bits()))
+                            .get_unchecked_mut(usize::from(vd.to_bits()))
                             .get_unchecked_mut(..bytes.len())
                             .copy_from_slice(bytes);
                     }
@@ -659,7 +659,7 @@ where
                     // <= 32` and `f < nf`. The value is in [0, 31], so it is a valid `VReg`
                     // encoding.
                     let field_vd = unsafe {
-                        VReg::from_bits(vd.bits() + f * data_group_regs).unwrap_unchecked()
+                        VReg::from_bits(vd.to_bits() + f * data_group_regs).unwrap_unchecked()
                     };
                     if zve64x_load_helpers::groups_overlap(
                         field_vd,
@@ -747,7 +747,7 @@ where
                     // <= 32` and `f < nf`. The value is in [0, 31], so it is a valid `VReg`
                     // encoding.
                     let field_vd = unsafe {
-                        VReg::from_bits(vd.bits() + f * data_group_regs).unwrap_unchecked()
+                        VReg::from_bits(vd.to_bits() + f * data_group_regs).unwrap_unchecked()
                     };
                     if zve64x_load_helpers::groups_overlap(
                         field_vd,

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
@@ -50,7 +50,7 @@ fn vreg_byte(
     reg: VReg,
     offset: usize,
 ) -> u8 {
-    state.ext_state.read_vreg()[usize::from(reg.to_bits())][offset]
+    state.ext_state.read_vregs().get(reg)[offset]
 }
 
 /// Read a full vector register as a byte slice copy
@@ -58,7 +58,7 @@ fn vreg_bytes(
     state: &TestInterpreterState<Zve64xLoadInstruction<Reg<u64>>>,
     reg: VReg,
 ) -> [u8; 32] {
-    state.ext_state.read_vreg()[usize::from(reg.to_bits())]
+    *state.ext_state.read_vregs().get(reg)
 }
 
 /// Set a vector register's bytes directly
@@ -67,8 +67,7 @@ fn set_vreg(
     reg: VReg,
     data: &[u8],
 ) {
-    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())];
-    dst[..data.len()].copy_from_slice(data);
+    state.ext_state.write_vregs().get_mut(reg)[..data.len()].copy_from_slice(data);
 }
 
 /// Execute a single instruction directly (not via the instruction fetcher)

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
@@ -30,7 +30,7 @@ fn setup(
 
 /// Encode a raw vtype value from SEW and LMUL (vta=false, vma=false)
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
 }
 
 /// Write a sequence of bytes into test memory starting at `addr`
@@ -50,7 +50,7 @@ fn vreg_byte(
     reg: VReg,
     offset: usize,
 ) -> u8 {
-    state.ext_state.read_vreg()[usize::from(reg.bits())][offset]
+    state.ext_state.read_vreg()[usize::from(reg.to_bits())][offset]
 }
 
 /// Read a full vector register as a byte slice copy
@@ -58,7 +58,7 @@ fn vreg_bytes(
     state: &TestInterpreterState<Zve64xLoadInstruction<Reg<u64>>>,
     reg: VReg,
 ) -> [u8; 32] {
-    state.ext_state.read_vreg()[usize::from(reg.bits())]
+    state.ext_state.read_vreg()[usize::from(reg.to_bits())]
 }
 
 /// Set a vector register's bytes directly
@@ -67,7 +67,7 @@ fn set_vreg(
     reg: VReg,
     data: &[u8],
 ) {
-    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.bits())];
+    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())];
     dst[..data.len()].copy_from_slice(data);
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/tests.rs
@@ -109,7 +109,7 @@ fn vlr_single_register_loads_vlenb_bytes() {
         Zve64xLoadInstruction::Vlr {
             vd: VReg::V2,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             eew: Eew::E8,
             rs2: Reg::Zero,
         },
@@ -133,7 +133,7 @@ fn vlr_two_registers_loads_two_vlenb_blocks() {
         Zve64xLoadInstruction::Vlr {
             vd: VReg::V2,
             rs1: Reg::A0,
-            nreg: 2,
+            nreg: LoadStoreNreg::N2,
             eew: Eew::E8,
             rs2: Reg::Zero,
         },
@@ -157,7 +157,7 @@ fn vlr_four_registers() {
         Zve64xLoadInstruction::Vlr {
             vd: VReg::V4,
             rs1: Reg::A0,
-            nreg: 4,
+            nreg: LoadStoreNreg::N4,
             eew: Eew::E8,
             rs2: Reg::Zero,
         },
@@ -188,7 +188,7 @@ fn vlr_ignores_vtype_and_vl() {
         Zve64xLoadInstruction::Vlr {
             vd: VReg::V0,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             eew: Eew::E8,
             rs2: Reg::Zero,
         },
@@ -212,7 +212,7 @@ fn vlr_resets_vstart_on_success() {
         Zve64xLoadInstruction::Vlr {
             vd: VReg::V1,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             eew: Eew::E8,
             rs2: Reg::Zero,
         },
@@ -236,7 +236,7 @@ fn vlr_misaligned_vd_is_illegal() {
         Zve64xLoadInstruction::Vlr {
             vd: VReg::V3,
             rs1: Reg::A0,
-            nreg: 2,
+            nreg: LoadStoreNreg::N2,
             eew: Eew::E8,
             rs2: Reg::Zero,
         },
@@ -257,7 +257,7 @@ fn vlr_out_of_bounds_memory_returns_error() {
         Zve64xLoadInstruction::Vlr {
             vd: VReg::V0,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             eew: Eew::E8,
             rs2: Reg::Zero,
         },
@@ -2166,7 +2166,7 @@ fn vlr_eight_registers() {
         Zve64xLoadInstruction::Vlr {
             vd: VReg::V0,
             rs1: Reg::A0,
-            nreg: 8,
+            nreg: LoadStoreNreg::N8,
             eew: Eew::E8,
             rs2: Reg::Zero,
         },

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
@@ -46,7 +46,7 @@ pub(in super::super) unsafe fn snapshot_mask<const VLENB: usize>(
         // SAFETY: `mask_bytes <= VLENB` by the caller's precondition
         unsafe {
             buf.get_unchecked_mut(..mask_bytes)
-                .copy_from_slice(vreg[usize::from(VReg::V0.bits())].get_unchecked(..mask_bytes));
+                .copy_from_slice(vreg[usize::from(VReg::V0.to_bits())].get_unchecked(..mask_bytes));
         }
     }
     buf
@@ -56,7 +56,7 @@ pub(in super::super) unsafe fn snapshot_mask<const VLENB: usize>(
 #[inline(always)]
 #[doc(hidden)]
 pub fn groups_overlap(a: VReg, a_regs: u8, b: VReg, b_regs: u8) -> bool {
-    let (a, b) = (a.bits(), b.bits());
+    let (a, b) = (a.to_bits(), b.to_bits());
     a < b + b_regs && b < a + a_regs
 }
 
@@ -96,7 +96,7 @@ pub fn indexed_load_overlap_allowed(
         return true;
     }
 
-    match sew.bytes_width().cmp(&index_eew.bytes()) {
+    match sew.bytes_width().cmp(&index_eew.bytes_width()) {
         // Equal EEW: the two groups coincide, overlap is permitted.
         Ordering::Equal => true,
         // Smaller data EEW: overlap must be in the lowest-numbered part of the index group, which
@@ -108,9 +108,9 @@ pub fn indexed_load_overlap_allowed(
         // recomputed here as `(index_eew / sew) * LMUL >= 1`.
         Ordering::Greater => {
             let (lmul_num, lmul_den) = vlmul.as_fraction();
-            let index_emul_at_least_one = u16::from(index_eew.bits()) * u16::from(lmul_num)
+            let index_emul_at_least_one = u16::from(index_eew.bits_width()) * u16::from(lmul_num)
                 >= u16::from(sew.bits_width()) * u16::from(lmul_den);
-            let (vd, vs2) = (vd.bits(), vs2.bits());
+            let (vd, vs2) = (vd.to_bits(), vs2.to_bits());
             index_emul_at_least_one && vd + data_regs == vs2 + index_regs
         }
     }
@@ -130,7 +130,7 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let vd = vd.bits();
+    let vd = vd.to_bits();
     if !vd.is_multiple_of(group_regs) || vd + group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -159,7 +159,7 @@ where
 {
     let group_regs = u32::from(group_regs);
     let nf = u32::from(nf.fields_per_segment());
-    let vd_idx = u32::from(vd.bits());
+    let vd_idx = u32::from(vd.to_bits());
     if vd_idx % group_regs != 0 || vd_idx + nf * group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -195,7 +195,7 @@ pub(in super::super) unsafe fn read_group_element<const VLENB: usize>(
     elem_i: u32,
     eew: Eew,
 ) -> [u8; Eew::MAX_BYTES as usize] {
-    let elem_bytes = usize::from(eew.bytes());
+    let elem_bytes = usize::from(eew.bytes_width());
     let elems_per_reg = VLENB / elem_bytes;
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * elem_bytes;
@@ -229,7 +229,7 @@ unsafe fn write_group_element<const VLENB: usize>(
     eew: Eew,
     buf: [u8; Eew::MAX_BYTES as usize],
 ) {
-    let elem_bytes = usize::from(eew.bytes());
+    let elem_bytes = usize::from(eew.bytes_width());
     let elems_per_reg = VLENB / elem_bytes;
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * elem_bytes;
@@ -252,8 +252,8 @@ fn read_mem_element(
     eew: Eew,
 ) -> Result<[u8; Eew::MAX_BYTES as usize], VirtualMemoryError> {
     let mut out = [0; _];
-    out[..usize::from(eew.bytes())]
-        .copy_from_slice(memory.read_slice(addr, u32::from(eew.bytes()))?);
+    out[..usize::from(eew.bytes_width())]
+        .copy_from_slice(memory.read_slice(addr, u32::from(eew.bytes_width()))?);
     Ok(out)
 }
 
@@ -298,7 +298,7 @@ where
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let elem_bytes = eew.bytes();
+    let elem_bytes = eew.bytes_width();
     let segment_stride = u64::from(nf.fields_per_segment()) * u64::from(elem_bytes);
 
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
@@ -353,7 +353,7 @@ where
 
         // All nf fields for element i were read successfully; commit to the register file.
         for f in 0..nf.fields_per_segment() {
-            let field_base_reg = vd.bits() + f * group_regs;
+            let field_base_reg = vd.to_bits() + f * group_regs;
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
             //
             // Let `elems_per_reg = VLENB / elem_bytes`.
@@ -422,7 +422,7 @@ where
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let elem_bytes = eew.bytes();
+    let elem_bytes = eew.bytes_width();
 
     // SAFETY: `vl <= VLMAX <= VLEN` (precondition), so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
@@ -446,7 +446,7 @@ where
                     return Err(ExecutionError::MemoryAccess(mem_err));
                 }
             };
-            let field_base_reg = vd.bits() + f * group_regs;
+            let field_base_reg = vd.to_bits() + f * group_regs;
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
             //
             // Let `elems_per_reg = VLENB / elem_bytes`.
@@ -511,7 +511,7 @@ where
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let index_base_reg = usize::from(vs2.bits());
+    let index_base_reg = usize::from(vs2.to_bits());
 
     // SAFETY: `vl <= VLMAX <= VLEN` (precondition), so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
@@ -533,7 +533,7 @@ where
         let offset = u64::from_le_bytes(index_buf);
         let elem_addr = base.wrapping_add(offset);
 
-        let data_elem_bytes = data_eew.bytes();
+        let data_elem_bytes = data_eew.bytes_width();
         for f in 0..nf.fields_per_segment() {
             let addr = elem_addr.wrapping_add(u64::from(f) * u64::from(data_elem_bytes));
             let data = match read_mem_element(memory, addr, data_eew) {
@@ -546,7 +546,7 @@ where
                     return Err(ExecutionError::MemoryAccess(mem_err));
                 }
             };
-            let field_base_reg = vd.bits() + f * data_group_regs;
+            let field_base_reg = vd.to_bits() + f * data_group_regs;
             // SAFETY: need `field_base_reg + i / (VLENB / data_eew.bytes()) < 32`.
             //
             // Let `data_elems_per_reg = VLENB / data_eew.bytes()`.

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
@@ -1,6 +1,6 @@
 //! Opaque helpers for Zve64x extension
 
-use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, ProgramCounter, VirtualMemory, VirtualMemoryError};
 use ab_riscv_primitives::prelude::*;
@@ -33,7 +33,7 @@ pub(in super::super) fn mask_bit(mask: &[u8], i: u32) -> bool {
 /// when `vl` is the current architectural `vl` (bounded by `VLMAX <= VLEN`).
 #[inline(always)]
 pub(in super::super) unsafe fn snapshot_mask<const VLENB: usize>(
-    vreg: &[[u8; VLENB]; 32],
+    vregs: &VectorRegisterFile<VLENB>,
     vm: bool,
     vl: u32,
 ) -> [u8; VLENB] {
@@ -46,7 +46,7 @@ pub(in super::super) unsafe fn snapshot_mask<const VLENB: usize>(
         // SAFETY: `mask_bytes <= VLENB` by the caller's precondition
         unsafe {
             buf.get_unchecked_mut(..mask_bytes)
-                .copy_from_slice(vreg[usize::from(VReg::V0.to_bits())].get_unchecked(..mask_bytes));
+                .copy_from_slice(vregs.get(VReg::V0).get_unchecked(..mask_bytes));
         }
     }
     buf
@@ -190,8 +190,9 @@ where
 /// a valid element index within the register group.
 #[inline(always)]
 pub(in super::super) unsafe fn read_group_element<const VLENB: usize>(
-    vreg: &[[u8; VLENB]; 32],
-    base_reg: usize,
+    vregs: &VectorRegisterFile<VLENB>,
+    base_reg: VReg,
+    // TODO: `elem_i` here and in other places shouldn't be `u32`
     elem_i: u32,
     eew: Eew,
 ) -> [u8; Eew::MAX_BYTES as usize] {
@@ -199,8 +200,10 @@ pub(in super::super) unsafe fn read_group_element<const VLENB: usize>(
     let elems_per_reg = VLENB / elem_bytes;
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * elem_bytes;
-    // SAFETY: `base_reg + reg_off < 32` by the caller's precondition.
-    let reg = unsafe { vreg.get_unchecked(base_reg + reg_off) };
+    // SAFETY: `base_reg + reg_off < 32` by the caller's precondition
+    let reg = unsafe {
+        vregs.get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
+    };
     // SAFETY: `byte_off + elem_bytes <= VLENB`: the maximum `byte_off` is
     // `(elems_per_reg - 1) * elem_bytes = VLENB - elem_bytes`, so
     // `byte_off + elem_bytes <= VLENB - elem_bytes + elem_bytes = VLENB`.
@@ -223,8 +226,8 @@ pub(in super::super) unsafe fn read_group_element<const VLENB: usize>(
 /// a valid element index within the register group.
 #[inline(always)]
 unsafe fn write_group_element<const VLENB: usize>(
-    vreg: &mut [[u8; VLENB]; 32],
-    base_reg: u8,
+    vregs: &mut VectorRegisterFile<VLENB>,
+    base_reg: VReg,
     elem_i: u32,
     eew: Eew,
     buf: [u8; Eew::MAX_BYTES as usize],
@@ -234,7 +237,9 @@ unsafe fn write_group_element<const VLENB: usize>(
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * elem_bytes;
     // SAFETY: `base_reg + reg_off < 32` by the caller's precondition
-    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg) + reg_off) };
+    let reg = unsafe {
+        vregs.get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
+    };
     // SAFETY: `byte_off + elem_bytes <= VLENB` and `elem_bytes <= Eew::MAX_BYTES`: same argument as
     // in `read_group_element`
     let dst = unsafe { reg.get_unchecked_mut(byte_off..byte_off + elem_bytes) };
@@ -302,7 +307,7 @@ where
     let segment_stride = u64::from(nf.fields_per_segment()) * u64::from(elem_bytes);
 
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         if !vm && !mask_bit(&mask_buf, i) {
@@ -353,7 +358,9 @@ where
 
         // All nf fields for element i were read successfully; commit to the register file.
         for f in 0..nf.fields_per_segment() {
-            let field_base_reg = vd.to_bits() + f * group_regs;
+            // SAFETY: Guaranteed by function contract
+            let field_base_reg =
+                unsafe { VReg::from_bits(vd.to_bits() + f * group_regs).unwrap_unchecked() };
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
             //
             // Let `elems_per_reg = VLENB / elem_bytes`.
@@ -372,7 +379,7 @@ where
             // above), so `f as usize < Nf::MAX = field_buf.len()`.
             unsafe {
                 write_group_element(
-                    ext_state.write_vreg(),
+                    ext_state.write_vregs(),
                     field_base_reg,
                     i,
                     eew,
@@ -425,7 +432,7 @@ where
     let elem_bytes = eew.bytes_width();
 
     // SAFETY: `vl <= VLMAX <= VLEN` (precondition), so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         if !vm && !mask_bit(&mask_buf, i) {
@@ -446,7 +453,9 @@ where
                     return Err(ExecutionError::MemoryAccess(mem_err));
                 }
             };
-            let field_base_reg = vd.to_bits() + f * group_regs;
+            // SAFETY: Guaranteed by function contract
+            let field_base_reg =
+                unsafe { VReg::from_bits(vd.to_bits() + f * group_regs).unwrap_unchecked() };
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
             //
             // Let `elems_per_reg = VLENB / elem_bytes`.
@@ -460,7 +469,7 @@ where
             //
             // Therefore, `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
             unsafe {
-                write_group_element(ext_state.write_vreg(), field_base_reg, i, eew, data);
+                write_group_element(ext_state.write_vregs(), field_base_reg, i, eew, data);
             }
         }
     }
@@ -511,10 +520,10 @@ where
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let index_base_reg = usize::from(vs2.to_bits());
+    let index_base_reg = vs2;
 
     // SAFETY: `vl <= VLMAX <= VLEN` (precondition), so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         if !vm && !mask_bit(&mask_buf, i) {
@@ -529,7 +538,7 @@ where
         // `i / (VLENB / index_eew.bytes()) < EMUL_index`, and therefore
         // `index_base_reg + i / (VLENB / index_eew.bytes()) < index_base_reg + EMUL_index <= 32`.
         let index_buf =
-            unsafe { read_group_element(ext_state.read_vreg(), index_base_reg, i, index_eew) };
+            unsafe { read_group_element(ext_state.read_vregs(), index_base_reg, i, index_eew) };
         let offset = u64::from_le_bytes(index_buf);
         let elem_addr = base.wrapping_add(offset);
 
@@ -546,7 +555,9 @@ where
                     return Err(ExecutionError::MemoryAccess(mem_err));
                 }
             };
-            let field_base_reg = vd.to_bits() + f * data_group_regs;
+            // SAFETY: Guaranteed by function contract
+            let field_base_reg =
+                unsafe { VReg::from_bits(vd.to_bits() + f * data_group_regs).unwrap_unchecked() };
             // SAFETY: need `field_base_reg + i / (VLENB / data_eew.bytes()) < 32`.
             //
             // Let `data_elems_per_reg = VLENB / data_eew.bytes()`.
@@ -561,7 +572,7 @@ where
             // Therefore,
             // `field_base_reg + i / data_elems_per_reg < field_base_reg + data_group_regs <= 32`.
             unsafe {
-                write_group_element(ext_state.write_vreg(), field_base_reg, i, data_eew, data);
+                write_group_element(ext_state.write_vregs(), field_base_reg, i, data_eew, data);
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
@@ -143,7 +143,7 @@ where
 /// register is group-aligned, and the first field group does not include `v0` when masked.
 ///
 /// Field `f` occupies registers `[vd + f * group_regs, vd + f * group_regs + group_regs)`.
-/// On `Ok`, `vd.bits() + nf * group_regs <= 32` is guaranteed.
+/// On `Ok`, `vd.to_bits() + nf * group_regs <= 32` is guaranteed.
 #[inline(always)]
 #[doc(hidden)]
 pub fn validate_segment_registers<Reg, Memory, PC, CustomError>(
@@ -272,12 +272,12 @@ fn read_mem_element(
 /// and returns `Ok`. An error at element `0` always propagates.
 ///
 /// # Safety
-/// - `vd.bits() % group_regs == 0`
-/// - `vd.bits() + nf * group_regs <= 32`
+/// - `vd.to_bits() % group_regs == 0`
+/// - `vd.to_bits() + nf * group_regs <= 32`
 /// - `vl <= group_regs * VLENB / eew.bytes()` (all `vl` elements fit within the destination
 ///   register group; this holds when `vl` is the architectural `vl` and `group_regs` is the EMUL
 ///   register count for the given `eew` and `vtype`)
-/// - When `vm=false`: `vd` does not overlap `v0` (i.e. `vd.bits() != 0`)
+/// - When `vm=false`: `vd` does not overlap `v0` (i.e. `vd.to_bits() != 0`)
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
@@ -367,10 +367,10 @@ where
             // `i < vl <= group_regs * elems_per_reg` (precondition), so
             // `i / elems_per_reg < group_regs`.
             //
-            // `field_base_reg = vd.bits() + f * group_regs`. Since `f < nf` and the
-            // precondition guarantees `vd.bits() + nf * group_regs <= 32`:
-            // `field_base_reg + group_regs <= vd.bits() + (f+1) * group_regs
-            //                             <= vd.bits() + nf * group_regs <= 32`.
+            // `field_base_reg = vd.to_bits() + f * group_regs`. Since `f < nf` and the
+            // precondition guarantees `vd.to_bits() + nf * group_regs <= 32`:
+            // `field_base_reg + group_regs <= vd.to_bits() + (f+1) * group_regs
+            //                             <= vd.to_bits() + nf * group_regs <= 32`.
             //
             // Therefore, `field_base_reg + i / elems_per_reg
             //            < field_base_reg + group_regs <= 32`.
@@ -400,10 +400,10 @@ where
 /// element `i` is at `addr[i] + f * eew.bytes()`.
 ///
 /// # Safety
-/// - `vd.bits() % group_regs == 0`
-/// - `vd.bits() + nf * group_regs <= 32`
+/// - `vd.to_bits() % group_regs == 0`
+/// - `vd.to_bits() + nf * group_regs <= 32`
 /// - `vl <= group_regs * VLENB / eew.bytes()`
-/// - When `vm=false`: `vd` does not overlap `v0` (i.e. `vd.bits() != 0`)
+/// - When `vm=false`: `vd` does not overlap `v0` (i.e. `vd.to_bits() != 0`)
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
@@ -462,10 +462,10 @@ where
             // `i < vl <= group_regs * elems_per_reg` (precondition), so
             // `i / elems_per_reg < group_regs`.
             //
-            // `field_base_reg = vd.bits() + f * group_regs`. Since `f < nf` and
-            // `vd.bits() + nf * group_regs <= 32` (precondition):
-            // `field_base_reg + group_regs <= vd.bits() + (f+1) * group_regs
-            //                             <= vd.bits() + nf * group_regs <= 32`.
+            // `field_base_reg = vd.to_bits() + f * group_regs`. Since `f < nf` and
+            // `vd.to_bits() + nf * group_regs <= 32` (precondition):
+            // `field_base_reg + group_regs <= vd.to_bits() + (f+1) * group_regs
+            //                             <= vd.to_bits() + nf * group_regs <= 32`.
             //
             // Therefore, `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
             unsafe {
@@ -487,13 +487,13 @@ where
 /// a software interpreter.
 ///
 /// # Safety
-/// - `vd.bits() % data_group_regs == 0`
-/// - `vd.bits() + nf * data_group_regs <= 32`
-/// - `vs2.bits() + (vl - 1) / (VLENB / index_eew.bytes()) < 32` (all `vl` index elements fit within
-///   the register file; satisfied when `vs2` is alignment-checked against `EMUL_index` and `vl` is
-///   the architectural `vl` bounded by `VLMAX`)
+/// - `vd.to_bits() % data_group_regs == 0`
+/// - `vd.to_bits() + nf * data_group_regs <= 32`
+/// - `vs2.to_bits() + (vl - 1) / (VLENB / index_eew.bytes()) < 32` (all `vl` index elements fit
+///   within the register file; satisfied when `vs2` is alignment-checked against `EMUL_index` and
+///   `vl` is the architectural `vl` bounded by `VLMAX`)
 /// - `vl <= data_group_regs * VLENB / data_eew.bytes()` (all `vl` elements fit in a data group)
-/// - When `vm=false`: `vd` does not overlap `v0` (i.e. `vd.bits() != 0`)
+/// - When `vm=false`: `vd` does not overlap `v0` (i.e. `vd.to_bits() != 0`)
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
@@ -533,7 +533,7 @@ where
         // SAFETY: need `index_base_reg + i / (VLENB / index_eew.bytes()) < 32`.
         //
         // The caller verified `vs2` is aligned to `EMUL_index` registers and that
-        // `vs2.bits() + EMUL_index <= 32`. `EMUL_index` is defined so that
+        // `vs2.to_bits() + EMUL_index <= 32`. `EMUL_index` is defined so that
         // `EMUL_index * (VLENB / index_eew.bytes()) = VLMAX`. Since `i < vl <= VLMAX`,
         // `i / (VLENB / index_eew.bytes()) < EMUL_index`, and therefore
         // `index_base_reg + i / (VLENB / index_eew.bytes()) < index_base_reg + EMUL_index <= 32`.
@@ -564,10 +564,10 @@ where
             // `i < vl <= data_group_regs * data_elems_per_reg` (precondition), so
             // `i / data_elems_per_reg < data_group_regs`.
             //
-            // `field_base_reg = vd.bits() + f * data_group_regs`. Since `f < nf` and
-            // `vd.bits() + nf * data_group_regs <= 32` (precondition):
-            // `field_base_reg + data_group_regs <= vd.bits() + (f+1) * data_group_regs
-            //                                  <= vd.bits() + nf * data_group_regs <= 32`.
+            // `field_base_reg = vd.to_bits() + f * data_group_regs`. Since `f < nf` and
+            // `vd.to_bits() + nf * data_group_regs <= 32` (precondition):
+            // `field_base_reg + data_group_regs <= vd.to_bits() + (f+1) * data_group_regs
+            //                                  <= vd.to_bits() + nf * data_group_regs <= 32`.
             //
             // Therefore,
             // `field_base_reg + i / data_elems_per_reg < field_base_reg + data_group_regs <= 32`.

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/load/zve64x_load_helpers.rs
@@ -322,7 +322,7 @@ where
             [[0u8; usize::from(Eew::MAX_BYTES)]; usize::from(Nf::MAX.fields_per_segment())];
 
         for f in 0..nf.fields_per_segment() {
-            let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
+            let addr = elem_base.wrapping_add(u64::from(f * elem_bytes));
             match read_mem_element(memory, addr, eew) {
                 Ok(data) => {
                     // SAFETY: `f < nf` and the precondition on this function requires
@@ -435,7 +435,7 @@ where
         let elem_base = base.wrapping_add(i64::from(i).wrapping_mul(stride).cast_unsigned());
 
         for f in 0..nf.fields_per_segment() {
-            let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
+            let addr = elem_base.wrapping_add(u64::from(f * elem_bytes));
             let data = match read_mem_element(memory, addr, eew) {
                 Ok(data) => data,
                 Err(mem_err) => {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask.rs
@@ -412,15 +412,15 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let vd_idx = vd.bits();
+                let vd_idx = vd.to_bits();
                 if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
                 // vd must not overlap vs2; vs2 is always a single mask register (group size 1).
-                let vd_start = u32::from(vd.bits());
-                let vs2_start = u32::from(vs2.bits());
+                let vd_start = u32::from(vd.to_bits());
+                let vs2_start = u32::from(vs2.to_bits());
                 if vd_start < vs2_start + 1 && vs2_start < vd_start + u32::from(group_regs) {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
@@ -454,7 +454,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     })?;
                 let group_regs = vtype.vlmul().register_count();
-                let vd_idx = vd.bits();
+                let vd_idx = vd.to_bits();
                 if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
@@ -56,7 +56,7 @@ fn exec(
 }
 
 fn get_vreg(state: &TestInterpreterState<Zve64xMaskInstruction<Reg<u64>>>, reg: VReg) -> [u8; 32] {
-    state.ext_state.read_vreg()[usize::from(reg.to_bits())]
+    *state.ext_state.read_vregs().get(reg)
 }
 
 fn set_vreg(
@@ -64,7 +64,7 @@ fn set_vreg(
     reg: VReg,
     data: [u8; 32],
 ) {
-    state.ext_state.write_vreg()[usize::from(reg.to_bits())] = data;
+    *state.ext_state.write_vregs().get_mut(reg) = data;
 }
 
 /// Read element `i` from a register group as a u64 (zero-extended), given SEW
@@ -78,7 +78,10 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -90,7 +93,7 @@ fn mask_bit(
     reg: VReg,
     i: u32,
 ) -> bool {
-    let byte = state.ext_state.read_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
+    let byte = state.ext_state.read_vregs().get(reg)[(i / u8::BITS) as usize];
     (byte >> (i % u8::BITS)) & 1 != 0
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/tests.rs
@@ -16,7 +16,7 @@ use ab_riscv_primitives::prelude::*;
 // helpers
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
 }
 
 fn setup(
@@ -56,7 +56,7 @@ fn exec(
 }
 
 fn get_vreg(state: &TestInterpreterState<Zve64xMaskInstruction<Reg<u64>>>, reg: VReg) -> [u8; 32] {
-    state.ext_state.read_vreg()[usize::from(reg.bits())]
+    state.ext_state.read_vreg()[usize::from(reg.to_bits())]
 }
 
 fn set_vreg(
@@ -64,7 +64,7 @@ fn set_vreg(
     reg: VReg,
     data: [u8; 32],
 ) {
-    state.ext_state.write_vreg()[usize::from(reg.bits())] = data;
+    state.ext_state.write_vreg()[usize::from(reg.to_bits())] = data;
 }
 
 /// Read element `i` from a register group as a u64 (zero-extended), given SEW
@@ -78,7 +78,7 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -90,7 +90,7 @@ fn mask_bit(
     reg: VReg,
     i: u32,
 ) -> bool {
-    let byte = state.ext_state.read_vreg()[usize::from(reg.bits())][(i / u8::BITS) as usize];
+    let byte = state.ext_state.read_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
     (byte >> (i % u8::BITS)) & 1 != 0
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
@@ -39,9 +39,17 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
     let vstart = ext_state.vstart();
     // Snapshot both sources before writing to handle vd overlapping vs2 or vs1
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
+    let vs2_snap = *unsafe {
+        ext_state
+            .read_vreg()
+            .get_unchecked(usize::from(vs2.to_bits()))
+    };
     // SAFETY: `vs1.bits() < 32`; `VReg` values are always in `0..32`
-    let vs1_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs1.bits())) };
+    let vs1_snap = *unsafe {
+        ext_state
+            .read_vreg()
+            .get_unchecked(usize::from(vs1.to_bits()))
+    };
     // Body elements [vstart, vl): compute the logical operation bit-by-bit. Prestart bits
     // [0, vstart) and tail bits [vl, VLEN) are left undisturbed.
     for i in u32::from(vstart)..vl {
@@ -86,7 +94,11 @@ pub unsafe fn execute_vcpop<Reg, Regs, ExtState, CustomError>(
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2` is a valid VReg index (< 32)
-    let vs2_reg = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
+    let vs2_reg = *unsafe {
+        ext_state
+            .read_vreg()
+            .get_unchecked(usize::from(vs2.to_bits()))
+    };
     let mut count = 0u32;
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
@@ -132,7 +144,11 @@ pub unsafe fn execute_vfirst<Reg, Regs, ExtState, CustomError>(
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2` is a valid VReg index (< 32)
-    let vs2_reg = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
+    let vs2_reg = *unsafe {
+        ext_state
+            .read_vreg()
+            .get_unchecked(usize::from(vs2.to_bits()))
+    };
     // -1 encoded as all-ones for the register width; `Into<u64>` on XLEN-wide type then back
     let not_found = u64::MAX;
     let mut result = not_found;
@@ -191,7 +207,11 @@ pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
+    let vs2_snap = *unsafe {
+        ext_state
+            .read_vreg()
+            .get_unchecked(usize::from(vs2.to_bits()))
+    };
     let mut found_first = false;
     for i in 0..vl {
         // Inactive elements: undisturbed
@@ -239,7 +259,11 @@ pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
+    let vs2_snap = *unsafe {
+        ext_state
+            .read_vreg()
+            .get_unchecked(usize::from(vs2.to_bits()))
+    };
     let mut found_first = false;
     for i in 0..vl {
         if !mask_bit(&mask_buf, i) {
@@ -287,7 +311,11 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
+    let vs2_snap = *unsafe {
+        ext_state
+            .read_vreg()
+            .get_unchecked(usize::from(vs2.to_bits()))
+    };
     let mut found_first = false;
     for i in 0..vl {
         if !mask_bit(&mask_buf, i) {
@@ -345,7 +373,11 @@ pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe { ext_state.read_vreg().get_unchecked(usize::from(vs2.bits())) };
+    let vs2_snap = *unsafe {
+        ext_state
+            .read_vreg()
+            .get_unchecked(usize::from(vs2.to_bits()))
+    };
     // Per spec §16.8: inactive vs2 elements are treated as zero for the prefix sum.
     // The prefix count advances only when the execution mask is active AND the
     // corresponding vs2 bit is set.

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
@@ -38,18 +38,8 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // Snapshot both sources before writing to handle vd overlapping vs2 or vs1
-    // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.to_bits()))
-    };
-    // SAFETY: `vs1.bits() < 32`; `VReg` values are always in `0..32`
-    let vs1_snap = *unsafe {
-        ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs1.to_bits()))
-    };
+    let vs2_snap = *ext_state.read_vregs().get(vs2);
+    let vs1_snap = *ext_state.read_vregs().get(vs1);
     // Body elements [vstart, vl): compute the logical operation bit-by-bit. Prestart bits
     // [0, vstart) and tail bits [vl, VLEN) are left undisturbed.
     for i in u32::from(vstart)..vl {
@@ -57,7 +47,7 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
         let b = mask_bit(&vs1_snap, i);
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
         unsafe {
-            write_mask_bit(ext_state.write_vreg(), vd, i, op(a, b));
+            write_mask_bit(ext_state.write_vregs(), vd, i, op(a, b));
         }
     }
     ext_state.mark_vs_dirty();
@@ -92,13 +82,8 @@ pub unsafe fn execute_vcpop<Reg, Regs, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
-    // SAFETY: `vs2` is a valid VReg index (< 32)
-    let vs2_reg = *unsafe {
-        ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.to_bits()))
-    };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
+    let vs2_reg = *ext_state.read_vregs().get(vs2);
     let mut count = 0u32;
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
@@ -142,13 +127,8 @@ pub unsafe fn execute_vfirst<Reg, Regs, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
-    // SAFETY: `vs2` is a valid VReg index (< 32)
-    let vs2_reg = *unsafe {
-        ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.to_bits()))
-    };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
+    let vs2_reg = *ext_state.read_vregs().get(vs2);
     // -1 encoded as all-ones for the register width; `Into<u64>` on XLEN-wide type then back
     let not_found = u64::MAX;
     let mut result = not_found;
@@ -205,13 +185,8 @@ pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
-    // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.to_bits()))
-    };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
+    let vs2_snap = *ext_state.read_vregs().get(vs2);
     let mut found_first = false;
     for i in 0..vl {
         // Inactive elements: undisturbed
@@ -226,7 +201,7 @@ pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
         }
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
         unsafe {
-            write_mask_bit(ext_state.write_vreg(), vd, i, result);
+            write_mask_bit(ext_state.write_vregs(), vd, i, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -257,13 +232,8 @@ pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
-    // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.to_bits()))
-    };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
+    let vs2_snap = *ext_state.read_vregs().get(vs2);
     let mut found_first = false;
     for i in 0..vl {
         if !mask_bit(&mask_buf, i) {
@@ -277,7 +247,7 @@ pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
         }
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
         unsafe {
-            write_mask_bit(ext_state.write_vreg(), vd, i, result);
+            write_mask_bit(ext_state.write_vregs(), vd, i, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -309,13 +279,8 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
-    // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.to_bits()))
-    };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
+    let vs2_snap = *ext_state.read_vregs().get(vs2);
     let mut found_first = false;
     for i in 0..vl {
         if !mask_bit(&mask_buf, i) {
@@ -329,7 +294,7 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
         }
         // SAFETY: `i < vl <= VLEN`, so `i / 8 < VLENB`
         unsafe {
-            write_mask_bit(ext_state.write_vreg(), vd, i, result);
+            write_mask_bit(ext_state.write_vregs(), vd, i, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -371,13 +336,8 @@ pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
     CustomError: fmt::Debug,
 {
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
-    // SAFETY: `vs2.bits() < 32`; `VReg` values are always in `0..32`
-    let vs2_snap = *unsafe {
-        ext_state
-            .read_vreg()
-            .get_unchecked(usize::from(vs2.to_bits()))
-    };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
+    let vs2_snap = *ext_state.read_vregs().get(vs2);
     // Per spec §16.8: inactive vs2 elements are treated as zero for the prefix sum.
     // The prefix count advances only when the execution mask is active AND the
     // corresponding vs2 bit is set.
@@ -388,7 +348,7 @@ pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
         }
         // SAFETY: `vd + i / elems_per_reg < 32` by caller's alignment + vl preconditions
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, prefix_count);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, prefix_count);
         }
         if mask_bit(&vs2_snap, i) {
             prefix_count += 1;
@@ -426,14 +386,14 @@ pub unsafe fn execute_vid<Reg, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: `vd + i / elems_per_reg < 32` by caller's alignment + vl preconditions
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, u64::from(i));
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, u64::from(i));
         }
     }
     ext_state.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/mask/zve64x_mask_helpers.rs
@@ -316,7 +316,7 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
 /// # Safety
 /// - `vd` does not overlap `vs2` (checked by caller)
 /// - `vm=false` implies `vd != v0` (checked by caller)
-/// - `vd.bits() % group_regs == 0` and `vd.bits() + group_regs <= 32` (checked by caller)
+/// - `vd.to_bits() % group_regs == 0` and `vd.to_bits() + group_regs <= 32` (checked by caller)
 /// - `vl <= VLMAX`; `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]
@@ -365,7 +365,7 @@ pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
 ///
 /// # Safety
 /// - `vm=false` implies `vd != v0` (checked by caller)
-/// - `vd.bits() % group_regs == 0` and `vd.bits() + group_regs <= 32` (checked by caller)
+/// - `vd.to_bits() % group_regs == 0` and `vd.to_bits() + group_regs <= 32` (checked by caller)
 /// - `vl <= group_regs * VLENB / sew_bytes`
 /// - `vl <= VLEN`
 #[inline(always)]

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
@@ -67,7 +67,10 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -83,7 +86,10 @@ fn read_wide_elem(
     let elems_per_reg = 16 / wide_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * wide_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..wide_bytes].copy_from_slice(&reg[byte_off..byte_off + wide_bytes]);
     u64::from_le_bytes(buf)
@@ -100,7 +106,10 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -116,7 +125,10 @@ fn write_wide_elem(
     let elems_per_reg = 16 / wide_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * wide_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + wide_bytes].copy_from_slice(&buf[..wide_bytes]);
 }
@@ -126,7 +138,7 @@ fn set_mask_bit(
     elem_i: u32,
     val: bool,
 ) {
-    let reg = &mut state.ext_state.write_vreg()[0];
+    let reg = state.ext_state.write_vregs().get_mut(VReg::V0);
     let byte = &mut reg[(elem_i / u8::BITS) as usize];
     if val {
         *byte |= 1 << (elem_i % u8::BITS);
@@ -217,7 +229,7 @@ fn vmul_vx_e64_m1() {
 fn vmul_masked_skips_inactive() {
     let mut state = setup(4, Vsew::E32, Vlmul::M1);
     // mask: only elements 0 and 2 active (bits 0 and 2 set)
-    state.ext_state.write_vreg()[0][0] = 0b0000_0101;
+    state.ext_state.write_vregs().get_mut(VReg::V0)[0] = 0b0000_0101;
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, 5);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 10);

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/tests.rs
@@ -18,7 +18,7 @@ use ab_riscv_primitives::prelude::*;
 //   E8/M4  -> VLMAX=128, 4 regs (vd for widening E32 uses 4 regs - but VLMAX=8 at E32/M1)
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3u8)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3u8)
 }
 
 fn setup(
@@ -67,7 +67,7 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -83,7 +83,7 @@ fn read_wide_elem(
     let elems_per_reg = 16 / wide_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * wide_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..wide_bytes].copy_from_slice(&reg[byte_off..byte_off + wide_bytes]);
     u64::from_le_bytes(buf)
@@ -100,7 +100,7 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -116,7 +116,7 @@ fn write_wide_elem(
     let elems_per_reg = 16 / wide_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * wide_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + wide_bytes].copy_from_slice(&buf[..wide_bytes]);
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
@@ -1,6 +1,6 @@
 //! Opaque helpers for Zve64x extension
 
-use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zve64x::arith::zve64x_arith_helpers::{
     OpSrc, check_vreg_group_alignment, sew_mask, sign_extend,
 };
@@ -99,7 +99,7 @@ where
 /// `base_reg + elem_i / (VLENB / (2*sew_bytes)) < 32` must hold.
 #[inline(always)]
 unsafe fn write_wide_element_u64<const VLENB: usize>(
-    vreg: &mut [[u8; VLENB]; 32],
+    vregs: &mut VectorRegisterFile<VLENB>,
     base_reg: VReg,
     elem_i: u32,
     sew: Vsew,
@@ -111,7 +111,9 @@ unsafe fn write_wide_element_u64<const VLENB: usize>(
     let byte_off = (elem_i as usize % elems_per_reg) * wide_bytes;
     let buf = value.to_le_bytes();
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.to_bits()) + reg_off) };
+    let reg = unsafe {
+        vregs.get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
+    };
     // SAFETY: `byte_off + wide_bytes <= VLENB`; `wide_bytes <= 8` for SEW < 64
     let dst = unsafe { reg.get_unchecked_mut(byte_off..byte_off + wide_bytes) };
     // SAFETY: `wide_bytes <= 8` because SEW < 64 is enforced before widening ops are called
@@ -149,24 +151,24 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
             OpSrc::Vreg(vs1_base) => unsafe {
-                read_element_u64(ext_state.read_vreg(), vs1_base, i, sew)
+                read_element_u64(ext_state.read_vregs(), vs1_base, i, sew)
             },
             OpSrc::Scalar(val) => val,
         };
         let result = op(a, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -206,17 +208,17 @@ pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
             OpSrc::Vreg(vs1_base) => unsafe {
-                read_element_u64(ext_state.read_vreg(), vs1_base, i, sew)
+                read_element_u64(ext_state.read_vregs(), vs1_base, i, sew)
             },
             OpSrc::Scalar(val) => val,
         };
@@ -225,7 +227,7 @@ pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
         // `vl <= src_group_regs * VLENB / sew_bytes` and dest stores at 2*SEW width so
         // `i < dest_group_regs * VLENB / (2*sew_bytes)`
         unsafe {
-            write_wide_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_wide_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -263,24 +265,26 @@ pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let acc = unsafe { read_element_u64(ext_state.read_vreg(), vd, i, sew) };
+        let acc = unsafe { read_element_u64(ext_state.read_vregs(), vd, i, sew) };
         // SAFETY: register bounds verified by caller
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), a_reg, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), a_reg, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(b_reg) => unsafe { read_element_u64(ext_state.read_vreg(), b_reg, i, sew) },
+            OpSrc::Vreg(b_reg) => unsafe {
+                read_element_u64(ext_state.read_vregs(), b_reg, i, sew)
+            },
             OpSrc::Scalar(val) => val,
         };
         let result = op(acc, a, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -315,22 +319,24 @@ pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let acc = unsafe { read_element_u64(ext_state.read_vreg(), vd, i, sew) };
+        let acc = unsafe { read_element_u64(ext_state.read_vregs(), vd, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(b_reg) => unsafe { read_element_u64(ext_state.read_vreg(), b_reg, i, sew) },
+            OpSrc::Vreg(b_reg) => unsafe {
+                read_element_u64(ext_state.read_vregs(), b_reg, i, sew)
+            },
             OpSrc::Scalar(val) => val,
         };
         let result = op(acc, scalar, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -371,7 +377,7 @@ pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
@@ -379,18 +385,20 @@ pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
         // Read the existing 2*SEW accumulator from vd
         // SAFETY: vd has dest_group_regs registers; element `i` fits within them (see
         // `execute_widening_op` for the bound argument)
-        let acc = unsafe { read_wide_element_u64(ext_state.read_vreg(), vd, i, sew) };
+        let acc = unsafe { read_wide_element_u64(ext_state.read_vregs(), vd, i, sew) };
         // SAFETY: register bounds verified by caller
-        let a = unsafe { read_element_u64(ext_state.read_vreg(), a_reg, i, sew) };
+        let a = unsafe { read_element_u64(ext_state.read_vregs(), a_reg, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(b_reg) => unsafe { read_element_u64(ext_state.read_vreg(), b_reg, i, sew) },
+            OpSrc::Vreg(b_reg) => unsafe {
+                read_element_u64(ext_state.read_vregs(), b_reg, i, sew)
+            },
             OpSrc::Scalar(val) => val,
         };
         let result = op(acc, a, b, sew);
         // SAFETY: same as acc read above
         unsafe {
-            write_wide_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_wide_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -425,23 +433,25 @@ pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, CustomError, F>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: vd has dest_group_regs registers; element `i` fits within them (see
         // `execute_widening_op` for the bound argument)
-        let acc = unsafe { read_wide_element_u64(ext_state.read_vreg(), vd, i, sew) };
+        let acc = unsafe { read_wide_element_u64(ext_state.read_vregs(), vd, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(b_reg) => unsafe { read_element_u64(ext_state.read_vreg(), b_reg, i, sew) },
+            OpSrc::Vreg(b_reg) => unsafe {
+                read_element_u64(ext_state.read_vregs(), b_reg, i, sew)
+            },
             OpSrc::Scalar(val) => val,
         };
         let result = op(acc, scalar, b, sew);
         // SAFETY: same as acc read above
         unsafe {
-            write_wide_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_wide_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     ext_state.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
@@ -128,7 +128,7 @@ unsafe fn write_wide_element_u64<const VLENB: usize>(
 /// # Safety
 /// - `vd` and source register alignment verified by caller
 /// - `vl <= group_regs * VLENB / sew_bytes`
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
@@ -185,7 +185,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 ///   and non-overlap verified by caller
 /// - `vl <= src_group_regs * VLENB / sew_bytes`
 /// - SEW < 64 verified by caller (so 2*SEW <= 64 and fits in u64)
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
@@ -242,7 +242,7 @@ pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
 /// # Safety
 /// - `vd`, `a_reg`, and `src` register alignment verified by caller
 /// - `vl <= group_regs * VLENB / sew_bytes`
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
@@ -354,7 +354,7 @@ pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
 /// - `vd` uses `dest_group_regs` registers (result of `widening_dest_register_count()`); alignment
 ///   and non-overlap verified by caller
 /// - SEW < 64 verified by caller
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/muldiv/zve64x_muldiv_helpers.rs
@@ -73,9 +73,9 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let vd_start = vd.bits();
+    let vd_start = vd.to_bits();
     let vd_end = vd_start + dest_group_regs;
-    let vs_start = vs.bits();
+    let vs_start = vs.to_bits();
     let vs_end = vs_start + src_group_regs;
     // Disjoint register groups are always fine
     if vs_start >= vd_end || vd_start >= vs_end {
@@ -111,7 +111,7 @@ unsafe fn write_wide_element_u64<const VLENB: usize>(
     let byte_off = (elem_i as usize % elems_per_reg) * wide_bytes;
     let buf = value.to_le_bytes();
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.bits()) + reg_off) };
+    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.to_bits()) + reg_off) };
     // SAFETY: `byte_off + wide_bytes <= VLENB`; `wide_bytes <= 8` for SEW < 64
     let dst = unsafe { reg.get_unchecked_mut(byte_off..byte_off + wide_bytes) };
     // SAFETY: `wide_bytes <= 8` because SEW < 64 is enforced before widening ops are called

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
@@ -78,7 +78,11 @@ where
                 // SAFETY: element 0 is always within register vs2, byte offset 0;
                 // VLENB >= sew.bytes() for all legal vtype configurations.
                 let raw = unsafe {
-                    zve64x_perm_helpers::read_element_0_u64(ext_state.read_vreg(), vs2.bits(), sew)
+                    zve64x_perm_helpers::read_element_0_u64(
+                        ext_state.read_vreg(),
+                        vs2.to_bits(),
+                        sew,
+                    )
                 };
                 let sign_extended = zve64x_perm_helpers::sign_extend_to_reg::<Reg>(raw, sew);
                 regs.write(rd, sign_extended);
@@ -110,7 +114,7 @@ where
                     unsafe {
                         zve64x_perm_helpers::write_element_0_u64(
                             ext_state.write_vreg(),
-                            vd.bits(),
+                            vd.to_bits(),
                             sew,
                             scalar,
                         );
@@ -813,8 +817,8 @@ where
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
                         ext_state.write_vreg(),
-                        vd.bits(),
-                        vs2.bits(),
+                        vd.to_bits(),
+                        vs2.to_bits(),
                         1,
                     );
                 }
@@ -830,7 +834,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vd.bits().is_multiple_of(2) || !vs2.bits().is_multiple_of(2) {
+                if !vd.to_bits().is_multiple_of(2) || !vs2.to_bits().is_multiple_of(2) {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -839,8 +843,8 @@ where
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
                         ext_state.write_vreg(),
-                        vd.bits(),
-                        vs2.bits(),
+                        vd.to_bits(),
+                        vs2.to_bits(),
                         2,
                     );
                 }
@@ -855,7 +859,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vd.bits().is_multiple_of(4) || !vs2.bits().is_multiple_of(4) {
+                if !vd.to_bits().is_multiple_of(4) || !vs2.to_bits().is_multiple_of(4) {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -864,8 +868,8 @@ where
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
                         ext_state.write_vreg(),
-                        vd.bits(),
-                        vs2.bits(),
+                        vd.to_bits(),
+                        vs2.to_bits(),
                         4,
                     );
                 }
@@ -880,7 +884,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vd.bits().is_multiple_of(8) || !vs2.bits().is_multiple_of(8) {
+                if !vd.to_bits().is_multiple_of(8) || !vs2.to_bits().is_multiple_of(8) {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -889,8 +893,8 @@ where
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
                         ext_state.write_vreg(),
-                        vd.bits(),
-                        vs2.bits(),
+                        vd.to_bits(),
+                        vs2.to_bits(),
                         8,
                     );
                 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
@@ -78,11 +78,7 @@ where
                 // SAFETY: element 0 is always within register vs2, byte offset 0;
                 // VLENB >= sew.bytes() for all legal vtype configurations.
                 let raw = unsafe {
-                    zve64x_perm_helpers::read_element_0_u64(
-                        ext_state.read_vreg(),
-                        vs2.to_bits(),
-                        sew,
-                    )
+                    zve64x_perm_helpers::read_element_0_u64(ext_state.read_vregs(), vs2, sew)
                 };
                 let sign_extended = zve64x_perm_helpers::sign_extend_to_reg::<Reg>(raw, sew);
                 regs.write(rd, sign_extended);
@@ -113,8 +109,8 @@ where
                     // SAFETY: element 0 always fits.
                     unsafe {
                         zve64x_perm_helpers::write_element_0_u64(
-                            ext_state.write_vreg(),
-                            vd.to_bits(),
+                            ext_state.write_vregs(),
+                            vd,
                             sew,
                             scalar,
                         );
@@ -816,9 +812,9 @@ where
                 // copying 1 register always fits.
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
-                        ext_state.write_vreg(),
-                        vd.to_bits(),
-                        vs2.to_bits(),
+                        ext_state.write_vregs(),
+                        vd,
+                        vs2,
                         1,
                     );
                 }
@@ -842,9 +838,9 @@ where
                 // SAFETY: alignment verified; 2 registers from aligned base always stay in [0, 32).
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
-                        ext_state.write_vreg(),
-                        vd.to_bits(),
-                        vs2.to_bits(),
+                        ext_state.write_vregs(),
+                        vd,
+                        vs2,
                         2,
                     );
                 }
@@ -867,9 +863,9 @@ where
                 // SAFETY: alignment verified; 4 registers from aligned base always stay in [0, 32).
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
-                        ext_state.write_vreg(),
-                        vd.to_bits(),
-                        vs2.to_bits(),
+                        ext_state.write_vregs(),
+                        vd,
+                        vs2,
                         4,
                     );
                 }
@@ -892,9 +888,9 @@ where
                 // SAFETY: alignment verified; 8 registers from aligned base always stay in [0, 32).
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
-                        ext_state.write_vreg(),
-                        vd.to_bits(),
-                        vs2.to_bits(),
+                        ext_state.write_vregs(),
+                        vd,
+                        vs2,
                         8,
                     );
                 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm.rs
@@ -808,8 +808,8 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                // SAFETY: both vd.bits() and vs2.bits() are always in [0, 32) by VReg invariant;
-                // copying 1 register always fits.
+                // SAFETY: both vd.to_bits() and vs2.to_bits() are always in [0, 32) by VReg
+                // invariant; copying 1 register always fits.
                 unsafe {
                     zve64x_perm_helpers::execute_whole_reg_move(
                         ext_state.write_vregs(),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
@@ -18,7 +18,7 @@ use ab_riscv_primitives::prelude::*;
 //   E64/Mf2 -> VLMAX=2,  1 reg,  4 elems/reg
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
 }
 
 fn setup(
@@ -67,7 +67,7 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -84,7 +84,7 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -94,14 +94,14 @@ fn set_vreg_bytes(
     reg: VReg,
     value: u8,
 ) {
-    state.ext_state.write_vreg()[usize::from(reg.bits())].fill(value);
+    state.ext_state.write_vreg()[usize::from(reg.to_bits())].fill(value);
 }
 
 fn get_vreg_bytes(
     state: &crate::rv64::test_utils::TestInterpreterState<Zve64xPermInstruction<Reg<u64>>>,
     reg: VReg,
 ) -> [u8; 32] {
-    state.ext_state.read_vreg()[usize::from(reg.bits())]
+    state.ext_state.read_vreg()[usize::from(reg.to_bits())]
 }
 
 fn set_mask_bit(
@@ -110,7 +110,8 @@ fn set_mask_bit(
     i: u32,
     val: bool,
 ) {
-    let byte = &mut state.ext_state.write_vreg()[usize::from(reg.bits())][(i / u8::BITS) as usize];
+    let byte =
+        &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
     if val {
         *byte |= 1 << (i % u8::BITS);
     } else {
@@ -1234,8 +1235,8 @@ fn vrgatherei16_vv_e8_m1_basic() {
         let reg_off = byte_off / 16;
         let b = byte_off % 16;
         let bytes = idx.to_le_bytes();
-        state.ext_state.write_vreg()[usize::from(VReg::V6.bits()) + reg_off][b] = bytes[0];
-        state.ext_state.write_vreg()[usize::from(VReg::V6.bits()) + reg_off][b + 1] = bytes[1];
+        state.ext_state.write_vreg()[usize::from(VReg::V6.to_bits()) + reg_off][b] = bytes[0];
+        state.ext_state.write_vreg()[usize::from(VReg::V6.to_bits()) + reg_off][b + 1] = bytes[1];
     }
     exec(
         &mut state,
@@ -1265,8 +1266,8 @@ fn vrgatherei16_vv_index_out_of_range_gives_zero() {
     for i in 0..8usize {
         let byte_off = i * 2;
         let bytes = 100u16.to_le_bytes();
-        state.ext_state.write_vreg()[usize::from(VReg::V6.bits())][byte_off] = bytes[0];
-        state.ext_state.write_vreg()[usize::from(VReg::V6.bits())][byte_off + 1] = bytes[1];
+        state.ext_state.write_vreg()[usize::from(VReg::V6.to_bits())][byte_off] = bytes[0];
+        state.ext_state.write_vreg()[usize::from(VReg::V6.to_bits())][byte_off + 1] = bytes[1];
     }
     exec(
         &mut state,
@@ -2125,7 +2126,7 @@ fn vcompress_vm_e32_basic() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 10) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xBEEF);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.bits())].fill(0);
+    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0);
     set_mask_bit(&mut state, VReg::V1, 1, true);
     set_mask_bit(&mut state, VReg::V1, 3, true);
     exec(
@@ -2153,7 +2154,7 @@ fn vcompress_vm_all_active() {
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 7) as u64);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.bits())].fill(0xFF);
+    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
     exec(
         &mut state,
         Zve64xPermInstruction::VcompressVm {
@@ -2181,7 +2182,7 @@ fn vcompress_vm_none_active() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, (i + 1) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xABCD);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.bits())].fill(0x00);
+    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0x00);
     exec(
         &mut state,
         Zve64xPermInstruction::VcompressVm {
@@ -2208,7 +2209,7 @@ fn vcompress_vm_e8_all_elements() {
     for i in 0..16usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E8, (15 - i) as u64);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.bits())].fill(0xFF);
+    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
     exec(
         &mut state,
         Zve64xPermInstruction::VcompressVm {
@@ -2269,7 +2270,7 @@ fn vcompress_vm_rejects_nonzero_vstart() {
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 10) as u64);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.bits())].fill(0xFF);
+    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
     state.ext_state.set_vstart(1);
     let err = exec(
         &mut state,
@@ -2292,7 +2293,7 @@ fn vcompress_vm_vstart_zero_normal_operation() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 10) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xDEAD);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.bits())].fill(0);
+    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0);
     set_mask_bit(&mut state, VReg::V1, 1, true);
     set_mask_bit(&mut state, VReg::V1, 2, true);
     exec(
@@ -2321,7 +2322,7 @@ fn vmv1r_v_copies_single_register() {
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32,
     ];
-    state.ext_state.write_vreg()[usize::from(VReg::V2.bits())] = src;
+    state.ext_state.write_vreg()[usize::from(VReg::V2.to_bits())] = src;
     set_vreg_bytes(&mut state, VReg::V4, 0xCC);
     exec(
         &mut state,
@@ -2416,12 +2417,12 @@ fn vmv4r_v_copies_four_registers() {
     for k in 0u8..4 {
         set_vreg_bytes(
             &mut state,
-            VReg::from_bits(VReg::V8.bits() + k).unwrap(),
+            VReg::from_bits(VReg::V8.to_bits() + k).unwrap(),
             k + 1,
         );
         set_vreg_bytes(
             &mut state,
-            VReg::from_bits(VReg::V12.bits() + k).unwrap(),
+            VReg::from_bits(VReg::V12.to_bits() + k).unwrap(),
             0xCC,
         );
     }
@@ -2437,7 +2438,7 @@ fn vmv4r_v_copies_four_registers() {
     .unwrap();
     for k in 0u8..4 {
         assert_eq!(
-            get_vreg_bytes(&state, VReg::from_bits(VReg::V12.bits() + k).unwrap()),
+            get_vreg_bytes(&state, VReg::from_bits(VReg::V12.to_bits() + k).unwrap()),
             [k + 1; 32],
             "reg offset {k}"
         );
@@ -2487,12 +2488,12 @@ fn vmv8r_v_copies_eight_registers() {
     for k in 0u8..8 {
         set_vreg_bytes(
             &mut state,
-            VReg::from_bits(VReg::V8.bits() + k).unwrap(),
+            VReg::from_bits(VReg::V8.to_bits() + k).unwrap(),
             k + 10,
         );
         set_vreg_bytes(
             &mut state,
-            VReg::from_bits(VReg::V16.bits() + k).unwrap(),
+            VReg::from_bits(VReg::V16.to_bits() + k).unwrap(),
             0xCC,
         );
     }
@@ -2508,7 +2509,7 @@ fn vmv8r_v_copies_eight_registers() {
     .unwrap();
     for k in 0u8..8 {
         assert_eq!(
-            get_vreg_bytes(&state, VReg::from_bits(VReg::V16.bits() + k).unwrap()),
+            get_vreg_bytes(&state, VReg::from_bits(VReg::V16.to_bits() + k).unwrap()),
             [k + 10; 32],
             "reg offset {k}"
         );
@@ -2899,7 +2900,7 @@ fn all_instructions_reset_vstart() {
             write_elem(&mut state, VReg::V2, i, Vsew::E32, (i + 1) as u64);
             write_elem(&mut state, VReg::V1, i, Vsew::E32, i as u64);
         }
-        state.ext_state.write_vreg()[usize::from(VReg::V1.bits())].fill(0xFF);
+        state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
         state.ext_state.set_vstart(2);
         state.regs.write(Reg::A0, 1u64);
         exec(&mut state, *instr).unwrap();
@@ -3075,7 +3076,7 @@ fn all_vector_instructions_mark_vs_dirty() {
             write_elem(&mut state, VReg::V1, i, Vsew::E32, i as u64);
         }
         state.regs.write(Reg::A0, 1u64);
-        state.ext_state.write_vreg()[usize::from(VReg::V1.bits())].fill(0xFF);
+        state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
         let before = state.ext_state.vs_dirty_count();
         exec(&mut state, *instr).unwrap();
         assert_eq!(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/tests.rs
@@ -67,7 +67,10 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -84,7 +87,10 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -94,14 +100,14 @@ fn set_vreg_bytes(
     reg: VReg,
     value: u8,
 ) {
-    state.ext_state.write_vreg()[usize::from(reg.to_bits())].fill(value);
+    state.ext_state.write_vregs().get_mut(reg).fill(value);
 }
 
 fn get_vreg_bytes(
     state: &crate::rv64::test_utils::TestInterpreterState<Zve64xPermInstruction<Reg<u64>>>,
     reg: VReg,
 ) -> [u8; 32] {
-    state.ext_state.read_vreg()[usize::from(reg.to_bits())]
+    *state.ext_state.read_vregs().get(reg)
 }
 
 fn set_mask_bit(
@@ -110,8 +116,7 @@ fn set_mask_bit(
     i: u32,
     val: bool,
 ) {
-    let byte =
-        &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())][(i / u8::BITS) as usize];
+    let byte = &mut state.ext_state.write_vregs().get_mut(reg)[(i / u8::BITS) as usize];
     if val {
         *byte |= 1 << (i % u8::BITS);
     } else {
@@ -518,7 +523,7 @@ fn vslideup_vx_masked() {
         write_elem(&mut state, VReg::V4, i, Vsew::E8, 0xAA);
     }
     // Active bits: 2, 4, 6
-    state.ext_state.write_vreg()[0].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
     set_mask_bit(&mut state, VReg::V0, 2, true);
     set_mask_bit(&mut state, VReg::V0, 4, true);
     set_mask_bit(&mut state, VReg::V0, 6, true);
@@ -748,7 +753,7 @@ fn vslidedown_masked() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 100) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xDEAD);
     }
-    state.ext_state.write_vreg()[0].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
     set_mask_bit(&mut state, VReg::V0, 0, true);
     set_mask_bit(&mut state, VReg::V0, 2, true);
     state.regs.write(Reg::A0, 1u64);
@@ -847,7 +852,7 @@ fn vslide1up_masked() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 10) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xDEAD);
     }
-    state.ext_state.write_vreg()[0].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
     set_mask_bit(&mut state, VReg::V0, 0, true);
     set_mask_bit(&mut state, VReg::V0, 2, true);
     state.regs.write(Reg::A0, 99u64);
@@ -966,7 +971,7 @@ fn vslide1down_masked() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 10) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xFFFF);
     }
-    state.ext_state.write_vreg()[0].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
     set_mask_bit(&mut state, VReg::V0, 1, true);
     set_mask_bit(&mut state, VReg::V0, 3, true);
     state.regs.write(Reg::A0, 77u64);
@@ -1086,7 +1091,7 @@ fn vrgather_vv_masked() {
         write_elem(&mut state, VReg::V1, i, Vsew::E32, (3 - i) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xABCD);
     }
-    state.ext_state.write_vreg()[0].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
     set_mask_bit(&mut state, VReg::V0, 0, true);
     set_mask_bit(&mut state, VReg::V0, 3, true);
     exec(
@@ -1235,8 +1240,15 @@ fn vrgatherei16_vv_e8_m1_basic() {
         let reg_off = byte_off / 16;
         let b = byte_off % 16;
         let bytes = idx.to_le_bytes();
-        state.ext_state.write_vreg()[usize::from(VReg::V6.to_bits()) + reg_off][b] = bytes[0];
-        state.ext_state.write_vreg()[usize::from(VReg::V6.to_bits()) + reg_off][b + 1] = bytes[1];
+        state
+            .ext_state
+            .write_vregs()
+            .get_mut(VReg::from_bits(VReg::V6.to_bits() + reg_off as u8).unwrap())[b] = bytes[0];
+        state
+            .ext_state
+            .write_vregs()
+            .get_mut(VReg::from_bits(VReg::V6.to_bits() + reg_off as u8).unwrap())[b + 1] =
+            bytes[1];
     }
     exec(
         &mut state,
@@ -1266,8 +1278,8 @@ fn vrgatherei16_vv_index_out_of_range_gives_zero() {
     for i in 0..8usize {
         let byte_off = i * 2;
         let bytes = 100u16.to_le_bytes();
-        state.ext_state.write_vreg()[usize::from(VReg::V6.to_bits())][byte_off] = bytes[0];
-        state.ext_state.write_vreg()[usize::from(VReg::V6.to_bits())][byte_off + 1] = bytes[1];
+        state.ext_state.write_vregs().get_mut(VReg::V6)[byte_off] = bytes[0];
+        state.ext_state.write_vregs().get_mut(VReg::V6)[byte_off + 1] = bytes[1];
     }
     exec(
         &mut state,
@@ -1371,7 +1383,7 @@ fn vmerge_vvm_blends_vs2_and_vs1() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, (i * 100) as u64);
         write_elem(&mut state, VReg::V1, i, Vsew::E32, (i * 10 + 1) as u64);
     }
-    state.ext_state.write_vreg()[0].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
     set_mask_bit(&mut state, VReg::V0, 1, true);
     set_mask_bit(&mut state, VReg::V0, 3, true);
     exec(
@@ -1404,7 +1416,7 @@ fn vmerge_vvm_all_mask_bits_set_equals_vmv_v_v() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, 0xDEAD);
         write_elem(&mut state, VReg::V1, i, Vsew::E32, (i + 1) as u64);
     }
-    state.ext_state.write_vreg()[0].fill(0xFF);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0xFF);
     exec(
         &mut state,
         Zve64xPermInstruction::VmergeVvm {
@@ -1433,7 +1445,7 @@ fn vmerge_vvm_all_mask_bits_clear_equals_copy_vs2() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 7) as u64);
         write_elem(&mut state, VReg::V1, i, Vsew::E32, 0xDEAD);
     }
-    state.ext_state.write_vreg()[0].fill(0x00);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0x00);
     exec(
         &mut state,
         Zve64xPermInstruction::VmergeVvm {
@@ -1509,7 +1521,7 @@ fn vmerge_vvm_vstart_skips_early_elements() {
         write_elem(&mut state, VReg::V1, i, Vsew::E32, (i * 10 + 1) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xBEEF);
     }
-    state.ext_state.write_vreg()[0].fill(0xFF);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0xFF);
     state.ext_state.set_vstart(2);
     exec(
         &mut state,
@@ -1541,8 +1553,8 @@ fn vmerge_vvm_e8_full_register() {
         write_elem(&mut state, VReg::V1, i, Vsew::E8, (i * 2 + 1) as u64);
     }
     // Mask: odd bits set (0b10101010_10101010).
-    state.ext_state.write_vreg()[0][0] = 0b1010_1010;
-    state.ext_state.write_vreg()[0][1] = 0b1010_1010;
+    state.ext_state.write_vregs().get_mut(VReg::V0)[0] = 0b1010_1010;
+    state.ext_state.write_vregs().get_mut(VReg::V0)[1] = 0b1010_1010;
     exec(
         &mut state,
         Zve64xPermInstruction::VmergeVvm {
@@ -1645,7 +1657,7 @@ fn vmerge_vxm_blends_vs2_and_scalar() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, (i * 100) as u64);
     }
     state.regs.write(Reg::A0, 999u64);
-    state.ext_state.write_vreg()[0].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
     set_mask_bit(&mut state, VReg::V0, 0, true);
     set_mask_bit(&mut state, VReg::V0, 2, true);
     exec(
@@ -1815,7 +1827,7 @@ fn vmerge_vim_blends_vs2_and_immediate() {
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E16, (i * 1000) as u64);
     }
-    state.ext_state.write_vreg()[0].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
     set_mask_bit(&mut state, VReg::V0, 1, true);
     set_mask_bit(&mut state, VReg::V0, 3, true);
     exec(
@@ -1886,7 +1898,7 @@ fn vmerge_vim_vstart_skips_early_elements() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, (i * 100) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xABCD);
     }
-    state.ext_state.write_vreg()[0].fill(0xFF);
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0xFF);
     state.ext_state.set_vstart(2);
     exec(
         &mut state,
@@ -2093,9 +2105,9 @@ fn vmerge_vxm_m2_e32_blends_across_group() {
     }
     state.regs.write(Reg::A0, 777u64);
     // Set even mask bits across both bytes: elements 0,2,..,14 active.
-    state.ext_state.write_vreg()[0].fill(0);
-    state.ext_state.write_vreg()[0][0] = 0b0101_0101;
-    state.ext_state.write_vreg()[0][1] = 0b0101_0101;
+    state.ext_state.write_vregs().get_mut(VReg::V0).fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V0)[0] = 0b0101_0101;
+    state.ext_state.write_vregs().get_mut(VReg::V0)[1] = 0b0101_0101;
     exec(
         &mut state,
         Zve64xPermInstruction::VmergeVxm {
@@ -2126,7 +2138,7 @@ fn vcompress_vm_e32_basic() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 10) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xBEEF);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V1).fill(0);
     set_mask_bit(&mut state, VReg::V1, 1, true);
     set_mask_bit(&mut state, VReg::V1, 3, true);
     exec(
@@ -2154,7 +2166,7 @@ fn vcompress_vm_all_active() {
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 7) as u64);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
+    state.ext_state.write_vregs().get_mut(VReg::V1).fill(0xFF);
     exec(
         &mut state,
         Zve64xPermInstruction::VcompressVm {
@@ -2182,7 +2194,7 @@ fn vcompress_vm_none_active() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, (i + 1) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xABCD);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0x00);
+    state.ext_state.write_vregs().get_mut(VReg::V1).fill(0x00);
     exec(
         &mut state,
         Zve64xPermInstruction::VcompressVm {
@@ -2209,7 +2221,7 @@ fn vcompress_vm_e8_all_elements() {
     for i in 0..16usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E8, (15 - i) as u64);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
+    state.ext_state.write_vregs().get_mut(VReg::V1).fill(0xFF);
     exec(
         &mut state,
         Zve64xPermInstruction::VcompressVm {
@@ -2270,7 +2282,7 @@ fn vcompress_vm_rejects_nonzero_vstart() {
     for i in 0..4usize {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 10) as u64);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
+    state.ext_state.write_vregs().get_mut(VReg::V1).fill(0xFF);
     state.ext_state.set_vstart(1);
     let err = exec(
         &mut state,
@@ -2293,7 +2305,7 @@ fn vcompress_vm_vstart_zero_normal_operation() {
         write_elem(&mut state, VReg::V2, i, Vsew::E32, ((i + 1) * 10) as u64);
         write_elem(&mut state, VReg::V4, i, Vsew::E32, 0xDEAD);
     }
-    state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0);
+    state.ext_state.write_vregs().get_mut(VReg::V1).fill(0);
     set_mask_bit(&mut state, VReg::V1, 1, true);
     set_mask_bit(&mut state, VReg::V1, 2, true);
     exec(
@@ -2322,7 +2334,7 @@ fn vmv1r_v_copies_single_register() {
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32,
     ];
-    state.ext_state.write_vreg()[usize::from(VReg::V2.to_bits())] = src;
+    *state.ext_state.write_vregs().get_mut(VReg::V2) = src;
     set_vreg_bytes(&mut state, VReg::V4, 0xCC);
     exec(
         &mut state,
@@ -2900,7 +2912,7 @@ fn all_instructions_reset_vstart() {
             write_elem(&mut state, VReg::V2, i, Vsew::E32, (i + 1) as u64);
             write_elem(&mut state, VReg::V1, i, Vsew::E32, i as u64);
         }
-        state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
+        state.ext_state.write_vregs().get_mut(VReg::V1).fill(0xFF);
         state.ext_state.set_vstart(2);
         state.regs.write(Reg::A0, 1u64);
         exec(&mut state, *instr).unwrap();
@@ -3076,7 +3088,7 @@ fn all_vector_instructions_mark_vs_dirty() {
             write_elem(&mut state, VReg::V1, i, Vsew::E32, i as u64);
         }
         state.regs.write(Reg::A0, 1u64);
-        state.ext_state.write_vreg()[usize::from(VReg::V1.to_bits())].fill(0xFF);
+        state.ext_state.write_vregs().get_mut(VReg::V1).fill(0xFF);
         let before = state.ext_state.vs_dirty_count();
         exec(&mut state, *instr).unwrap();
         assert_eq!(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/zve64x_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/zve64x_perm_helpers.rs
@@ -113,7 +113,7 @@ pub unsafe fn write_element_0_u64<const VLENB: usize>(
     }
 }
 
-/// Sign-extend the low `sew.bits()` of `val` to the register type width.
+/// Sign-extend the low `sew.bits_width()` of `val` to the register type width.
 ///
 /// The arithmetic is performed entirely in 64-bit signed integer space: we shift the SEW-wide
 /// value left to place its sign bit at bit 63, then arithmetic-right-shift back to propagate it.
@@ -157,7 +157,7 @@ where
 /// # Safety
 /// - `vd` and `vs2` are validly aligned and non-overlapping (verified by caller).
 /// - `vl <= group_regs * VLENB / sew_bytes`.
-/// - When `vm=false`: `vd.bits() != 0`.
+/// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
@@ -205,7 +205,7 @@ pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
 /// # Safety
 /// - `vd` and `vs2` are validly aligned (verified by caller); overlap is permitted.
 /// - `vl <= vlmax`.
-/// - When `vm=false`: `vd.bits() != 0`.
+/// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
@@ -260,7 +260,7 @@ pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
 /// # Safety
 /// - `vd` and `vs2` are validly aligned and non-overlapping (verified by caller).
 /// - `vl <= group_regs * VLENB / sew_bytes`.
-/// - When `vm=false`: `vd.bits() != 0`.
+/// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
@@ -314,7 +314,7 @@ pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
 /// # Safety
 /// - `vd` and `vs2` are validly aligned (verified by caller); overlap is permitted.
 /// - `vl <= group_regs * VLENB / sew_bytes`.
-/// - When `vm=false`: `vd.bits() != 0`.
+/// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
@@ -360,7 +360,7 @@ pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
 /// # Safety
 /// - `vd`, `vs2`, and `vs1` are validly aligned and mutually non-overlapping (verified by caller).
 /// - `vl <= vlmax`.
-/// - When `vm=false`: `vd.bits() != 0`.
+/// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
@@ -409,7 +409,7 @@ pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
 /// # Safety
 /// - `vd` and `vs2` are validly aligned and non-overlapping (verified by caller).
 /// - `vl <= vlmax`.
-/// - When `vm=false`: `vd.bits() != 0`.
+/// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
@@ -461,7 +461,7 @@ pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
 /// - `vd`, `vs2`, and `vs1` are validly aligned and mutually non-overlapping (verified by caller).
 /// - `vl <= vlmax` (for the data register group) AND `vl <= index_group_regs * VLENB / 2` (for the
 ///   index register group).
-/// - When `vm=false`: `vd.bits() != 0`.
+/// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/zve64x_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/zve64x_perm_helpers.rs
@@ -25,8 +25,8 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let a_start = u16::from(a.bits());
-    let b_start = u16::from(b.bits());
+    let a_start = u16::from(a.to_bits());
+    let b_start = u16::from(b.to_bits());
     let count = u16::from(count);
     // Intervals [a_start, a_start+count) and [b_start, b_start+count) overlap iff
     // each starts before the other ends. Arithmetic is widened to u16 to avoid u8 overflow
@@ -57,8 +57,8 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let a_start = u16::from(a.bits());
-    let b_start = u16::from(b.bits());
+    let a_start = u16::from(a.to_bits());
+    let b_start = u16::from(b.to_bits());
     let a_count = u16::from(a_count);
     let b_count = u16::from(b_count);
     // Intervals [a_start, a_start+a_count) and [b_start, b_start+b_count) overlap iff
@@ -648,7 +648,7 @@ pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
     // SAFETY: mask_bytes <= VLENB since vl <= VLEN; vs1_base < 32
     unsafe {
         vs1_buf.get_unchecked_mut(..mask_bytes).copy_from_slice(
-            vreg.get_unchecked(usize::from(vs1.bits()))
+            vreg.get_unchecked(usize::from(vs1.to_bits()))
                 .get_unchecked(..mask_bytes),
         );
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/zve64x_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/perm/zve64x_perm_helpers.rs
@@ -1,6 +1,6 @@
 //! Opaque helpers for Zve64x extension
 
-use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zve64x::arith::zve64x_arith_helpers::check_vreg_group_alignment;
 use crate::v::zve64x::arith::zve64x_arith_helpers::{read_element_u64, write_element_u64};
 use crate::v::zve64x::load::zve64x_load_helpers::{mask_bit, snapshot_mask};
@@ -74,41 +74,43 @@ where
 /// Read element 0 of register `base_reg` as `u64`, zero-extended.
 ///
 /// # Safety
-/// `base_reg < 32` and `sew.bytes() <= VLENB` must hold.
+/// `sew.bytes() <= VLENB`
 #[inline(always)]
 pub unsafe fn read_element_0_u64<const VLENB: usize>(
-    vreg: &[[u8; VLENB]; 32],
-    base_reg: u8,
+    vregs: &VectorRegisterFile<VLENB>,
+    base_reg: VReg,
     sew: Vsew,
 ) -> u64 {
     let sew_bytes = usize::from(sew.bytes_width());
-    // SAFETY: `base_reg < 32` by VReg invariant
-    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg)) };
+    let reg = vregs.get(base_reg);
     let mut buf = [0u8; 8];
     // SAFETY: `sew_bytes <= VLENB` for all legal vtype; `sew_bytes <= 8`
-    unsafe { buf.get_unchecked_mut(..sew_bytes) }
-        .copy_from_slice(unsafe { reg.get_unchecked(..sew_bytes) });
+    unsafe {
+        buf.get_unchecked_mut(..sew_bytes)
+            .copy_from_slice(reg.get_unchecked(..sew_bytes));
+    }
     u64::from_le_bytes(buf)
 }
 
 /// Write element 0 of register `base_reg` from the low `sew_bytes` of `value`.
 ///
 /// # Safety
-/// `base_reg < 32` and `sew.bytes() <= VLENB` must hold.
+/// `sew.bytes() <= VLENB`
 #[inline(always)]
 pub unsafe fn write_element_0_u64<const VLENB: usize>(
-    vreg: &mut [[u8; VLENB]; 32],
-    base_reg: u8,
+    vregs: &mut VectorRegisterFile<VLENB>,
+    base_reg: VReg,
     sew: Vsew,
     value: u64,
 ) {
     let sew_bytes = usize::from(sew.bytes_width());
     let buf = value.to_le_bytes();
-    // SAFETY: `base_reg < 32` by VReg invariant
-    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg)) };
+    let reg = vregs.get_mut(base_reg);
     // SAFETY: `sew_bytes <= VLENB`; `sew_bytes <= 8`
-    unsafe { reg.get_unchecked_mut(..sew_bytes) }
-        .copy_from_slice(unsafe { buf.get_unchecked(..sew_bytes) });
+    unsafe {
+        reg.get_unchecked_mut(..sew_bytes)
+            .copy_from_slice(buf.get_unchecked(..sew_bytes));
+    }
 }
 
 /// Sign-extend the low `sew.bits()` of `val` to the register type width.
@@ -176,7 +178,7 @@ pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     // Per spec §16.3.1: elements 0..offset are never written (vd keeps its value).
     // The active range starts at max(vstart, offset).
     let start = u32::from(vstart).max(offset.min(u64::from(u32::MAX)) as u32);
@@ -186,10 +188,10 @@ pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
         }
         let src_idx = u64::from(i) - offset;
         // SAFETY: src_idx < vl <= group_regs * elems_per_reg, so source element is in range
-        let val = unsafe { read_element_u64(ext_state.read_vreg(), vs2, src_idx as u32, sew) };
+        let val = unsafe { read_element_u64(ext_state.read_vregs(), vs2, src_idx as u32, sew) };
         // SAFETY: i < vl <= group_regs * elems_per_reg, so dest element is in range
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -225,7 +227,7 @@ pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
@@ -236,13 +238,13 @@ pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
             && src_idx < u64::from(vlmax)
         {
             // SAFETY: src_idx < vlmax <= group_regs * elems_per_reg, so element is in range
-            unsafe { read_element_u64(ext_state.read_vreg(), vs2, src_idx as u32, sew) }
+            unsafe { read_element_u64(ext_state.read_vregs(), vs2, src_idx as u32, sew) }
         } else {
             0
         };
         // SAFETY: i < vl <= vlmax <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -279,7 +281,7 @@ pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
@@ -288,11 +290,11 @@ pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
             scalar
         } else {
             // SAFETY: i - 1 < vl <= group_regs * elems_per_reg
-            unsafe { read_element_u64(ext_state.read_vreg(), vs2, i - 1, sew) }
+            unsafe { read_element_u64(ext_state.read_vregs(), vs2, i - 1, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -333,20 +335,20 @@ pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         let val = if i + 1 < vl {
             // SAFETY: i + 1 < vl <= group_regs * elems_per_reg
-            unsafe { read_element_u64(ext_state.read_vreg(), vs2, i + 1, sew) }
+            unsafe { read_element_u64(ext_state.read_vregs(), vs2, i + 1, sew) }
         } else {
             scalar
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -380,22 +382,22 @@ pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg for vs1
-        let index = unsafe { read_element_u64(ext_state.read_vreg(), vs1, i, sew) };
+        let index = unsafe { read_element_u64(ext_state.read_vregs(), vs1, i, sew) };
         let val = if index < u64::from(vlmax) {
             // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(ext_state.read_vreg(), vs2, index as u32, sew) }
+            unsafe { read_element_u64(ext_state.read_vregs(), vs2, index as u32, sew) }
         } else {
             0u64
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -429,11 +431,11 @@ pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     // Pre-compute the gathered value; it's the same for all elements.
     let val = if index < u64::from(vlmax) {
         // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
-        unsafe { read_element_u64(ext_state.read_vreg(), vs2, index as u32, sew) }
+        unsafe { read_element_u64(ext_state.read_vregs(), vs2, index as u32, sew) }
     } else {
         0u64
     };
@@ -443,7 +445,7 @@ pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -492,7 +494,7 @@ pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
         "vl={vl} exceeds vlmax={vlmax} or index_capacity={index_capacity}"
     );
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
@@ -500,16 +502,16 @@ pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
         // Read 16-bit index from vs1; EEW=16 always.
         // SAFETY: i < vl <= index_capacity = index_group_regs * (VLENB/2), so element i
         // fits within the index register group.
-        let index = unsafe { read_element_u64(ext_state.read_vreg(), vs1, i, Vsew::E16) };
+        let index = unsafe { read_element_u64(ext_state.read_vregs(), vs1, i, Vsew::E16) };
         let val = if index < u64::from(vlmax) {
             // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(ext_state.read_vreg(), vs2, index as u32, sew) }
+            unsafe { read_element_u64(ext_state.read_vregs(), vs2, index as u32, sew) }
         } else {
             0u64
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -547,20 +549,20 @@ pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
     // For vmv.v.v (vm=true) the mask is all-ones so snapshot_mask is still valid.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         let mask_set = mask_bit(&mask_buf, i);
         let val = if mask_set {
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs1
-            unsafe { read_element_u64(ext_state.read_vreg(), vs1, i, sew) }
+            unsafe { read_element_u64(ext_state.read_vregs(), vs1, i, sew) }
         } else {
             // mask_set=false only reachable when vm=false (vmerge path).
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) }
+            unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -597,18 +599,18 @@ pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         let val = if mask_bit(&mask_buf, i) {
             scalar
         } else {
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) }
+            unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, val);
         }
     }
     ext_state.mark_vs_dirty();
@@ -643,14 +645,13 @@ pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
     CustomError: fmt::Debug,
 {
     let mask_bytes = vl.div_ceil(u8::BITS) as usize;
-    let vreg = ext_state.read_vreg();
+    let vreg = ext_state.read_vregs();
     let mut vs1_buf = [0u8; { ExtState::VLENB as usize }];
     // SAFETY: mask_bytes <= VLENB since vl <= VLEN; vs1_base < 32
     unsafe {
-        vs1_buf.get_unchecked_mut(..mask_bytes).copy_from_slice(
-            vreg.get_unchecked(usize::from(vs1.to_bits()))
-                .get_unchecked(..mask_bytes),
-        );
+        vs1_buf
+            .get_unchecked_mut(..mask_bytes)
+            .copy_from_slice(vreg.get(vs1).get_unchecked(..mask_bytes));
     }
     let mut out_idx = 0u32;
     for i in 0..vl {
@@ -658,10 +659,10 @@ pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
             continue;
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg
-        let val = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let val = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         // SAFETY: out_idx <= popcount(vs1[0..vl)) <= vl
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, out_idx, sew, val);
+            write_element_u64(ext_state.write_vregs(), vd, out_idx, sew, val);
         }
         out_idx += 1;
     }
@@ -684,9 +685,9 @@ pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_whole_reg_move<const VLENB: usize>(
-    vreg: &mut [[u8; VLENB]; 32],
-    dst_base: u8,
-    src_base: u8,
+    vregs: &mut VectorRegisterFile<VLENB>,
+    dst_base: VReg,
+    src_base: VReg,
     count: u8,
 ) {
     let count = usize::from(count);
@@ -695,13 +696,13 @@ pub unsafe fn execute_whole_reg_move<const VLENB: usize>(
     // This is correct for all overlap patterns without direction-dependent logic.
     let mut tmp = [[0u8; VLENB]; 8];
     for (k, item) in tmp.iter_mut().enumerate().take(count) {
-        let src_idx = usize::from(src_base) + k;
-        // SAFETY: src_idx < 32 per caller guarantee
-        *item = *unsafe { vreg.get_unchecked(src_idx) };
+        // SAFETY: Guaranteed by function contract
+        let src = unsafe { VReg::from_bits(src_base.to_bits() + k as u8).unwrap_unchecked() };
+        *item = *vregs.get(src);
     }
     for (k, item) in tmp.iter().enumerate().take(count) {
-        let dst_idx = usize::from(dst_base) + k;
-        // SAFETY: dst_idx < 32 per caller guarantee
-        *unsafe { vreg.get_unchecked_mut(dst_idx) } = *item;
+        // SAFETY: Guaranteed by function contract
+        let dst = unsafe { VReg::from_bits(dst_base.to_bits() + k as u8).unwrap_unchecked() };
+        *vregs.get_mut(dst) = *item;
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 use ab_riscv_primitives::prelude::*;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
 }
 
 fn setup(
@@ -56,7 +56,7 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -73,7 +73,7 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -83,7 +83,7 @@ fn set_mask_bit(
     elem_i: u32,
     active: bool,
 ) {
-    let byte = &mut state.ext_state.write_vreg()[usize::from(VReg::V0.bits())]
+    let byte = &mut state.ext_state.write_vreg()[usize::from(VReg::V0.to_bits())]
         [(elem_i / u8::BITS) as usize];
     if active {
         *byte |= 1 << (elem_i % u8::BITS);

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/tests.rs
@@ -56,7 +56,10 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -73,7 +76,10 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
@@ -83,8 +89,7 @@ fn set_mask_bit(
     elem_i: u32,
     active: bool,
 ) {
-    let byte = &mut state.ext_state.write_vreg()[usize::from(VReg::V0.to_bits())]
-        [(elem_i / u8::BITS) as usize];
+    let byte = &mut state.ext_state.write_vregs().get_mut(VReg::V0)[(elem_i / u8::BITS) as usize];
     if active {
         *byte |= 1 << (elem_i % u8::BITS);
     } else {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/zve64x_reduction_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/zve64x_reduction_helpers.rs
@@ -10,7 +10,7 @@ use core::fmt;
 /// Execute a single-width integer reduction.
 ///
 /// # Safety
-/// - `vs2.bits() % group_regs == 0` and `vs2.bits() + group_regs <= 32` (verified by caller)
+/// - `vs2.to_bits() % group_regs == 0` and `vs2.to_bits() + group_regs <= 32` (verified by caller)
 /// - `vstart == 0` (verified by caller; reductions with non-zero vstart are illegal)
 /// - `vl <= group_regs * VLENB / sew_bytes`
 /// - `vl <= VLEN`
@@ -66,8 +66,8 @@ pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
 /// Execute a widening integer sum reduction.
 ///
 /// # Safety
-/// - `vs2.bits() % group_regs == 0` and `vs2.bits() + group_regs <= 32` (verified by caller)
-/// - `2 * sew.bits() <= ELEN` (verified by caller)
+/// - `vs2.to_bits() % group_regs == 0` and `vs2.to_bits() + group_regs <= 32` (verified by caller)
+/// - `sew.double_width().is_some()` (verified by caller)
 /// - `vstart == 0` (verified by caller)
 /// - `vl <= group_regs * VLENB / sew_bytes`
 /// - `vl <= VLEN`
@@ -93,12 +93,9 @@ pub unsafe fn execute_widening_reduce_op<Reg, ExtState, CustomError, F>(
     CustomError: fmt::Debug,
     F: Fn(u64, u64, Vsew) -> u64,
 {
-    let wide_sew = match sew {
-        Vsew::E8 => Vsew::E16,
-        Vsew::E16 => Vsew::E32,
-        Vsew::E32 => Vsew::E64,
+    let Some(wide_sew) = sew.double_width() else {
         // SAFETY: caller verified `2*SEW <= ELEN`; E64 widening is unreachable here
-        Vsew::E64 => unsafe { core::hint::unreachable_unchecked() },
+        unsafe { core::hint::unreachable_unchecked() }
     };
     if vl == 0 {
         ext_state.reset_vstart();

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/zve64x_reduction_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/reduction/zve64x_reduction_helpers.rs
@@ -43,21 +43,21 @@ pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
         return;
     }
     // SAFETY: element 0 always fits within register vs1
-    let init = unsafe { read_element_u64(ext_state.read_vreg(), vs1, 0, sew) };
+    let init = unsafe { read_element_u64(ext_state.read_vregs(), vs1, 0, sew) };
     // SAFETY: `vl <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     let mut acc = init;
     for i in 0..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`
-        let elem = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let elem = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         acc = op(acc, elem, sew);
     }
     // SAFETY: element 0 always fits within register vd
     unsafe {
-        write_element_u64(ext_state.write_vreg(), vd, 0, sew, acc);
+        write_element_u64(ext_state.write_vregs(), vd, 0, sew, acc);
     }
     ext_state.mark_vs_dirty();
     ext_state.reset_vstart();
@@ -105,16 +105,16 @@ pub unsafe fn execute_widening_reduce_op<Reg, ExtState, CustomError, F>(
         return;
     }
     // SAFETY: element 0 always fits within register vs1
-    let init = unsafe { read_element_u64(ext_state.read_vreg(), vs1, 0, wide_sew) };
+    let init = unsafe { read_element_u64(ext_state.read_vregs(), vs1, 0, wide_sew) };
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     let mut acc = init;
     for i in 0..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: same bounds argument as `execute_reduce_op`
-        let raw = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let raw = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let elem = if sign_extend_src {
             sign_extend(raw, sew).cast_unsigned()
         } else {
@@ -124,7 +124,7 @@ pub unsafe fn execute_widening_reduce_op<Reg, ExtState, CustomError, F>(
     }
     // SAFETY: element 0 always fits within register vd
     unsafe {
-        write_element_u64(ext_state.write_vreg(), vd, 0, wide_sew, acc);
+        write_element_u64(ext_state.write_vregs(), vd, 0, wide_sew, acc);
     }
     ext_state.mark_vs_dirty();
     ext_state.reset_vstart();

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
@@ -64,6 +64,7 @@ where
             // to `nreg`. Ignores vtype, vl, masking. Honors `vstart` in byte units: the first
             // `vstart` bytes are skipped. If `vstart >= EVL`, the instruction is a no-op.
             Self::Vsr { vs3, rs1: _, nreg } => {
+                let nreg = nreg.num_registers();
                 if !ext_state.vector_instructions_allowed() {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
@@ -70,7 +70,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if u32::from(vs3.to_bits()) % u32::from(nreg) != 0 {
+                if vs3.to_bits() % nreg != 0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -84,16 +84,14 @@ where
                     while byte_off < evl {
                         let reg_off = byte_off / vlenb;
                         let in_reg = (byte_off % vlenb) as usize;
-                        let reg_idx = (u64::from(vs3.to_bits()) + reg_off) as usize;
-                        // SAFETY: `reg_idx < 32` because the decoder guarantees `nreg` in
-                        // {1,2,4,8} and `vs3` is `nreg`-aligned (checked above), so
-                        // `vs3.bits() + nreg - 1 <= 31`. `in_reg < VLENB` by construction.
-                        let src = unsafe {
-                            ext_state
-                                .read_vreg()
-                                .get_unchecked(reg_idx)
-                                .get_unchecked(in_reg..)
+                        // SAFETY: the decoder guarantees `nreg` in {1,2,4,8} and `vs3` is
+                        // `nreg`-aligned (checked above), so `vs3.bits() + nreg - 1 <= 31`
+                        let reg = unsafe {
+                            VReg::from_bits(vs3.to_bits() + reg_off as u8).unwrap_unchecked()
                         };
+                        // SAFETY: `in_reg < VLENB` by construction
+                        let src =
+                            unsafe { ext_state.read_vregs().get(reg).get_unchecked(in_reg..) };
                         if let Err(error) = memory.write_slice(base + byte_off, src) {
                             ext_state.set_vstart(byte_off as u16);
                             return Err(ExecutionError::MemoryAccess(error));
@@ -117,14 +115,13 @@ where
                 let start_byte = ext_state.vstart();
                 if u32::from(start_byte) < evl_bytes {
                     let base = rs1_value.as_u64();
-                    // SAFETY: `vs3.bits() < 32` is guaranteed by `VReg`.
-                    // `evl_bytes = vl.div_ceil(8) <= VLEN / 8 = VLENB` because `vl <= VLMAX <=
-                    // VLEN`, so the slice `start_byte..evl_bytes` is in bounds of the
-                    // `VLENB`-byte source register.
+                    // SAFETY: `evl_bytes = vl.div_ceil(8) <= VLEN / 8 = VLENB` because
+                    // `vl <= VLMAX <= VLEN`, so the slice `start_byte..evl_bytes` is in bounds of
+                    // the `VLENB`-byte source register
                     let src = unsafe {
                         ext_state
-                            .read_vreg()
-                            .get_unchecked(usize::from(vs3.to_bits()))
+                            .read_vregs()
+                            .get(vs3)
                             .get_unchecked(usize::from(start_byte)..evl_bytes as usize)
                     };
                     memory

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
@@ -69,7 +69,7 @@ where
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if u32::from(vs3.bits()) % u32::from(nreg) != 0 {
+                if u32::from(vs3.to_bits()) % u32::from(nreg) != 0 {
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zve64x_helpers::INSTRUCTION_SIZE),
                     });
@@ -83,7 +83,7 @@ where
                     while byte_off < evl {
                         let reg_off = byte_off / vlenb;
                         let in_reg = (byte_off % vlenb) as usize;
-                        let reg_idx = (u64::from(vs3.bits()) + reg_off) as usize;
+                        let reg_idx = (u64::from(vs3.to_bits()) + reg_off) as usize;
                         // SAFETY: `reg_idx < 32` because the decoder guarantees `nreg` in
                         // {1,2,4,8} and `vs3` is `nreg`-aligned (checked above), so
                         // `vs3.bits() + nreg - 1 <= 31`. `in_reg < VLENB` by construction.
@@ -123,7 +123,7 @@ where
                     let src = unsafe {
                         ext_state
                             .read_vreg()
-                            .get_unchecked(usize::from(vs3.bits()))
+                            .get_unchecked(usize::from(vs3.to_bits()))
                             .get_unchecked(usize::from(start_byte)..evl_bytes as usize)
                     };
                     memory

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store.rs
@@ -85,7 +85,7 @@ where
                         let reg_off = byte_off / vlenb;
                         let in_reg = (byte_off % vlenb) as usize;
                         // SAFETY: the decoder guarantees `nreg` in {1,2,4,8} and `vs3` is
-                        // `nreg`-aligned (checked above), so `vs3.bits() + nreg - 1 <= 31`
+                        // `nreg`-aligned (checked above), so `vs3.to_bits() + nreg - 1 <= 31`
                         let reg = unsafe {
                             VReg::from_bits(vs3.to_bits() + reg_off as u8).unwrap_unchecked()
                         };

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
@@ -36,8 +36,7 @@ fn set_vreg(
     reg: VReg,
     data: &[u8],
 ) {
-    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())];
-    dst[..data.len()].copy_from_slice(data);
+    state.ext_state.write_vregs().get_mut(reg)[..data.len()].copy_from_slice(data);
 }
 
 fn read_mem_bytes<const N: usize>(

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
@@ -89,7 +89,7 @@ fn vsr_single_register_stores_vlenb_bytes() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V2,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             rs2: Reg::Zero,
         },
     )
@@ -115,7 +115,7 @@ fn vsr_two_registers_stores_two_vlenb_blocks() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V2,
             rs1: Reg::A0,
-            nreg: 2,
+            nreg: LoadStoreNreg::N2,
             rs2: Reg::Zero,
         },
     )
@@ -140,7 +140,7 @@ fn vsr_four_registers_stores_four_vlenb_blocks() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V4,
             rs1: Reg::A0,
-            nreg: 4,
+            nreg: LoadStoreNreg::N4,
             rs2: Reg::Zero,
         },
     )
@@ -170,7 +170,7 @@ fn vsr_eight_registers_stores_eight_vlenb_blocks() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V8,
             rs1: Reg::A0,
-            nreg: 8,
+            nreg: LoadStoreNreg::N8,
             rs2: Reg::Zero,
         },
     )
@@ -197,7 +197,7 @@ fn vsr_misaligned_register_returns_illegal_instruction() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V3,
             rs1: Reg::A0,
-            nreg: 2,
+            nreg: LoadStoreNreg::N2,
             rs2: Reg::Zero,
         },
     );
@@ -225,7 +225,7 @@ fn vsr_ignores_vtype_and_vl() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V0,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             rs2: Reg::Zero,
         },
     )
@@ -247,7 +247,7 @@ fn vsr_vector_not_allowed_returns_illegal_instruction() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V0,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             rs2: Reg::Zero,
         },
     );
@@ -275,7 +275,7 @@ fn vsr_honors_nonzero_vstart() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V2,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             rs2: Reg::Zero,
         },
     )
@@ -308,7 +308,7 @@ fn vsr_vstart_at_or_past_evl_writes_nothing() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V2,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             rs2: Reg::Zero,
         },
     )
@@ -338,7 +338,7 @@ fn vsr_nreg2_vstart_spans_register_boundary() {
         Zve64xStoreInstruction::Vsr {
             vs3: VReg::V2,
             rs1: Reg::A0,
-            nreg: 2,
+            nreg: LoadStoreNreg::N2,
             rs2: Reg::Zero,
         },
     )

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/tests.rs
@@ -28,7 +28,7 @@ fn setup(
 }
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
 }
 
 fn set_vreg(
@@ -36,7 +36,7 @@ fn set_vreg(
     reg: VReg,
     data: &[u8],
 ) {
-    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.bits())];
+    let dst = &mut state.ext_state.write_vreg()[usize::from(reg.to_bits())];
     dst[..data.len()].copy_from_slice(data);
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
@@ -103,7 +103,7 @@ where
     let elem_bytes = eew.bytes_width();
     let segment_stride = u64::from(nf.fields_per_segment() * elem_bytes);
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !vm && !mask_bit(&mask_buf, i) {
             continue;
@@ -111,7 +111,9 @@ where
         let elem_base = base.wrapping_add(u64::from(i) * segment_stride);
         for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f * elem_bytes));
-            let field_base_reg = vs3.to_bits() + f * group_regs;
+            // SAFETY: Guaranteed by function contract
+            let field_base_reg =
+                unsafe { VReg::from_bits(vs3.to_bits() + f * group_regs).unwrap_unchecked() };
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
             //
             // Let `elems_per_reg = VLENB / elem_bytes`.
@@ -125,9 +127,8 @@ where
             //
             // Therefore,
             // `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
-            let data = unsafe {
-                read_group_element(ext_state.read_vreg(), usize::from(field_base_reg), i, eew)
-            };
+            let data =
+                unsafe { read_group_element(ext_state.read_vregs(), field_base_reg, i, eew) };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
             if let Err(error) = write_mem_element(memory, addr, eew, data) {
@@ -180,7 +181,7 @@ where
     let vstart = ext_state.vstart();
     let elem_bytes = eew.bytes_width();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !vm && !mask_bit(&mask_buf, i) {
             continue;
@@ -188,13 +189,14 @@ where
         let elem_base = base.wrapping_add(i64::from(i).wrapping_mul(stride).cast_unsigned());
         for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f * elem_bytes));
-            let field_base_reg = vs3.to_bits() + f * group_regs;
+            // SAFETY: Guaranteed by function contract
+            let field_base_reg =
+                unsafe { VReg::from_bits(vs3.to_bits() + f * group_regs).unwrap_unchecked() };
             // SAFETY: same argument as `execute_unit_stride_store`; `field_base_reg +
             // i / elems_per_reg < field_base_reg + group_regs <= vs3.bits() + nf *
             // group_regs <= 32`.
-            let data = unsafe {
-                read_group_element(ext_state.read_vreg(), usize::from(field_base_reg), i, eew)
-            };
+            let data =
+                unsafe { read_group_element(ext_state.read_vregs(), field_base_reg, i, eew) };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
             if let Err(error) = write_mem_element(memory, addr, eew, data) {
@@ -253,38 +255,27 @@ where
     let vstart = ext_state.vstart();
     let data_elem_bytes = data_eew.bytes_width();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
     for i in u32::from(vstart)..vl {
         if !vm && !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: `i < vl <= index_group_regs * VLENB / index_eew.bytes()` (precondition), so
         // `vs2.bits() + i / (VLENB / index_eew.bytes()) < vs2.bits() + index_group_regs <= 32`.
-        let index_buf = unsafe {
-            read_group_element(
-                ext_state.read_vreg(),
-                usize::from(vs2.to_bits()),
-                i,
-                index_eew,
-            )
-        };
+        let index_buf = unsafe { read_group_element(ext_state.read_vregs(), vs2, i, index_eew) };
         // SAFETY: `index_eew.bytes() <= Eew::MAX_BYTES` always holds.
         let offset = unsafe { index_buf_to_u64(index_buf, index_eew) };
         let elem_base = base.wrapping_add(offset);
         for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(data_elem_bytes));
-            let field_base_reg = vs3.to_bits() + f * data_group_regs;
+            // SAFETY: Guaranteed by function contract
+            let field_base_reg =
+                unsafe { VReg::from_bits(vs3.to_bits() + f * data_group_regs).unwrap_unchecked() };
             // SAFETY: `i < vl <= data_group_regs * VLENB / data_eew.bytes()` (precondition), so
             // `field_base_reg + i / elems_per_reg < field_base_reg + data_group_regs
             //                                    <= vs3.bits() + nf * data_group_regs <= 32`.
-            let data = unsafe {
-                read_group_element(
-                    ext_state.read_vreg(),
-                    usize::from(field_base_reg),
-                    i,
-                    data_eew,
-                )
-            };
+            let data =
+                unsafe { read_group_element(ext_state.read_vregs(), field_base_reg, i, data_eew) };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
             if let Err(error) = write_mem_element(memory, addr, data_eew, data) {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
@@ -32,7 +32,7 @@ fn write_mem_element(
     eew: Eew,
     buf: [u8; Eew::MAX_BYTES as usize],
 ) -> Result<(), VirtualMemoryError> {
-    memory.write_slice(addr, &buf[..usize::from(eew.bytes())])
+    memory.write_slice(addr, &buf[..usize::from(eew.bytes_width())])
 }
 
 /// Validate a segment store's destination register group.
@@ -53,7 +53,8 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     check_register_group_alignment::<Reg, _, _, _>(program_counter, vs3, group_regs)?;
-    let total = u32::from(vs3.bits()) + u32::from(nf.fields_per_segment()) * u32::from(group_regs);
+    let total =
+        u32::from(vs3.to_bits()) + u32::from(nf.fields_per_segment()) * u32::from(group_regs);
     if total > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -99,7 +100,7 @@ where
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let elem_bytes = eew.bytes();
+    let elem_bytes = eew.bytes_width();
     let segment_stride = u64::from(nf.fields_per_segment() * elem_bytes);
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLEN / 8 = VLENB`.
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
@@ -110,7 +111,7 @@ where
         let elem_base = base.wrapping_add(u64::from(i) * segment_stride);
         for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f * elem_bytes));
-            let field_base_reg = vs3.bits() + f * group_regs;
+            let field_base_reg = vs3.to_bits() + f * group_regs;
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
             //
             // Let `elems_per_reg = VLENB / elem_bytes`.
@@ -177,7 +178,7 @@ where
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let elem_bytes = eew.bytes();
+    let elem_bytes = eew.bytes_width();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     for i in u32::from(vstart)..vl {
@@ -187,7 +188,7 @@ where
         let elem_base = base.wrapping_add(i64::from(i).wrapping_mul(stride).cast_unsigned());
         for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f * elem_bytes));
-            let field_base_reg = vs3.bits() + f * group_regs;
+            let field_base_reg = vs3.to_bits() + f * group_regs;
             // SAFETY: same argument as `execute_unit_stride_store`; `field_base_reg +
             // i / elems_per_reg < field_base_reg + group_regs <= vs3.bits() + nf *
             // group_regs <= 32`.
@@ -250,7 +251,7 @@ where
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let data_elem_bytes = data_eew.bytes();
+    let data_elem_bytes = data_eew.bytes_width();
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`.
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
     for i in u32::from(vstart)..vl {
@@ -260,14 +261,19 @@ where
         // SAFETY: `i < vl <= index_group_regs * VLENB / index_eew.bytes()` (precondition), so
         // `vs2.bits() + i / (VLENB / index_eew.bytes()) < vs2.bits() + index_group_regs <= 32`.
         let index_buf = unsafe {
-            read_group_element(ext_state.read_vreg(), usize::from(vs2.bits()), i, index_eew)
+            read_group_element(
+                ext_state.read_vreg(),
+                usize::from(vs2.to_bits()),
+                i,
+                index_eew,
+            )
         };
         // SAFETY: `index_eew.bytes() <= Eew::MAX_BYTES` always holds.
         let offset = unsafe { index_buf_to_u64(index_buf, index_eew) };
         let elem_base = base.wrapping_add(offset);
         for f in 0..nf.fields_per_segment() {
             let addr = elem_base.wrapping_add(u64::from(f) * u64::from(data_elem_bytes));
-            let field_base_reg = vs3.bits() + f * data_group_regs;
+            let field_base_reg = vs3.to_bits() + f * data_group_regs;
             // SAFETY: `i < vl <= data_group_regs * VLENB / data_eew.bytes()` (precondition), so
             // `field_base_reg + i / elems_per_reg < field_base_reg + data_group_regs
             //                                    <= vs3.bits() + nf * data_group_regs <= 32`.

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
@@ -109,7 +109,7 @@ where
         }
         let elem_base = base.wrapping_add(u64::from(i) * segment_stride);
         for f in 0..nf.fields_per_segment() {
-            let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
+            let addr = elem_base.wrapping_add(u64::from(f * elem_bytes));
             let field_base_reg = vs3.bits() + f * group_regs;
             // SAFETY: need `field_base_reg + i / (VLENB / elem_bytes) < 32`.
             //
@@ -186,7 +186,7 @@ where
         }
         let elem_base = base.wrapping_add(i64::from(i).wrapping_mul(stride).cast_unsigned());
         for f in 0..nf.fields_per_segment() {
-            let addr = elem_base.wrapping_add(u64::from(f) * u64::from(elem_bytes));
+            let addr = elem_base.wrapping_add(u64::from(f * elem_bytes));
             let field_base_reg = vs3.bits() + f * group_regs;
             // SAFETY: same argument as `execute_unit_stride_store`; `field_base_reg +
             // i / elems_per_reg < field_base_reg + group_regs <= vs3.bits() + nf *

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/store/zve64x_store_helpers.rs
@@ -70,12 +70,12 @@ where
 /// plain unit-stride store.
 ///
 /// # Safety
-/// - `vs3.bits() % group_regs == 0`
-/// - `vs3.bits() + nf * group_regs <= 32`
+/// - `vs3.to_bits() % group_regs == 0`
+/// - `vs3.to_bits() + nf * group_regs <= 32`
 /// - `vl <= group_regs * VLENB / eew.bytes()` (all `vl` elements fit within the source register
 ///   group; this holds when `vl` is the architectural `vl` and `group_regs` is the EMUL register
 ///   count for the given `eew` and `vtype`)
-/// - When `vm=false`: `vs3` does not overlap `v0` (i.e. `vs3.bits() != 0`)
+/// - When `vm=false`: `vs3` does not overlap `v0` (i.e. `vs3.to_bits() != 0`)
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
@@ -120,10 +120,10 @@ where
             // `i < vl <= group_regs * elems_per_reg` (precondition), so
             // `i / elems_per_reg < group_regs`.
             //
-            // `field_base_reg = vs3.bits() + f * group_regs`. Since `f < nf` and the
-            // precondition guarantees `vs3.bits() + nf * group_regs <= 32`:
-            // `field_base_reg + group_regs <= vs3.bits() + (f+1) * group_regs
-            //                             <= vs3.bits() + nf * group_regs <= 32`.
+            // `field_base_reg = vs3.to_bits() + f * group_regs`. Since `f < nf` and the
+            // precondition guarantees `vs3.to_bits() + nf * group_regs <= 32`:
+            // `field_base_reg + group_regs <= vs3.to_bits() + (f+1) * group_regs
+            //                             <= vs3.to_bits() + nf * group_regs <= 32`.
             //
             // Therefore,
             // `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
@@ -150,10 +150,10 @@ where
 /// specification where the stride operand is a two's-complement signed offset.
 ///
 /// # Safety
-/// - `vs3.bits() % group_regs == 0`
-/// - `vs3.bits() + nf * group_regs <= 32`
+/// - `vs3.to_bits() % group_regs == 0`
+/// - `vs3.to_bits() + nf * group_regs <= 32`
 /// - `vl <= group_regs * VLENB / eew.bytes()`
-/// - When `vm=false`: `vs3.bits() != 0`
+/// - When `vm=false`: `vs3.to_bits() != 0`
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
@@ -193,7 +193,7 @@ where
             let field_base_reg =
                 unsafe { VReg::from_bits(vs3.to_bits() + f * group_regs).unwrap_unchecked() };
             // SAFETY: same argument as `execute_unit_stride_store`; `field_base_reg +
-            // i / elems_per_reg < field_base_reg + group_regs <= vs3.bits() + nf *
+            // i / elems_per_reg < field_base_reg + group_regs <= vs3.to_bits() + nf *
             // group_regs <= 32`.
             let data =
                 unsafe { read_group_element(ext_state.read_vregs(), field_base_reg, i, eew) };
@@ -220,13 +220,13 @@ where
 /// `index_eew` is the element width of the indices (from the instruction encoding).
 ///
 /// # Safety
-/// - `vs3.bits() % data_group_regs == 0`
-/// - `vs3.bits() + nf * data_group_regs <= 32`
+/// - `vs3.to_bits() % data_group_regs == 0`
+/// - `vs3.to_bits() + nf * data_group_regs <= 32`
 /// - `vs2` register group is aligned and fits within `[0, 32)` (caller must verify via
 ///   `check_register_group_alignment` before calling)
 /// - `vl <= data_group_regs * VLENB / data_eew.bytes()`
 /// - `vl <= index_group_regs * VLENB / index_eew.bytes()` (caller must verify)
-/// - When `vm=false`: `vs3.bits() != 0`
+/// - When `vm=false`: `vs3.to_bits() != 0`
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
@@ -261,7 +261,8 @@ where
             continue;
         }
         // SAFETY: `i < vl <= index_group_regs * VLENB / index_eew.bytes()` (precondition), so
-        // `vs2.bits() + i / (VLENB / index_eew.bytes()) < vs2.bits() + index_group_regs <= 32`.
+        // `vs2.to_bits() + i / (VLENB / index_eew.bytes()) <
+        //     vs2.to_bits() + index_group_regs <= 32`
         let index_buf = unsafe { read_group_element(ext_state.read_vregs(), vs2, i, index_eew) };
         // SAFETY: `index_eew.bytes() <= Eew::MAX_BYTES` always holds.
         let offset = unsafe { index_buf_to_u64(index_buf, index_eew) };
@@ -273,7 +274,7 @@ where
                 unsafe { VReg::from_bits(vs3.to_bits() + f * data_group_regs).unwrap_unchecked() };
             // SAFETY: `i < vl <= data_group_regs * VLENB / data_eew.bytes()` (precondition), so
             // `field_base_reg + i / elems_per_reg < field_base_reg + data_group_regs
-            //                                    <= vs3.bits() + nf * data_group_regs <= 32`.
+            //                                    <= vs3.to_bits() + nf * data_group_regs <= 32`.
             let data =
                 unsafe { read_group_element(ext_state.read_vregs(), field_base_reg, i, data_eew) };
             // Record the current element index in `vstart` so that, on a memory fault, the failing

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
@@ -56,7 +56,10 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .read_vregs()
+        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -73,13 +76,16 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
+    let reg = state
+        .ext_state
+        .write_vregs()
+        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }
 
 fn write_mask(state: &mut TestInterpreterState<Zve64xWidenNarrowInstruction<Reg<u64>>>, bits: u32) {
-    let reg = &mut state.ext_state.write_vreg()[0];
+    let reg = state.ext_state.write_vregs().get_mut(VReg::V0);
     reg.fill(0);
     for i in 0..32 {
         if (bits >> i) & 1 != 0 {

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 use ab_riscv_primitives::prelude::*;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
-    u64::from(vlmul.to_bits()) | (u64::from(vsew.bits()) << 3)
+    u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
 }
 
 fn setup(
@@ -56,7 +56,7 @@ fn read_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &state.ext_state.read_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let mut buf = [0u8; 8];
     buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
     u64::from_le_bytes(buf)
@@ -73,7 +73,7 @@ fn write_elem(
     let elems_per_reg = 32 / sew_bytes;
     let reg_off = elem_i / elems_per_reg;
     let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.bits()) + reg_off];
+    let reg = &mut state.ext_state.write_vreg()[usize::from(base_reg.to_bits()) + reg_off];
     let buf = value.to_le_bytes();
     reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
@@ -21,7 +21,7 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let vd_idx = vd.bits();
+    let vd_idx = vd.to_bits();
     if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -51,7 +51,7 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let vs2_idx = vs2.bits();
+    let vs2_idx = vs2.to_bits();
     if !vs2_idx.is_multiple_of(src_group_regs) || vs2_idx + src_group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -59,7 +59,7 @@ where
     }
     // The wide destination (group_regs) may overlap the narrow source (src_group_regs) only in the
     // highest-numbered part of the destination group, and only when the source EMUL >= 1.
-    if widen_src_overlap_illegal(vd.bits(), group_regs, vs2_idx, src_group_regs) {
+    if widen_src_overlap_illegal(vd.to_bits(), group_regs, vs2_idx, src_group_regs) {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
@@ -93,19 +93,19 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let vd_idx = vd.bits();
+    let vd_idx = vd.to_bits();
     if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
-    if widen_src_overlap_illegal(vd_idx, wide_group_regs, vs_a.bits(), group_regs) {
+    if widen_src_overlap_illegal(vd_idx, wide_group_regs, vs_a.to_bits(), group_regs) {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     }
     if let Some(vs_b) = vs_b_opt
-        && widen_src_overlap_illegal(vd_idx, wide_group_regs, vs_b.bits(), group_regs)
+        && widen_src_overlap_illegal(vd_idx, wide_group_regs, vs_b.to_bits(), group_regs)
     {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -145,7 +145,7 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let vs_idx = vs.bits();
+    let vs_idx = vs.to_bits();
     if !vs_idx.is_multiple_of(wide_group_regs) || vs_idx + wide_group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -170,7 +170,7 @@ where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let vd_idx = vd.bits();
+    let vd_idx = vd.to_bits();
     if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
         return Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(INSTRUCTION_SIZE),
@@ -212,7 +212,7 @@ unsafe fn snapshot_mask<const VLENB: usize>(
         // SAFETY: `mask_bytes <= VLENB` by precondition
         unsafe {
             buf.get_unchecked_mut(..mask_bytes)
-                .copy_from_slice(vreg[usize::from(VReg::V0.bits())].get_unchecked(..mask_bytes));
+                .copy_from_slice(vreg[usize::from(VReg::V0.to_bits())].get_unchecked(..mask_bytes));
         }
     }
     buf
@@ -235,7 +235,7 @@ unsafe fn read_element_u64<const VLENB: usize>(
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * sew_bytes;
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.bits()) + reg_off) };
+    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.to_bits()) + reg_off) };
     // SAFETY: `byte_off + sew_bytes <= VLENB`
     let src = unsafe { reg.get_unchecked(byte_off..byte_off + sew_bytes) };
     let mut buf = [0u8; 8];
@@ -262,7 +262,7 @@ unsafe fn write_element_u64<const VLENB: usize>(
     let byte_off = (elem_i as usize % elems_per_reg) * sew_bytes;
     let buf = value.to_le_bytes();
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.bits()) + reg_off) };
+    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.to_bits()) + reg_off) };
     // SAFETY: `byte_off + sew_bytes <= VLENB`
     let dst = unsafe { reg.get_unchecked_mut(byte_off..byte_off + sew_bytes) };
     // SAFETY: `sew_bytes <= 8`

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
@@ -1,6 +1,6 @@
 //! Opaque helpers for Zve64x extension
 
-use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zve64x::arith::zve64x_arith_helpers::{OpSrc, check_vreg_group_alignment};
 use crate::v::zve64x::zve64x_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, ProgramCounter};
@@ -200,7 +200,7 @@ fn mask_bit(mask: &[u8], i: u32) -> bool {
 /// `vl.div_ceil(8) <= VLENB` must hold. This is guaranteed when `vl <= VLEN`.
 #[inline(always)]
 unsafe fn snapshot_mask<const VLENB: usize>(
-    vreg: &[[u8; VLENB]; 32],
+    vregs: &VectorRegisterFile<VLENB>,
     vm: bool,
     vl: u32,
 ) -> [u8; VLENB] {
@@ -212,7 +212,7 @@ unsafe fn snapshot_mask<const VLENB: usize>(
         // SAFETY: `mask_bytes <= VLENB` by precondition
         unsafe {
             buf.get_unchecked_mut(..mask_bytes)
-                .copy_from_slice(vreg[usize::from(VReg::V0.to_bits())].get_unchecked(..mask_bytes));
+                .copy_from_slice(vregs.get(VReg::V0).get_unchecked(..mask_bytes));
         }
     }
     buf
@@ -225,7 +225,7 @@ unsafe fn snapshot_mask<const VLENB: usize>(
 /// `base_reg + elem_i / (VLENB / sew.bytes_width()) < 32`
 #[inline(always)]
 unsafe fn read_element_u64<const VLENB: usize>(
-    vreg: &[[u8; VLENB]; 32],
+    vregs: &VectorRegisterFile<VLENB>,
     base_reg: VReg,
     elem_i: u32,
     sew: Vsew,
@@ -235,7 +235,9 @@ unsafe fn read_element_u64<const VLENB: usize>(
     let reg_off = elem_i as usize / elems_per_reg;
     let byte_off = (elem_i as usize % elems_per_reg) * sew_bytes;
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked(usize::from(base_reg.to_bits()) + reg_off) };
+    let reg = unsafe {
+        vregs.get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
+    };
     // SAFETY: `byte_off + sew_bytes <= VLENB`
     let src = unsafe { reg.get_unchecked(byte_off..byte_off + sew_bytes) };
     let mut buf = [0u8; 8];
@@ -250,7 +252,7 @@ unsafe fn read_element_u64<const VLENB: usize>(
 /// `base_reg + elem_i / (VLENB / sew.bytes_width()) < 32`
 #[inline(always)]
 unsafe fn write_element_u64<const VLENB: usize>(
-    vreg: &mut [[u8; VLENB]; 32],
+    vregs: &mut VectorRegisterFile<VLENB>,
     base_reg: VReg,
     elem_i: u32,
     sew: Vsew,
@@ -262,7 +264,9 @@ unsafe fn write_element_u64<const VLENB: usize>(
     let byte_off = (elem_i as usize % elems_per_reg) * sew_bytes;
     let buf = value.to_le_bytes();
     // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe { vreg.get_unchecked_mut(usize::from(base_reg.to_bits()) + reg_off) };
+    let reg = unsafe {
+        vregs.get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
+    };
     // SAFETY: `byte_off + sew_bytes <= VLENB`
     let dst = unsafe { reg.get_unchecked_mut(byte_off..byte_off + sew_bytes) };
     // SAFETY: `sew_bytes <= 8`
@@ -374,7 +378,7 @@ pub unsafe fn execute_widen_op<Reg, ExtState, CustomError, F>(
         .expect("SEW < 64 is enforced by caller, hence this is always valid; qed");
 
     // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLENB`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
@@ -382,7 +386,7 @@ pub unsafe fn execute_widen_op<Reg, ExtState, CustomError, F>(
         }
         // SAFETY: `vs2` aligned to `group_regs`;
         // `i < vl <= group_regs * (VLENB / sew.bytes_width())`
-        let raw_a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, sew) };
+        let raw_a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, sew) };
         let wide_a = if zero_extend_a {
             raw_a
         } else {
@@ -391,7 +395,7 @@ pub unsafe fn execute_widen_op<Reg, ExtState, CustomError, F>(
         let wide_b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                let raw_b = unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) };
+                let raw_b = unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) };
                 if zero_extend_b {
                     raw_b
                 } else {
@@ -411,7 +415,7 @@ pub unsafe fn execute_widen_op<Reg, ExtState, CustomError, F>(
         // `i < vl <= group_regs * (VLENB / sew.bytes_width())` so
         // `i < 2*group_regs * (VLENB / wide_sew.bytes_width())` - element fits in the wide group
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, wide_sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, wide_sew, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -458,7 +462,7 @@ pub unsafe fn execute_widen_w_op<Reg, ExtState, CustomError, F>(
         .expect("SEW < 64 is enforced by caller, hence this is always valid; qed");
 
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
@@ -466,13 +470,13 @@ pub unsafe fn execute_widen_w_op<Reg, ExtState, CustomError, F>(
         }
         // vs2 is already 2×SEW; read at wide width
         // SAFETY: `vs2` aligned to `2*group_regs`; element `i` fits within it
-        let wide_a = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, wide_sew) };
+        let wide_a = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, wide_sew) };
         let wide_b = match src {
             OpSrc::Vreg(vs1) => {
                 // SAFETY: `vs1` is aligned to `group_regs` and fits within `[0, 32)`,
                 // verified by caller; `i < vl <= group_regs * (VLENB / sew.bytes_width())`,
                 // so `vs1_base + i / elems_per_reg < vs1_base + group_regs <= 32`
-                let raw_b = unsafe { read_element_u64(ext_state.read_vreg(), vs1, i, sew) };
+                let raw_b = unsafe { read_element_u64(ext_state.read_vregs(), vs1, i, sew) };
                 if zero_extend_b {
                     raw_b
                 } else {
@@ -490,7 +494,7 @@ pub unsafe fn execute_widen_w_op<Reg, ExtState, CustomError, F>(
         let result = op(wide_a, wide_b);
         // SAFETY: same as `execute_widen_op` for vd
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, wide_sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, wide_sew, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -539,20 +543,20 @@ pub unsafe fn execute_narrow_shift<Reg, ExtState, CustomError>(
     let shamt_mask = u64::from(wide_sew.bits_width() - 1);
 
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: `vs2` is the wide source group
-        let wide_val = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, wide_sew) };
+        let wide_val = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, wide_sew) };
         let shamt = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: `vs1` is aligned to `group_regs` and fits within `[0, 32)`,
                 // verified by caller; `i < vl <= group_regs * (VLENB / sew.bytes_width())`,
                 // so `vs1_base + i / elems_per_reg < vs1_base + group_regs <= 32`
-                let raw = unsafe { read_element_u64(ext_state.read_vreg(), vs1_base, i, sew) };
+                let raw = unsafe { read_element_u64(ext_state.read_vregs(), vs1_base, i, sew) };
                 raw & shamt_mask
             }
             // Scalar shift amount: only the low log2(2*SEW) bits are used per spec
@@ -570,7 +574,7 @@ pub unsafe fn execute_narrow_shift<Reg, ExtState, CustomError>(
         let result = result_wide & ((1u64 << sew.bits_width()) - 1);
         // SAFETY: `vd` is the narrow destination group
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     ext_state.mark_vs_dirty();
@@ -616,14 +620,14 @@ pub unsafe fn execute_extension<Reg, ExtState, CustomError>(
         .expect("SEW >= factor*8 and valid according to function contract; qed");
 
     // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(ext_state.read_vreg(), vm, vl) };
+    let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
 
     for i in u32::from(vstart)..vl {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
         // SAFETY: vs2 group covers `vl` narrow elements
-        let raw = unsafe { read_element_u64(ext_state.read_vreg(), vs2, i, src_sew) };
+        let raw = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, src_sew) };
         let result = if sign {
             sign_extend_bits(raw, src_sew.bits_width()).cast_unsigned()
         } else {
@@ -631,7 +635,7 @@ pub unsafe fn execute_extension<Reg, ExtState, CustomError>(
         };
         // SAFETY: vd group covers `vl` wide elements
         unsafe {
-            write_element_u64(ext_state.write_vreg(), vd, i, sew, result);
+            write_element_u64(ext_state.write_vregs(), vd, i, sew, result);
         }
     }
     ext_state.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zve64x/widen_narrow/zve64x_widen_narrow_helpers.rs
@@ -348,7 +348,7 @@ fn scalar_signed_for_sew(val: u64, sew_bits: u8) -> u64 {
 ///   caller)
 /// - `vl <= group_regs * VLENB / sew.bytes_width()` (all elements fit)
 /// - SEW < 64
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
@@ -433,7 +433,7 @@ pub unsafe fn execute_widen_op<Reg, ExtState, CustomError, F>(
 /// - `src` register (when `WidenSrc::Vreg`) aligned to `group_regs`, fits in `[0,32)`
 /// - `vl <= group_regs * VLENB / sew.bytes_width()`
 /// - SEW < 64
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
@@ -515,7 +515,7 @@ pub unsafe fn execute_widen_w_op<Reg, ExtState, CustomError, F>(
 /// - `src` register (when `OpSrc::Vreg`) aligned to `group_regs`, fits in `[0,32)`
 /// - `vl <= group_regs * VLENB / sew.bytes_width()`
 /// - SEW < 64
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_narrow_shift<Reg, ExtState, CustomError>(
@@ -594,7 +594,7 @@ pub unsafe fn execute_narrow_shift<Reg, ExtState, CustomError>(
 /// - `vs2` aligned to `src_group_regs`, fits in `[0,32)`, does not overlap `vd`
 /// - `vl <= group_regs * VLENB / sew.bytes_width()`
 /// - `sew.divide_by_factor(factor).is_some()`
-/// - When `vm=false`: `vd.bits() != 0`
+/// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
 pub unsafe fn execute_extension<Reg, ExtState, CustomError>(

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -142,7 +142,7 @@ impl Vlmul {
     #[inline(always)]
     pub const fn index_register_count(self, index_eew: Eew, sew: Vsew) -> Option<u8> {
         let (lmul_num, lmul_den) = self.as_fraction();
-        let num = u16::from(index_eew.bits()) * u16::from(lmul_num);
+        let num = u16::from(index_eew.bits_width()) * u16::from(lmul_num);
         let den = u16::from(sew.bits_width()) * u16::from(lmul_den);
         // Both are products of powers of two; GCD equals the smaller value.
         let g = if num < den { num } else { den };
@@ -238,7 +238,7 @@ impl Vsew {
 
     /// Encode to the 3-bit vsew field
     #[inline(always)]
-    pub const fn bits(self) -> u8 {
+    pub const fn to_bits(self) -> u8 {
         match self {
             Vsew::E8 => 0b000,
             Vsew::E16 => 0b001,
@@ -321,18 +321,18 @@ impl fmt::Display for Vsew {
 #[repr(u8)]
 pub enum Eew {
     /// 8-bit elements
-    E8 = 0b000,
+    E8 = 1,
     /// 16-bit elements
-    E16 = 0b101,
+    E16 = 2,
     /// 32-bit elements
-    E32 = 0b110,
+    E32 = 4,
     /// 64-bit elements
-    E64 = 0b111,
+    E64 = 8,
 }
 
 impl Eew {
     /// Max element width in bytes
-    pub const MAX_BYTES: u8 = 8;
+    pub const MAX_BYTES: u8 = Self::E64.bytes_width();
 
     /// Decode the width field into an element width
     #[inline(always)]
@@ -346,9 +346,20 @@ impl Eew {
         }
     }
 
+    /// Encode to the 3-bit Eew field
+    #[inline(always)]
+    pub const fn to_bits(self) -> u8 {
+        match self {
+            Eew::E8 => 0b000,
+            Eew::E16 => 0b101,
+            Eew::E32 => 0b110,
+            Eew::E64 => 0b111,
+        }
+    }
+
     /// Element width in bits
     #[inline(always)]
-    pub const fn bits(self) -> u8 {
+    pub const fn bits_width(self) -> u8 {
         match self {
             Self::E8 => 8,
             Self::E16 => 16,
@@ -361,7 +372,7 @@ impl Eew {
     ///
     /// Guaranteed to be `<= Self::MAX_BYTES`.
     #[inline(always)]
-    pub const fn bytes(self) -> u8 {
+    pub const fn bytes_width(self) -> u8 {
         match self {
             Self::E8 => 1,
             Self::E16 => 2,
@@ -372,8 +383,9 @@ impl Eew {
 }
 
 impl fmt::Display for Eew {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.bits().fmt(f)
+        self.bits_width().fmt(f)
     }
 }
 
@@ -508,7 +520,7 @@ impl<const ELEN: u32, const VLEN: u32> Vtype<ELEN, VLEN> {
     {
         let mut raw = 0u8;
         raw |= self.vlmul.to_bits();
-        raw |= self.vsew.bits() << 3u8;
+        raw |= self.vsew.to_bits() << 3u8;
 
         if self.vta {
             raw |= 1 << 6u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -385,7 +385,7 @@ impl Eew {
 impl fmt::Display for Eew {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.bits_width().fmt(f)
+        fmt::Display::fmt(&self.bits_width(), f)
     }
 }
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x.rs
@@ -29,7 +29,7 @@ use crate::instructions::v::zve64x::arith::Zve64xArithInstruction;
 use crate::instructions::v::zve64x::carry::Zve64xCarryInstruction;
 use crate::instructions::v::zve64x::config::Zve64xConfigInstruction;
 use crate::instructions::v::zve64x::fixed_point::Zve64xFixedPointInstruction;
-use crate::instructions::v::zve64x::load::{Nf, SegVmNf, Zve64xLoadInstruction};
+use crate::instructions::v::zve64x::load::{LoadStoreNreg, Nf, SegVmNf, Zve64xLoadInstruction};
 use crate::instructions::v::zve64x::mask::Zve64xMaskInstruction;
 use crate::instructions::v::zve64x::muldiv::Zve64xMulDivInstruction;
 use crate::instructions::v::zve64x::perm::Zve64xPermInstruction;

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/load.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/load.rs
@@ -35,7 +35,7 @@ pub enum Nf {
 impl fmt::Display for Nf {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.fields_per_segment())
+        fmt::Display::fmt(&self.fields_per_segment(), f)
     }
 }
 
@@ -98,6 +98,47 @@ impl SegVmNf {
     }
 }
 
+/// `nreg` field for load/store instructions
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LoadStoreNreg {
+    /// 1 register
+    N1 = 1,
+    /// 2 registers
+    N2 = 2,
+    /// 4 registers
+    N4 = 4,
+    /// 8 registers
+    N8 = 8,
+}
+
+impl fmt::Display for LoadStoreNreg {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.num_registers(), f)
+    }
+}
+
+impl LoadStoreNreg {
+    /// Create a new instance
+    #[inline(always)]
+    pub const fn new(n: u8) -> Option<Self> {
+        match n {
+            1 => Some(Self::N1),
+            2 => Some(Self::N2),
+            4 => Some(Self::N4),
+            8 => Some(Self::N8),
+            _ => None,
+        }
+    }
+
+    /// Get the number of registers
+    #[inline(always)]
+    pub const fn num_registers(&self) -> u8 {
+        *self as u8
+    }
+}
+
 /// RISC-V Zve64x vector load instruction.
 ///
 /// Encoded under the LOAD-FP major opcode (0x07). All loads use rs1 (GPR) as a base address and vd
@@ -134,7 +175,7 @@ pub enum Zve64xLoadInstruction<Reg> {
     /// Whole-register load: `vl{nreg}re{eew}.v vd, (rs1)`
     ///
     /// mop=00, lumop=01000, vm=1. nreg must be 1, 2, 4, or 8.
-    Vlr { vd: VReg, rs1: Reg, nreg: u8, eew: Eew },
+    Vlr { vd: VReg, rs1: Reg, nreg: LoadStoreNreg, eew: Eew },
     /// Unit-stride segment load: `vlseg{nf}e{eew}.v vd, (rs1), vm`
     ///
     /// mop=00, lumop=00000, nf>0
@@ -219,16 +260,8 @@ where
                             None?;
                         }
                         let eew = Eew::from_width(width)?;
-                        // nf encodes nreg: nf+1 must be 1, 2, 4, or 8
-                        match nf_val {
-                            1 | 2 | 4 | 8 => Some(Self::Vlr {
-                                vd,
-                                rs1,
-                                nreg: nf_val,
-                                eew,
-                            }),
-                            _ => None,
-                        }
+                        let nreg = LoadStoreNreg::new(nf_val)?;
+                        Some(Self::Vlr { vd, rs1, nreg, eew })
                     }
                     // Mask load
                     0b0_1011 => {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/load/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/load/tests.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use crate::instructions::Instruction;
 use crate::instructions::v::Eew;
-use crate::instructions::v::zve64x::load::{Nf, SegVmNf, Zve64xLoadInstruction};
+use crate::instructions::v::zve64x::load::{LoadStoreNreg, Nf, SegVmNf, Zve64xLoadInstruction};
 use crate::registers::general_purpose::Reg;
 use crate::registers::vector::VReg;
 use alloc::format;
@@ -282,7 +282,7 @@ fn test_vl1re8() {
         Some(Zve64xLoadInstruction::Vlr {
             vd: VReg::V8,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             eew: Eew::E8,
             rs2: Reg::Zero,
         })
@@ -299,7 +299,7 @@ fn test_vl2re32() {
         Some(Zve64xLoadInstruction::Vlr {
             vd: VReg::V8,
             rs1: Reg::A0,
-            nreg: 2,
+            nreg: LoadStoreNreg::N2,
             eew: Eew::E32,
             rs2: Reg::Zero,
         })
@@ -316,7 +316,7 @@ fn test_vl4re64() {
         Some(Zve64xLoadInstruction::Vlr {
             vd: VReg::V8,
             rs1: Reg::A0,
-            nreg: 4,
+            nreg: LoadStoreNreg::N4,
             eew: Eew::E64,
             rs2: Reg::Zero,
         })
@@ -333,7 +333,7 @@ fn test_vl8re16() {
         Some(Zve64xLoadInstruction::Vlr {
             vd: VReg::V0,
             rs1: Reg::A0,
-            nreg: 8,
+            nreg: LoadStoreNreg::N8,
             eew: Eew::E16,
             rs2: Reg::Zero,
         })

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/store.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/store.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use crate::instructions::Instruction;
 use crate::instructions::v::Eew;
-use crate::instructions::v::zve64x::load::{Nf, SegVmNf};
+use crate::instructions::v::zve64x::load::{LoadStoreNreg, Nf, SegVmNf};
 use crate::registers::general_purpose::Register;
 use crate::registers::vector::VReg;
 use ab_riscv_macros::instruction;
@@ -43,7 +43,7 @@ pub enum Zve64xStoreInstruction<Reg> {
     /// Whole-register store: `vs{nreg}r.v vs3, (rs1)`
     ///
     /// mop=00, sumop=01000, vm=1. nreg must be 1, 2, 4, or 8.
-    Vsr { vs3: VReg, rs1: Reg, nreg: u8 },
+    Vsr { vs3: VReg, rs1: Reg, nreg: LoadStoreNreg },
     /// Unit-stride segment store: `vsseg{nf}e{eew}.v vs3, (rs1), vm`
     ///
     /// mop=00, sumop=00000, nf>0
@@ -121,15 +121,8 @@ where
                         if !vm || width != 0b000 {
                             None?;
                         }
-                        // nreg must be 1, 2, 4, or 8
-                        match nf_val {
-                            1 | 2 | 4 | 8 => Some(Self::Vsr {
-                                vs3,
-                                rs1,
-                                nreg: nf_val,
-                            }),
-                            _ => None,
-                        }
+                        let nreg = LoadStoreNreg::new(nf_val)?;
+                        Some(Self::Vsr { vs3, rs1, nreg })
                     }
                     // Mask store
                     0b0_1011 => {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/store/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zve64x/store/tests.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use crate::instructions::Instruction;
 use crate::instructions::v::Eew;
-use crate::instructions::v::zve64x::load::{Nf, SegVmNf};
+use crate::instructions::v::zve64x::load::{LoadStoreNreg, Nf, SegVmNf};
 use crate::instructions::v::zve64x::store::Zve64xStoreInstruction;
 use crate::registers::general_purpose::Reg;
 use crate::registers::vector::VReg;
@@ -241,7 +241,7 @@ fn test_vs1r() {
         Some(Zve64xStoreInstruction::Vsr {
             vs3: VReg::V8,
             rs1: Reg::A0,
-            nreg: 1,
+            nreg: LoadStoreNreg::N1,
             rs2: Reg::Zero,
         })
     );
@@ -257,7 +257,7 @@ fn test_vs2r() {
         Some(Zve64xStoreInstruction::Vsr {
             vs3: VReg::V8,
             rs1: Reg::A0,
-            nreg: 2,
+            nreg: LoadStoreNreg::N2,
             rs2: Reg::Zero,
         })
     );
@@ -272,7 +272,7 @@ fn test_vs4r() {
         Some(Zve64xStoreInstruction::Vsr {
             vs3: VReg::V8,
             rs1: Reg::A0,
-            nreg: 4,
+            nreg: LoadStoreNreg::N4,
             rs2: Reg::Zero,
         })
     );
@@ -287,7 +287,7 @@ fn test_vs8r() {
         Some(Zve64xStoreInstruction::Vsr {
             vs3: VReg::V0,
             rs1: Reg::A0,
-            nreg: 8,
+            nreg: LoadStoreNreg::N8,
             rs2: Reg::Zero,
         })
     );

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -45,7 +45,7 @@ pub use crate::instructions::v::zve64x::arith::Zve64xArithInstruction;
 pub use crate::instructions::v::zve64x::carry::Zve64xCarryInstruction;
 pub use crate::instructions::v::zve64x::config::Zve64xConfigInstruction;
 pub use crate::instructions::v::zve64x::fixed_point::Zve64xFixedPointInstruction;
-pub use crate::instructions::v::zve64x::load::{Nf, SegVmNf, Zve64xLoadInstruction};
+pub use crate::instructions::v::zve64x::load::{LoadStoreNreg, Nf, SegVmNf, Zve64xLoadInstruction};
 pub use crate::instructions::v::zve64x::mask::Zve64xMaskInstruction;
 pub use crate::instructions::v::zve64x::muldiv::Zve64xMulDivInstruction;
 pub use crate::instructions::v::zve64x::perm::Zve64xPermInstruction;

--- a/crates/execution/ab-riscv-primitives/src/registers/vector.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/vector.rs
@@ -115,7 +115,7 @@ impl VReg {
 
     /// Return the 5-bit encoding of this register
     #[inline(always)]
-    pub const fn bits(self) -> u8 {
+    pub const fn to_bits(self) -> u8 {
         self as u8
     }
 }

--- a/crates/farmer/ab-farmer/src/farm.rs
+++ b/crates/farmer/ab-farmer/src/farm.rs
@@ -290,7 +290,7 @@ pub struct DecodedFarmingError {
 impl fmt::Display for DecodedFarmingError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.error.fmt(f)
+        fmt::Display::fmt(&self.error, f)
     }
 }
 

--- a/crates/farmer/ab-proof-of-space-gpu/build.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/build.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // TODO: This should not be needed: https://github.com/Rust-GPU/rust-gpu/issues/386
         .capability(Capability::GroupNonUniformShuffle)
         // Avoid Cargo deadlock, customize target
-        .target_dir_path(out_dir.to_string_lossy().to_string());
+        .target_dir_path(out_dir.clone());
     spirv_builder.build_script.defaults = true;
     spirv_builder
         .build_script

--- a/crates/shared/ab-core-primitives/src/address.rs
+++ b/crates/shared/ab-core-primitives/src/address.rs
@@ -21,14 +21,14 @@ pub struct FormattedAddress {
 impl fmt::Debug for FormattedAddress {
     #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.as_str().fmt(f)
+        fmt::Debug::fmt(self.as_str(), f)
     }
 }
 
 impl fmt::Display for FormattedAddress {
     #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.as_str().fmt(f)
+        fmt::Display::fmt(self.as_str(), f)
     }
 }
 

--- a/crates/shared/ab-core-primitives/src/balance.rs
+++ b/crates/shared/ab-core-primitives/src/balance.rs
@@ -21,7 +21,7 @@ impl fmt::Debug for Balance {
 
 impl fmt::Display for Balance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        u128::from(self).fmt(f)
+        fmt::Display::fmt(&u128::from(self), f)
     }
 }
 


### PR DESCRIPTION
This brings a few new types and various cleanups, primarily for vector extension implementation. There should be a bit less `unsafe` now and more performance optimization opportunities for the compiler.