### PR TITLE
Skip objdump when building ACT4 ELFs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -632,6 +632,7 @@ jobs:
             -v ./work:/act4/work \
             -v ./res/abundance:/act4/config/abundance:ro \
             -e CONFIG_FILES="config/abundance/abundance-rv32i-max/test_config.yaml config/abundance/abundance-rv64i-max/test_config.yaml" \
+            -e FAST=True \
             ${{ steps.build.outputs.imageid }} \
             make
         if: steps.restore-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
This will save time and reduce cache size