### PR TITLE
Improve `Vlmul` API

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
@@ -98,9 +98,7 @@ where
     /// Compute `VLMAX` for a given vtype
     #[inline(always)]
     fn vlmax_for_vtype(&self, vtype: Vtype<{ Self::ELEN }, { Self::VLEN }>) -> u32 {
-        vtype
-            .vlmul()
-            .vlmax(Self::VLEN, u32::from(vtype.vsew().bits_width()))
+        vtype.vlmul().vlmax::<{ Self::VLEN }>(vtype.vsew())
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/tests.rs
@@ -1144,45 +1144,45 @@ fn vsetvl_all_bits_set_in_rs2_sets_vill() {
 
 #[test]
 fn vlmul_vlmax_m1_e32_vlen128() {
-    assert_eq!(Vlmul::M1.vlmax(128, 32), 4);
+    assert_eq!(Vlmul::M1.vlmax::<128>(Vsew::E32), 4);
 }
 
 #[test]
 fn vlmul_vlmax_m2_e32_vlen128() {
-    assert_eq!(Vlmul::M2.vlmax(128, 32), 8);
+    assert_eq!(Vlmul::M2.vlmax::<128>(Vsew::E32), 8);
 }
 
 #[test]
 fn vlmul_vlmax_m4_e32_vlen128() {
-    assert_eq!(Vlmul::M4.vlmax(128, 32), 16);
+    assert_eq!(Vlmul::M4.vlmax::<128>(Vsew::E32), 16);
 }
 
 #[test]
 fn vlmul_vlmax_m8_e8_vlen128() {
-    assert_eq!(Vlmul::M8.vlmax(128, 8), 128);
+    assert_eq!(Vlmul::M8.vlmax::<128>(Vsew::E8), 128);
 }
 
 #[test]
 fn vlmul_vlmax_mf2_e32_vlen128() {
-    assert_eq!(Vlmul::Mf2.vlmax(128, 32), 2);
+    assert_eq!(Vlmul::Mf2.vlmax::<128>(Vsew::E32), 2);
 }
 
 #[test]
 fn vlmul_vlmax_mf4_e16_vlen128() {
     // 128 / (16*4) = 2
-    assert_eq!(Vlmul::Mf4.vlmax(128, 16), 2);
+    assert_eq!(Vlmul::Mf4.vlmax::<128>(Vsew::E16), 2);
 }
 
 #[test]
 fn vlmul_vlmax_mf8_e8_vlen128() {
     // 128 / (8*8) = 2
-    assert_eq!(Vlmul::Mf8.vlmax(128, 8), 2);
+    assert_eq!(Vlmul::Mf8.vlmax::<128>(Vsew::E8), 2);
 }
 
 #[test]
 fn vlmul_vlmax_zero_when_too_small() {
     // e64 with mf8 on VLEN=128: 128/(64*8) = 0
-    assert_eq!(Vlmul::Mf8.vlmax(128, 64), 0);
+    assert_eq!(Vlmul::Mf8.vlmax::<128>(Vsew::E64), 0);
 }
 
 // Vtype decode/encode round-trip tests

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -42,7 +42,7 @@ impl VsStatus {
     }
 }
 
-/// Vector length multiplier (LMUL) setting
+/// Vector length multiplier (LMUL) setting.
 ///
 /// Encoded in `vtype[2:0]` as a signed 3-bit value.
 /// `LMUL = 2^vlmul` where `vlmul` is sign-extended. Positive values give integer multipliers,
@@ -93,22 +93,23 @@ impl Vlmul {
     /// For fractional LMUL, this is `VLEN / (SEW * denominator)`.
     /// Returns 0 when the result would be less than 1 (insufficient bits).
     #[inline(always)]
-    pub const fn vlmax(self, vlen_bits: u32, sew_bits: u32) -> u32 {
+    pub const fn vlmax<const VLEN: u32>(self, sew: Vsew) -> u32 {
+        let sew_bits = u32::from(sew.bits_width());
         match self {
-            Self::M1 => vlen_bits / sew_bits,
-            Self::M2 => (vlen_bits * 2) / sew_bits,
-            Self::M4 => (vlen_bits * 4) / sew_bits,
-            Self::M8 => (vlen_bits * 8) / sew_bits,
-            Self::Mf2 => vlen_bits / (sew_bits * 2),
-            Self::Mf4 => vlen_bits / (sew_bits * 4),
-            Self::Mf8 => vlen_bits / (sew_bits * 8),
+            Self::M1 => VLEN / sew_bits,
+            Self::M2 => (VLEN * 2) / sew_bits,
+            Self::M4 => (VLEN * 4) / sew_bits,
+            Self::M8 => (VLEN * 8) / sew_bits,
+            Self::Mf2 => VLEN / (sew_bits * 2),
+            Self::Mf4 => VLEN / (sew_bits * 4),
+            Self::Mf8 => VLEN / (sew_bits * 8),
         }
     }
 
     /// Number of vector registers occupied by one register group at this `LMUL`.
     ///
-    /// Fractional `LMUL` values (`Mf2`, `Mf4`, `Mf8`) each occupy exactly `1` register.
-    /// Integer `LMUL` values occupy `1`, `2`, `4, or `8` registers respectively.
+    /// Fractional `LMUL` values (`Mf2`, `Mf4`, `Mf8`) each occupy exactly 1 register.
+    /// Integer `LMUL` values occupy 1, 2, 4, or 8 registers respectively.
     #[inline(always)]
     pub const fn register_count(self) -> u8 {
         match self {
@@ -203,7 +204,8 @@ pub enum VsewFactor {
 }
 
 impl VsewFactor {
-    /// Divide Vsew width by a given factor
+    /// Return the numeric divisor used to scale down a [`Vsew`] bit-width
+    #[inline(always)]
     pub const fn factor(self) -> u8 {
         self as u8
     }
@@ -253,6 +255,7 @@ impl Vsew {
     }
 
     /// Get the double element width, if available
+    #[inline(always)]
     pub const fn double_width(self) -> Option<Self> {
         match self {
             Self::E8 => Some(Self::E16),
@@ -266,6 +269,7 @@ impl Vsew {
     }
 
     /// Divide Vsew width by a given factor
+    #[inline(always)]
     pub const fn divide_by_factor(self, factor: VsewFactor) -> Option<Self> {
         let Some(divide_by_factor) = self.bits_width().div_exact(factor.factor()) else {
             cold_path();
@@ -523,7 +527,7 @@ impl<const ELEN: u32, const VLEN: u32> Vtype<ELEN, VLEN> {
             return None;
         }
 
-        if vlmul.vlmax(VLEN, u32::from(sew)) == 0 {
+        if vlmul.vlmax::<VLEN>(vsew) == 0 {
             cold_path();
             return None;
         }


### PR DESCRIPTION
I actually looked into optimizing its implementation, but even with clear positive changes the performance actually got worse. I'm very confused, so pushing only the API changes.

This is yet another example of improved type safety.