### PR TITLE
Optimize CSR handling performance

### DIFF
--- a/crates/execution/ab-riscv-act4-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/instruction.rs
@@ -105,7 +105,7 @@ where
             rs1_value,
             rs2_value: _,
         }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
-        regs: &mut Regs,
+        _regs: &mut Regs,
         ext_state: &mut ExtState,
         _memory: &mut Memory,
         _program_counter: &mut PC,

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -157,7 +157,7 @@ where
             rs1_value,
             rs2_value: _,
         }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
-        regs: &mut Regs,
+        _regs: &mut Regs,
         ext_state: &mut ExtState,
         _memory: &mut Memory,
         _program_counter: &mut PC,

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -60,7 +60,6 @@
 
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![feature(
-    bool_to_result,
     const_cmp,
     const_convert,
     const_default,
@@ -121,6 +120,7 @@ pub mod zvbc;
 use crate::private::BasicIntSealed;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
+use core::hint::cold_path;
 use core::ops::{ControlFlow, Sub};
 
 type RegisterType<I> = <<I as Instruction>::Reg as Register>::Type;
@@ -392,6 +392,7 @@ where
     /// and return the output value on success. The default implementation of the method should be
     /// fine most of the time but can be overridden in special cases or for testing purposes.
     #[doc(hidden)]
+    #[inline(always)]
     fn process_csr_read<I>(
         &self,
         csr_index: u16,
@@ -401,10 +402,17 @@ where
         I: ExecutableInstructionCsr<Self, CustomError, Reg = Reg>,
     {
         let mut out = Reg::Type::default();
-        I::prepare_csr_read(self, csr_index, raw_value, &mut out)?
-            .ok_or(CsrError::IllegalRead { csr_index })?;
-
-        Ok(out)
+        match I::prepare_csr_read(self, csr_index, raw_value, &mut out) {
+            Ok(true) => Ok(out),
+            Ok(false) => {
+                cold_path();
+                Err(CsrError::IllegalRead { csr_index })
+            }
+            Err(err) => {
+                cold_path();
+                Err(err)
+            }
+        }
     }
 
     // TODO: Remove this method once tests do not need to customize it
@@ -415,6 +423,7 @@ where
     /// should be fine most of the time but can be overridden in special cases or for testing
     /// purposes.
     #[doc(hidden)]
+    #[inline(always)]
     fn process_csr_write<I>(
         &mut self,
         csr_index: u16,
@@ -424,10 +433,17 @@ where
         I: ExecutableInstructionCsr<Self, CustomError, Reg = Reg>,
     {
         let mut out = Reg::Type::default();
-        I::prepare_csr_write(self, csr_index, write_value, &mut out)?
-            .ok_or(CsrError::IllegalWrite { csr_index })?;
-
-        Ok(out)
+        match I::prepare_csr_write(self, csr_index, write_value, &mut out) {
+            Ok(true) => Ok(out),
+            Ok(false) => {
+                cold_path();
+                Err(CsrError::IllegalWrite { csr_index })
+            }
+            Err(err) => {
+                cold_path();
+                Err(err)
+            }
+        }
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
@@ -61,7 +61,7 @@ where
             rs1_value,
             rs2_value,
         }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
-        regs: &mut Regs,
+        _regs: &mut Regs,
         ext_state: &mut ExtState,
         memory: &mut Memory,
         program_counter: &mut PC,

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -39,7 +39,7 @@ where
             rs1_value,
             rs2_value: _,
         }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
-        regs: &mut Regs,
+        _regs: &mut Regs,
         ext_state: &mut ExtState,
         _memory: &mut Memory,
         _program_counter: &mut PC,
@@ -68,14 +68,28 @@ where
                 let write_value = rs1_value;
 
                 // Per spec: if `rd == x0`, the CSR read (and its side effects) must not occur
-                if rd != Reg::ZERO {
-                    let raw_value = ext_state.read_csr(csr_index)?;
-                    let output_value = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
-                    regs.write(rd, output_value);
-                }
+                let read_output = if rd == Reg::ZERO {
+                    ::core::hint::cold_path();
+                    Reg::Type::from(0u8)
+                } else {
+                    let read_value = match ext_state.read_csr(csr_index) {
+                        Ok(read_value) => read_value,
+                        Err(err) => {
+                            ::core::hint::cold_path();
+                            return Err(ExecutionError::CsrError(err));
+                        }
+                    };
+                    ext_state.process_csr_read::<Self>(csr_index, read_value)?
+                };
 
-                let output_value = ext_state.process_csr_write::<Self>(csr_index, write_value)?;
-                ext_state.write_csr(csr_index, output_value)?;
+                let write_output = ext_state.process_csr_write::<Self>(csr_index, write_value)?;
+                match ext_state.write_csr(csr_index, write_output) {
+                    Ok(()) => Ok(ControlFlow::Continue((rd, read_output))),
+                    Err(err) => {
+                        ::core::hint::cold_path();
+                        Err(ExecutionError::CsrError(err))
+                    }
+                }
             }
 
             // Atomic read and set bits in CSR.
@@ -90,16 +104,27 @@ where
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                let raw_value = ext_state.read_csr(csr_index)?;
-                let read_output = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
-                regs.write(rd, read_output);
+                let read_value = match ext_state.read_csr(csr_index) {
+                    Ok(read_value) => read_value,
+                    Err(error) => {
+                        ::core::hint::cold_path();
+                        return Err(ExecutionError::CsrError(error));
+                    }
+                };
+                let read_output = ext_state.process_csr_read::<Self>(csr_index, read_value)?;
 
-                if rs1 != Reg::ZERO {
-                    let write_value = raw_value | rs1_value;
+                if rs1 == Reg::ZERO {
+                    ::core::hint::cold_path();
+                } else {
+                    let write_value = read_value | rs1_value;
                     let write_output =
                         ext_state.process_csr_write::<Self>(csr_index, write_value)?;
-                    ext_state.write_csr(csr_index, write_output)?;
+                    if let Err(error) = ext_state.write_csr(csr_index, write_output) {
+                        ::core::hint::cold_path();
+                        return Err(ExecutionError::CsrError(error));
+                    }
                 }
+                Ok(ControlFlow::Continue((rd, read_output)))
             }
 
             // Atomic read and clear bits in CSR.
@@ -114,16 +139,28 @@ where
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                let raw_value = ext_state.read_csr(csr_index)?;
-                let read_output = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
-                regs.write(rd, read_output);
+                let read_value = match ext_state.read_csr(csr_index) {
+                    Ok(read_value) => read_value,
+                    Err(error) => {
+                        ::core::hint::cold_path();
+                        return Err(ExecutionError::CsrError(error));
+                    }
+                };
+                let read_output = ext_state.process_csr_read::<Self>(csr_index, read_value)?;
 
-                if rs1 != Reg::ZERO {
-                    let write_value = raw_value & !rs1_value;
+                if rs1 == Reg::ZERO {
+                    ::core::hint::cold_path();
+                } else {
+                    let write_value = read_value & !rs1_value;
                     let write_output =
                         ext_state.process_csr_write::<Self>(csr_index, write_value)?;
-                    ext_state.write_csr(csr_index, write_output)?;
+                    if let Err(error) = ext_state.write_csr(csr_index, write_output) {
+                        ::core::hint::cold_path();
+                        return Err(ExecutionError::CsrError(error));
+                    }
                 }
+
+                Ok(ControlFlow::Continue((rd, read_output)))
             }
 
             // Atomic read/write CSR immediate.
@@ -141,14 +178,28 @@ where
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                if rd != Reg::ZERO {
-                    let raw_value = ext_state.read_csr(csr_index)?;
-                    let output_value = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
-                    regs.write(rd, output_value);
-                }
+                let read_output = if rd == Reg::ZERO {
+                    ::core::hint::cold_path();
+                    Reg::Type::from(0u8)
+                } else {
+                    let read_value = match ext_state.read_csr(csr_index) {
+                        Ok(read_value) => read_value,
+                        Err(error) => {
+                            ::core::hint::cold_path();
+                            return Err(ExecutionError::CsrError(error));
+                        }
+                    };
+                    ext_state.process_csr_read::<Self>(csr_index, read_value)?
+                };
 
-                let output_value = ext_state.process_csr_write::<Self>(csr_index, zimm.into())?;
-                ext_state.write_csr(csr_index, output_value)?;
+                let write_output = ext_state.process_csr_write::<Self>(csr_index, zimm.into())?;
+                match ext_state.write_csr(csr_index, write_output) {
+                    Ok(()) => Ok(ControlFlow::Continue((rd, read_output))),
+                    Err(error) => {
+                        ::core::hint::cold_path();
+                        Err(ExecutionError::CsrError(error))
+                    }
+                }
             }
 
             // Atomic read and set bits in CSR immediate.
@@ -167,16 +218,28 @@ where
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                let raw_value = ext_state.read_csr(csr_index)?;
-                let read_output = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
-                regs.write(rd, read_output);
+                let read_value = match ext_state.read_csr(csr_index) {
+                    Ok(read_value) => read_value,
+                    Err(error) => {
+                        ::core::hint::cold_path();
+                        return Err(ExecutionError::CsrError(error));
+                    }
+                };
+                let read_output = ext_state.process_csr_read::<Self>(csr_index, read_value)?;
 
-                if zimm != 0 {
-                    let write_value = raw_value | Reg::Type::from(zimm);
+                if zimm == 0 {
+                    ::core::hint::cold_path();
+                } else {
+                    let write_value = read_value | Reg::Type::from(zimm);
                     let write_output =
                         ext_state.process_csr_write::<Self>(csr_index, write_value)?;
-                    ext_state.write_csr(csr_index, write_output)?;
+                    if let Err(error) = ext_state.write_csr(csr_index, write_output) {
+                        ::core::hint::cold_path();
+                        return Err(ExecutionError::CsrError(error));
+                    }
                 }
+
+                Ok(ControlFlow::Continue((rd, read_output)))
             }
 
             // Atomic read and clear bits in CSR immediate.
@@ -195,19 +258,29 @@ where
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
-                let raw_value = ext_state.read_csr(csr_index)?;
-                let read_output = ext_state.process_csr_read::<Self>(csr_index, raw_value)?;
-                regs.write(rd, read_output);
+                let read_value = match ext_state.read_csr(csr_index) {
+                    Ok(read_value) => read_value,
+                    Err(error) => {
+                        ::core::hint::cold_path();
+                        return Err(ExecutionError::CsrError(error));
+                    }
+                };
+                let read_output = ext_state.process_csr_read::<Self>(csr_index, read_value)?;
 
-                if zimm != 0 {
-                    let write_value = raw_value & !Reg::Type::from(zimm);
+                if zimm == 0 {
+                    ::core::hint::cold_path();
+                } else {
+                    let write_value = read_value & !Reg::Type::from(zimm);
                     let write_output =
                         ext_state.process_csr_write::<Self>(csr_index, write_value)?;
-                    ext_state.write_csr(csr_index, write_output)?;
+                    if let Err(error) = ext_state.write_csr(csr_index, write_output) {
+                        ::core::hint::cold_path();
+                        return Err(ExecutionError::CsrError(error));
+                    }
                 }
+
+                Ok(ControlFlow::Continue((rd, read_output)))
             }
         }
-
-        Ok(ControlFlow::Continue(Default::default()))
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -63,7 +63,7 @@ where
             rs1_value,
             rs2_value,
         }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
-        regs: &mut Regs,
+        _regs: &mut Regs,
         ext_state: &mut ExtState,
         memory: &mut Memory,
         program_counter: &mut PC,

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -61,7 +61,7 @@ where
             rs1_value,
             rs2_value,
         }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
-        regs: &mut Regs,
+        _regs: &mut Regs,
         ext_state: &mut ExtState,
         memory: &mut Memory,
         program_counter: &mut PC,

--- a/crates/execution/ab-riscv-interpreter/src/zvbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc.rs
@@ -61,7 +61,7 @@ where
             rs1_value,
             rs2_value,
         }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
-        regs: &mut Regs,
+        _regs: &mut Regs,
         ext_state: &mut ExtState,
         memory: &mut Memory,
         program_counter: &mut PC,


### PR DESCRIPTION
Due to explicit GPR writes simply enabling `Zicsr` extension (without using it) was causing a serious performance regression. Returning `(rd, read_output)` helps with that.

While at it I also normalized the naming and added cold path hints.

All this together seems to mostly remove the penalty of enabling `Zicsr` extension.