### PR TITLE
Merkle Tree improvements

### DIFF
--- a/crates/shared/ab-merkle-tree/Cargo.toml
+++ b/crates/shared/ab-merkle-tree/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2024"
 include = [
+    "/benches",
     "/src",
     "/tests",
     "/Cargo.toml",
@@ -22,7 +23,11 @@ all-features = true
 bench = false
 
 [[bench]]
-name = "merkle_tree"
+name = "balanced"
+harness = false
+
+[[bench]]
+name = "unbalanced"
 harness = false
 
 [[bench]]

--- a/crates/shared/ab-merkle-tree/Cargo.toml
+++ b/crates/shared/ab-merkle-tree/Cargo.toml
@@ -25,6 +25,14 @@ bench = false
 name = "merkle_tree"
 harness = false
 
+[[bench]]
+name = "mmr"
+harness = false
+
+[[bench]]
+name = "sparse"
+harness = false
+
 [dependencies]
 ab-blake3 = { workspace = true }
 # NOTE: `blake3` is here only for `no-panic` feature

--- a/crates/shared/ab-merkle-tree/benches/balanced.rs
+++ b/crates/shared/ab-merkle-tree/benches/balanced.rs
@@ -1,0 +1,67 @@
+#![expect(incomplete_features, reason = "generic_const_*")]
+#![feature(generic_const_args, min_generic_const_args)]
+
+use ab_merkle_tree::balanced::BalancedMerkleTree;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Intentional inlining prevention doesn't allow the compiler to prove lack of panics
+    if cfg!(feature = "no-panic") {
+        return;
+    }
+
+    balanced::<2>(c);
+    balanced::<4>(c);
+    balanced::<256>(c);
+    balanced::<32768>(c);
+    balanced::<65536>(c);
+}
+
+fn balanced<const N: usize>(c: &mut Criterion) {
+    // SAFETY: Data structure filled with zeroes is a valid invariant
+    let mut input = unsafe { Box::<[[u8; 32]; N]>::new_zeroed().assume_init() };
+    for (index, input) in input.iter_mut().enumerate() {
+        *input = [(index % u8::MAX as usize + 1) as u8; 32];
+    }
+
+    let mut instance = Box::new_uninit();
+
+    c.bench_function(&format!("{N}/balanced/new"), |b| {
+        b.iter(|| {
+            BalancedMerkleTree::new_in(black_box(&mut instance), black_box(&input));
+        });
+    });
+    c.bench_function(&format!("{N}/balanced/compute-root-only"), |b| {
+        b.iter(|| {
+            black_box(BalancedMerkleTree::compute_root_only(black_box(&input)));
+        });
+    });
+
+    let tree = &*BalancedMerkleTree::<N>::new_in(black_box(&mut instance), black_box(&input));
+
+    c.bench_function(&format!("{N}/balanced/all-proofs"), |b| {
+        b.iter(|| {
+            black_box(black_box(black_box(tree).all_proofs()).count());
+        });
+    });
+
+    let root = tree.root();
+    let all_proofs = tree.all_proofs().collect::<Vec<_>>();
+
+    c.bench_function(&format!("{N}/balanced/verify"), |b| {
+        b.iter(|| {
+            for (index, proof) in all_proofs.iter().enumerate() {
+                black_box(BalancedMerkleTree::<N>::verify(
+                    black_box(&root),
+                    black_box(proof),
+                    black_box(index),
+                    black_box(input[index]),
+                ));
+            }
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/shared/ab-merkle-tree/benches/merkle_tree.rs
+++ b/crates/shared/ab-merkle-tree/benches/merkle_tree.rs
@@ -27,9 +27,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     unbalanced::<256>(c);
     unbalanced::<32768>(c);
     unbalanced::<65536>(c);
-
-    // TODO: MMR benches
-    // TODO: Spase Merkle Tree benches
 }
 
 fn balanced<const N: usize>(c: &mut Criterion) {

--- a/crates/shared/ab-merkle-tree/benches/mmr.rs
+++ b/crates/shared/ab-merkle-tree/benches/mmr.rs
@@ -1,0 +1,97 @@
+#![expect(incomplete_features, reason = "generic_const_*")]
+#![feature(generic_const_args, generic_const_items, min_generic_const_args)]
+
+use ab_merkle_tree::mmr::MerkleMountainRange;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::mem::MaybeUninit;
+
+const U64_TO_USIZE<const N: u64>: usize = N as usize;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Intentional inlining prevention doesn't allow the compiler to prove lack of panics
+    if cfg!(feature = "no-panic") {
+        return;
+    }
+
+    mmr::<1>(c);
+    mmr::<2>(c);
+    mmr::<4>(c);
+    mmr::<256>(c);
+    mmr::<32768>(c);
+    mmr::<65536>(c);
+}
+
+fn mmr<const MAX_N: u64>(c: &mut Criterion) {
+    // SAFETY: Data structure filled with zeroes is a valid invariant
+    let mut input = unsafe { Box::<[[u8; 32]; U64_TO_USIZE::<MAX_N>]>::new_zeroed().assume_init() };
+    for (index, input) in input.iter_mut().enumerate() {
+        *input = [(index % u8::MAX as usize + 1) as u8; 32];
+    }
+
+    // Aggregate all leaves in bulk and compute the root
+    c.bench_function(&format!("{MAX_N}/mmr/add-leaves-root"), |b| {
+        b.iter(|| {
+            let mut mmr = MerkleMountainRange::<MAX_N>::new();
+            black_box(mmr.add_leaves(black_box(input.iter().copied())));
+            black_box(mmr.root());
+        });
+    });
+
+    // Aggregate all leaves incrementally and compute the root
+    c.bench_function(&format!("{MAX_N}/mmr/add-leaf-root"), |b| {
+        b.iter(|| {
+            let mut mmr = MerkleMountainRange::<MAX_N>::new();
+            for leaf in black_box(&input) {
+                black_box(mmr.add_leaf(black_box(leaf)));
+            }
+            black_box(mmr.root());
+        });
+    });
+
+    // Aggregate all leaves incrementally, generating an inclusion proof for each of them
+    c.bench_function(&format!("{MAX_N}/mmr/add-leaf-and-compute-proof"), |b| {
+        b.iter(|| {
+            let mut mmr = MerkleMountainRange::<MAX_N>::new();
+            let mut proof = [MaybeUninit::uninit(); _];
+
+            for leaf in black_box(&input) {
+                black_box(mmr.add_leaf_and_compute_proof_in(black_box(leaf), &mut proof));
+            }
+        });
+    });
+
+    // Collect a root and proof snapshot for a subset of leaf indices to benchmark verification
+    let indices = (0..input.len()).step_by(100).collect::<Vec<_>>();
+    let snapshots = {
+        let mut mmr = MerkleMountainRange::<MAX_N>::new();
+        let mut proof = Box::new([MaybeUninit::uninit(); _]);
+        let mut snapshots = Vec::new();
+
+        for (index, leaf) in input.iter().enumerate() {
+            let (root, proof) = mmr.add_leaf_and_compute_proof_in(leaf, &mut proof).unwrap();
+            if indices.contains(&index) {
+                snapshots.push((root, proof.to_vec(), index as u64, *leaf, index as u64 + 1));
+            }
+        }
+
+        snapshots
+    };
+
+    c.bench_function(&format!("{MAX_N}/mmr/verify"), |b| {
+        b.iter(|| {
+            for (root, proof, leaf_index, leaf, num_leaves) in &snapshots {
+                black_box(MerkleMountainRange::<MAX_N>::verify(
+                    black_box(root),
+                    black_box(proof),
+                    black_box(*leaf_index),
+                    black_box(*leaf),
+                    black_box(*num_leaves),
+                ));
+            }
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/shared/ab-merkle-tree/benches/mmr.rs
+++ b/crates/shared/ab-merkle-tree/benches/mmr.rs
@@ -14,7 +14,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         return;
     }
 
-    mmr::<1>(c);
     mmr::<2>(c);
     mmr::<4>(c);
     mmr::<256>(c);

--- a/crates/shared/ab-merkle-tree/benches/sparse.rs
+++ b/crates/shared/ab-merkle-tree/benches/sparse.rs
@@ -1,0 +1,99 @@
+#![expect(incomplete_features, reason = "generic_const_*")]
+#![feature(generic_const_args, min_generic_const_args)]
+
+use ab_merkle_tree::balanced::BalancedMerkleTree;
+use ab_merkle_tree::sparse::{Leaf, PROOF_ELEMENTS, SparseMerkleTree};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::num::NonZeroU128;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Intentional inlining prevention doesn't allow the compiler to prove lack of panics
+    if cfg!(feature = "no-panic") {
+        return;
+    }
+
+    // Fully materialized trees (all leaves occupied), cross-checked against the Balanced Merkle
+    // Tree
+    sparse_full::<8, 256>(c);
+    sparse_full::<12, 4096>(c);
+    sparse_full::<16, 65536>(c);
+
+    // Sparse trees of intractable size, where the vast majority of leaves are empty
+    sparse_skip::<32>(c);
+    sparse_skip::<64>(c);
+    sparse_skip::<128>(c);
+}
+
+/// Benchmarks a fully occupied tree of `2^BITS == N` leaves
+fn sparse_full<const BITS: u8, const N: usize>(c: &mut Criterion) {
+    assert_eq!(2usize.pow(u32::from(BITS)), N);
+
+    // SAFETY: Data structure filled with zeroes is a valid invariant
+    let mut input = unsafe { Box::<[[u8; 32]; N]>::new_zeroed().assume_init() };
+    for (index, input) in input.iter_mut().enumerate() {
+        *input = [(index % u8::MAX as usize + 1) as u8; 32];
+    }
+
+    c.bench_function(&format!("{BITS}/sparse/compute-root-only"), |b| {
+        b.iter(|| {
+            black_box(SparseMerkleTree::<BITS>::compute_root_only(
+                black_box(&input).iter().map(|leaf| Leaf::Occupied { leaf }),
+            ));
+        });
+    });
+
+    // A fully occupied Sparse Merkle Tree has the same root and proofs as a Balanced Merkle Tree,
+    // which is used here to conveniently generate proofs for the verification benchmark
+    let mut instance = Box::new_uninit();
+    let tree = &*BalancedMerkleTree::<N>::new_in(&mut instance, &input);
+    let root = tree.root();
+
+    let indices = (0..N).step_by(100).collect::<Vec<_>>();
+    let proofs = tree
+        .all_proofs()
+        .enumerate()
+        .filter(|(index, _proof)| indices.contains(index))
+        .map(|(_index, proof)| {
+            <[[u8; 32]; PROOF_ELEMENTS::<BITS>]>::try_from(proof.as_slice())
+                .expect("Balanced Merkle Tree proof has exactly `BITS` elements; qed")
+        })
+        .collect::<Vec<_>>();
+
+    c.bench_function(&format!("{BITS}/sparse/verify"), |b| {
+        b.iter(|| {
+            for (&index, proof) in indices.iter().zip(&proofs) {
+                black_box(SparseMerkleTree::<BITS>::verify(
+                    black_box(&root),
+                    black_box(proof),
+                    black_box(index as u128),
+                    black_box(input[index]),
+                ));
+            }
+        });
+    });
+}
+
+/// Benchmarks a tree of intractable `2^BITS` size, where only a single leaf is occupied and the
+/// rest are empty
+fn sparse_skip<const BITS: u8>(c: &mut Criterion) {
+    let leaf = [1u8; 32];
+    // Number of empty leaves following the single occupied leaf
+    let skip_count = if u32::from(BITS) < u128::BITS {
+        NonZeroU128::new((1u128 << BITS) - 1).unwrap()
+    } else {
+        NonZeroU128::MAX
+    };
+
+    c.bench_function(&format!("{BITS}/sparse/compute-root-only-skip"), |b| {
+        b.iter(|| {
+            black_box(SparseMerkleTree::<BITS>::compute_root_only([
+                black_box(Leaf::Occupied { leaf: &leaf }),
+                black_box(Leaf::Empty { skip_count }),
+            ]));
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/shared/ab-merkle-tree/benches/unbalanced.rs
+++ b/crates/shared/ab-merkle-tree/benches/unbalanced.rs
@@ -1,7 +1,6 @@
 #![expect(incomplete_features, reason = "generic_const_*")]
 #![feature(generic_const_args, generic_const_items, min_generic_const_args)]
 
-use ab_merkle_tree::balanced::BalancedMerkleTree;
 use ab_merkle_tree::unbalanced::UnbalancedMerkleTree;
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
@@ -15,63 +14,12 @@ fn criterion_benchmark(c: &mut Criterion) {
         return;
     }
 
-    balanced::<2>(c);
-    balanced::<4>(c);
-    balanced::<256>(c);
-    balanced::<32768>(c);
-    balanced::<65536>(c);
-
     unbalanced::<1>(c);
     unbalanced::<2>(c);
     unbalanced::<4>(c);
     unbalanced::<256>(c);
     unbalanced::<32768>(c);
     unbalanced::<65536>(c);
-}
-
-fn balanced<const N: usize>(c: &mut Criterion) {
-    // SAFETY: Data structure filled with zeroes is a valid invariant
-    let mut input = unsafe { Box::<[[u8; 32]; N]>::new_zeroed().assume_init() };
-    for (index, input) in input.iter_mut().enumerate() {
-        *input = [(index % u8::MAX as usize + 1) as u8; 32];
-    }
-
-    let mut instance = Box::new_uninit();
-
-    c.bench_function(&format!("{N}/balanced/new"), |b| {
-        b.iter(|| {
-            BalancedMerkleTree::new_in(black_box(&mut instance), black_box(&input));
-        });
-    });
-    c.bench_function(&format!("{N}/balanced/compute-root-only"), |b| {
-        b.iter(|| {
-            black_box(BalancedMerkleTree::compute_root_only(black_box(&input)));
-        });
-    });
-
-    let tree = &*BalancedMerkleTree::<N>::new_in(black_box(&mut instance), black_box(&input));
-
-    c.bench_function(&format!("{N}/balanced/all-proofs"), |b| {
-        b.iter(|| {
-            black_box(black_box(black_box(tree).all_proofs()).count());
-        });
-    });
-
-    let root = tree.root();
-    let all_proofs = tree.all_proofs().collect::<Vec<_>>();
-
-    c.bench_function(&format!("{N}/balanced/verify"), |b| {
-        b.iter(|| {
-            for (index, proof) in all_proofs.iter().enumerate() {
-                black_box(BalancedMerkleTree::<N>::verify(
-                    black_box(&root),
-                    black_box(proof),
-                    black_box(index),
-                    black_box(input[index]),
-                ));
-            }
-        });
-    });
 }
 
 fn unbalanced<const MAX_N: u64>(c: &mut Criterion) {

--- a/crates/shared/ab-merkle-tree/src/lib.rs
+++ b/crates/shared/ab-merkle-tree/src/lib.rs
@@ -17,7 +17,7 @@
 //! turn an optimized version of [`MerkleMountainRange`], and all 3 will return the same results for
 //! identical inputs.
 //!
-//! [`SparseMerkleTree`] is a special kind of Merkle Tree, usually of untractable size, where most
+//! [`SparseMerkleTree`] is a special kind of Merkle Tree, usually of intractable size, where most
 //! of the leaves are empty (missing). It will also produce the same root as other trees in case the
 //! tree doesn't have any empty leaves, though it is unlikely to happen in practice.
 //!

--- a/crates/shared/ab-merkle-tree/src/mmr.rs
+++ b/crates/shared/ab-merkle-tree/src/mmr.rs
@@ -13,7 +13,16 @@ use core::ops::{Deref, DerefMut};
 pub const NUM_PEAKS<const MAX_N: u64>: usize = MAX_N.next_power_of_two().ilog2() as usize;
 /// Max number of elements in a proof for MMR with `MAX_N` leaves
 pub const MAX_PROOF_ELEMENTS<const MAX_N: u64>: usize = MAX_N.next_power_of_two().ilog2() as usize;
-const STACK_SIZE<const MAX_N: u64>: usize = MAX_N.next_power_of_two().ilog2() as usize + 1;
+const STACK_SIZE<const MAX_N: u64>: usize = {
+    // This constraint is actually needed to prevent issues related to MMR peaks, but making it
+    // unrepresentable is better
+    assert!(
+        MAX_N > 1,
+        "This Merkle Mountain Range must have MAX_N > 1 leaves"
+    );
+
+    MAX_N.next_power_of_two().ilog2() as usize + 1
+};
 
 /// Size of [`MerkleMountainRange`]/[`MerkleMountainRangeBytes`] in bytes
 const MERKLE_MOUNTAIN_RANGE_BYTES_SIZE<const MAX_N: u64>: usize =

--- a/crates/shared/ab-merkle-tree/src/mmr.rs
+++ b/crates/shared/ab-merkle-tree/src/mmr.rs
@@ -17,12 +17,26 @@ const STACK_SIZE<const MAX_N: u64>: usize = MAX_N.next_power_of_two().ilog2() as
 
 /// Size of [`MerkleMountainRange`]/[`MerkleMountainRangeBytes`] in bytes
 const MERKLE_MOUNTAIN_RANGE_BYTES_SIZE<const MAX_N: u64>: usize =
-    size_of::<u64>() + OUT_LEN * (MAX_N.ilog2() as usize + 1);
+    size_of::<u64>() + OUT_LEN * (MAX_N.next_power_of_two().ilog2() as usize + 1);
 
 const {
     assert!(size_of::<MerkleMountainRangeBytes<2>>() == MERKLE_MOUNTAIN_RANGE_BYTES_SIZE::<2>);
     assert!(size_of::<MerkleMountainRange<2>>() == MERKLE_MOUNTAIN_RANGE_BYTES_SIZE::<2>);
     assert!(align_of::<MerkleMountainRangeBytes<2>>() == align_of::<MerkleMountainRange<2>>());
+
+    // `MAX_N` doesn't have to be a power of two, verify the layout formula for a few more shapes,
+    // including a large one, to guard against regressions in `MERKLE_MOUNTAIN_RANGE_BYTES_SIZE`
+    assert!(size_of::<MerkleMountainRangeBytes<100>>() == MERKLE_MOUNTAIN_RANGE_BYTES_SIZE::<100>);
+    assert!(size_of::<MerkleMountainRange<100>>() == MERKLE_MOUNTAIN_RANGE_BYTES_SIZE::<100>);
+    assert!(align_of::<MerkleMountainRangeBytes<100>>() == align_of::<MerkleMountainRange<100>>());
+
+    assert!(
+        size_of::<MerkleMountainRangeBytes<65536>>() == MERKLE_MOUNTAIN_RANGE_BYTES_SIZE::<65536>
+    );
+    assert!(size_of::<MerkleMountainRange<65536>>() == MERKLE_MOUNTAIN_RANGE_BYTES_SIZE::<65536>);
+    assert!(
+        align_of::<MerkleMountainRangeBytes<65536>>() == align_of::<MerkleMountainRange<65536>>()
+    );
 }
 
 /// MMR peaks for [`MerkleMountainRange`].

--- a/crates/shared/ab-merkle-tree/src/sparse.rs
+++ b/crates/shared/ab-merkle-tree/src/sparse.rs
@@ -63,7 +63,7 @@ impl<'a> From<&'a [u8; OUT_LEN]> for Leaf<'a> {
 /// (have value `[0u8; 32]`).
 ///
 /// In contrast to a proper Balanced Merkle Tree, constant `BITS` here specifies the max number of
-/// leaves hypothetically possible in a tree (2^BITS, often untractable), rather than the number of
+/// leaves hypothetically possible in a tree (2^BITS, often intractable), rather than the number of
 /// non-empty leaves actually present.
 #[derive(Debug)]
 pub struct SparseMerkleTree<const BITS: u8>;

--- a/crates/shared/ab-merkle-tree/tests/mmr.rs
+++ b/crates/shared/ab-merkle-tree/tests/mmr.rs
@@ -1,0 +1,279 @@
+#![expect(incomplete_features, reason = "generic_const_*")]
+#![feature(generic_const_args, min_generic_const_args)]
+
+//! Tests for [`MerkleMountainRange`]-specific behavior that is not covered by `balanced.rs` and
+//! `unbalanced.rs` (which focus on cross-checking the root and proofs against the other Merkle Tree
+//! implementations).
+
+use ab_blake3::OUT_LEN;
+use ab_merkle_tree::mmr::{MerkleMountainRange, MerkleMountainRangeBytes, MmrPeaks};
+use ab_merkle_tree::unbalanced::UnbalancedMerkleTree;
+use chacha20::ChaCha8Rng;
+use chacha20::rand_core::{Rng, SeedableRng};
+use std::mem::MaybeUninit;
+
+fn random_leaves<const N: usize>(rng: &mut ChaCha8Rng) -> [[u8; OUT_LEN]; N] {
+    let mut leaves = [[0u8; OUT_LEN]; N];
+    for hash in &mut leaves {
+        rng.fill_bytes(hash);
+    }
+    leaves
+}
+
+#[test]
+fn mmr_empty() {
+    let mmr = MerkleMountainRange::<8>::new();
+
+    // An empty Merkle Mountain Range has no root
+    assert_eq!(mmr.num_leaves(), 0);
+    assert!(mmr.root().is_none());
+    // `Default` is identical to `new()`
+    assert_eq!(
+        mmr.num_leaves(),
+        MerkleMountainRange::<8>::default().num_leaves()
+    );
+
+    // Peaks of an empty instance round-trip back to an empty instance
+    let peaks = mmr.peaks();
+    assert_eq!(peaks.num_leaves, 0);
+    assert_eq!(peaks.num_peaks(), 0);
+    let restored = MerkleMountainRange::<8>::from_peaks(&peaks).unwrap();
+    assert_eq!(restored.num_leaves(), 0);
+    assert!(restored.root().is_none());
+}
+
+#[test]
+fn mmr_too_many_leaves() {
+    const MAX_N: u64 = 3;
+
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+    let leaves = random_leaves::<{ MAX_N as usize + 1 }>(&mut rng);
+
+    let mut mmr = MerkleMountainRange::<MAX_N>::new();
+    for leaf in leaves.iter().take(MAX_N as usize) {
+        assert!(mmr.add_leaf(leaf));
+    }
+    assert_eq!(mmr.num_leaves(), MAX_N);
+    let root = mmr.root().unwrap();
+
+    // Adding one leaf beyond the maximum must fail and leave the instance untouched
+    let extra_leaf = &leaves[MAX_N as usize];
+    {
+        let mut mmr = mmr;
+        assert!(!mmr.add_leaf(extra_leaf));
+        assert_eq!(mmr.num_leaves(), MAX_N);
+        assert_eq!(mmr.root().unwrap(), root);
+    }
+    {
+        let mut mmr = mmr;
+        assert!(!mmr.add_leaves([extra_leaf].into_iter().copied()));
+        assert_eq!(mmr.num_leaves(), MAX_N);
+        assert_eq!(mmr.root().unwrap(), root);
+    }
+    {
+        let mut mmr = mmr;
+        let proof_buffer = &mut [MaybeUninit::uninit(); _];
+        assert!(
+            mmr.add_leaf_and_compute_proof_in(extra_leaf, proof_buffer)
+                .is_none()
+        );
+        assert_eq!(mmr.num_leaves(), MAX_N);
+        assert_eq!(mmr.root().unwrap(), root);
+    }
+    #[cfg(feature = "alloc")]
+    {
+        let mut mmr = mmr;
+        assert!(mmr.add_leaf_and_compute_proof(extra_leaf).is_none());
+        assert_eq!(mmr.num_leaves(), MAX_N);
+        assert_eq!(mmr.root().unwrap(), root);
+    }
+
+    // Bulk insertion stops as soon as capacity is exhausted
+    let mut mmr = MerkleMountainRange::<MAX_N>::new();
+    assert!(!mmr.add_leaves(leaves.iter().copied()));
+    assert_eq!(mmr.num_leaves(), MAX_N);
+    assert_eq!(mmr.root().unwrap(), root);
+}
+
+#[test]
+fn mmr_bytes_round_trip() {
+    const MAX_N: u64 = 8;
+
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+    let leaves = random_leaves::<{ MAX_N as usize }>(&mut rng);
+
+    // Round-trip the state for every possible number of leaves
+    for num_leaves in 0..=leaves.len() {
+        let mut mmr = MerkleMountainRange::<MAX_N>::new();
+        assert!(mmr.add_leaves(leaves.iter().copied().take(num_leaves)));
+
+        // A default byte representation corresponds to an empty instance
+        let bytes = *mmr.as_bytes();
+        // `Deref` exposes the underlying byte array
+        assert_eq!(
+            bytes.len(),
+            MerkleMountainRangeBytes::<MAX_N>::default().len()
+        );
+
+        // Byte array conversions round-trip
+        let array: [u8; _] = bytes.into();
+        let bytes_from_array = MerkleMountainRangeBytes::<MAX_N>::from(array);
+        assert_eq!(bytes.as_slice(), bytes_from_array.as_slice());
+
+        // SAFETY: Bytes were just produced by `as_bytes()`
+        let restored = unsafe { MerkleMountainRange::<MAX_N>::from_bytes(&bytes_from_array) };
+        assert_eq!(restored.num_leaves(), mmr.num_leaves());
+        assert_eq!(restored.root(), mmr.root());
+        assert_eq!(restored.peaks(), mmr.peaks());
+    }
+
+    // `DerefMut` allows mutating the underlying byte array
+    let mut bytes = MerkleMountainRangeBytes::<MAX_N>::default();
+    bytes[0] = 1;
+    assert_eq!(bytes[0], 1);
+}
+
+#[test]
+fn mmr_bytes_round_trip_large() {
+    const MAX_N: u64 = 65536;
+
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+    // SAFETY: Data structure filled with zeroes is a valid invariant
+    let mut leaves = unsafe { Box::<[[u8; OUT_LEN]; MAX_N as usize]>::new_zeroed().assume_init() };
+    for leaf in &mut leaves {
+        rng.fill_bytes(leaf);
+    }
+
+    // Counts chosen to produce non-trivial peak sets (several simultaneously active levels), a
+    // single peak (power of two) and the fully saturated case, at a scale where the `#[repr(C)]`
+    // byte layout spans many more stack levels than the `MAX_N = 8` case above
+    for &num_leaves in &[0usize, 1, 2, 3, 100, 12_345, 65_535, 65_536] {
+        let mut mmr = MerkleMountainRange::<MAX_N>::new();
+        assert!(mmr.add_leaves(leaves.iter().copied().take(num_leaves)));
+
+        let bytes = *mmr.as_bytes();
+        // SAFETY: Bytes were just produced by `as_bytes()`
+        let restored = unsafe { MerkleMountainRange::<MAX_N>::from_bytes(&bytes) };
+
+        assert_eq!(
+            restored.num_leaves(),
+            mmr.num_leaves(),
+            "num_leaves {num_leaves}"
+        );
+        assert_eq!(restored.root(), mmr.root(), "num_leaves {num_leaves}");
+        assert_eq!(restored.peaks(), mmr.peaks(), "num_leaves {num_leaves}");
+    }
+}
+
+#[test]
+fn mmr_peak_merging_boundaries() {
+    const MAX_N: u64 = 128;
+    // Counts landing exactly on power-of-two boundaries (where a single insertion merges the
+    // maximum number of peaks), immediately before/after them, values with many bits set (forcing
+    // a long cascade of merges on the very next insertion), and full capacity saturation
+    const BOUNDARY_COUNTS: &[usize] = &[
+        1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 85, 100, 101, 127, 128,
+    ];
+
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+    let leaves = random_leaves::<{ MAX_N as usize }>(&mut rng);
+
+    let mmr_proof_buffer = &mut [MaybeUninit::uninit(); _];
+    let unbalanced_proof_buffer = &mut [MaybeUninit::uninit(); _];
+
+    for &num_leaves in BOUNDARY_COUNTS {
+        let prefix = &leaves[..num_leaves];
+
+        let mut mmr = MerkleMountainRange::<MAX_N>::new();
+
+        for (leaf_index, leaf) in prefix.iter().enumerate() {
+            let (mmr_root, mmr_proof) = mmr
+                .add_leaf_and_compute_proof_in(leaf, mmr_proof_buffer)
+                .unwrap();
+
+            // After each insertion the MMR represents a tree of exactly `leaf_index + 1` leaves,
+            // so the reference must be computed over that same sub-prefix, not the full one
+            let (expected_root, expected_proof) =
+                UnbalancedMerkleTree::compute_root_and_proof_in::<MAX_N, _, _>(
+                    prefix[..=leaf_index].iter().copied(),
+                    leaf_index,
+                    unbalanced_proof_buffer,
+                )
+                .unwrap();
+
+            assert_eq!(
+                mmr_root, expected_root,
+                "num_leaves {num_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                mmr_proof, expected_proof,
+                "num_leaves {num_leaves} leaf_index {leaf_index}"
+            );
+            assert!(
+                MerkleMountainRange::<MAX_N>::verify(
+                    &mmr_root,
+                    mmr_proof,
+                    leaf_index as u64,
+                    *leaf,
+                    leaf_index as u64 + 1
+                ),
+                "num_leaves {num_leaves} leaf_index {leaf_index}"
+            );
+        }
+
+        assert_eq!(
+            mmr.num_leaves(),
+            num_leaves as u64,
+            "num_leaves {num_leaves}"
+        );
+        assert_eq!(
+            mmr.root().unwrap(),
+            UnbalancedMerkleTree::compute_root_only::<MAX_N, _, _>(prefix.iter().copied()).unwrap(),
+            "num_leaves {num_leaves}"
+        );
+    }
+}
+
+#[test]
+fn mmr_peaks_round_trip() {
+    const MAX_N: u64 = 32;
+
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+    let leaves = random_leaves::<{ MAX_N as usize }>(&mut rng);
+
+    for num_leaves in 0..=leaves.len() {
+        let mut mmr = MerkleMountainRange::<MAX_N>::new();
+        assert!(mmr.add_leaves(leaves.iter().copied().take(num_leaves)));
+
+        let peaks = mmr.peaks();
+        assert_eq!(peaks.num_leaves, num_leaves as u64);
+        // The number of occupied peaks equals the number of set bits in the number of leaves
+        assert_eq!(
+            u32::from(peaks.num_peaks()),
+            (num_leaves as u64).count_ones(),
+            "num_leaves {num_leaves}"
+        );
+
+        let restored = MerkleMountainRange::<MAX_N>::from_peaks(&peaks).unwrap();
+        assert_eq!(
+            restored.num_leaves(),
+            mmr.num_leaves(),
+            "num_leaves {num_leaves}"
+        );
+        assert_eq!(restored.root(), mmr.root(), "num_leaves {num_leaves}");
+        assert_eq!(restored.peaks(), peaks, "num_leaves {num_leaves}");
+    }
+}
+
+#[test]
+fn mmr_from_peaks_invalid() {
+    const MAX_N: u64 = 4;
+
+    // A number of leaves that doesn't fit into `MAX_N` references peaks/stack levels that don't
+    // exist, hence must be rejected
+    let peaks = MmrPeaks::<MAX_N> {
+        num_leaves: 8,
+        peaks: [[0u8; OUT_LEN]; _],
+    };
+    assert!(MerkleMountainRange::<MAX_N>::from_peaks(&peaks).is_none());
+}

--- a/crates/shared/ab-merkle-tree/tests/sparse.rs
+++ b/crates/shared/ab-merkle-tree/tests/sparse.rs
@@ -97,6 +97,47 @@ fn smt_32_full() {
 }
 
 #[test]
+fn smt_occupied_owned() {
+    const N: usize = 32;
+    const BITS: u8 = N.ilog2() as u8;
+
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+
+    let leaves = {
+        let mut leaves = [[0u8; OUT_LEN]; N];
+        for hash in &mut leaves {
+            rng.fill_bytes(hash);
+        }
+        leaves
+    };
+
+    let root_borrowed =
+        SparseMerkleTree::<BITS>::compute_root_only(leaves.iter().map(Leaf::from)).unwrap();
+    // `Leaf::OccupiedOwned` must produce an identical root to `Leaf::Occupied` for the same values
+    let root_owned = SparseMerkleTree::<BITS>::compute_root_only(
+        leaves
+            .iter()
+            .map(|leaf| Leaf::OccupiedOwned { leaf: *leaf }),
+    )
+    .unwrap();
+    assert_eq!(root_borrowed, root_owned);
+
+    // Mixing borrowed and owned occupied leaves together must still produce the same root as an
+    // all-borrowed sequence of the same values
+    let mixed_root = SparseMerkleTree::<BITS>::compute_root_only(leaves.iter().enumerate().map(
+        |(index, leaf)| {
+            if index.is_multiple_of(2) {
+                Leaf::OccupiedOwned { leaf: *leaf }
+            } else {
+                Leaf::Occupied { leaf }
+            }
+        },
+    ))
+    .unwrap();
+    assert_eq!(mixed_root, root_borrowed);
+}
+
+#[test]
 fn smt_32_1_missing() {
     test_32(1);
 }

--- a/crates/shared/ab-merkle-tree/tests/unbalanced.rs
+++ b/crates/shared/ab-merkle-tree/tests/unbalanced.rs
@@ -3,6 +3,7 @@
 
 use ab_blake3::OUT_LEN;
 use ab_merkle_tree::hash_pair;
+use ab_merkle_tree::mmr::MerkleMountainRange;
 use ab_merkle_tree::unbalanced::UnbalancedMerkleTree;
 use chacha20::ChaCha8Rng;
 use chacha20::rand_core::{Rng, SeedableRng};
@@ -246,7 +247,6 @@ fn mt_unbalanced_large_range() {
     }
 }
 
-// TODO: Add MMR tests here
 fn test_basic(number_of_leaves: u64) {
     let mut rng = ChaCha8Rng::from_seed(Default::default());
 
@@ -278,6 +278,18 @@ fn test_basic(number_of_leaves: u64) {
     };
 
     let proof_buffer = &mut [MaybeUninit::uninit(); _];
+
+    // Merkle Mountain Range aggregates leaves incrementally, so after adding `leaf_index + 1`
+    // leaves it represents a tree of that many leaves, whose root and proofs must match those
+    // produced by the other implementations for the same prefix of leaves.
+    let mut mmr = MerkleMountainRange::<MAX_N>::new();
+    assert_eq!(
+        mmr.peaks(),
+        MerkleMountainRange::from_peaks(&mmr.peaks())
+            .unwrap()
+            .peaks()
+    );
+    let proof_buffer_mmr = &mut [MaybeUninit::uninit(); _];
 
     for (leaf_index, leaf) in leaves.iter().copied().enumerate() {
         let (computed_root, proof) =
@@ -439,6 +451,186 @@ fn test_basic(number_of_leaves: u64) {
             ),
             "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
         );
+
+        // Ensure MMR implementation produces the same root and proofs as the other implementations
+        // and can verify them successfully
+        let mmr_before = mmr;
+        let num_leaves = leaf_index as u64 + 1;
+        let partial_root =
+            SimpleUnbalancedMerkleTree::compute_root_only(leaves[..=leaf_index].iter()).unwrap();
+
+        // Add leaf individually with proof generation
+        let (mmr_root, mmr_proof) = mmr
+            .add_leaf_and_compute_proof_in(&leaf, proof_buffer_mmr)
+            .unwrap();
+        assert_eq!(
+            mmr.peaks(),
+            MerkleMountainRange::from_peaks(&mmr.peaks())
+                .unwrap()
+                .peaks(),
+            "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+        );
+        assert_eq!(
+            mmr.num_leaves(),
+            num_leaves,
+            "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+        );
+        assert_eq!(
+            mmr_root, partial_root,
+            "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+        );
+        assert_eq!(
+            mmr.root().unwrap(),
+            mmr_root,
+            "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+        );
+        assert!(
+            UnbalancedMerkleTree::verify(&mmr_root, mmr_proof, leaf_index as u64, leaf, num_leaves),
+            "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+        );
+        assert!(
+            MerkleMountainRange::<MAX_N>::verify(
+                &mmr_root,
+                mmr_proof,
+                leaf_index as u64,
+                leaf,
+                num_leaves
+            ),
+            "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+        );
+
+        // Add leaf individually without proof generation
+        {
+            let mut mmr = mmr_before;
+            assert!(
+                mmr.add_leaf(&leaf),
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                mmr.num_leaves(),
+                num_leaves,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                mmr.root().unwrap(),
+                mmr_root,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+        }
+
+        // Add leaf individually with proof generation and `alloc`
+        #[cfg(feature = "alloc")]
+        {
+            let mut mmr = mmr_before;
+            let (alloc_root, alloc_proof) = mmr.add_leaf_and_compute_proof(&leaf).unwrap();
+            assert_eq!(
+                mmr.num_leaves(),
+                num_leaves,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                alloc_root, mmr_root,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                alloc_proof.as_slice(),
+                mmr_proof,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+        }
+
+        // Add leaves in bulk from scratch
+        {
+            let mut mmr = MerkleMountainRange::<MAX_N>::new();
+            assert!(
+                mmr.add_leaves(leaves.iter().copied().take(leaf_index + 1)),
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                mmr.num_leaves(),
+                num_leaves,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                mmr.root().unwrap(),
+                mmr_root,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+        }
+
+        // Add leaves incrementally, then the rest in bulk
+        {
+            let mut mmr = MerkleMountainRange::<MAX_N>::new();
+            for leaf in leaves.iter().take(leaf_index) {
+                assert!(
+                    mmr.add_leaf(leaf),
+                    "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+                );
+            }
+            assert!(
+                mmr.add_leaves(leaves.iter().copied().skip(leaf_index).take(1)),
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                mmr.num_leaves(),
+                num_leaves,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                mmr.root().unwrap(),
+                mmr_root,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+        }
+
+        // MMR proof must not verify with a tampered leaf, index or proof
+        assert!(
+            !MerkleMountainRange::<MAX_N>::verify(
+                &mmr_root,
+                mmr_proof,
+                leaf_index as u64,
+                random_hash,
+                num_leaves
+            ),
+            "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+        );
+        if num_leaves > 1 {
+            assert!(
+                !MerkleMountainRange::<MAX_N>::verify(
+                    &mmr_root,
+                    &random_proof,
+                    leaf_index as u64,
+                    leaf,
+                    num_leaves
+                ),
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+        }
+        if let Some(bad_leaf_index) = leaf_index.checked_sub(1) {
+            assert!(
+                !MerkleMountainRange::<MAX_N>::verify(
+                    &mmr_root,
+                    mmr_proof,
+                    bad_leaf_index as u64,
+                    leaf,
+                    num_leaves
+                ),
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+        }
+
+        // The final MMR state covers all leaves, so its root and the proof for the last leaf must
+        // match the full tree computed by the unbalanced implementation
+        if leaf_index == leaves.len() - 1 {
+            assert_eq!(
+                mmr_root, root,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+            assert_eq!(
+                mmr_proof, computed_proof,
+                "number_of_leaves {number_of_leaves} leaf_index {leaf_index}"
+            );
+        }
     }
 
     assert!(


### PR DESCRIPTION
This introduces a bunch more tests, MMR/SMT benchmarks and covers more edge-cases. Also one bug was fixed where `MERKLE_MOUNTAIN_RANGE_BYTES_SIZE` wasn't computed correctly for non-power-of-to sizes.

UPD: And also fixed one more edge-case for MMR with `MAX_N == 1`.