### PR TITLE
Disable Naga's bounds checks

### DIFF
--- a/crates/farmer/ab-farmer/src/bin/ab-farmer/main.rs
+++ b/crates/farmer/ab-farmer/src/bin/ab-farmer/main.rs
@@ -1,4 +1,8 @@
 #![feature(type_changing_struct_update)]
+#![expect(incomplete_features, reason = "generic_const_exprs")]
+// TODO: This feature is not actually used in this crate, but is added as a workaround for
+//  https://github.com/rust-lang/rust/issues/141492
+#![feature(generic_const_exprs)]
 
 mod commands;
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/host.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/host.rs
@@ -36,7 +36,7 @@ use wgpu::{
     ComputePassDescriptor, ComputePipeline, ComputePipelineDescriptor, DeviceDescriptor,
     DeviceType, Instance, InstanceDescriptor, InstanceFlags, MapMode, MemoryBudgetThresholds,
     PipelineCompilationOptions, PipelineLayoutDescriptor, PollError, PollType, Queue,
-    RequestDeviceError, ShaderModule, ShaderStages,
+    RequestDeviceError, ShaderModule, ShaderRuntimeChecks, ShaderStages,
 };
 
 /// Proof creation error
@@ -151,7 +151,19 @@ impl Device {
                         .inspect_err(|error| {
                             warn!(%id, ?adapter_info, %error, "Failed to request the device");
                         })?;
-                    let module = device.create_shader_module(shader.clone());
+                    let module = if cfg!(debug_assertions) {
+                        device.create_shader_module(shader.clone())
+                    } else {
+                        // SAFETY: The shader is trusted, individual tests include correctness
+                        // checks and debug builds of this crate too only release version skips
+                        // checks for better runtime performance
+                        unsafe {
+                            device.create_shader_module_trusted(
+                                shader.clone(),
+                                ShaderRuntimeChecks::unchecked(),
+                            )
+                        }
+                    };
 
                     Ok::<_, RequestDeviceError>((device, queue, module))
                 })

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/compute_f1/gpu_tests.rs
@@ -100,7 +100,6 @@ async fn compute_f1_adapter(
     initial_state: &ChaCha8State,
     adapter: Adapter,
 ) -> Option<Vec<Vec<PositionR>>> {
-    // TODO: Test both versions of the shader here
     let (shader, required_features, required_limits) = select_shader_features_limits(&adapter)?;
 
     let (device, queue) = adapter

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f2/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f2/gpu_tests.rs
@@ -204,7 +204,6 @@ async fn find_matches_and_compute_f2_adapter(
     Box<[[[Position; 2]; REDUCED_MATCHES_COUNT]; NUM_MATCH_BUCKETS]>,
     Box<[[Metadata; REDUCED_MATCHES_COUNT]; NUM_MATCH_BUCKETS]>,
 )> {
-    // TODO: Test both versions of the shader here
     let (shader, required_features, required_limits) = select_shader_features_limits(&adapter)?;
 
     let (device, queue) = adapter

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7/gpu_tests.rs
@@ -192,7 +192,6 @@ async fn find_matches_and_compute_f7_adapter(
     Box<[u32; NUM_S_BUCKETS]>,
     Box<[[ProofTargets; NUM_ELEMENTS_PER_S_BUCKET]; NUM_S_BUCKETS]>,
 )> {
-    // TODO: Test both versions of the shader here
     let (shader, required_features, required_limits) = select_shader_features_limits(&adapter)?;
 
     let (device, queue) = adapter

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/gpu_tests.rs
@@ -247,7 +247,6 @@ async fn find_matches_and_compute_fn_adapter<const TABLE_NUMBER: u8>(
     Box<[[[Position; 2]; REDUCED_MATCHES_COUNT]; NUM_MATCH_BUCKETS]>,
     Box<[[Metadata; REDUCED_MATCHES_COUNT]; NUM_MATCH_BUCKETS]>,
 )> {
-    // TODO: Test both versions of the shader here
     let (shader, required_features, required_limits) = select_shader_features_limits(&adapter)?;
 
     let (device, queue) = adapter

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
@@ -120,7 +120,6 @@ async fn find_matches_in_buckets_adapter(
 ) -> Option<Vec<Vec<Match>>> {
     let num_bucket_pairs = buckets.len() - 1;
 
-    // TODO: Test both versions of the shader here
     let (shader, required_features, required_limits) = select_shader_features_limits(&adapter)?;
 
     let (device, queue) = adapter

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_proofs/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_proofs/gpu_tests.rs
@@ -220,7 +220,6 @@ async fn find_proofs_adapter(
     Box<[u8; Record::NUM_S_BUCKETS / u8::BITS as usize]>,
     Box<[PosProof; NUM_S_BUCKETS]>,
 )> {
-    // TODO: Test both versions of the shader here
     let (shader, required_features, required_limits) = select_shader_features_limits(&adapter)?;
 
     let (device, queue) = adapter

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/sort_buckets/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/sort_buckets/gpu_tests.rs
@@ -117,7 +117,6 @@ async fn sort_buckets_adapter(
     buckets: &[[PositionR; MAX_BUCKET_SIZE]; NUM_BUCKETS],
     adapter: Adapter,
 ) -> Option<Box<[[PositionR; MAX_BUCKET_SIZE]; NUM_BUCKETS]>> {
-    // TODO: Test both versions of the shader here
     let (shader, required_features, required_limits) = select_shader_features_limits(&adapter)?;
 
     let (device, queue) = adapter


### PR DESCRIPTION
Should improve performance, at least on some platforms. On RADV the impact is minimum to none.