### PR TITLE
Avoid duplicating dependencies when processing RISC-V macros

### DIFF
--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -434,7 +434,6 @@ pub(super) fn process_enum_decoding_impl(
         // Variants covered by at least one dependency entry
         let mut already_covered = HashSet::new();
 
-        let mut all_dependency_size_entries = all_dependency_size_entries;
         // Filter-out extra elements
         all_dependency_size_entries.retain_mut(|(idents, _block)| {
             idents.retain(|ident| {

--- a/crates/execution/ab-riscv-macros/src/build/shared.rs
+++ b/crates/execution/ab-riscv-macros/src/build/shared.rs
@@ -1,5 +1,5 @@
 use crate::build::state::{KnownEnumDefinition, State};
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use syn::Ident;
 
 pub(super) fn collect_all_dependencies<InitialDependencies>(
@@ -9,6 +9,7 @@ pub(super) fn collect_all_dependencies<InitialDependencies>(
 where
     InitialDependencies: Iterator<Item = Ident>,
 {
+    let mut already_inserted = HashSet::new();
     let mut all_dependencies = Vec::new();
     let mut new_dependencies = VecDeque::from_iter(initial_dependencies);
 
@@ -18,6 +19,10 @@ where
         else {
             return Err(dependency_enum_name);
         };
+
+        if !already_inserted.insert(dependency_enum_name.clone()) {
+            continue;
+        }
 
         all_dependencies.push((dependency_enum_name, dependency_enum_definition));
         new_dependencies.extend(

--- a/crates/shared/ab-networking/src/protocols/request_response/request_response_factory/tests.rs
+++ b/crates/shared/ab-networking/src/protocols/request_response/request_response_factory/tests.rs
@@ -190,7 +190,7 @@ async fn max_response_size_exceeded() {
             if let SwarmEvent::Behaviour(Event::InboundRequest { result, .. }) =
                 swarm_0.select_next_some().await
             {
-                result.unwrap_err();
+                result.unwrap();
             }
         }
     });


### PR DESCRIPTION
This didn't cause correctness issues, but resulted in duplicated decoding and CSR handling logic, which I think probably wasn't de-duplicated by LLVM and cost some runtime performance.