### PR TITLE
Make the proof-of-space reusable with a pluggable s-bucket convention (CPU + GPU)

### DIFF
--- a/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
+++ b/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
@@ -22,10 +22,16 @@ ab-chacha8 = { workspace = true }
 derive_more = { workspace = true, features = ["from", "into"] }
 spirv-std = { workspace = true }
 
+[features]
+default = ["record-encoding"]
+# The `RecordsEncoder` implementation that plots full sectors (Reed-Solomon erasure coding + record
+# encoding). Disable to depend on just the GPU proof producer.
+record-encoding = ["dep:ab-erasure-coding", "dep:ab-farmer-components"]
+
 [target.'cfg(not(target_arch = "spirv"))'.dependencies]
 ab-core-primitives = { workspace = true }
-ab-erasure-coding = { workspace = true }
-ab-farmer-components = { workspace = true }
+ab-erasure-coding = { workspace = true, optional = true }
+ab-farmer-components = { workspace = true, optional = true }
 ab-proof-of-space = { workspace = true }
 anyhow = { workspace = true }
 async-lock = { workspace = true, features = ["std"] }

--- a/crates/farmer/ab-proof-of-space-gpu/src/host.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/host.rs
@@ -41,7 +41,7 @@ use wgpu::{
 
 /// Proof creation error
 #[derive(Debug, thiserror::Error)]
-enum RecordEncodingError {
+pub enum RecordEncodingError {
     /// Too many records
     #[error("Too many records: {0}")]
     TooManyRecords(usize),
@@ -56,9 +56,23 @@ enum RecordEncodingError {
     DevicePoll(#[from] PollError),
 }
 
-struct ProofsHostWrapper<'a> {
+/// Handle to GPU-produced proofs; keeps the underlying buffer mapped until dropped.
+pub struct ProofsHostWrapper<'a> {
     proofs: &'a ProofsHost,
     proofs_host: &'a Buffer,
+}
+
+impl ProofsHostWrapper<'_> {
+    /// Proofs produced for a single seed.
+    pub fn proofs(&self) -> &ProofsHost {
+        self.proofs
+    }
+}
+
+impl fmt::Debug for ProofsHostWrapper<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProofsHostWrapper").finish_non_exhaustive()
+    }
 }
 
 impl Drop for ProofsHostWrapper<'_> {
@@ -217,6 +231,29 @@ impl Device {
         self.adapter_info.backend
     }
 
+    /// One proof-producing encoder instance per queue, for consumers that run their own record
+    /// encoding. `f7_override` replaces the native f7 binning with a given shader module and its
+    /// entry-point name (which must not collide with abundance's own).
+    pub fn create_proofs_encoder_instances(
+        &self,
+        f7_override: Option<(wgpu::ShaderModuleDescriptor<'static>, &'static str)>,
+    ) -> Vec<GpuRecordsEncoderInstance> {
+        self.devices
+            .clone()
+            .into_iter()
+            .map(|(device, queue, module)| {
+                let (f7_module, f7_entry_point) = match &f7_override {
+                    Some((descriptor, entry_point)) => (
+                        Some(device.create_shader_module(descriptor.clone())),
+                        *entry_point,
+                    ),
+                    None => (None, "find_matches_and_compute_f7"),
+                };
+                GpuRecordsEncoderInstance::new(device, queue, module, f7_module, f7_entry_point)
+            })
+            .collect()
+    }
+
     pub fn instantiate(
         &self,
         erasure_coding: ErasureCoding,
@@ -361,7 +398,13 @@ impl GpuRecordsEncoder {
             instances: devices
                 .into_iter()
                 .map(|(device, queue, module)| {
-                    Mutex::new(GpuRecordsEncoderInstance::new(device, queue, module))
+                    Mutex::new(GpuRecordsEncoderInstance::new(
+                        device,
+                        queue,
+                        module,
+                        None,
+                        "find_matches_and_compute_f7",
+                    ))
                 })
                 .collect(),
             thread_pool,
@@ -372,7 +415,7 @@ impl GpuRecordsEncoder {
     }
 }
 
-struct GpuRecordsEncoderInstance {
+pub struct GpuRecordsEncoderInstance {
     device: wgpu::Device,
     queue: Queue,
     mapping_error: Arc<Mutex<Option<BufferAsyncError>>>,
@@ -403,8 +446,21 @@ struct GpuRecordsEncoderInstance {
     compute_pipeline_find_proofs: ComputePipeline,
 }
 
+impl fmt::Debug for GpuRecordsEncoderInstance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GpuRecordsEncoderInstance")
+            .finish_non_exhaustive()
+    }
+}
+
 impl GpuRecordsEncoderInstance {
-    fn new(device: wgpu::Device, queue: Queue, module: ShaderModule) -> Self {
+    fn new(
+        device: wgpu::Device,
+        queue: Queue,
+        module: ShaderModule,
+        f7_module: Option<ShaderModule>,
+        f7_entry_point: &str,
+    ) -> Self {
         let initial_state_host = device.create_buffer(&BufferDescriptor {
             label: Some("initial_state_host"),
             size: size_of::<ChaCha8Block>() as BufferAddress,
@@ -605,11 +661,12 @@ impl GpuRecordsEncoderInstance {
         let (bind_group_find_matches_and_compute_f7, compute_pipeline_find_matches_and_compute_f7) =
             bind_group_and_pipeline_find_matches_and_compute_f7(
                 &device,
-                &module,
+                f7_module.as_ref().unwrap_or(&module),
                 &buckets_b_gpu,
                 &metadatas_b_gpu,
                 &table_6_proof_targets_sizes_gpu,
                 &table_6_proof_targets_gpu,
+                f7_entry_point,
             );
 
         let (bind_group_find_proofs, compute_pipeline_find_proofs) =
@@ -658,7 +715,7 @@ impl GpuRecordsEncoderInstance {
         }
     }
 
-    fn create_proofs(
+    pub fn create_proofs(
         &mut self,
         seed: &PosSeed,
     ) -> Result<ProofsHostWrapper<'_>, RecordEncodingError> {
@@ -1219,6 +1276,7 @@ fn bind_group_and_pipeline_find_matches_and_compute_f7(
     parent_metadatas_gpu: &Buffer,
     table_6_proof_targets_sizes_gpu: &Buffer,
     table_6_proof_targets_gpu: &Buffer,
+    entry_point: &str,
 ) -> (BindGroup, ComputePipeline) {
     let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         label: Some("find_matches_and_compute_f7"),
@@ -1281,7 +1339,7 @@ fn bind_group_and_pipeline_find_matches_and_compute_f7(
         label: Some("find_matches_and_compute_f7"),
         layout: Some(&pipeline_layout),
         module,
-        entry_point: Some("find_matches_and_compute_f7"),
+        entry_point: Some(entry_point),
     });
 
     let bind_group = device.create_bind_group(&BindGroupDescriptor {

--- a/crates/farmer/ab-proof-of-space-gpu/src/host.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/host.rs
@@ -10,23 +10,12 @@ use crate::shader::find_proofs::ProofsHost;
 use crate::shader::types::{Metadata, Position, PositionR};
 use crate::shader::{compute_f1, find_proofs, select_shader_features_limits};
 use ab_chacha8::{ChaCha8Block, ChaCha8State, block_to_bytes};
-use ab_core_primitives::pieces::{PieceOffset, Record};
 use ab_core_primitives::pos::PosSeed;
-use ab_core_primitives::sectors::SectorId;
-use ab_erasure_coding::ErasureCoding;
-use ab_farmer_components::plotting::RecordsEncoder;
-use ab_farmer_components::sector::SectorContentsMap;
-use async_lock::Mutex as AsyncMutex;
 use futures::stream::FuturesOrdered;
 use futures::{StreamExt, TryStreamExt};
 use parking_lot::Mutex;
-use rayon::prelude::*;
-use rayon::{ThreadPool, ThreadPoolBuilder};
 use rclite::Arc;
 use std::num::NonZeroU8;
-use std::simd::Simd;
-use std::sync::Arc as StdArc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::{fmt, iter};
 use tracing::{debug, warn};
 use wgpu::{
@@ -39,10 +28,33 @@ use wgpu::{
     RequestDeviceError, ShaderModule, ShaderRuntimeChecks, ShaderStages,
 };
 
+#[cfg(feature = "record-encoding")]
+use ab_core_primitives::{
+    pieces::{PieceOffset, Record},
+    sectors::SectorId,
+};
+#[cfg(feature = "record-encoding")]
+use ab_erasure_coding::ErasureCoding;
+#[cfg(feature = "record-encoding")]
+use ab_farmer_components::{plotting::RecordsEncoder, sector::SectorContentsMap};
+#[cfg(feature = "record-encoding")]
+use async_lock::Mutex as AsyncMutex;
+#[cfg(feature = "record-encoding")]
+use rayon::{ThreadPool, ThreadPoolBuilder, prelude::*};
+#[cfg(feature = "record-encoding")]
+use std::{
+    simd::Simd,
+    sync::{
+        Arc as StdArc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
 /// Proof creation error
 #[derive(Debug, thiserror::Error)]
 pub enum RecordEncodingError {
     /// Too many records
+    #[cfg(feature = "record-encoding")]
     #[error("Too many records: {0}")]
     TooManyRecords(usize),
     /// Proof creation failed previously and the device is now considered broken
@@ -254,6 +266,7 @@ impl Device {
             .collect()
     }
 
+    #[cfg(feature = "record-encoding")]
     pub fn instantiate(
         &self,
         erasure_coding: ErasureCoding,
@@ -269,6 +282,7 @@ impl Device {
     }
 }
 
+#[cfg(feature = "record-encoding")]
 pub struct GpuRecordsEncoder {
     id: u32,
     instances: Vec<Mutex<GpuRecordsEncoderInstance>>,
@@ -278,6 +292,7 @@ pub struct GpuRecordsEncoder {
     global_mutex: StdArc<AsyncMutex<()>>,
 }
 
+#[cfg(feature = "record-encoding")]
 impl fmt::Debug for GpuRecordsEncoder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GpuRecordsEncoder")
@@ -291,6 +306,7 @@ impl fmt::Debug for GpuRecordsEncoder {
     }
 }
 
+#[cfg(feature = "record-encoding")]
 impl RecordsEncoder for GpuRecordsEncoder {
     // TODO: Run more than one encoding per device concurrently
     fn encode_records(
@@ -380,6 +396,7 @@ impl RecordsEncoder for GpuRecordsEncoder {
     }
 }
 
+#[cfg(feature = "record-encoding")]
 impl GpuRecordsEncoder {
     fn new(
         id: u32,

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -5,7 +5,10 @@
 
 #![cfg_attr(target_arch = "spirv", no_std)]
 #![feature(generic_const_exprs, step_trait)]
-#![cfg_attr(not(target_arch = "spirv"), feature(iter_array_chunks, portable_simd))]
+#![cfg_attr(
+    all(not(target_arch = "spirv"), feature = "record-encoding"),
+    feature(iter_array_chunks, portable_simd)
+)]
 #![expect(incomplete_features, reason = "generic_const_exprs")]
 #![cfg_attr(all(test, not(target_arch = "spirv")), feature(maybe_uninit_fill))]
 
@@ -20,10 +23,10 @@ pub mod shader;
 pub use crate::shader::find_proofs::ProofsHost;
 #[cfg(not(target_arch = "spirv"))]
 use ab_core_primitives::pos::PosProof;
+#[cfg(all(not(target_arch = "spirv"), feature = "record-encoding"))]
+pub use host::GpuRecordsEncoder;
 #[cfg(not(target_arch = "spirv"))]
-pub use host::{
-    Device, GpuRecordsEncoder, GpuRecordsEncoderInstance, ProofsHostWrapper, RecordEncodingError,
-};
+pub use host::{Device, GpuRecordsEncoderInstance, ProofsHostWrapper, RecordEncodingError};
 #[cfg(not(target_arch = "spirv"))]
 pub use wgpu::{Backend, DeviceType};
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -17,9 +17,13 @@ pub mod shader;
 
 // TODO: Remove gate after https://github.com/Rust-GPU/rust-gpu/pull/249
 #[cfg(not(target_arch = "spirv"))]
+pub use crate::shader::find_proofs::ProofsHost;
+#[cfg(not(target_arch = "spirv"))]
 use ab_core_primitives::pos::PosProof;
 #[cfg(not(target_arch = "spirv"))]
-pub use host::{Device, GpuRecordsEncoder};
+pub use host::{
+    Device, GpuRecordsEncoder, GpuRecordsEncoderInstance, ProofsHostWrapper, RecordEncodingError,
+};
 #[cfg(not(target_arch = "spirv"))]
 pub use wgpu::{Backend, DeviceType};
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader.rs
@@ -8,6 +8,7 @@ pub mod find_matches_and_compute_fn;
 pub mod find_matches_in_buckets;
 pub mod find_proofs;
 mod polyfills;
+pub mod sbucket;
 #[cfg(not(target_arch = "spirv"))]
 mod shader_bytes;
 pub mod sort_buckets;

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7.rs
@@ -11,6 +11,7 @@ use crate::shader::constants::{
 use crate::shader::find_matches_in_buckets::{FindMatchesShared, find_matches_in_buckets_impl};
 #[cfg(target_arch = "spirv")]
 use crate::shader::polyfills::ArrayIndexingPolyfill;
+use crate::shader::sbucket::{IdentityMap, SBucketMap};
 use crate::shader::types::{Match, Metadata, Position, PositionR, Y};
 use core::fmt;
 use core::mem::MaybeUninit;
@@ -117,7 +118,7 @@ impl fmt::Debug for FindMatchesAndComputeF7Shared {
     clippy::too_many_arguments,
     reason = "Both I/O and Vulkan stuff together take a lot of arguments"
 )]
-unsafe fn compute_f7_into_buckets_inner(
+unsafe fn compute_f7_into_buckets_inner<M: SBucketMap>(
     index: u32,
     left_bucket_base: u32,
     absolute_position_base: u32,
@@ -179,7 +180,8 @@ unsafe fn compute_f7_into_buckets_inner(
         right_metadata,
     );
 
-    let s_bucket = y.first_k_bits() as usize;
+    let first_k_bits = y.first_k_bits();
+    let s_bucket = M::map(first_k_bits) as usize;
     // TODO: More idiomatic version currently doesn't compile:
     //  https://github.com/Rust-GPU/rust-gpu/issues/241#issuecomment-3005693043
     // let Some(bucket_count) = bucket_sizes.get_mut(s_bucket) else {
@@ -223,7 +225,7 @@ unsafe fn compute_f7_into_buckets_inner(
     clippy::too_many_arguments,
     reason = "Both I/O and Vulkan stuff together take a lot of arguments"
 )]
-unsafe fn compute_f7_into_buckets(
+unsafe fn compute_f7_into_buckets<M: SBucketMap>(
     local_invocation_id: u32,
     left_bucket_index: u32,
     left_bucket: &[PositionR; MAX_BUCKET_SIZE],
@@ -261,7 +263,7 @@ unsafe fn compute_f7_into_buckets(
     // SAFETY: Guaranteed by function contract
     unsafe {
         if (local_invocation_id as usize) < matches_count {
-            compute_f7_into_buckets_inner(
+            compute_f7_into_buckets_inner::<M>(
                 local_invocation_id,
                 left_bucket_base,
                 absolute_position_base,
@@ -274,7 +276,7 @@ unsafe fn compute_f7_into_buckets(
             );
         }
         if ((local_invocation_id + WORKGROUP_SIZE) as usize) < matches_count {
-            compute_f7_into_buckets_inner(
+            compute_f7_into_buckets_inner::<M>(
                 local_invocation_id + WORKGROUP_SIZE,
                 left_bucket_base,
                 absolute_position_base,
@@ -318,6 +320,39 @@ pub unsafe fn find_matches_and_compute_f7(
     #[spirv(workgroup)] matches: &mut [MaybeUninit<Match>; MAX_BUCKET_SIZE],
     #[spirv(workgroup)] shared: &mut FindMatchesAndComputeF7Shared,
 ) {
+    // SAFETY: Guaranteed by function contract
+    unsafe {
+        find_matches_and_compute_f7_impl::<IdentityMap>(
+            local_invocation_id,
+            workgroup_id,
+            parent_buckets,
+            parent_metadatas,
+            table_6_proof_targets_sizes,
+            table_6_proof_targets,
+            matches,
+            shared,
+        );
+    }
+}
+
+/// # Safety
+/// Must be called from [`WORKGROUP_SIZE`] threads. All buckets must contain valid positions.
+#[inline(always)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Both I/O and Vulkan stuff together take a lot of arguments"
+)]
+pub unsafe fn find_matches_and_compute_f7_impl<M: SBucketMap>(
+    local_invocation_id: UVec3,
+    workgroup_id: UVec3,
+    parent_buckets: &[[PositionR; MAX_BUCKET_SIZE]; NUM_BUCKETS],
+    parent_metadatas: &[Metadata; REDUCED_MATCHES_COUNT * NUM_MATCH_BUCKETS],
+    table_6_proof_targets_sizes: &mut [u32; NUM_S_BUCKETS],
+    table_6_proof_targets: &mut [[MaybeUninit<ProofTargets>; NUM_ELEMENTS_PER_S_BUCKET];
+             NUM_S_BUCKETS],
+    matches: &mut [MaybeUninit<Match>; MAX_BUCKET_SIZE],
+    shared: &mut FindMatchesAndComputeF7Shared,
+) {
     let local_invocation_id = local_invocation_id.x;
     let workgroup_id = workgroup_id.x;
 
@@ -342,7 +377,7 @@ pub unsafe fn find_matches_and_compute_f7(
 
     // SAFETY: Guaranteed by function contract and call to `find_matches_in_buckets_impl`
     unsafe {
-        compute_f7_into_buckets(
+        compute_f7_into_buckets::<M>(
             local_invocation_id,
             left_bucket_index,
             left_bucket,

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/sbucket.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/sbucket.rs
@@ -1,0 +1,26 @@
+//! S-bucket binning convention for proof targets.
+//!
+//! The engine is convention-agnostic: f7 maps a table-7 entry's `first_k_bits` to an s-bucket via
+//! the supplied [`SBucketMap`], defaulting to the native [`IdentityMap`]. Consumers with a
+//! different challenge convention provide their own implementation.
+
+// TODO: Duplicated verbatim in the CPU `ab-proof-of-space` chiapos. Consolidate into one
+//  `ab-core-primitives` definition once that crate can be used from the SPIR-V shader; today it
+//  is gated there as `cfg(not(target_arch = "spirv"))`.
+/// Maps a table-7 entry's `first_k_bits` to its target s-bucket. A returned value `>=
+/// NUM_S_BUCKETS` discards the entry (the caller bound-checks against `NUM_S_BUCKETS`).
+pub trait SBucketMap {
+    /// Map `first_k_bits` to an s-bucket, or a value `>= NUM_S_BUCKETS` to discard.
+    fn map(first_k_bits: u32) -> u32;
+}
+
+/// Native convention: the s-bucket is the raw `first_k_bits`.
+#[derive(Debug)]
+pub struct IdentityMap;
+
+impl SBucketMap for IdentityMap {
+    #[inline(always)]
+    fn map(first_k_bits: u32) -> u32 {
+        first_k_bits
+    }
+}

--- a/crates/shared/ab-proof-of-space/src/chia.rs
+++ b/crates/shared/ab-proof-of-space/src/chia.rs
@@ -4,6 +4,8 @@
 use crate::PosProofs;
 #[cfg(feature = "alloc")]
 use crate::TableGenerator;
+#[cfg(feature = "alloc")]
+use crate::chiapos::IdentityMap;
 use crate::chiapos::Tables;
 #[cfg(feature = "alloc")]
 use crate::chiapos::TablesCache;
@@ -27,12 +29,13 @@ pub struct ChiaTableGenerator {
 #[cfg(feature = "alloc")]
 impl TableGenerator<ChiaTable> for ChiaTableGenerator {
     fn create_proofs(&self, seed: &PosSeed) -> Box<PosProofs> {
-        Tables::<K>::create_proofs((*seed).into(), &self.tables_cache).into()
+        Tables::<K>::create_proofs::<IdentityMap>((*seed).into(), &self.tables_cache).into()
     }
 
     #[cfg(feature = "parallel")]
     fn create_proofs_parallel(&self, seed: &PosSeed) -> Box<PosProofs> {
-        Tables::<K>::create_proofs_parallel((*seed).into(), &self.tables_cache).into()
+        Tables::<K>::create_proofs_parallel::<IdentityMap>((*seed).into(), &self.tables_cache)
+            .into()
     }
 }
 

--- a/crates/shared/ab-proof-of-space/src/chiapos.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos.rs
@@ -39,6 +39,32 @@ mod private {
     pub trait Supported {}
 }
 
+// TODO: Duplicated verbatim in the GPU shader. Consolidate into one `ab-core-primitives`
+//  definition once that crate can be used from the SPIR-V shader; today it is gated there as
+//  `cfg(not(target_arch = "spirv"))`.
+/// Maps a table-7 entry's `first_k_bits` to its target s-bucket during proof generation.
+///
+/// A returned value `>= Record::NUM_S_BUCKETS` discards the entry (callers bound-check). Lets a
+/// consumer bin proofs under its own challenge convention; the engine ships only [`IdentityMap`].
+#[cfg(feature = "alloc")]
+pub trait SBucketMap {
+    /// Map `first_k_bits` to an s-bucket, or a value `>= Record::NUM_S_BUCKETS` to discard.
+    fn map(first_k_bits: u32) -> u32;
+}
+
+/// Native convention: the s-bucket is the raw `first_k_bits`.
+#[cfg(feature = "alloc")]
+#[derive(Debug)]
+pub struct IdentityMap;
+
+#[cfg(feature = "alloc")]
+impl SBucketMap for IdentityMap {
+    #[inline(always)]
+    fn map(first_k_bits: u32) -> u32 {
+        first_k_bits
+    }
+}
+
 /// Proof-of-space proofs
 #[derive(Debug)]
 #[cfg(feature = "alloc")]
@@ -192,7 +218,7 @@ where
     /// There is also `Self::create_proofs_parallel()` that can achieve higher performance and lower
     /// latency at the cost of lower CPU efficiency and higher memory usage.
     #[cfg(feature = "alloc")]
-    pub fn create_proofs(seed: Seed, cache: &TablesCache) -> Box<Proofs<K>>
+    pub fn create_proofs<M: SBucketMap>(seed: Seed, cache: &TablesCache) -> Box<Proofs<K>>
     where
         [(); 2usize.pow(u32::from(NUM_TABLES - 1)) * usize::from(K) / u8::BITS as usize]:,
     {
@@ -202,7 +228,8 @@ where
         let (table_4, table_3) = Table::<K, 4>::create(table_3, cache);
         let (table_5, table_4) = Table::<K, 5>::create(table_4, cache);
         let (table_6, table_5) = Table::<K, 6>::create(table_5, cache);
-        let (table_6_proof_targets, table_6) = Table::<K, 7>::create_proof_targets(table_6, cache);
+        let (table_6_proof_targets, table_6) =
+            Table::<K, 7>::create_proof_targets::<M>(table_6, cache);
 
         // TODO: Rewrite this more efficiently
         let mut proofs = Box::<Proofs<K>>::new_uninit();
@@ -289,7 +316,7 @@ where
     /// Almost the same as [`Self::create_proofs()`], but uses parallelism internally for better
     /// performance and lower latency at the cost of lower CPU efficiency and higher memory usage
     #[cfg(feature = "parallel")]
-    pub fn create_proofs_parallel(seed: Seed, cache: &TablesCache) -> Box<Proofs<K>>
+    pub fn create_proofs_parallel<M: SBucketMap>(seed: Seed, cache: &TablesCache) -> Box<Proofs<K>>
     where
         [(); 2usize.pow(u32::from(NUM_TABLES - 1)) * usize::from(K) / u8::BITS as usize]:,
     {
@@ -300,7 +327,7 @@ where
         let (table_5, table_4) = Table::<K, 5>::create_parallel(table_4, cache);
         let (table_6, table_5) = Table::<K, 6>::create_parallel(table_5, cache);
         let (table_6_proof_targets, table_6) =
-            Table::<K, 7>::create_proof_targets_parallel(table_6, cache);
+            Table::<K, 7>::create_proof_targets_parallel::<M>(table_6, cache);
 
         // TODO: Rewrite this more efficiently
         let mut proofs = Box::<Proofs<K>>::new_uninit();

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -1467,7 +1467,7 @@ where
 {
     /// Proof targets from the last table into the previous table, one for each
     /// [`Record::NUM_S_BUCKETS`].
-    pub(super) fn create_proof_targets(
+    pub(super) fn create_proof_targets<M: super::SBucketMap>(
         parent_table: Table<K, 6>,
         cache: &TablesCache,
     ) -> (
@@ -1514,9 +1514,11 @@ where
                     const {
                         assert!(Record::NUM_S_BUCKETS == (u16::MAX as usize) + 1);
                     }
-                    let Ok(s_bucket) = u16::try_from(s_bucket) else {
+                    let s_bucket = M::map(s_bucket);
+                    if s_bucket >= Record::NUM_S_BUCKETS as u32 {
                         continue;
-                    };
+                    }
+                    let s_bucket = s_bucket as u16;
                     let positions = &mut table_6_proof_targets[usize::from(s_bucket)];
                     if positions == &[Position::ZERO; 2] {
                         *positions = p;
@@ -1532,9 +1534,11 @@ where
                 const {
                     assert!(Record::NUM_S_BUCKETS == (u16::MAX as usize) + 1);
                 }
-                let Ok(s_bucket) = u16::try_from(s_bucket) else {
+                let s_bucket = M::map(s_bucket);
+                if s_bucket >= Record::NUM_S_BUCKETS as u32 {
                     continue;
-                };
+                }
+                let s_bucket = s_bucket as u16;
 
                 let positions = &mut table_6_proof_targets[usize::from(s_bucket)];
                 if positions == &[Position::ZERO; 2] {
@@ -1552,7 +1556,7 @@ where
     /// better performance (though not efficiency of CPU and memory usage), if you create multiple
     /// tables in parallel, prefer this method for better overall performance.
     #[cfg(feature = "parallel")]
-    pub(super) fn create_proof_targets_parallel(
+    pub(super) fn create_proof_targets_parallel<M: super::SBucketMap>(
         parent_table: Table<K, 6>,
         cache: &TablesCache,
     ) -> (
@@ -1635,9 +1639,11 @@ where
                             const {
                                 assert!(Record::NUM_S_BUCKETS == (u16::MAX as usize) + 1);
                             }
-                            let Ok(s_bucket) = u16::try_from(s_bucket) else {
+                            let s_bucket = M::map(s_bucket);
+                            if s_bucket >= Record::NUM_S_BUCKETS as u32 {
                                 continue;
-                            };
+                            }
+                            let s_bucket = s_bucket as u16;
 
                             buckets_positions[reduced_count].write((s_bucket, p));
                             reduced_count += 1;
@@ -1653,9 +1659,11 @@ where
                         const {
                             assert!(Record::NUM_S_BUCKETS == (u16::MAX as usize) + 1);
                         }
-                        let Ok(s_bucket) = u16::try_from(s_bucket) else {
+                        let s_bucket = M::map(s_bucket);
+                        if s_bucket >= Record::NUM_S_BUCKETS as u32 {
                             continue;
-                        };
+                        }
+                        let s_bucket = s_bucket as u16;
 
                         buckets_positions[reduced_count].write((s_bucket, p));
                         reduced_count += 1;

--- a/crates/shared/ab-proof-of-space/src/chiapos/tests.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/tests.rs
@@ -1,6 +1,6 @@
 #![cfg(not(miri))]
 
-use crate::chiapos::{Tables, TablesCache};
+use crate::chiapos::{IdentityMap, Tables, TablesCache};
 use ab_core_primitives::sectors::SBucket;
 use alloc::vec::Vec;
 
@@ -14,9 +14,9 @@ fn self_verification() {
     #[cfg(feature = "parallel")]
     let tables_parallel = Tables::<K>::create_parallel(seed, &cache);
 
-    let all_proofs = Tables::<K>::create_proofs(seed, &cache);
+    let all_proofs = Tables::<K>::create_proofs::<IdentityMap>(seed, &cache);
     #[cfg(feature = "parallel")]
-    let all_proofs_parallel = Tables::<K>::create_proofs_parallel(seed, &cache);
+    let all_proofs_parallel = Tables::<K>::create_proofs_parallel::<IdentityMap>(seed, &cache);
 
     for challenge_index in 0..1000_u32 {
         let mut challenge = [0; 32];


### PR DESCRIPTION
This is the abundance-side result of integrating the proof-of-space into Subspace's wgpu plotter. It all stays generic and non-breaking for abundance; the genericity is what lets Subspace bring its own s-bucket convention and record encoding. Three commits, best read one by one:

- Make the s-bucket binning generic across both the CPU and GPU paths, so a consumer can supply its own convention. Abundance's own behaviour is unchanged.
- Expose the proofs-only GPU path, so an external crate can run GPU proof generation and read the proofs back without abundance's encoding.
- Put Reed-Solomon record encoding behind a default-on feature, so a consumer that only needs the proof producer can drop it.
