### PR TITLE
RISC-V no-panic (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,7 @@ version = "0.0.4"
 dependencies = [
  "ab-riscv-macros",
  "ab-riscv-primitives",
+ "no-panic-const",
  "replace_with",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ name = "ab-riscv-primitives"
 version = "0.0.4"
 dependencies = [
  "ab-riscv-macros",
+ "no-panic-const",
 ]
 
 [[package]]
@@ -4227,6 +4228,17 @@ name = "no-panic"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f967505aabc8af5752d098c34146544a43684817cdba8f9725b292530cabbf53"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "no-panic-const"
+version = "0.1.36-const-0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedffaa9a3c8e9097071d9f7229370c36796b9b4c030fa2442abc727e924f94c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ mimalloc = "0.1.52"
 multihash = "0.19.5"
 nohash-hasher = "0.2.0"
 no-panic = "0.1.36"
+no-panic-const = "0.1.36-const-0"
 num_cpus = "1.17.0"
 object = { version = "0.39.1", default-features = false }
 once_cell = { version = "1.21.4", default-features = false }

--- a/crates/execution/ab-riscv-interpreter/Cargo.toml
+++ b/crates/execution/ab-riscv-interpreter/Cargo.toml
@@ -18,16 +18,28 @@ include = [
 links = "ab-riscv-interpreter"
 
 [package.metadata.docs.rs]
-all-features = true
+all-features = false
 
 [dependencies]
 ab-riscv-macros = { workspace = true, features = ["proc-macro"] }
 ab-riscv-primitives = { workspace = true }
+no-panic-const = { workspace = true, optional = true }
 replace_with = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]
 ab-riscv-macros = { workspace = true, features = ["build"] }
+
+[features]
+# TODO: no-panic coverage is incomplete with the following missing:
+#  * `// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]` comments in vector code
+#  * All `fn execute` methods
+#  * `BasicInterpreterState::execute` method
+# Check that code can't panic under any conditions
+no-panic = [
+    "dep:no-panic-const",
+    "ab-riscv-primitives/no-panic",
+]
 
 [lints]
 workspace = true

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -88,6 +88,7 @@ where
     Reg: [const] BasicRegister,
 {
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn read(&self, reg: Reg) -> Reg::Type {
         if reg == Reg::ZERO {
             // Always zero
@@ -99,6 +100,7 @@ where
     }
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn write(&mut self, reg: Reg, value: Reg::Type) {
         // SAFETY: register offset is always within bounds
         *unsafe { self.regs.get_unchecked_mut(usize::from(reg.offset())) } = value;
@@ -135,6 +137,8 @@ impl<Regs, ExtState, Memory, IF, InstructionHandler>
     /// The implementation is designed to be efficient with little left to optimize further. Though
     /// it is still possible to improve performance by applying additional constraints on the
     /// program.
+    // TODO: It might be impractical to support `no-panic` here directly in a general case, but it
+    //  should be possible to do so for small extensions to verify the workflow
     pub fn execute<I>(&mut self) -> Result<(), ExecutionError<Address<I>>>
     where
         Regs: RegisterFile<<I as Instruction>::Reg>,
@@ -218,6 +222,7 @@ pub struct BasicMemory<const BASE_ADDR: u64, const SIZE: usize> {
 
 impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE_ADDR, SIZE> {
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn read<T>(&self, address: u64) -> Result<T, VirtualMemoryError>
     where
         T: BasicInt,
@@ -244,6 +249,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
     }
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     unsafe fn read_unchecked<T>(&self, address: u64) -> T
     where
         T: BasicInt,
@@ -259,6 +265,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
         }
     }
 
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn read_slice(&self, address: u64, len: u32) -> Result<&[u8], VirtualMemoryError> {
         let Some(offset) = address.checked_sub(BASE_ADDR) else {
             cold_path();
@@ -276,6 +283,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
             .ok_or(VirtualMemoryError::OutOfBoundsRead { address })
     }
 
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn read_slice_up_to(&self, address: u64, len: u32) -> &[u8] {
         let Some(offset) = address.checked_sub(BASE_ADDR) else {
             cold_path();
@@ -292,6 +300,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
     }
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn write<T>(&mut self, address: u64, value: T) -> Result<(), VirtualMemoryError>
     where
         T: BasicInt,
@@ -318,6 +327,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
         Ok(())
     }
 
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn write_slice(&mut self, address: u64, data: &[u8]) -> Result<(), VirtualMemoryError> {
         let Some(offset) = address.checked_sub(BASE_ADDR) else {
             cold_path();
@@ -356,6 +366,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> BasicMemory<BASE_ADDR, SIZE> {
     /// Get a mutable slice of memory.
     ///
     /// This is primarily useful for setting up the program and should not be used beyond that.
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub fn get_mut_bytes(
         &mut self,
         address: u64,
@@ -410,11 +421,14 @@ where
     }
 
     #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn set_pc(
         &mut self,
-        _memory: &Memory,
+        memory: &Memory,
         pc: Address<I>,
     ) -> Result<ControlFlow<()>, ProgramCounterError<Address<I>, CustomError>> {
+        // TODO: Workaround for https://github.com/rust-lang/rust-clippy/issues/17430
+        let _: &Memory = memory;
         if pc == self.return_trap_address {
             cold_path();
             return Ok(ControlFlow::Break(()));
@@ -438,6 +452,7 @@ where
     Memory: VirtualMemory,
 {
     #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn fetch_instruction(
         &mut self,
         memory: &Memory,
@@ -500,12 +515,16 @@ where
     Regs: RegisterFile<Reg>,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn handle_ecall(
         &mut self,
-        _regs: &mut Regs,
-        _memory: &mut Memory,
+        regs: &mut Regs,
+        memory: &mut Memory,
         program_counter: &mut PC,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
+        // TODO: Workaround for https://github.com/rust-lang/rust-clippy/issues/17430
+        let _: &Regs = regs;
+        let _: &Memory = memory;
         Err(ExecutionError::IllegalInstruction {
             address: program_counter.old_pc(size_of::<u32>() as u8),
         })

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -73,6 +73,7 @@
     min_generic_const_args,
     signed_bigint_helpers
 )]
+#![cfg_attr(feature = "no-panic", feature(const_closures))]
 #![cfg_attr(
     not(any(
         all(target_arch = "riscv32", target_feature = "zbkx"),
@@ -252,6 +253,7 @@ pub trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder> 
     /// advanced during instruction fetching. As such, `pc - instruction_size` is expected to never
     /// underflow.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn old_pc(&self, instruction_size: u8) -> Address
     where
         Address: From<u8> + Sub<Output = Address>,
@@ -399,6 +401,7 @@ where
     /// fine most of the time but can be overridden in special cases or for testing purposes.
     #[doc(hidden)]
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn process_csr_read<I>(
         &self,
         csr_index: u16,
@@ -430,6 +433,7 @@ where
     /// purposes.
     #[doc(hidden)]
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn process_csr_write<I>(
         &mut self,
         csr_index: u16,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb/rv32_zbb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb/rv32_zbb_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn orc_b(src: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc/rv32_zbc_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc/rv32_zbc_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn clmul(a: u32, b: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -18,6 +19,7 @@ pub fn clmul(a: u32, b: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn clmulh(a: u32, b: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -34,6 +36,7 @@ pub fn clmulh(a: u32, b: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn clmulr(a: u32, b: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -52,6 +55,7 @@ pub fn clmulr(a: u32, b: u32) -> u32 {
 #[cfg(any(miri, not(all(target_arch = "riscv32", target_feature = "zbc"))))]
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn clmul_internal(a: u32, b: u32) -> u64 {
     let a = u64::from(a);
     let b = u64::from(b);

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
@@ -8,6 +8,7 @@ use core::ops::ControlFlow;
 #[inline]
 #[doc(hidden)]
 #[expect(clippy::type_complexity, reason = "Internal helper")]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn do_push<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,
@@ -36,6 +37,7 @@ where
 /// Returns the value of ra (x1) for use with popret/popretz.
 #[inline]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn do_pop<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb/rv32_zbkb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb/rv32_zbkb_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn zip(src: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -30,6 +31,7 @@ pub fn zip(src: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn unzip(src: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx/rv32_zbkx_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx/rv32_zbkx_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn xperm4(rs1: u32, rs2: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -31,6 +32,7 @@ pub fn xperm4(rs1: u32, rs2: u32) -> u32 {
 
 #[inline]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn xperm8(rs1: u32, rs2: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd/rv32_zknd_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd/rv32_zknd_helpers.rs
@@ -79,6 +79,7 @@ pub(crate) const INV_SBOX: [u8; 256] = [
     ))
 ))]
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub(crate) fn gmul(mut a: u8, mut b: u8) -> u8 {
     let mut p = 0u8;
     for _ in 0..8u8 {
@@ -121,6 +122,7 @@ pub(in super::super) mod soft {
     /// r3 = 0x0b*b
     /// ```
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub(super) fn inv_mix_col_byte(b: u8) -> u32 {
         let r0 = u32::from(gmul(b, 0x0e));
         let r1 = u32::from(gmul(b, 0x09));
@@ -139,6 +141,7 @@ pub(in super::super) mod soft {
     /// rd    = rs1 ^ rol32(so, shamt)
     /// ```
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub(super) fn aes32dsi(rs1: u32, rs2: u32, bs: u8) -> u32 {
         let shamt = u32::from(bs) * 8;
         let si = ((rs2 >> shamt) & 0xff) as u8;
@@ -157,6 +160,7 @@ pub(in super::super) mod soft {
     /// rd    = rs1 ^ rol32(mixed, shamt)
     /// ```
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub(super) fn aes32dsmi(rs1: u32, rs2: u32, bs: u8) -> u32 {
         let shamt = u32::from(bs) * 8;
         let si = ((rs2 >> shamt) & 0xff) as u8;
@@ -168,6 +172,7 @@ pub(in super::super) mod soft {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes32dsi(rs1: u32, rs2: u32, bs: Rv32AesBs) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -187,6 +192,7 @@ pub fn aes32dsi(rs1: u32, rs2: u32, bs: Rv32AesBs) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes32dsmi(rs1: u32, rs2: u32, bs: Rv32AesBs) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne/rv32_zkne_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne/rv32_zkne_helpers.rs
@@ -28,6 +28,7 @@ pub(in super::super) mod soft {
     /// r3 = 0x03*b
     /// ```
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub(super) fn mix_col_byte(b: u8) -> u32 {
         let r0 = u32::from(gmul(b, 0x02));
         let r1 = u32::from(b);
@@ -46,6 +47,7 @@ pub(in super::super) mod soft {
     /// rd    = rs1 ^ rol32(so, shamt)
     /// ```
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub(super) fn aes32esi(rs1: u32, rs2: u32, bs: u8) -> u32 {
         let shamt = u32::from(bs) * 8;
         let si = ((rs2 >> shamt) & 0xff) as u8;
@@ -64,6 +66,7 @@ pub(in super::super) mod soft {
     /// rd    = rs1 ^ rol32(mixed, shamt)
     /// ```
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub(super) fn aes32esmi(rs1: u32, rs2: u32, bs: u8) -> u32 {
         let shamt = u32::from(bs) * 8;
         let si = ((rs2 >> shamt) & 0xff) as u8;
@@ -75,6 +78,7 @@ pub(in super::super) mod soft {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes32esi(rs1: u32, rs2: u32, bs: Rv32AesBs) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -94,6 +98,7 @@ pub fn aes32esi(rs1: u32, rs2: u32, bs: Rv32AesBs) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes32esmi(rs1: u32, rs2: u32, bs: Rv32AesBs) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh/rv32_zknh_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh/rv32_zknh_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha256sig0(x: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -17,6 +18,7 @@ pub fn sha256sig0(x: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha256sig1(x: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -32,6 +34,7 @@ pub fn sha256sig1(x: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha256sum0(x: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -47,6 +50,7 @@ pub fn sha256sum0(x: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha256sum1(x: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -71,6 +75,7 @@ pub fn sha256sum1(x: u32) -> u32 {
 /// ```
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sig0h(rs1: u32, rs2: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -93,6 +98,7 @@ pub fn sha512sig0h(rs1: u32, rs2: u32) -> u32 {
 /// ```
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sig0l(rs1: u32, rs2: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -117,6 +123,7 @@ pub fn sha512sig0l(rs1: u32, rs2: u32) -> u32 {
 /// ```
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sig1h(rs1: u32, rs2: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -139,6 +146,7 @@ pub fn sha512sig1h(rs1: u32, rs2: u32) -> u32 {
 /// ```
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sig1l(rs1: u32, rs2: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -172,6 +180,7 @@ pub fn sha512sig1l(rs1: u32, rs2: u32) -> u32 {
 /// ```
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sum0r(rs1: u32, rs2: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -205,6 +214,7 @@ pub fn sha512sum0r(rs1: u32, rs2: u32) -> u32 {
 /// ```
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sum1r(rs1: u32, rs2: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb/rv64_zbb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb/rv64_zbb_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn orc_b(src: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc/rv64_zbc_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc/rv64_zbc_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn clmul(a: u64, b: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -18,6 +19,7 @@ pub fn clmul(a: u64, b: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn clmulh(a: u64, b: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -34,6 +36,7 @@ pub fn clmulh(a: u64, b: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn clmulr(a: u64, b: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -51,6 +54,7 @@ pub fn clmulr(a: u64, b: u64) -> u64 {
 /// Carryless multiplication helper
 #[cfg(any(miri, not(all(target_arch = "riscv64", target_feature = "zbc"))))]
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn clmul_internal(a: u64, b: u64) -> u128 {
     cfg_select! {
         // TODO: `llvm.aarch64.neon.pmull64` is not supported in Miri yet:

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
@@ -8,6 +8,7 @@ use core::ops::ControlFlow;
 #[inline]
 #[doc(hidden)]
 #[expect(clippy::type_complexity, reason = "Internal helper")]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn do_push<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,
@@ -36,6 +37,7 @@ where
 /// Returns the value of ra (x1) for use with popret/popretz.
 #[inline]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn do_pop<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx/rv64_zbkx_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx/rv64_zbkx_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn xperm4(rs1: u64, rs2: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -32,6 +33,7 @@ pub fn xperm4(rs1: u64, rs2: u64) -> u64 {
 
 #[inline]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn xperm8(rs1: u64, rs2: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd/rv64_zknd_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd/rv64_zknd_helpers.rs
@@ -25,6 +25,7 @@ mod ks {
     ///   rd = temp | (temp << 32)
     /// ```
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub(super) fn aes64ks1i(rs1: u64, rnum: Rv64ZkndKsRnum) -> u64 {
         let w = (rs1 >> 32u8) as u32;
 
@@ -58,6 +59,7 @@ mod ks {
     ///   rd = w0 | (w1 << 32)
     /// ```
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub(super) fn aes64ks2(rs1: u64, rs2: u64) -> u64 {
         let w0 = (rs1 >> 32u8) as u32 ^ rs2 as u32;
         let w1 = w0 ^ (rs2 >> 32u8) as u32;
@@ -89,6 +91,7 @@ cfg_select! {
             /// with the round key. Zero key -> no-op XOR, matching `aes64ds`.
             #[inline]
             #[target_feature(enable = "aes,sse4.1")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64ds(rs1: u64, rs2: u64) -> u64 {
                 let state = _mm_set_epi64x(rs2.cast_signed(), rs1.cast_signed());
                 let zero = _mm_setzero_si128();
@@ -100,6 +103,7 @@ cfg_select! {
             /// then XORs with the round key. Zero key -> no-op XOR.
             #[inline]
             #[target_feature(enable = "aes,sse4.1")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64dsm(rs1: u64, rs2: u64) -> u64 {
                 let state = _mm_set_epi64x(rs2.cast_signed(), rs1.cast_signed());
                 let zero = _mm_setzero_si128();
@@ -111,6 +115,7 @@ cfg_select! {
             /// `rs1` is replicated into both halves; we extract the low 64 bits.
             #[inline]
             #[target_feature(enable = "aes,sse4.1")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64im(rs1: u64) -> u64 {
                 let state = _mm_set_epi64x(rs1.cast_signed(), rs1.cast_signed());
                 let result = _mm_aesimc_si128(state);
@@ -135,6 +140,7 @@ cfg_select! {
             /// `(rs1, rs2)` is loaded little-endian; no swap needed.
             #[inline]
             #[target_feature(enable = "aes")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64ds(rs1: u64, rs2: u64) -> u64 {
                 let state = vreinterpretq_u8_u64(vcombine_u64(vcreate_u64(rs1), vcreate_u64(rs2)));
                 let zero = vdupq_n_u8(0);
@@ -145,6 +151,7 @@ cfg_select! {
             /// `vaesimcq_u8(vaesdq_u8(state, zero))` maps exactly to `aes64dsm`
             #[inline]
             #[target_feature(enable = "aes")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64dsm(rs1: u64, rs2: u64) -> u64 {
                 let state = vreinterpretq_u8_u64(vcombine_u64(vcreate_u64(rs1), vcreate_u64(rs2)));
                 let zero = vdupq_n_u8(0);
@@ -155,6 +162,7 @@ cfg_select! {
 
             #[inline]
             #[target_feature(enable = "aes")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64im(rs1: u64) -> u64 {
                 let state = vreinterpretq_u8_u64(vcombine_u64(vcreate_u64(rs1), vcreate_u64(rs1)));
                 let result = vaesimcq_u8(state);
@@ -172,6 +180,7 @@ cfg_select! {
             use crate::rv32::zk::zkn::zknd::rv32_zknd_helpers::{INV_SBOX, gmul};
 
             #[inline(always)]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             fn inv_mix_col(col: u32) -> u32 {
                 let s0 = col as u8;
                 let s1 = (col >> 8u8) as u8;
@@ -194,6 +203,7 @@ cfg_select! {
             /// InvShiftRows shifts row `r` right by `r` columns (cyclically over 4).
             /// Output low half contains post-transform columns 0 and 1.
             #[inline(always)]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64ds(rs1: u64, rs2: u64) -> u64 {
                 let state_byte = |col: usize, row: usize| -> u8 {
                     let word = if col < 2 { rs1 } else { rs2 };
@@ -212,6 +222,7 @@ cfg_select! {
             }
 
             #[inline(always)]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64dsm(rs1: u64, rs2: u64) -> u64 {
                 let lo = aes64ds(rs1, rs2);
                 let col0 = inv_mix_col(lo as u32);
@@ -220,6 +231,7 @@ cfg_select! {
             }
 
             #[inline(always)]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64im(rs1: u64) -> u64 {
                 let col0 = inv_mix_col(rs1 as u32);
                 let col1 = inv_mix_col((rs1 >> 32u8) as u32);
@@ -231,6 +243,7 @@ cfg_select! {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes64ds(rs1: u64, rs2: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -262,6 +275,7 @@ pub fn aes64ds(rs1: u64, rs2: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes64dsm(rs1: u64, rs2: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -293,6 +307,7 @@ pub fn aes64dsm(rs1: u64, rs2: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes64im(rs1: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -324,6 +339,7 @@ pub fn aes64im(rs1: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes64ks1i(rs1: u64, rnum: Rv64ZkndKsRnum) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -343,6 +359,7 @@ pub fn aes64ks1i(rs1: u64, rnum: Rv64ZkndKsRnum) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes64ks2(rs1: u64, rs2: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne/rv64_zkne_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne/rv64_zkne_helpers.rs
@@ -24,6 +24,7 @@ cfg_select! {
             /// the round key. Zero key -> no-op XOR, matching `aes64es`.
             #[inline]
             #[target_feature(enable = "aes,sse4.1")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64es(rs1: u64, rs2: u64) -> u64 {
                 let state = _mm_set_epi64x(rs2.cast_signed(), rs1.cast_signed());
                 let zero = _mm_setzero_si128();
@@ -35,6 +36,7 @@ cfg_select! {
             /// XORs with the round key. Zero key -> no-op XOR, matching `aes64esm`.
             #[inline]
             #[target_feature(enable = "aes,sse4.1")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64esm(rs1: u64, rs2: u64) -> u64 {
                 let state = _mm_set_epi64x(rs2.cast_signed(), rs1.cast_signed());
                 let zero = _mm_setzero_si128();
@@ -61,6 +63,7 @@ cfg_select! {
 
             #[inline]
             #[target_feature(enable = "aes")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64es(rs1: u64, rs2: u64) -> u64 {
                 let state = vreinterpretq_u8_u64(vcombine_u64(vcreate_u64(rs1), vcreate_u64(rs2)));
                 let zero = vdupq_n_u8(0);
@@ -71,6 +74,7 @@ cfg_select! {
             /// `vaesmcq_u8(vaeseq_u8(state, zero))` maps exactly to `aes64esm`
             #[inline]
             #[target_feature(enable = "aes")]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64esm(rs1: u64, rs2: u64) -> u64 {
                 let state = vreinterpretq_u8_u64(vcombine_u64(vcreate_u64(rs1), vcreate_u64(rs2)));
                 let zero = vdupq_n_u8(0);
@@ -90,6 +94,7 @@ cfg_select! {
             use crate::rv32::zk::zkn::zknd::rv32_zknd_helpers::{SBOX, gmul};
 
             #[inline(always)]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             fn mix_col(col: u32) -> u32 {
                 let s0 = col as u8;
                 let s1 = (col >> 8) as u8;
@@ -109,6 +114,7 @@ cfg_select! {
             /// ShiftRows shifts row `r` left by `r` columns (cyclically over 4).
             /// Output low half contains post-transform columns 0 and 1.
             #[inline(always)]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64es(rs1: u64, rs2: u64) -> u64 {
                 let state_byte = |col: usize, row: usize| -> u8 {
                     let word = if col < 2 { rs1 } else { rs2 };
@@ -127,6 +133,7 @@ cfg_select! {
             }
 
             #[inline(always)]
+            #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
             pub(super) fn aes64esm(rs1: u64, rs2: u64) -> u64 {
                 let lo = aes64es(rs1, rs2);
                 let col0 = mix_col(lo as u32);
@@ -139,6 +146,7 @@ cfg_select! {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes64es(rs1: u64, rs2: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -170,6 +178,7 @@ pub fn aes64es(rs1: u64, rs2: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn aes64esm(rs1: u64, rs2: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh/rv64_zknh_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh/rv64_zknh_helpers.rs
@@ -2,6 +2,7 @@
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha256sig0(x: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -17,6 +18,7 @@ pub fn sha256sig0(x: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha256sig1(x: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -32,6 +34,7 @@ pub fn sha256sig1(x: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha256sum0(x: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -47,6 +50,7 @@ pub fn sha256sum0(x: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha256sum1(x: u32) -> u32 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -62,6 +66,7 @@ pub fn sha256sum1(x: u32) -> u32 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sig0(x: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -77,6 +82,7 @@ pub fn sha512sig0(x: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sig1(x: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -92,6 +98,7 @@ pub fn sha512sig1(x: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sum0(x: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {
@@ -107,6 +114,7 @@ pub fn sha512sum0(x: u64) -> u64 {
 
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sha512sum1(x: u64) -> u64 {
     // TODO: Miri is excluded because corresponding intrinsic is not implemented there
     cfg_select! {

--- a/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
@@ -23,6 +23,7 @@ const impl<const VLEN: Vlen> Default for VectorRegisterFile<VLEN> {
 impl<const VLEN: Vlen> VectorRegisterFile<VLEN> {
     /// Get reference to a vector register
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub fn get(&self, index: VReg) -> &[u8; VLENB_USIZE::<VLEN>] {
         // SAFETY: Always in-range
         unsafe { self.0.get_unchecked(usize::from(index.to_bits())) }
@@ -30,6 +31,7 @@ impl<const VLEN: Vlen> VectorRegisterFile<VLEN> {
 
     /// Get mutable reference to a vector register
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub fn get_mut(&mut self, index: VReg) -> &mut [u8; VLENB_USIZE::<VLEN>] {
         // SAFETY: Always in-range
         unsafe { self.0.get_unchecked_mut(usize::from(index.to_bits())) }
@@ -91,12 +93,14 @@ where
     /// sophisticated implementations may return values in `[ceil(AVL/2), VLMAX]` for
     /// `AVL < 2*VLMAX`, but this simple strategy satisfies all three spec requirements.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn compute_vl(&self, avl: Vl, vlmax: Vl) -> Vl {
         avl.min(vlmax)
     }
 
     /// Compute `VLMAX` for a given vtype
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn vlmax_for_vtype(&self, vtype: Vtype<{ Self::ELEN }, { Self::VLEN }>) -> Vl {
         vtype.vlmul().vlmax::<{ Self::VLEN }>(vtype.vsew())
     }
@@ -123,6 +127,7 @@ where
     /// Per spec: `vtype.vill` = 1, remaining `vtype` bits = `0`, `vl` = 0.
     /// `vstart`, `vxrm`, `vxsat` may have arbitrary values at reset but are zeroed here for
     /// deterministic behavior.
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn initialize_vector_state(&mut self) {
         self.set_vtype(None);
         self.set_vl(Vl::ZERO);
@@ -133,6 +138,7 @@ where
 
     /// Get current `vstart`
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn vstart(&self) -> Vstart {
         let raw = self
             .read_csr(VectorCsr::Vstart.to_csr_index())
@@ -141,26 +147,35 @@ where
         Vstart::from(raw as u16)
     }
 
-    /// Set `vstart`
+    /// Set `vstart`.
+    ///
+    /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
+    /// debug.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn set_vstart(&mut self, vstart: Vstart) {
-        self.write_csr(
+        let result = self.write_csr(
             VectorCsr::Vstart.to_csr_index(),
             Reg::Type::from(u16::from(vstart)),
-        )
-        .expect("Implementation didn't initialize `vstart` CSR");
+        );
+        debug_assert!(
+            result.is_ok(),
+            "Implementation must initialize `vstart` CSR"
+        );
     }
 
     /// Reset `vstart` to zero.
     ///
     /// Per spec, all vector instructions reset `vstart` to zero at the end of execution.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn reset_vstart(&mut self) {
         self.set_vstart(Vstart::ZERO);
     }
 
     /// Get `vxsat` (single bit)
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn vxsat(&self) -> bool {
         let raw = self
             .read_csr(VectorCsr::Vxsat.to_csr_index())
@@ -169,23 +184,28 @@ where
         (raw & 1) == 1
     }
 
-    /// Set `vxsat`
+    /// Set `vxsat`.
+    ///
+    /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
+    /// debug.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn set_vxsat(&mut self, vxsat: bool) {
         let masked = Reg::Type::from(u8::from(vxsat));
-        self.write_csr(VectorCsr::Vxsat.to_csr_index(), masked)
-            .expect("Implementation didn't initialize `vxsat` CSR");
+        let result = self.write_csr(VectorCsr::Vxsat.to_csr_index(), masked);
+        debug_assert!(result.is_ok(), "Implementation must initialize `vxsat` CSR");
         // Mirror `vxsat` into `vcsr[0]`, preserving `vcsr[2:1]` (`vxrm`)
         let old_vcsr = self
             .read_csr(VectorCsr::Vcsr.to_csr_index())
             .unwrap_or_default();
         let new_vcsr = (old_vcsr & !Reg::Type::from(1u8)) | masked;
-        self.write_csr(VectorCsr::Vcsr.to_csr_index(), new_vcsr)
-            .expect("Implementation didn't initialize `vcsr` CSR");
+        let result = self.write_csr(VectorCsr::Vcsr.to_csr_index(), new_vcsr);
+        debug_assert!(result.is_ok(), "Implementation must initialize `vcsr` CSR");
     }
 
     /// Get `vxrm`
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn vxrm(&self) -> Vxrm {
         let raw = self
             .read_csr(VectorCsr::Vxrm.to_csr_index())
@@ -194,23 +214,28 @@ where
         Vxrm::from_bits(raw as u8)
     }
 
-    /// Set `vxrm`
+    /// Set `vxrm`.
+    ///
+    /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
+    /// debug.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn set_vxrm(&mut self, vxrm: Vxrm) {
         let masked = Reg::Type::from(vxrm.to_bits());
-        self.write_csr(VectorCsr::Vxrm.to_csr_index(), masked)
-            .expect("Implementation didn't initialize `vxrm` CSR");
+        let result = self.write_csr(VectorCsr::Vxrm.to_csr_index(), masked);
+        debug_assert!(result.is_ok(), "Implementation must initialize `vxrm` CSR");
         // Mirror `vxrm` into `vcsr[2:1]`, preserving `vcsr[0]` (`vxsat`)
         let old_vcsr = self
             .read_csr(VectorCsr::Vcsr.to_csr_index())
             .unwrap_or_default();
         let new_vcsr = (old_vcsr & !Reg::Type::from(0b110u8)) | (masked << 1u8);
-        self.write_csr(VectorCsr::Vcsr.to_csr_index(), new_vcsr)
-            .expect("Implementation didn't initialize `vcsr` CSR");
+        let result = self.write_csr(VectorCsr::Vcsr.to_csr_index(), new_vcsr);
+        debug_assert!(result.is_ok(), "Implementation must initialize `vcsr` CSR");
     }
 
     /// Get the current vl
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn vl(&self) -> Vl {
         let vl = self
             .read_csr(VectorCsr::Vl.to_csr_index())
@@ -224,13 +249,19 @@ where
     ///
     /// The implementation must update both its internal decoded cache and the raw CSR value (for
     /// reads via Zicsr, writes via Zicsr are not allowed).
+    ///
+    /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
+    /// debug.
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn set_vl(&mut self, vl: Vl) {
-        self.write_csr(VectorCsr::Vl.to_csr_index(), Reg::Type::from(u32::from(vl)))
-            .expect("Implementation didn't initialize `vl` CSR");
+        let result = self.write_csr(VectorCsr::Vl.to_csr_index(), Reg::Type::from(u32::from(vl)));
+        debug_assert!(result.is_ok(), "Implementation must initialize `vl` CSR");
     }
 
     /// Get the current decoded vtype
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn vtype(&self) -> Option<Vtype<{ Self::ELEN }, { Self::VLEN }>> {
         self.read_csr(VectorCsr::Vtype.to_csr_index())
             .ok()
@@ -241,7 +272,11 @@ where
     ///
     /// The implementation must update both its internal decoded cache and the raw CSR value (for
     /// reads via Zicsr, writes via Zicsr are not allowed).
+    ///
+    /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
+    /// debug.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn set_vtype(&mut self, vtype: Option<Vtype<{ Self::ELEN }, { Self::VLEN }>>) {
         let vtype_raw = if let Some(vt) = vtype {
             vt.to_raw::<Reg>()
@@ -249,7 +284,7 @@ where
             Vtype::<{ Self::ELEN }, { Self::VLEN }>::illegal_raw::<Reg>()
         };
 
-        self.write_csr(VectorCsr::Vtype.to_csr_index(), vtype_raw)
-            .expect("Implementation didn't initialize `vtype` CSR");
+        let result = self.write_csr(VectorCsr::Vtype.to_csr_index(), vtype_raw);
+        debug_assert!(result.is_ok(), "Implementation must initialize `vtype` CSR");
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
@@ -7,19 +7,22 @@ use crate::{ExecutionError, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::hint::cold_path;
+use core::num::NonZeroU8;
 
 /// Check that `vreg` (`vd`/`vs`) is aligned to `group_regs` and fits within `[0, 32)`
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_vreg_group_alignment<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vreg: VReg,
-    group_regs: u8,
+    group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let group_regs = group_regs.get();
     let vreg_idx = vreg.to_bits();
     if !vreg_idx.is_multiple_of(group_regs) || vreg_idx + group_regs > 32 {
         cold_path();
@@ -37,16 +40,18 @@ where
 /// the encoding is reserved and raises an illegal instruction.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_mask_dest_no_overlap<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vd: VReg,
     src_base: VReg,
-    group_regs: u8,
+    group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let group_regs = group_regs.get();
     if group_regs > 1 {
         let vd_idx = vd.to_bits();
         let src = src_base.to_bits();
@@ -71,6 +76,7 @@ where
 /// # Safety
 /// `base_reg + elem_i / (VLEN.bytes() / sew_bytes) < 32` must hold.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub(crate) unsafe fn read_element_u64<const VLEN: Vlen>(
     vregs: &VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -99,6 +105,7 @@ pub(crate) unsafe fn read_element_u64<const VLEN: Vlen>(
 /// # Safety
 /// `base_reg + elem_i / (VLEN.bytes() / sew_bytes) < 32` must hold.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub(crate) unsafe fn write_element_u64<const VLEN: Vlen>(
     vregs: &mut VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -131,6 +138,7 @@ pub(crate) unsafe fn write_element_u64<const VLEN: Vlen>(
 /// `elem_i / 8 < VLEN.bytes()` must hold, i.e. `elem_i < VLEN`. This is guaranteed when
 /// `elem_i < vl <= VLMAX <= VLEN`.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub(in super::super) unsafe fn write_mask_bit<const VLEN: Vlen>(
     vregs: &mut VectorRegisterFile<VLEN>,
     vd: VReg,
@@ -171,6 +179,7 @@ pub enum OpSrc {
 /// - When `vm=false`: `vd.to_bits() != 0` (vd does not overlap v0)
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -236,6 +245,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 /// - `vl <= VLEN` (so every element index fits within the mask register)
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -289,6 +299,7 @@ pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
 /// Sign-extend the low `sew.bits_width()` of `val` to a full `i64`
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sign_extend(val: u64, sew: Vsew) -> i64 {
     let shift = u64::BITS - u32::from(sew.bits_width());
     (val.cast_signed() << shift) >> shift
@@ -300,6 +311,7 @@ pub fn sign_extend(val: u64, sew: Vsew) -> i64 {
 /// SEW = 64 this is a no-op (all bits are significant).
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sew_mask(sew: Vsew) -> u64 {
     if u32::from(sew.bits_width()) == u64::BITS {
         u64::MAX

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
@@ -19,6 +19,7 @@ use core::fmt;
 /// # Safety
 /// `i / 8 < VLEN.bytes()` must hold, guaranteed when `i < vl <= VLEN`.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub(in super::super) unsafe fn carry_bit<const VLEN: Vlen>(
     vregs: &VectorRegisterFile<VLEN>,
     i: u16,
@@ -41,6 +42,7 @@ pub(in super::super) unsafe fn carry_bit<const VLEN: Vlen>(
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -100,6 +102,7 @@ pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, ExtState, CustomErr
 /// Same as [`execute_carry_add()`].
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -161,6 +164,7 @@ pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
 /// - vd overlap constraints checked by caller
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -225,6 +229,7 @@ pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, ExtState, Cust
 /// Same as [`execute_carry_add_mask()`].
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_carry_sub_mask<const WITH_BORROW: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
@@ -29,12 +29,15 @@ where
     /// All vector CSRs are accessible from unprivileged code (U-mode).
     /// Reads are pass-through: the raw value stored in the CSR is the output value.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn prepare_csr_read(
-        _ext_state: &ExtState,
+        ext_state: &ExtState,
         csr_index: u16,
         raw_value: Reg::Type,
         output_value: &mut Reg::Type,
     ) -> Result<bool, CsrError<CustomError>> {
+        // TODO: Workaround for https://github.com/rust-lang/rust-clippy/issues/17430
+        let _: &ExtState = ext_state;
         if VectorCsr::from_csr_index(csr_index).is_some() {
             *output_value = raw_value;
             Ok(true)
@@ -53,6 +56,7 @@ where
     /// - `vcsr`: only bits `[2:0]` are writable; mirrors into `vxsat` and `vxrm`
     /// - `vstart`: full XLEN write allowed (WARL, implementation may restrict range)
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn prepare_csr_write(
         ext_state: &mut ExtState,
         csr_index: u16,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/zvexx_config_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/zvexx_config_helpers.rs
@@ -15,6 +15,7 @@ use core::hint::cold_path;
 /// Returns `rd_value`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn apply_vsetvl<Reg, ExtState, Memory, PC, CustomError>(
     ext_state: &mut ExtState,
     program_counter: &PC,
@@ -97,6 +98,7 @@ where
 /// Returns `rd_value`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn apply_vsetivli<Reg, ExtState, Memory, PC, CustomError>(
     ext_state: &mut ExtState,
     program_counter: &PC,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
@@ -19,6 +19,7 @@ use core::hint::cold_path;
 /// When `shift == 0` there are no fractional bits so the increment is always zero.
 /// `current_result_lsb` is the LSB of the truncated result, required for `Rne` and `Rod`.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn round_increment(val: u64, shift: u32, mode: Vxrm, current_result_lsb: u64) -> u64 {
     if shift == 0 {
         return 0;
@@ -49,6 +50,7 @@ fn round_increment(val: u64, shift: u32, mode: Vxrm, current_result_lsb: u64) ->
 /// Returns `(val >> shift) + round_increment`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn rounded_srl(val: u64, shift: u32, mode: Vxrm) -> u64 {
     let truncated = val >> shift;
     let r = round_increment(val, shift, mode, truncated & 1);
@@ -60,6 +62,7 @@ pub fn rounded_srl(val: u64, shift: u32, mode: Vxrm) -> u64 {
 /// Returns the SEW-wide signed result as `u64` (sign bits above SEW are meaningful).
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn rounded_sra(val: u64, shift: u32, mode: Vxrm, sew: Vsew) -> u64 {
     let signed = sign_extend(val, sew);
     // Treat the raw bits for rounding purposes: rounding uses the unsigned representation of the
@@ -75,6 +78,7 @@ pub fn rounded_sra(val: u64, shift: u32, mode: Vxrm, sew: Vsew) -> u64 {
 /// Sets `vxsat` to `true` on overflow.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sat_addu(a: u64, b: u64, sew: Vsew, vxsat: &mut bool) -> u64 {
     let mask = sew_mask(sew);
     let a_w = a & mask;
@@ -94,6 +98,7 @@ pub fn sat_addu(a: u64, b: u64, sew: Vsew, vxsat: &mut bool) -> u64 {
 /// Sets `vxsat` to `true` on overflow.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sat_add(a: u64, b: u64, sew: Vsew, vxsat: &mut bool) -> u64 {
     let sa = i128::from(sign_extend(a, sew));
     let sb = i128::from(sign_extend(b, sew));
@@ -116,6 +121,7 @@ pub fn sat_add(a: u64, b: u64, sew: Vsew, vxsat: &mut bool) -> u64 {
 /// Sets `vxsat` to `true` on overflow (underflow to negative).
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sat_subu(a: u64, b: u64, sew: Vsew, vxsat: &mut bool) -> u64 {
     let mask = sew_mask(sew);
     let a_w = a & mask;
@@ -133,6 +139,7 @@ pub fn sat_subu(a: u64, b: u64, sew: Vsew, vxsat: &mut bool) -> u64 {
 /// Sets `vxsat` to `true` on overflow.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sat_sub(a: u64, b: u64, sew: Vsew, vxsat: &mut bool) -> u64 {
     let sa = i128::from(sign_extend(a, sew));
     let sb = i128::from(sign_extend(b, sew));
@@ -155,6 +162,7 @@ pub fn sat_sub(a: u64, b: u64, sew: Vsew, vxsat: &mut bool) -> u64 {
 /// Uses a 1-bit wider intermediate to avoid overflow; no saturation, no `vxsat`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn avg_addu(a: u64, b: u64, sew: Vsew, mode: Vxrm) -> u64 {
     let mask = sew_mask(sew);
     let a_w = a & mask;
@@ -179,6 +187,7 @@ pub fn avg_addu(a: u64, b: u64, sew: Vsew, mode: Vxrm) -> u64 {
 /// No saturation, no `vxsat`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn avg_add(a: u64, b: u64, sew: Vsew, mode: Vxrm) -> u64 {
     let sa = sign_extend(a, sew);
     let sb = sign_extend(b, sew);
@@ -209,6 +218,7 @@ pub fn avg_add(a: u64, b: u64, sew: Vsew, mode: Vxrm) -> u64 {
 /// No saturation, no `vxsat`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn avg_subu(a: u64, b: u64, sew: Vsew, mode: Vxrm) -> u64 {
     let mask = sew_mask(sew);
     let a_w = a & mask;
@@ -236,6 +246,7 @@ pub fn avg_subu(a: u64, b: u64, sew: Vsew, mode: Vxrm) -> u64 {
 /// No saturation, no `vxsat`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn avg_sub(a: u64, b: u64, sew: Vsew, mode: Vxrm) -> u64 {
     let sa = sign_extend(a, sew);
     let sb = sign_extend(b, sew);
@@ -265,6 +276,7 @@ pub fn avg_sub(a: u64, b: u64, sew: Vsew, mode: Vxrm) -> u64 {
 /// Sets `vxsat` on overflow.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn smul(a: u64, b: u64, sew: Vsew, mode: Vxrm, vxsat: &mut bool) -> u64 {
     // SEW-wide signed min and max in i64 (valid for all SEW <= 64)
     let min_sew = i64::MIN >> (i64::BITS - u32::from(sew.bits_width()));
@@ -323,6 +335,7 @@ pub fn smul(a: u64, b: u64, sew: Vsew, mode: Vxrm, vxsat: &mut bool) -> u64 {
 /// `vs2_elem` is passed as `u64`; for SEW = 32 it holds a 64-bit (2*SEW) value.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn nclipu(vs2_elem: u64, shamt: u32, sew: Vsew, mode: Vxrm, vxsat: &mut bool) -> u64 {
     // Shift right with rounding
     let shifted = rounded_srl(vs2_elem, shamt, mode);
@@ -342,6 +355,7 @@ pub fn nclipu(vs2_elem: u64, shamt: u32, sew: Vsew, mode: Vxrm, vxsat: &mut bool
 /// Same SEW constraint as [`nclipu`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn nclip(vs2_elem: u64, shamt: u32, sew: Vsew, mode: Vxrm, vxsat: &mut bool) -> u64 {
     // Sign-extend vs2_elem to full i64 treating it as a 2*SEW-bit signed value.
     // For SEW=8 the source is 16-bit, for SEW=16 it is 32-bit, for SEW=32 it is 64-bit.
@@ -386,6 +400,7 @@ pub fn nclip(vs2_elem: u64, shamt: u32, sew: Vsew, mode: Vxrm, vxsat: &mut bool)
 /// - `2*SEW <= 64` (Zve64x constraint: only valid for SEW <= 32; caller must verify)
 /// - `base_reg + elem_i / (VLEN.bytes() / (2*sew_bytes)) < 32`
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn read_wide_element_u64<const VLEN: Vlen>(
     vregs: &VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -418,6 +433,7 @@ pub unsafe fn read_wide_element_u64<const VLEN: Vlen>(
 /// Same preconditions as `execute_arith_op` in the arithmetic helpers.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -483,6 +499,7 @@ pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -540,6 +557,7 @@ pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
 /// Returns `Err(IllegalInstruction)` when `sew.bits_width() > 32`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_narrowing_sew<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     sew: Vsew,
@@ -568,6 +586,7 @@ where
 /// `sew` is the destination (narrow) SEW; it must be at most 32 (see [`check_narrowing_sew()`]).
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_vs2_narrowing_alignment<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vs2: VReg,
@@ -598,6 +617,7 @@ where
             address: program_counter.old_pc(INSTRUCTION_SIZE),
         });
     };
+    let wide_group = wide_group.get();
     let vs2_idx = vs2.to_bits();
     if !vs2_idx.is_multiple_of(wide_group) || vs2_idx + wide_group > 32 {
         cold_path();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -163,7 +163,14 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && zvexx_load_helpers::groups_overlap(vd, group_regs, VReg::V0, 1) {
+                if !vm
+                    && zvexx_load_helpers::groups_overlap(
+                        vd,
+                        group_regs,
+                        VReg::V0,
+                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                    )
+                {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -221,7 +228,14 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && zvexx_load_helpers::groups_overlap(vd, group_regs, VReg::V0, 1) {
+                if !vm
+                    && zvexx_load_helpers::groups_overlap(
+                        vd,
+                        group_regs,
+                        VReg::V0,
+                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                    )
+                {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -273,7 +287,14 @@ where
                     vd,
                     group_regs,
                 )?;
-                if !vm && zvexx_load_helpers::groups_overlap(vd, group_regs, VReg::V0, 1) {
+                if !vm
+                    && zvexx_load_helpers::groups_overlap(
+                        vd,
+                        group_regs,
+                        VReg::V0,
+                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                    )
+                {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -358,7 +379,14 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vm && zvexx_load_helpers::groups_overlap(vd, data_group_regs, VReg::V0, 1) {
+                if !vm
+                    && zvexx_load_helpers::groups_overlap(
+                        vd,
+                        data_group_regs,
+                        VReg::V0,
+                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                    )
+                {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -446,7 +474,14 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                if !vm && zvexx_load_helpers::groups_overlap(vd, data_group_regs, VReg::V0, 1) {
+                if !vm
+                    && zvexx_load_helpers::groups_overlap(
+                        vd,
+                        data_group_regs,
+                        VReg::V0,
+                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                    )
+                {
                     ::core::hint::cold_path();
                     return Err(ExecutionError::IllegalInstruction {
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
@@ -683,7 +718,7 @@ where
                     // <= 32` and `f < nf`. The value is in [0, 31], so it is a valid `VReg`
                     // encoding.
                     let field_vd = unsafe {
-                        VReg::from_bits(vd.to_bits() + f * data_group_regs).unwrap_unchecked()
+                        VReg::from_bits(vd.to_bits() + f * data_group_regs.get()).unwrap_unchecked()
                     };
                     if zvexx_load_helpers::groups_overlap(
                         field_vd,
@@ -774,7 +809,7 @@ where
                     // <= 32` and `f < nf`. The value is in [0, 31], so it is a valid `VReg`
                     // encoding.
                     let field_vd = unsafe {
-                        VReg::from_bits(vd.to_bits() + f * data_group_regs).unwrap_unchecked()
+                        VReg::from_bits(vd.to_bits() + f * data_group_regs.get()).unwrap_unchecked()
                     };
                     if zvexx_load_helpers::groups_overlap(
                         field_vd,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -7,12 +7,14 @@ use ab_riscv_primitives::prelude::*;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hint::cold_path;
+use core::num::NonZeroU8;
 
 /// Return whether mask bit `i` is set in the mask byte slice.
 ///
 /// Bits are stored LSB-first within each byte: bit `i` is at byte `i / 8`, position `i % 8`.
 /// Returns `false` for any `i` outside the slice bounds.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub(crate) fn mask_bit(mask: &[u8], i: u16) -> bool {
     mask.get(usize::from(i / u8::BITS as u16))
         .is_some_and(|b| (b >> (i % u8::BITS as u16)) & 1 != 0)
@@ -33,6 +35,7 @@ pub(crate) fn mask_bit(mask: &[u8], i: u16) -> bool {
 /// `vl` must be `<= VLEN`, which is always true when `vl` is the current architectural `vl`
 /// (bounded by `VLMAX <= VLEN`).
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub(in super::super) unsafe fn snapshot_mask<const VLEN: Vlen>(
     vregs: &VectorRegisterFile<VLEN>,
     vm: bool,
@@ -56,9 +59,10 @@ pub(in super::super) unsafe fn snapshot_mask<const VLEN: Vlen>(
 /// Return whether register groups `[a, a+a_regs)` and `[b, b+b_regs)` overlap.
 #[inline(always)]
 #[doc(hidden)]
-pub fn groups_overlap(a: VReg, a_regs: u8, b: VReg, b_regs: u8) -> bool {
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+pub fn groups_overlap(a: VReg, a_regs: NonZeroU8, b: VReg, b_regs: NonZeroU8) -> bool {
     let (a, b) = (a.to_bits(), b.to_bits());
-    a < b + b_regs && b < a + a_regs
+    a < b + b_regs.get() && b < a + a_regs.get()
 }
 
 /// Return whether a *non-segment* indexed load's data destination group
@@ -84,11 +88,12 @@ pub fn groups_overlap(a: VReg, a_regs: u8, b: VReg, b_regs: u8) -> bool {
 /// and index EEW match.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn indexed_load_overlap_allowed(
     vd: VReg,
-    data_regs: u8,
+    data_regs: NonZeroU8,
     vs2: VReg,
-    index_regs: u8,
+    index_regs: NonZeroU8,
     index_eew: Eew,
     sew: Vsew,
     vlmul: Vlmul,
@@ -112,7 +117,7 @@ pub fn indexed_load_overlap_allowed(
             let index_emul_at_least_one = u16::from(index_eew.bits_width()) * u16::from(lmul_num)
                 >= u16::from(sew.bits_width()) * u16::from(lmul_den);
             let (vd, vs2) = (vd.to_bits(), vs2.to_bits());
-            index_emul_at_least_one && vd + data_regs == vs2 + index_regs
+            index_emul_at_least_one && vd + data_regs.get() == vs2 + index_regs.get()
         }
     }
 }
@@ -122,15 +127,17 @@ pub fn indexed_load_overlap_allowed(
 /// Per spec, the base register of every register group must be a multiple of the group size.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_register_group_alignment<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vd: VReg,
-    group_regs: u8,
+    group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let group_regs = group_regs.get();
     let vd = vd.to_bits();
     if !vd.is_multiple_of(group_regs) || vd + group_regs > 32 {
         cold_path();
@@ -148,18 +155,19 @@ where
 /// On `Ok`, `vd.to_bits() + nf * group_regs <= 32` is guaranteed.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn validate_segment_registers<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vd: VReg,
     vm: bool,
-    group_regs: u8,
+    group_regs: NonZeroU8,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    let group_regs = u32::from(group_regs);
+    let group_regs = u32::from(group_regs.get());
     let nf = u32::from(nf.fields_per_segment());
     let vd_idx = u32::from(vd.to_bits());
     if vd_idx % group_regs != 0 || vd_idx + nf * group_regs > 32 {
@@ -193,6 +201,7 @@ where
 /// `base_reg + elem_i / (VLEN.bytes() / eew.bytes())` must be less than 32, i.e. `elem_i` must be
 /// a valid element index within the register group.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub(in super::super) unsafe fn read_group_element<const VLEN: Vlen>(
     vregs: &VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -228,6 +237,7 @@ pub(in super::super) unsafe fn read_group_element<const VLEN: Vlen>(
 /// `base_reg + elem_i / (VLEN.bytes() / eew.bytes())` must be less than 32, i.e. `elem_i` must be
 /// a valid element index within the register group.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 unsafe fn write_group_element<const VLEN: Vlen>(
     vregs: &mut VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -254,6 +264,7 @@ unsafe fn write_group_element<const VLEN: Vlen>(
 /// Read `eew`-sized data from memory at `addr` into a `[u8; Eew::MAX_BYTES]` buffer
 /// (little-endian)
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn read_mem_element(
     memory: &impl VirtualMemory,
     addr: u64,
@@ -290,6 +301,7 @@ fn read_mem_element(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_unit_stride_load<
     const FAULT_ONLY_FIRST: bool,
     Reg,
@@ -303,7 +315,7 @@ pub unsafe fn execute_unit_stride_load<
     vm: bool,
     base: u64,
     eew: Eew,
-    group_regs: u8,
+    group_regs: NonZeroU8,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -313,6 +325,7 @@ where
     Memory: VirtualMemory,
     CustomError: fmt::Debug,
 {
+    let group_regs = group_regs.get();
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     let elem_bytes = eew.bytes_width();
@@ -421,6 +434,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_strided_load<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &Memory,
@@ -429,7 +443,7 @@ pub unsafe fn execute_strided_load<Reg, ExtState, Memory, CustomError>(
     base: u64,
     stride: i64,
     eew: Eew,
-    group_regs: u8,
+    group_regs: NonZeroU8,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -439,6 +453,7 @@ where
     Memory: VirtualMemory,
     CustomError: fmt::Debug,
 {
+    let group_regs = group_regs.get();
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     let elem_bytes = eew.bytes_width();
@@ -511,6 +526,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_indexed_load<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &Memory,
@@ -520,7 +536,7 @@ pub unsafe fn execute_indexed_load<Reg, ExtState, Memory, CustomError>(
     base: u64,
     data_eew: Eew,
     index_eew: Eew,
-    data_group_regs: u8,
+    data_group_regs: NonZeroU8,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -530,6 +546,7 @@ where
     Memory: VirtualMemory,
     CustomError: fmt::Debug,
 {
+    let data_group_regs = data_group_regs.get();
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     let index_base_reg = vs2;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -114,8 +114,9 @@ pub fn indexed_load_overlap_allowed(
         // recomputed here as `(index_eew / sew) * LMUL >= 1`.
         Ordering::Greater => {
             let (lmul_num, lmul_den) = vlmul.as_fraction();
-            let index_emul_at_least_one = u16::from(index_eew.bits_width()) * u16::from(lmul_num)
-                >= u16::from(sew.bits_width()) * u16::from(lmul_den);
+            let index_emul_at_least_one = u16::from(index_eew.bits_width())
+                * u16::from(lmul_num.get())
+                >= u16::from(sew.bits_width()) * u16::from(lmul_den.get());
             let (vd, vs2) = (vd.to_bits(), vs2.to_bits());
             index_emul_at_least_one && vd + data_regs.get() == vs2 + index_regs.get()
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -414,7 +414,7 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                let group_regs = vtype.vlmul().register_count();
+                let group_regs = vtype.vlmul().register_count().get();
                 let vd_idx = vd.to_bits();
                 if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
                     ::core::hint::cold_path();
@@ -461,7 +461,7 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 };
-                let group_regs = vtype.vlmul().register_count();
+                let group_regs = vtype.vlmul().register_count().get();
                 let vd_idx = vd.to_bits();
                 if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
                     ::core::hint::cold_path();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/zvexx_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/zvexx_mask_helpers.rs
@@ -19,6 +19,7 @@ use core::fmt;
 /// The operation snapshots both sources before writing, so `vd` may safely overlap either source.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -64,6 +65,7 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
 /// Returns `rd_value`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vcpop<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vs2: VReg,
@@ -109,6 +111,7 @@ where
 /// Returns `rd_value`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vfirst<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vs2: VReg,
@@ -167,6 +170,7 @@ where
 /// - `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -212,6 +216,7 @@ pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
 /// Same as [`execute_vmsbf`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -257,6 +262,7 @@ pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
 /// Same as [`execute_vmsbf`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -311,6 +317,7 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
 /// - `vl <= VLMAX`; `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -359,6 +366,7 @@ pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
 /// - `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vid<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
@@ -6,6 +6,7 @@ use crate::{
     Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
+use core::num::NonZeroU8;
 use core::ops::ControlFlow;
 
 // With TEST_VLEN=256, VLENB=32:
@@ -2110,11 +2111,29 @@ fn widening_dest_register_count_values() {
     // M2 (2)    -> 4/1 = 4   -> 4 regs
     // M4 (4)    -> 8/1 = 8   -> 8 regs
     // M8 (8)    -> 16/1 = 16 -> None (illegal)
-    assert_eq!(widening_dest_register_count(Vlmul::Mf8), Some(1));
-    assert_eq!(widening_dest_register_count(Vlmul::Mf4), Some(1));
-    assert_eq!(widening_dest_register_count(Vlmul::Mf2), Some(1));
-    assert_eq!(widening_dest_register_count(Vlmul::M1), Some(2));
-    assert_eq!(widening_dest_register_count(Vlmul::M2), Some(4));
-    assert_eq!(widening_dest_register_count(Vlmul::M4), Some(8));
+    assert_eq!(
+        widening_dest_register_count(Vlmul::Mf8),
+        Some(NonZeroU8::new(1).unwrap())
+    );
+    assert_eq!(
+        widening_dest_register_count(Vlmul::Mf4),
+        Some(NonZeroU8::new(1).unwrap())
+    );
+    assert_eq!(
+        widening_dest_register_count(Vlmul::Mf2),
+        Some(NonZeroU8::new(1).unwrap())
+    );
+    assert_eq!(
+        widening_dest_register_count(Vlmul::M1),
+        Some(NonZeroU8::new(2).unwrap())
+    );
+    assert_eq!(
+        widening_dest_register_count(Vlmul::M2),
+        Some(NonZeroU8::new(4).unwrap())
+    );
+    assert_eq!(
+        widening_dest_register_count(Vlmul::M4),
+        Some(NonZeroU8::new(8).unwrap())
+    );
     assert_eq!(widening_dest_register_count(Vlmul::M8), None);
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -12,6 +12,7 @@ use crate::{ExecutionError, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::hint::cold_path;
+use core::num::NonZeroU8;
 
 /// Compute the destination register count for a widening operation (`EMUL = 2 × LMUL`).
 ///
@@ -23,7 +24,8 @@ use core::hint::cold_path;
 /// exactly one physical register.
 #[inline(always)]
 #[doc(hidden)]
-pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<u8> {
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<NonZeroU8> {
     let (lmul_num, lmul_den) = vlmul.as_fraction();
     // EMUL = 2 × LMUL = (2 * lmul_num) / lmul_den
     let Some(emul_num) = 2u8.checked_mul(lmul_num) else {
@@ -44,7 +46,7 @@ pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<u8> {
         return None;
     }
     // Register count: max(1, n/d) = n when d==1, else 1
-    Some(if d > 1 { 1 } else { n })
+    Some(NonZeroU8::new(if d > 1 { 1 } else { n }).expect("Not zero; qed"))
 }
 
 /// Check that a narrower source register group does not *illegally* overlap the wider destination
@@ -67,17 +69,20 @@ pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<u8> {
 /// rejected as an illegal instruction.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_no_widening_overlap<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vd: VReg,
     vs: VReg,
-    dest_group_regs: u8,
-    src_group_regs: u8,
+    dest_group_regs: NonZeroU8,
+    src_group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let dest_group_regs = dest_group_regs.get();
+    let src_group_regs = src_group_regs.get();
     let vd_start = vd.to_bits();
     let vd_end = vd_start + dest_group_regs;
     let vs_start = vs.to_bits();
@@ -105,6 +110,7 @@ where
 /// # Safety
 /// `base_reg + elem_i / (VLEN.bytes() / (2*sew_bytes)) < 32` must hold.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 unsafe fn write_wide_element_u64<const VLEN: Vlen>(
     vregs: &mut VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -138,6 +144,7 @@ unsafe fn write_wide_element_u64<const VLEN: Vlen>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -193,6 +200,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -248,6 +256,7 @@ pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -300,6 +309,7 @@ pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
 /// Same as [`execute_muladd_op`], minus constraints on `a_reg`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -356,6 +366,7 @@ pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -410,6 +421,7 @@ pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
 /// Same as [`execute_widening_muladd_op`], minus constraints on `a_reg`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -459,6 +471,7 @@ pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, CustomError, F>(
 /// 2*SEW product are returned (zero-extended to u64 for writeback into a SEW-wide element slot).
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn mulh_ss(a: u64, b: u64, sew: Vsew) -> u64 {
     let sa = i128::from(sign_extend(a, sew));
     let sb = i128::from(sign_extend(b, sew));
@@ -471,6 +484,7 @@ pub fn mulh_ss(a: u64, b: u64, sew: Vsew) -> u64 {
 /// Unsigned × unsigned high half
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn mulhu_uu(a: u64, b: u64, sew: Vsew) -> u64 {
     let ua = u128::from(a & sew_mask(sew));
     let ub = u128::from(b & sew_mask(sew));
@@ -484,6 +498,7 @@ pub fn mulhu_uu(a: u64, b: u64, sew: Vsew) -> u64 {
 /// `a` (vs2) is the signed operand; `b` (vs1/rs1) is the unsigned operand.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn mulhsu_su(a: u64, b: u64, sew: Vsew) -> u64 {
     let sa = i128::from(sign_extend(a, sew));
     let ub = u128::from(b & sew_mask(sew));
@@ -499,6 +514,7 @@ pub fn mulhsu_su(a: u64, b: u64, sew: Vsew) -> u64 {
 /// - Signed overflow (MIN / −1): result = MIN (i.e., `1 << (SEW-1)`)
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sdiv(a: u64, b: u64, sew: Vsew) -> u64 {
     let sa = sign_extend(a, sew);
     let sb = sign_extend(b, sew);
@@ -525,6 +541,7 @@ pub fn sdiv(a: u64, b: u64, sew: Vsew) -> u64 {
     clippy::modulo_arithmetic,
     reason = "This is what the code is supposed to do"
 )]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn srem(a: u64, b: u64, sew: Vsew) -> u64 {
     let sa = sign_extend(a, sew);
     let sb = sign_extend(b, sew);

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -28,11 +28,11 @@ use core::num::NonZeroU8;
 pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<NonZeroU8> {
     let (lmul_num, lmul_den) = vlmul.as_fraction();
     // EMUL = 2 × LMUL = (2 * lmul_num) / lmul_den
-    let Some(emul_num) = 2u8.checked_mul(lmul_num) else {
+    let Some(emul_num) = 2u8.checked_mul(lmul_num.get()) else {
         cold_path();
         return None;
     };
-    let emul_den = lmul_den;
+    let emul_den = lmul_den.get();
     // Reduce the fraction by GCD (both are powers of two so min works as GCD)
     let g = emul_num.min(emul_den);
     let (n, d) = (emul_num / g, emul_den / g);

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -832,7 +832,12 @@ where
                     group_regs,
                 )?;
                 // vs1 is a mask register; check it doesn't overlap vd
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(program_counter, vd, vs1, 1)?;
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    program_counter,
+                    vd,
+                    vs1,
+                    ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                )?;
                 let sew = vtype.vsew();
                 let vl = ext_state.vl();
                 unsafe {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
@@ -9,6 +9,7 @@ use crate::{ExecutionError, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::hint::cold_path;
+use core::num::NonZeroU8;
 
 /// Check that register groups `[a, a+count)` and `[b, b+count)` do not overlap.
 ///
@@ -16,11 +17,12 @@ use core::hint::cold_path;
 /// [`check_no_overlap_asymmetric`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_no_overlap<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     a: VReg,
     b: VReg,
-    count: u8,
+    count: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
@@ -28,7 +30,7 @@ where
 {
     let a_start = u16::from(a.to_bits());
     let b_start = u16::from(b.to_bits());
-    let count = u16::from(count);
+    let count = u16::from(count.get());
     // Intervals [a_start, a_start+count) and [b_start, b_start+count) overlap iff
     // each starts before the other ends. Arithmetic is widened to u16 to avoid u8 overflow
     // (e.g., b_start=30 + count=8 = 38, which overflows u8).
@@ -48,12 +50,13 @@ where
 /// uses EEW=16-derived `index_group_regs`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_no_overlap_asymmetric<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     a: VReg,
-    a_count: u8,
+    a_count: NonZeroU8,
     b: VReg,
-    b_count: u8,
+    b_count: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
@@ -61,8 +64,8 @@ where
 {
     let a_start = u16::from(a.to_bits());
     let b_start = u16::from(b.to_bits());
-    let a_count = u16::from(a_count);
-    let b_count = u16::from(b_count);
+    let a_count = u16::from(a_count.get());
+    let b_count = u16::from(b_count.get());
     // Intervals [a_start, a_start+a_count) and [b_start, b_start+b_count) overlap iff
     // each starts before the other ends.
     if a_start < b_start + b_count && b_start < a_start + a_count {
@@ -79,6 +82,7 @@ where
 /// # Safety
 /// `sew.bytes() <= VLEN.bytes()`
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn read_element_0_u64<const VLEN: Vlen>(
     vregs: &VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -100,6 +104,7 @@ pub unsafe fn read_element_0_u64<const VLEN: Vlen>(
 /// # Safety
 /// `sew.bytes() <= VLEN.bytes()`
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn write_element_0_u64<const VLEN: Vlen>(
     vregs: &mut VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -131,6 +136,7 @@ pub unsafe fn write_element_0_u64<const VLEN: Vlen>(
 /// `Reg::Type: Shl<u8>`, we reconstruct the 64-bit value by OR-ing two 32-bit halves shifted
 /// into position.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sign_extend_to_reg<Reg>(val: u64, sew: Vsew) -> Reg::Type
 where
     Reg: Register,
@@ -163,6 +169,7 @@ where
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -211,6 +218,7 @@ pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -264,6 +272,7 @@ pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -316,6 +325,7 @@ pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -361,6 +371,7 @@ pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -408,6 +419,7 @@ pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -460,6 +472,7 @@ pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -468,13 +481,14 @@ pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
     vm: bool,
     sew: Vsew,
     vlmax: Vl,
-    index_group_regs: u8,
+    index_group_regs: NonZeroU8,
 ) where
     Reg: Register,
     ExtState: VectorRegistersExt<Reg, CustomError>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     CustomError: fmt::Debug,
 {
+    let index_group_regs = index_group_regs.get();
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     // Maximum number of EEW=16 elements the index register group can hold.
@@ -523,6 +537,7 @@ pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -572,6 +587,7 @@ pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -618,6 +634,7 @@ pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
 /// - `vl <= VLMAX`.
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -669,6 +686,7 @@ pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
 /// - `dst_base % COUNT == 0` and `src_base % COUNT == 0` (verified by caller).
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_whole_reg_move<const COUNT: usize, const VLEN: Vlen>(
     vregs: &mut VectorRegisterFile<VLEN>,
     dst_base: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/zvexx_reduction_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/zvexx_reduction_helpers.rs
@@ -18,6 +18,7 @@ use core::hint::cold_path;
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -74,6 +75,7 @@ pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widening_reduce_op<
     const SIGN_EXTEND_SRC: bool,
     Reg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
@@ -9,6 +9,7 @@ use crate::{ExecutionError, ProgramCounter, VirtualMemory, VirtualMemoryError};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::hint::cold_path;
+use core::num::NonZeroU8;
 
 /// Interpret `buf[..index_eew.bytes()]` as a little-endian unsigned integer and return it as
 /// `u64`. Used to convert a packed index element into a byte offset.
@@ -16,6 +17,7 @@ use core::hint::cold_path;
 /// # Safety
 /// `index_eew.bytes() <= Eew::MAX_BYTES`, which is always true by construction.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 unsafe fn index_buf_to_u64(
     buf: [u8; const { usize::from(Eew::MAX_BYTES) }],
     index_eew: Eew,
@@ -30,6 +32,7 @@ unsafe fn index_buf_to_u64(
 
 /// Write `eew`-sized data from `buf[..eew.bytes()]` to memory at `addr` (little-endian)
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn write_mem_element(
     memory: &mut impl VirtualMemory,
     addr: u64,
@@ -46,10 +49,11 @@ fn write_mem_element(
 /// applies only to load destinations.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn validate_segment_store_registers<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vs3: VReg,
-    group_regs: u8,
+    group_regs: NonZeroU8,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -63,7 +67,7 @@ where
         return Err(error);
     }
     let total =
-        u32::from(vs3.to_bits()) + u32::from(nf.fields_per_segment()) * u32::from(group_regs);
+        u32::from(vs3.to_bits()) + u32::from(nf.fields_per_segment()) * u32::from(group_regs.get());
     if total > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
@@ -89,6 +93,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_unit_stride_store<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &mut Memory,
@@ -96,7 +101,7 @@ pub unsafe fn execute_unit_stride_store<Reg, ExtState, Memory, CustomError>(
     vm: bool,
     base: u64,
     eew: Eew,
-    group_regs: u8,
+    group_regs: NonZeroU8,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -106,6 +111,7 @@ where
     Memory: VirtualMemory,
     CustomError: fmt::Debug,
 {
+    let group_regs = group_regs.get();
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     let elem_bytes = eew.bytes_width();
@@ -166,6 +172,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_strided_store<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &mut Memory,
@@ -174,7 +181,7 @@ pub unsafe fn execute_strided_store<Reg, ExtState, Memory, CustomError>(
     base: u64,
     stride: i64,
     eew: Eew,
-    group_regs: u8,
+    group_regs: NonZeroU8,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -184,6 +191,7 @@ where
     Memory: VirtualMemory,
     CustomError: fmt::Debug,
 {
+    let group_regs = group_regs.get();
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     let elem_bytes = eew.bytes_width();
@@ -238,6 +246,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_indexed_store<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &mut Memory,
@@ -247,7 +256,7 @@ pub unsafe fn execute_indexed_store<Reg, ExtState, Memory, CustomError>(
     base: u64,
     data_eew: Eew,
     index_eew: Eew,
-    data_group_regs: u8,
+    data_group_regs: NonZeroU8,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
@@ -257,6 +266,7 @@ where
     Memory: VirtualMemory,
     CustomError: fmt::Debug,
 {
+    let data_group_regs = data_group_regs.get();
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
     let data_elem_bytes = data_eew.bytes_width();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -1594,7 +1594,8 @@ where
                 }
                 let group_regs = vtype.vlmul().register_count();
                 // EMUL for source = LMUL / 2; src_group = max(1, group_regs / 2)
-                let src_group = group_regs.max(2) / 2;
+                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(2) / 2)
+                    .expect("Not zero; qed");
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
@@ -1648,7 +1649,8 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = group_regs.max(4) / 4;
+                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(4) / 4)
+                    .expect("Not zero; qed");
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
@@ -1702,7 +1704,8 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = group_regs.max(8) / 8;
+                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(8) / 8)
+                    .expect("Not zero; qed");
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
@@ -1755,7 +1758,8 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = group_regs.max(2) / 2;
+                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(2) / 2)
+                    .expect("Not zero; qed");
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
@@ -1808,7 +1812,8 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = group_regs.max(4) / 4;
+                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(4) / 4)
+                    .expect("Not zero; qed");
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,
@@ -1861,7 +1866,8 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = group_regs.max(8) / 8;
+                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(8) / 8)
+                    .expect("Not zero; qed");
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
                     program_counter,
                     vs2,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
@@ -8,20 +8,23 @@ use ab_riscv_primitives::instructions::v::Vsew;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::hint::cold_path;
+use core::num::NonZeroU8;
 
 /// Check that a widening destination `vd` is aligned to `wide_group_regs` and fits within
 /// `[0,32)`, without any source overlap check
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_vd_widen_no_src_check<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vd: VReg,
-    wide_group_regs: u8,
+    wide_group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let wide_group_regs = wide_group_regs.get();
     let vd_idx = vd.to_bits();
     if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
         cold_path();
@@ -42,17 +45,20 @@ where
 /// the wide `{v0..v7}` destination). Any other overlap is illegal.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_vs_ext_alignment<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vs2: VReg,
-    src_group_regs: u8,
+    src_group_regs: NonZeroU8,
     vd: VReg,
-    group_regs: u8,
+    group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let src_group_regs = src_group_regs.get();
+    let group_regs = group_regs.get();
     let vs2_idx = vs2.to_bits();
     if !vs2_idx.is_multiple_of(src_group_regs) || vs2_idx + src_group_regs > 32 {
         cold_path();
@@ -85,18 +91,21 @@ where
 /// Any other overlap is illegal.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_vd_widen_alignment<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vd: VReg,
     vs_a: VReg,
     vs_b_opt: Option<VReg>,
-    group_regs: u8,
-    wide_group_regs: u8,
+    group_regs: NonZeroU8,
+    wide_group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let wide_group_regs = wide_group_regs.get();
+    let group_regs = group_regs.get();
     let vd_idx = vd.to_bits();
     if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
         cold_path();
@@ -130,6 +139,7 @@ where
 /// both counts collapse to 1) - and the source occupies the highest-numbered registers of the
 /// destination group.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn widen_src_overlap_illegal(vd_idx: u8, wide_group_regs: u8, vs_idx: u8, group_regs: u8) -> bool {
     if !ranges_overlap(vd_idx, wide_group_regs, vs_idx, group_regs) {
         return false;
@@ -143,15 +153,17 @@ fn widen_src_overlap_illegal(vd_idx: u8, wide_group_regs: u8, vs_idx: u8, group_
 /// and fits within `[0, 32)`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_vs_wide_alignment<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vs: VReg,
-    wide_group_regs: u8,
+    wide_group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let wide_group_regs = wide_group_regs.get();
     let vs_idx = vs.to_bits();
     if !vs_idx.is_multiple_of(wide_group_regs) || vs_idx + wide_group_regs > 32 {
         cold_path();
@@ -169,15 +181,17 @@ where
 /// permit `vd` to alias the low half of the wide `vs2` register group per spec §11.7.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_vd_narrow_alignment<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vd: VReg,
-    group_regs: u8,
+    group_regs: NonZeroU8,
 ) -> Result<(), ExecutionError<Reg::Type, CustomError>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
+    let group_regs = group_regs.get();
     let vd_idx = vd.to_bits();
     if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
         cold_path();
@@ -190,12 +204,14 @@ where
 
 /// Returns `true` when `[a_start, a_start+a_len)` overlaps `[b_start, b_start+b_len)`.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn ranges_overlap(a_start: u8, a_len: u8, b_start: u8, b_len: u8) -> bool {
     a_start < b_start + b_len && b_start < a_start + a_len
 }
 
 /// Return whether mask bit `i` is set in the mask byte slice (LSB-first within each byte).
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn mask_bit(mask: &[u8], i: u16) -> bool {
     mask.get(usize::from(i / u8::BITS as u16))
         .is_some_and(|b| (b >> (i % u8::BITS as u16)) & 1 != 0)
@@ -208,6 +224,7 @@ fn mask_bit(mask: &[u8], i: u16) -> bool {
 /// # Safety
 /// `vl <= VLEN` must hold
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 unsafe fn snapshot_mask<const VLEN: Vlen>(
     vregs: &VectorRegisterFile<VLEN>,
     vm: bool,
@@ -233,6 +250,7 @@ unsafe fn snapshot_mask<const VLEN: Vlen>(
 /// # Safety
 /// `base_reg + elem_i / (VLEN.bytes() / sew.bytes_width()) < 32`
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 unsafe fn read_element_u64<const VLEN: Vlen>(
     vregs: &VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -260,6 +278,7 @@ unsafe fn read_element_u64<const VLEN: Vlen>(
 /// # Safety
 /// `base_reg + elem_i / (VLEN.bytes() / sew.bytes_width()) < 32`
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 unsafe fn write_element_u64<const VLEN: Vlen>(
     vregs: &mut VectorRegisterFile<VLEN>,
     base_reg: VReg,
@@ -285,6 +304,7 @@ unsafe fn write_element_u64<const VLEN: Vlen>(
 /// Sign-extend the low `bits` of `val` to `i64`.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sign_extend_bits(val: u64, bits: u8) -> i64 {
     let shift = u64::BITS - u32::from(bits);
     (val.cast_signed() << shift) >> shift
@@ -311,6 +331,7 @@ pub fn sign_extend_bits(val: u64, bits: u8) -> i64 {
 ///
 /// This helper performs that SEW-width truncation without sign extension.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn scalar_unsigned_for_sew(val: u64, sew_bits: u8) -> u64 {
     val & (u64::MAX >> (u64::BITS - u32::from(sew_bits)))
 }
@@ -337,6 +358,7 @@ fn scalar_unsigned_for_sew(val: u64, sew_bits: u8) -> u64 {
 /// This matches the signed widening behavior required by instructions such
 /// as vwadd.vx and vwsub.vx.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn scalar_signed_for_sew(val: u64, sew_bits: u8) -> u64 {
     sign_extend_bits(val, sew_bits).cast_unsigned()
 }
@@ -360,6 +382,7 @@ fn scalar_signed_for_sew(val: u64, sew_bits: u8) -> u64 {
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -441,6 +464,7 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, Custom
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -519,6 +543,7 @@ pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, Custo
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -595,6 +620,7 @@ pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, Custom
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
+// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_extension<const SIGN: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/zicsr_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/zicsr_helpers.rs
@@ -11,6 +11,7 @@ use core::hint::cold_path;
 /// extensions anyway.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn check_csr_privilege_level<Reg, C, CustomError>(
     csrs: &C,
     csr_index: u16,

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvbb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvbb_helpers.rs
@@ -22,6 +22,7 @@ use core::fmt;
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vbrev<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -70,6 +71,7 @@ pub unsafe fn execute_vbrev<Reg, ExtState, CustomError>(
 /// Same register-group constraints as [`execute_vbrev`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vclz<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -115,6 +117,7 @@ pub unsafe fn execute_vclz<Reg, ExtState, CustomError>(
 /// Same register-group constraints as [`execute_vbrev`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vctz<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -159,6 +162,7 @@ pub unsafe fn execute_vctz<Reg, ExtState, CustomError>(
 /// Same register-group constraints as [`execute_vbrev`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vcpop<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -210,6 +214,7 @@ pub unsafe fn execute_vcpop<Reg, ExtState, CustomError>(
 /// - `vl <= dest_group_regs * VLEN.bytes() / double_sew_bytes`
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vwsll<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/zvkb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/zvkb_helpers.rs
@@ -21,6 +21,7 @@ use core::fmt;
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vandn<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -77,6 +78,7 @@ pub unsafe fn execute_vandn<Reg, ExtState, CustomError>(
 /// Same register-group constraints as [`execute_vandn`], minus the `src` constraint.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vbrev8<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -125,6 +127,7 @@ pub unsafe fn execute_vbrev8<Reg, ExtState, CustomError>(
 /// Same register-group constraints as [`execute_vandn`], minus the `src` constraint.
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vrev8<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -170,6 +173,7 @@ pub unsafe fn execute_vrev8<Reg, ExtState, CustomError>(
 /// Same register-group constraints as [`execute_vandn`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vrol<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -228,6 +232,7 @@ pub unsafe fn execute_vrol<Reg, ExtState, CustomError>(
 /// Same register-group constraints as [`execute_vandn`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vror<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/zvbc/zvbc_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc/zvbc_helpers.rs
@@ -14,6 +14,7 @@ use core::fmt;
 /// the scalar register may carry bits above the SEW boundary) behaves identically to the VV
 /// form (where `read_element_u64` already zero-extends elements to exactly SEW bits).
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn vclmul_element(a: u64, b: u64, sew: Vsew) -> u64 {
     let mask = sew_mask(sew);
     let a = a & mask;
@@ -30,6 +31,7 @@ fn vclmul_element(a: u64, b: u64, sew: Vsew) -> u64 {
 /// since the product never reaches bit 64.
 /// For SEW = 64, `clmulh` directly returns the upper half of the 128-bit product.
 #[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 fn vclmulh_element(a: u64, b: u64, sew: Vsew) -> u64 {
     let mask = sew_mask(sew);
     let a = a & mask;
@@ -57,6 +59,7 @@ fn vclmulh_element(a: u64, b: u64, sew: Vsew) -> u64 {
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vclmul<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -110,6 +113,7 @@ pub unsafe fn execute_vclmul<Reg, ExtState, CustomError>(
 /// Same register-group constraints as [`execute_vclmul`].
 #[inline(always)]
 #[doc(hidden)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vclmulh<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -389,6 +389,10 @@ pub(super) fn process_enum_decoding_impl(
             redundant code like `Some(None?)`"
         )]
         #[allow(
+            clippy::needless_match,
+            reason = "When `no-panic` macro is applied on expanded code, this lint gets triggered"
+        )]
+        #[allow(
             clippy::same_functions_in_if_condition,
             reason = "In presence of ignored instructions, simple replacement sometimes results in \
             redundant code like `Some(None?)`"

--- a/crates/execution/ab-riscv-primitives/Cargo.toml
+++ b/crates/execution/ab-riscv-primitives/Cargo.toml
@@ -18,13 +18,18 @@ include = [
 links = "ab-riscv-primitives"
 
 [package.metadata.docs.rs]
-all-features = true
+all-features = false
 
 [dependencies]
 ab-riscv-macros = { workspace = true, features = ["proc-macro"] }
+no-panic-const = { workspace = true, optional = true }
 
 [build-dependencies]
 ab-riscv-macros = { workspace = true, features = ["build"] }
+
+[features]
+# Check that code can't panic under any conditions
+no-panic = ["dep:no-panic-const"]
 
 [lints]
 workspace = true

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
@@ -93,6 +93,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b.rs
@@ -28,6 +28,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zba.rs
@@ -25,6 +25,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbb.rs
@@ -40,6 +40,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbc.rs
@@ -25,6 +25,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbs.rs
@@ -37,6 +37,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
@@ -86,6 +86,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         /// Map a 3-bit "prime" register field to an absolute register number
         #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/m.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/m.rs
@@ -31,6 +31,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/m/zmmul.rs
@@ -23,6 +23,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb.rs
@@ -27,6 +27,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }
@@ -102,6 +103,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         /// Map a 3-bit "prime" register field to an absolute register number
         #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
@@ -160,6 +160,7 @@ where
     /// Note: urlist=15 is {ra, s0-s11} (13 registers, including s10);
     /// {ra, s0-s10} has no encoding.
     #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub fn reg_list(self) -> impl Iterator<Item = Reg> {
         let regs: &[u8] = match self.inner {
             ZcmpUrlistInner::Ra => &[1],
@@ -258,6 +259,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }
@@ -330,6 +332,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         /// Map the Zcmp 3-bit "s-register" field to an absolute register number.
         /// 000->x8(s0), 001->x9(s1), 010->x18(s2)..111->x23(s7)

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkb.rs
@@ -39,6 +39,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkc.rs
@@ -23,6 +23,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkx.rs
@@ -24,6 +24,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn.rs
@@ -38,6 +38,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknd.rs
@@ -107,6 +107,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zkne.rs
@@ -62,6 +62,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknh.rs
@@ -47,6 +47,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
@@ -109,6 +109,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b.rs
@@ -28,6 +28,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zba.rs
@@ -30,6 +30,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbb.rs
@@ -47,6 +47,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbc.rs
@@ -25,6 +25,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbs.rs
@@ -37,6 +37,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
@@ -98,6 +98,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         /// Map a 3-bit "prime" register field to an absolute register number
         #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/m.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/m.rs
@@ -38,6 +38,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/m/zmmul.rs
@@ -23,6 +23,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb.rs
@@ -27,6 +27,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }
@@ -105,6 +106,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         /// Map a 3-bit "prime" register field to an absolute register number
         #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
@@ -26,6 +26,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }
@@ -98,6 +99,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         /// Map the Zcmp 3-bit "s-register" field to an absolute register number.
         /// 000->x8(s0), 001->x9(s1), 010->x18(s2)..111->x23(s7)

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkb.rs
@@ -35,6 +35,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkc.rs
@@ -23,6 +23,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkx.rs
@@ -24,6 +24,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn.rs
@@ -38,6 +38,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknd.rs
@@ -64,6 +64,7 @@ impl Rv64ZkndKsRnum {
 
     /// Round constant (unless final)
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn constant(self) -> Option<u8> {
         if matches!(self, Rv64ZkndKsRnum::Final) {
             None
@@ -101,6 +102,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zkne.rs
@@ -31,6 +31,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknh.rs
@@ -30,6 +30,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/utils.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/utils.rs
@@ -93,6 +93,7 @@ impl U24 {
     ///
     /// The input value is truncated to 24 bits, providing larger value panics in a debug build.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn from_u32(v: u32) -> Self {
         let b = v.to_le_bytes();
         debug_assert!(
@@ -104,6 +105,7 @@ impl U24 {
 
     /// Convert to an unsigned 32-bit integer
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn to_u32(self) -> u32 {
         let [a, b, c] = self.0;
         u32::from_le_bytes([a, b, c, 0])
@@ -197,6 +199,7 @@ impl I24 {
     ///
     /// The input value is truncated to 24 bits, providing larger value panics in a debug build.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn from_i32(v: i32) -> Self {
         let b = v.to_le_bytes();
         debug_assert!(
@@ -208,6 +211,7 @@ impl I24 {
 
     /// Convert to a signed 32-bit integer
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn to_i32(self) -> i32 {
         let [a, b, c] = self.0;
         // Sign-extend
@@ -269,6 +273,7 @@ impl<const LOW_ZEROED_BITS: u8> I24WithZeroedBits<LOW_ZEROED_BITS> {
     /// When converted back with [`Self::to_i32`], the value is shifted back with low bits being
     /// zero.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn from_i32(v_original: i32) -> Self {
         let v = v_original >> LOW_ZEROED_BITS;
         let b = v.to_le_bytes();
@@ -284,6 +289,7 @@ impl<const LOW_ZEROED_BITS: u8> I24WithZeroedBits<LOW_ZEROED_BITS> {
 
     /// Convert to a signed 32-bit integer
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn to_i32(self) -> i32 {
         let [a, b, c] = self.0;
         // Sign-extend and shift back

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -373,8 +373,8 @@ impl Vlmul {
     /// Both values are powers of two with exactly one equal to `1`. Useful for computing
     /// `EMUL = (EEW / SEW) * LMUL` without floating-point arithmetic.
     #[inline(always)]
-    pub const fn as_fraction(self) -> (u8, u8) {
-        match self {
+    pub const fn as_fraction(self) -> (NonZeroU8, NonZeroU8) {
+        let (numerator, denominator) = match self {
             Self::Mf8 => (1, 8),
             Self::Mf4 => (1, 4),
             Self::Mf2 => (1, 2),
@@ -382,7 +382,12 @@ impl Vlmul {
             Self::M2 => (2, 1),
             Self::M4 => (4, 1),
             Self::M8 => (8, 1),
-        }
+        };
+
+        (
+            NonZeroU8::new(numerator).expect("Not zero; qed"),
+            NonZeroU8::new(denominator).expect("Not zero; qed"),
+        )
     }
 
     /// Compute `EMUL` for an indexed load: `EMUL = (index_eew / sew) * LMUL`.
@@ -393,8 +398,8 @@ impl Vlmul {
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn index_register_count(self, index_eew: Eew, sew: Vsew) -> Option<NonZeroU8> {
         let (lmul_num, lmul_den) = self.as_fraction();
-        let num = u16::from(index_eew.bits_width()) * u16::from(lmul_num);
-        let den = u16::from(sew.bits_width()) * u16::from(lmul_den);
+        let num = u16::from(index_eew.bits_width()) * u16::from(lmul_num.get());
+        let den = u16::from(sew.bits_width()) * u16::from(lmul_den.get());
         // Both are products of powers of two; GCD equals the smaller value.
         let g = if num < den { num } else { den };
         let (n, d) = (num / g, den / g);

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -5,6 +5,7 @@ pub mod zvexx;
 use crate::registers::general_purpose::{RegType, Register};
 use core::hint::cold_path;
 use core::marker::ConstParamTy;
+use core::num::NonZeroU8;
 use core::ops::RangeInclusive;
 use core::{cmp, fmt};
 
@@ -356,13 +357,15 @@ impl Vlmul {
     /// Fractional `LMUL` values (`Mf2`, `Mf4`, `Mf8`) each occupy exactly 1 register.
     /// Integer `LMUL` values occupy 1, 2, 4, or 8 registers respectively.
     #[inline(always)]
-    pub const fn register_count(self) -> u8 {
-        match self {
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    pub const fn register_count(self) -> NonZeroU8 {
+        let register_count = match self {
             Self::Mf8 | Self::Mf4 | Self::Mf2 | Self::M1 => 1,
             Self::M2 => 2,
             Self::M4 => 4,
             Self::M8 => 8,
-        }
+        };
+        NonZeroU8::new(register_count).expect("Not zero; qed")
     }
 
     /// LMUL as a `(numerator, denominator)` fraction where `LMUL = num / den`.
@@ -388,7 +391,7 @@ impl Vlmul {
     /// outside the legal range `[1/8, 8]`.
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    pub const fn index_register_count(self, index_eew: Eew, sew: Vsew) -> Option<u8> {
+    pub const fn index_register_count(self, index_eew: Eew, sew: Vsew) -> Option<NonZeroU8> {
         let (lmul_num, lmul_den) = self.as_fraction();
         let num = u16::from(index_eew.bits_width()) * u16::from(lmul_num);
         let den = u16::from(sew.bits_width()) * u16::from(lmul_den);
@@ -405,7 +408,7 @@ impl Vlmul {
             return None;
         }
         // Register count is max(1, n/d) = n when d==1, else 1
-        Some(if d > 1 { 1 } else { n as u8 })
+        Some(NonZeroU8::new(if d > 1 { 1 } else { n as u8 }).expect("Not zero; qed"))
     }
 
     /// Compute EMUL for a data operand of a memory instruction with a given effective element
@@ -419,7 +422,7 @@ impl Vlmul {
     /// Returns `None` when the resulting EMUL falls outside the legal range `[1/8, 8]`.
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    pub const fn data_register_count(self, eew: Eew, sew: Vsew) -> Option<u8> {
+    pub const fn data_register_count(self, eew: Eew, sew: Vsew) -> Option<NonZeroU8> {
         self.index_register_count(eew, sew)
     }
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -335,6 +335,7 @@ impl Vlmul {
     /// For fractional LMUL, this is `VLEN / (SEW * denominator)`.
     /// Returns `Vl::ZERO` when the result would be less than 1 (insufficient bits).
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn vlmax<const VLEN: Vlen>(self, sew: Vsew) -> Vl {
         let sew_bits = u32::from(sew.bits_width());
         let vl = match self {
@@ -386,6 +387,7 @@ impl Vlmul {
     /// Returns the register count for the index register group, or `None` when `EMUL` falls
     /// outside the legal range `[1/8, 8]`.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn index_register_count(self, index_eew: Eew, sew: Vsew) -> Option<u8> {
         let (lmul_num, lmul_den) = self.as_fraction();
         let num = u16::from(index_eew.bits_width()) * u16::from(lmul_num);
@@ -416,6 +418,7 @@ impl Vlmul {
     ///
     /// Returns `None` when the resulting EMUL falls outside the legal range `[1/8, 8]`.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn data_register_count(self, eew: Eew, sew: Vsew) -> Option<u8> {
         self.index_register_count(eew, sew)
     }
@@ -514,6 +517,7 @@ impl Vsew {
 
     /// Divide Vsew width by a given factor
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn divide_by_factor(self, factor: VsewFactor) -> Option<Self> {
         let Some(divide_by_factor) = self.bits_width().div_exact(factor.factor()) else {
             cold_path();
@@ -745,6 +749,7 @@ where
     /// All bits in `[Reg::XLEN-1:8]` must be zero; non-zero bits indicate an unrecognized
     /// encoding and cause `None` to be returned (this includes `vill`).
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn from_raw<Reg>(raw: Reg::Type) -> Option<Self>
     where
         Reg: [const] Register,
@@ -796,6 +801,7 @@ where
     /// `vill = 0`. To construct a raw value with `vill = 1` (illegal configuration), use
     /// [`Self::illegal_raw`].
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn to_raw<Reg>(self) -> Reg::Type
     where
         Reg: [const] Register,
@@ -821,6 +827,7 @@ where
     /// subsequent vector instruction that depends on `vtype` will raise an illegal-instruction
     /// exception.
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn illegal_raw<Reg>() -> Reg::Type
     where
         Reg: [const] Register,

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx.rs
@@ -74,6 +74,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
     }

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/arith.rs
@@ -156,6 +156,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/carry.rs
@@ -80,6 +80,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/config.rs
@@ -42,6 +42,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/fixed_point.rs
@@ -96,6 +96,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/load.rs
@@ -80,6 +80,7 @@ pub struct SegVmNf(u8);
 impl SegVmNf {
     /// Create a new instance
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn new(vm: bool, nf: Nf) -> Self {
         Self((nf.fields_per_segment() << 1) | u8::from(vm))
     }
@@ -92,6 +93,7 @@ impl SegVmNf {
 
     /// Extracts the `nf` field from the `SegVmNf` representation
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn nf(&self) -> Nf {
         // SAFETY: Protected internal invariant
         unsafe { Nf::new(self.0 >> 1).unwrap_unchecked() }
@@ -206,6 +208,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/mask.rs
@@ -91,6 +91,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/muldiv.rs
@@ -121,6 +121,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/perm.rs
@@ -111,6 +111,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/reduction.rs
@@ -50,6 +50,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/store.rs
@@ -70,6 +70,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/widen_narrow.rs
@@ -124,6 +124,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/zicond.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zicond.rs
@@ -26,6 +26,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/zicsr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zicsr.rs
@@ -28,6 +28,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         let rd_bits = ((instruction >> 7) & 0x1f) as u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbb.rs
@@ -84,6 +84,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbb/zvkb.rs
@@ -88,6 +88,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbc.rs
@@ -62,6 +62,7 @@ where
     type Reg = Reg;
 
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         let opcode = (instruction & 0b111_1111) as u8;
         if opcode != 0b101_0111 {

--- a/crates/execution/ab-riscv-primitives/src/lib.rs
+++ b/crates/execution/ab-riscv-primitives/src/lib.rs
@@ -15,7 +15,7 @@
 //! Certification Tests runner for <https://github.com/riscv-non-isa/riscv-arch-test> that ensures
 //! correct implementation.
 //!
-//! Does not require a standard library (`no_std`) or an allocator.
+//! Does not require a standard library (`no_std`) or an allocator, never panics.
 //!
 //! ## Supported ISA variants and extensions
 //!
@@ -81,6 +81,7 @@
     stmt_expr_attributes,
     try_blocks
 )]
+#![cfg_attr(feature = "no-panic", feature(const_closures))]
 
 pub mod instructions;
 pub mod prelude;

--- a/crates/execution/ab-riscv-primitives/src/registers/machine.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/machine.rs
@@ -120,6 +120,7 @@ impl MCauseException {
 
     /// Convert this exception to its full raw `mcause` CSR value
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn to_raw<Reg>(self) -> Reg::Type
     where
         Reg: [const] Register,
@@ -173,6 +174,7 @@ impl MCauseInterrupt {
 
     /// Convert this interrupt to its full raw `mcause` CSR value
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn to_raw<Reg>(self) -> Reg::Type
     where
         Reg: [const] Register,
@@ -205,6 +207,7 @@ impl From<MCauseInterrupt> for MCause {
 impl MCause {
     /// Try to create `MCause` from a raw `mcause` CSR value
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn from_raw<Reg>(raw: Reg::Type) -> Option<Self>
     where
         Reg: [const] Register,
@@ -222,6 +225,7 @@ impl MCause {
 
     /// Convert this `MCause` back to the full raw `mcause` CSR value
     #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn to_raw<Reg>(self) -> Reg::Type
     where
         Reg: [const] Register,

--- a/crates/shared/ab-merkle-tree/Cargo.toml
+++ b/crates/shared/ab-merkle-tree/Cargo.toml
@@ -37,6 +37,7 @@ criterion = { workspace = true }
 
 [features]
 alloc = []
+# Check that code can't panic under any conditions
 no-panic = [
     "dep:no-panic",
     # Helps with testing on CPUs without AVX512 support

--- a/crates/shared/ab-merkle-tree/src/lib.rs
+++ b/crates/shared/ab-merkle-tree/src/lib.rs
@@ -26,7 +26,8 @@
 //! [`UnbalancedMerkleTree`]: unbalanced::UnbalancedMerkleTree
 //! [`SparseMerkleTree`]: sparse::SparseMerkleTree
 //!
-//! Does not require a standard library (`no_std`), most APIs are usable without an allocator.
+//! Does not require a standard library (`no_std`), most APIs are usable without an allocator, never
+//! panics.
 
 #![expect(incomplete_features, reason = "generic_const_*")]
 #![feature(
@@ -95,7 +96,7 @@ pub fn hash_pair_block(pair: &[u8; BLOCK_LEN]) -> [u8; OUT_LEN] {
     all(feature = "no-panic", not(target_arch = "riscv64")),
     no_panic::no_panic
 )]
-pub fn hash_pairs<const NUM_BLOCKS: usize, const NUM_LEAVES: usize>(
+fn hash_pairs<const NUM_BLOCKS: usize, const NUM_LEAVES: usize>(
     pairs: &[[u8; OUT_LEN]; NUM_LEAVES],
 ) -> [[u8; OUT_LEN]; NUM_BLOCKS] {
     // This protects the invariant of the function


### PR DESCRIPTION
This guarantees no panics in `ab-riscv-primitives` and adds some (but not complete) guarantees for `ab-riscv-interpreter`.

There is a lot of code in the interpreter, so it'll take some time to figure out how to clean things up.

I had to create a fork of `no-panic` crate for this that supports `const fn` and `const Trait` on Rust nightly: https://crates.io/crates/no-panic-const