### PR TITLE
Tiny cleanup for `ContractInstruction`

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -247,7 +247,7 @@ unsafe impl const ZcmpRegister for ContractRegister {
 
 /// An instruction type used by contracts
 #[instruction(
-    ignore = [Fence, FenceTso, Ecall],
+    ignore = [Ecall],
     inherit = [
         Rv64ZcaInstruction,
         Rv64ZcbInstruction,
@@ -258,7 +258,6 @@ unsafe impl const ZcmpRegister for ContractRegister {
         Rv64ZbcInstruction,
         Rv64ZknInstruction,
         ZicondInstruction,
-        Rv64ZknhInstruction,
     ],
 )]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Fence instructions are harmless, just let them be. `Rv64ZknhInstruction` is a part of `Rv64ZknInstruction` and was left there by accident.