### PR TITLE
Update rust-gpu with fixed locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ dependencies = [
 [[package]]
 name = "cargo-gpu-install"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=ad79728bf2961a257e1e1f76edaa1130ee8c0638#ad79728bf2961a257e1e1f76edaa1130ee8c0638"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.21.0",
@@ -5263,7 +5263,7 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 [[package]]
 name = "rustc_codegen_spirv-types"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=ad79728bf2961a257e1e1f76edaa1130ee8c0638#ad79728bf2961a257e1e1f76edaa1130ee8c0638"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
 dependencies = [
  "rspirv",
  "semver",
@@ -5750,7 +5750,7 @@ dependencies = [
 [[package]]
 name = "spirv-builder"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=ad79728bf2961a257e1e1f76edaa1130ee8c0638#ad79728bf2961a257e1e1f76edaa1130ee8c0638"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
 dependencies = [
  "cargo_metadata 0.21.0",
  "log",
@@ -5766,7 +5766,7 @@ dependencies = [
 [[package]]
 name = "spirv-std"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=ad79728bf2961a257e1e1f76edaa1130ee8c0638#ad79728bf2961a257e1e1f76edaa1130ee8c0638"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
 dependencies = [
  "bitflags 1.3.2",
  "glam",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-macros"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=ad79728bf2961a257e1e1f76edaa1130ee8c0638#ad79728bf2961a257e1e1f76edaa1130ee8c0638"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5790,7 +5790,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-types"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=ad79728bf2961a257e1e1f76edaa1130ee8c0638#ad79728bf2961a257e1e1f76edaa1130ee8c0638"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ bech32 = { version = "0.12.0", default-features = false }
 blake3 = { version = "1.8.5", default-features = false }
 bytes = { version = "1.12.1", default-features = false }
 bytesize = { version = "2.4.2", default-features = false }
-cargo-gpu-install = { version = "=0.10.0-alpha.1", git = "https://github.com/Rust-GPU/rust-gpu", rev = "ad79728bf2961a257e1e1f76edaa1130ee8c0638" }
+cargo-gpu-install = { version = "=0.10.0-alpha.1", git = "https://github.com/Rust-GPU/rust-gpu", rev = "63d5a41422010cd3f732b587b9dcd1d1a2b42de7" }
 cargo_metadata = { version = "0.23.1" }
 chacha20 = { version = "0.10.1", default-features = false }
 clap = { version = "4.6.2", features = ["derive"] }
@@ -128,7 +128,7 @@ serde_json = "1.0.150"
 serde-big-array = "0.5.1"
 sha2 = { version = "0.11.0", default-features = false }
 smallvec = { version = "1.15.2", features = ["union"] }
-spirv-std = { version = "=0.10.0-alpha.1", git = "https://github.com/Rust-GPU/rust-gpu", rev = "ad79728bf2961a257e1e1f76edaa1130ee8c0638" }
+spirv-std = { version = "=0.10.0-alpha.1", git = "https://github.com/Rust-GPU/rust-gpu", rev = "63d5a41422010cd3f732b587b9dcd1d1a2b42de7" }
 stable_deref_trait = { version = "1.2.1", default-features = false }
 strum = { version = "0.28.0", default-features = false, features = ["derive"] }
 syn = "3.0.1"


### PR DESCRIPTION
This should finally address CI flakiness (https://github.com/Rust-GPU/rust-gpu/pull/631)