### PR TITLE
Add `vm == false && vd == V0` check to Zvkb and Zvbb extensions, add corresponding tests

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -81,6 +81,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -107,6 +113,12 @@ where
             // vclz: count leading zeros within each SEW-wide element; result in [0, SEW]
             Self::VclzV { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -143,6 +155,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -169,6 +187,12 @@ where
             // vcpop: population count (number of set bits) within each SEW-wide element
             Self::VcpopV { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -201,6 +225,12 @@ where
             // SEW=E64 is illegal (cannot double); LMUL=M8 is illegal (EMUL(vd)=16 out of range).
             Self::VwsllVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -268,6 +298,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -317,6 +353,12 @@ where
             // vwsll.vi: standard 5-bit immediate; vm is the normal mask-control bit
             Self::VwsllVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/tests.rs
@@ -5,6 +5,7 @@ use crate::{
     Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
@@ -1190,10 +1191,7 @@ fn error_vector_not_allowed() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1212,10 +1210,7 @@ fn error_vill_vtype() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1232,10 +1227,7 @@ fn error_misaligned_vd_lmul_m2() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1252,10 +1244,7 @@ fn error_misaligned_vs2_lmul_m4() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 // vwsll-specific error paths
@@ -1275,10 +1264,7 @@ fn error_vwsll_sew_e64_illegal() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1296,10 +1282,7 @@ fn error_vwsll_lmul_m8_illegal() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1317,10 +1300,7 @@ fn error_vwsll_misaligned_dest_lmul_m1() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1338,8 +1318,122 @@ fn error_vwsll_misaligned_vs1_lmul_m2() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+// vm=false with vd==v0 is illegal: a masked instruction's destination must not overlap the
+// mask register v0.
+
+#[test]
+fn error_vbrev_v_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbbInstruction::VbrevV {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vclz_v_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbbInstruction::VclzV {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vctz_v_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbbInstruction::VctzV {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vcpop_v_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbbInstruction::VcpopV {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vwsll_vv_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbbInstruction::VwsllVv {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vwsll_vx_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbbInstruction::VwsllVx {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            rs1: Reg::Zero,
+            vm: false,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vwsll_vi_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbbInstruction::VwsllVi {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            uimm: 1,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -79,6 +79,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -126,6 +132,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -165,6 +177,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -196,6 +214,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -222,6 +246,12 @@ where
             // vrol: vd[i] = rotate_left(vs2[i], src[i] % SEW)
             Self::VrolVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -274,6 +304,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -308,6 +344,12 @@ where
             // vror: vd[i] = rotate_right(vs2[i], src[i] % SEW)
             Self::VrorVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -360,6 +402,12 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
+                if !vm && vd == VReg::V0 {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
@@ -394,6 +442,12 @@ where
             // vror.vi: 5-bit immediate in vs1[19:15]; bit[25] is the standard vm mask-control bit
             Self::VrorVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
+                    ::core::hint::cold_path();
+                    return Err(ExecutionError::IllegalInstruction {
+                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    });
+                }
+                if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/tests.rs
@@ -5,6 +5,7 @@ use crate::{
     Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
@@ -1248,10 +1249,7 @@ fn error_vector_not_allowed() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1271,10 +1269,7 @@ fn error_vill_vtype() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1291,10 +1286,7 @@ fn error_misaligned_vd_lmul_m2() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1311,10 +1303,7 @@ fn error_misaligned_vs2_lmul_m4() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -1331,10 +1320,7 @@ fn error_misaligned_vs1_lmul_m2() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 // vstart partial execution
@@ -1401,4 +1387,155 @@ fn vandn_vv_vl_zero_no_writes() {
         );
     }
     assert_eq!(state.ext_state.vs_dirty_count(), 1);
+}
+
+// vm=false with vd==v0 is illegal: a masked instruction's destination must not overlap the
+// mask register v0.
+
+#[test]
+fn error_vandn_vv_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::VandnVv {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vandn_vx_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::VandnVx {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            rs1: Reg::Zero,
+            vm: false,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vbrev8_v_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::Vbrev8V {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vrev8_v_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E32, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::Vrev8V {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vrol_vv_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::VrolVv {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vrol_vx_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::VrolVx {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            rs1: Reg::Zero,
+            vm: false,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vror_vv_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::VrorVv {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vror_vx_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::VrorVx {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            rs1: Reg::Zero,
+            vm: false,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vror_vi_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E8, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvkbInstruction::VrorVi {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            uimm: 1,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbc/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc/tests.rs
@@ -5,6 +5,7 @@ use crate::{
     Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
@@ -871,10 +872,7 @@ fn error_vector_not_allowed() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -894,10 +892,7 @@ fn error_vill_vtype() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -914,10 +909,7 @@ fn error_misaligned_vd_lmul_m2() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -934,10 +926,7 @@ fn error_misaligned_vs2_lmul_m4() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -954,10 +943,7 @@ fn error_misaligned_vs1_lmul_m2() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }
 
 #[test]
@@ -974,8 +960,74 @@ fn error_vclmulh_misaligned_vd_lmul_m2() {
             rs2: Reg::Zero,
         },
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+// vm=false with vd==v0 is illegal: a masked instruction's destination must not overlap the
+// mask register v0.
+
+#[test]
+fn error_vclmul_vv_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E16, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbcInstruction::VclmulVv {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vclmul_vx_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E16, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbcInstruction::VclmulVx {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            rs1: Reg::Zero,
+            vm: false,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vclmulh_vv_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E16, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbcInstruction::VclmulhVv {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            vs1: VReg::V1,
+            vm: false,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
+}
+
+#[test]
+fn error_vclmulh_vx_masked_dest_v0() {
+    let mut state = setup(4, Vsew::E16, Vlmul::M1);
+    let result = exec(
+        &mut state,
+        ZvbcInstruction::VclmulhVx {
+            vd: VReg::V0,
+            vs2: VReg::V2,
+            rs1: Reg::Zero,
+            vm: false,
+            rs2: Reg::Zero,
+        },
+    );
+    assert_matches!(result, Err(ExecutionError::IllegalInstruction { .. }));
 }


### PR DESCRIPTION
The check was present in https://github.com/nazar-pc/abundance/pull/711, but not https://github.com/nazar-pc/abundance/pull/710.

And in both cases there were no tests for it.