### PR TITLE
RISC-V no-panic (part 2)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -660,7 +660,7 @@ jobs:
       - name: Set up RUSTFLAGS
         shell: bash
         run: |
-          echo "RUSTFLAGS=${RUSTFLAGS} -Cllvm-args=--inline-threshold=7000 -C embed-bitcode -C lto -Z dylib-lto ${{ matrix.target == '' && '-C target-cpu=native' || '' }}" >> $GITHUB_ENV
+          echo "RUSTFLAGS=${RUSTFLAGS} -Cllvm-args=--inline-threshold=10000 -C embed-bitcode -C lto -Z dylib-lto ${{ matrix.target == '' && '-C target-cpu=native' || '' }}" >> $GITHUB_ENV
 
       - name: Ensure no panics in annotated code
         shell: bash

--- a/crates/execution/ab-riscv-interpreter/Cargo.toml
+++ b/crates/execution/ab-riscv-interpreter/Cargo.toml
@@ -32,7 +32,6 @@ ab-riscv-macros = { workspace = true, features = ["build"] }
 
 [features]
 # TODO: no-panic coverage is incomplete with the following missing:
-#  * `// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]` comments in vector code
 #  * All `fn execute` methods
 #  * `BasicInterpreterState::execute` method
 # Check that code can't panic under any conditions

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -71,7 +71,8 @@
     inherent_associated_types,
     integer_widen_truncate,
     min_generic_const_args,
-    signed_bigint_helpers
+    signed_bigint_helpers,
+    widening_mul
 )]
 #![cfg_attr(feature = "no-panic", feature(const_closures))]
 #![cfg_attr(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
@@ -179,7 +179,7 @@ pub enum OpSrc {
 /// - When `vm=false`: `vd.to_bits() != 0` (vd does not overlap v0)
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -245,7 +245,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 /// - `vl <= VLEN` (so every element index fits within the mask register)
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
@@ -42,7 +42,7 @@ pub(in super::super) unsafe fn carry_bit<const VLEN: Vlen>(
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -102,7 +102,7 @@ pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, ExtState, CustomErr
 /// Same as [`execute_carry_add()`].
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -164,7 +164,7 @@ pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
 /// - vd overlap constraints checked by caller
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -229,7 +229,7 @@ pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, ExtState, Cust
 /// Same as [`execute_carry_add_mask()`].
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_carry_sub_mask<const WITH_BORROW: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/zvexx_config_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/zvexx_config_helpers.rs
@@ -15,7 +15,7 @@ use core::hint::cold_path;
 /// Returns `rd_value`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn apply_vsetvl<Reg, ExtState, Memory, PC, CustomError>(
     ext_state: &mut ExtState,
     program_counter: &PC,
@@ -98,7 +98,7 @@ where
 /// Returns `rd_value`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn apply_vsetivli<Reg, ExtState, Memory, PC, CustomError>(
     ext_state: &mut ExtState,
     program_counter: &PC,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
@@ -433,7 +433,7 @@ pub unsafe fn read_wide_element_u64<const VLEN: Vlen>(
 /// Same preconditions as `execute_arith_op` in the arithmetic helpers.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -499,7 +499,7 @@ pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -302,7 +302,7 @@ fn read_mem_element(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_unit_stride_load<
     const FAULT_ONLY_FIRST: bool,
     Reg,
@@ -435,7 +435,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_strided_load<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &Memory,
@@ -527,7 +527,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_indexed_load<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &Memory,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/zvexx_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/zvexx_mask_helpers.rs
@@ -19,7 +19,7 @@ use core::fmt;
 /// The operation snapshots both sources before writing, so `vd` may safely overlap either source.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -65,7 +65,7 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
 /// Returns `rd_value`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vcpop<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vs2: VReg,
@@ -111,7 +111,7 @@ where
 /// Returns `rd_value`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vfirst<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vs2: VReg,
@@ -317,7 +317,7 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
 /// - `vl <= VLMAX`; `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -366,7 +366,7 @@ pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
 /// - `vl <= VLEN`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_vid<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -514,7 +514,7 @@ pub fn mulhsu_su(a: u64, b: u64, sew: Vsew) -> u64 {
 /// - Signed overflow (MIN / −1): result = MIN (i.e., `1 << (SEW-1)`)
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn sdiv(a: u64, b: u64, sew: Vsew) -> u64 {
     let sa = sign_extend(a, sew);
     let sb = sign_extend(b, sew);
@@ -522,12 +522,7 @@ pub fn sdiv(a: u64, b: u64, sew: Vsew) -> u64 {
     if sb == 0 {
         return sew_mask(sew);
     }
-    // Signed overflow: MIN / -1 returns MIN
-    let sew_min = i64::MIN >> (u64::BITS - u32::from(sew.bits_width()));
-    if sa == sew_min && sb == -1 {
-        return sew_min.cast_unsigned() & sew_mask(sew);
-    }
-    (sa / sb).cast_unsigned() & sew_mask(sew)
+    sa.wrapping_div(sb).cast_unsigned() & sew_mask(sew)
 }
 
 /// Signed remainder with division-by-zero and signed-overflow semantics from the RISC-V V spec
@@ -537,11 +532,7 @@ pub fn sdiv(a: u64, b: u64, sew: Vsew) -> u64 {
 /// - Signed overflow (MIN % −1): remainder = 0
 #[inline(always)]
 #[doc(hidden)]
-#[expect(
-    clippy::modulo_arithmetic,
-    reason = "This is what the code is supposed to do"
-)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn srem(a: u64, b: u64, sew: Vsew) -> u64 {
     let sa = sign_extend(a, sew);
     let sb = sign_extend(b, sew);
@@ -549,10 +540,5 @@ pub fn srem(a: u64, b: u64, sew: Vsew) -> u64 {
     if sb == 0 {
         return a & sew_mask(sew);
     }
-    // Signed overflow: MIN % -1 = 0
-    let sew_min = i64::MIN >> (u64::BITS - u32::from(sew.bits_width()));
-    if sa == sew_min && sb == -1 {
-        return 0;
-    }
-    (sa % sb).cast_unsigned() & sew_mask(sew)
+    sa.wrapping_rem(sb).cast_unsigned() & sew_mask(sew)
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -144,7 +144,7 @@ unsafe fn write_wide_element_u64<const VLEN: Vlen>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -200,7 +200,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -256,7 +256,7 @@ pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -309,7 +309,7 @@ pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
 /// Same as [`execute_muladd_op`], minus constraints on `a_reg`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -366,7 +366,7 @@ pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -421,7 +421,7 @@ pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
 /// Same as [`execute_widening_muladd_op`], minus constraints on `a_reg`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -473,11 +473,11 @@ pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, CustomError, F>(
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn mulh_ss(a: u64, b: u64, sew: Vsew) -> u64 {
-    let sa = i128::from(sign_extend(a, sew));
-    let sb = i128::from(sign_extend(b, sew));
-    let product = sa.wrapping_mul(sb);
+    let sa = sign_extend(a, sew);
+    let sb = sign_extend(b, sew);
+    let product = sa.widening_mul(sb);
     // Extract bits [2*SEW-1 : SEW] of the product
-    let high = (product >> u32::from(sew.bits_width())).cast_unsigned() as u64;
+    let high = (product >> sew.bits_width()).cast_unsigned() as u64;
     high & sew_mask(sew)
 }
 
@@ -486,10 +486,10 @@ pub fn mulh_ss(a: u64, b: u64, sew: Vsew) -> u64 {
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn mulhu_uu(a: u64, b: u64, sew: Vsew) -> u64 {
-    let ua = u128::from(a & sew_mask(sew));
-    let ub = u128::from(b & sew_mask(sew));
-    let product = ua.wrapping_mul(ub);
-    let high = (product >> u32::from(sew.bits_width())) as u64;
+    let ua = a & sew_mask(sew);
+    let ub = b & sew_mask(sew);
+    let product = ua.widening_mul(ub);
+    let high = (product >> sew.bits_width()) as u64;
     high & sew_mask(sew)
 }
 
@@ -501,10 +501,9 @@ pub fn mulhu_uu(a: u64, b: u64, sew: Vsew) -> u64 {
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn mulhsu_su(a: u64, b: u64, sew: Vsew) -> u64 {
     let sa = i128::from(sign_extend(a, sew));
-    let ub = u128::from(b & sew_mask(sew));
-    // Compute signed × unsigned as i128 to preserve sign
-    let product = sa.wrapping_mul(ub.cast_signed());
-    let high = (product >> u32::from(sew.bits_width())).cast_unsigned() as u64;
+    let ub = i128::from(b & sew_mask(sew));
+    let product = sa.wrapping_mul(ub);
+    let high = (product >> sew.bits_width()).cast_unsigned() as u64;
     high & sew_mask(sew)
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
@@ -169,7 +169,7 @@ where
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -218,7 +218,7 @@ pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -272,7 +272,7 @@ pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -325,7 +325,7 @@ pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -371,7 +371,7 @@ pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -419,7 +419,7 @@ pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
 /// - When `vm=false`: `vd.to_bits() != 0`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -472,7 +472,7 @@ pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -537,7 +537,7 @@ pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -587,7 +587,7 @@ pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
 /// - `vl <= group_regs * VLEN.bytes() / sew_bytes`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -634,7 +634,7 @@ pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
 /// - `vl <= VLMAX`.
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/zvexx_reduction_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/zvexx_reduction_helpers.rs
@@ -18,7 +18,7 @@ use core::hint::cold_path;
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -75,7 +75,7 @@ pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widening_reduce_op<
     const SIGN_EXTEND_SRC: bool,
     Reg,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
@@ -93,7 +93,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_unit_stride_store<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &mut Memory,
@@ -172,7 +172,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_strided_store<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &mut Memory,
@@ -246,7 +246,7 @@ where
 #[inline(always)]
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_indexed_store<Reg, ExtState, Memory, CustomError>(
     ext_state: &mut ExtState,
     memory: &mut Memory,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -327,9 +327,11 @@ where
                     });
                 }
                 // Scalar is sign-extended from XLEN to 64 bits
-                let scalar =
-                    zvexx_widen_narrow_helpers::sign_extend_bits(rs1_value.as_u64(), Reg::XLEN)
-                        .cast_unsigned();
+                let scalar = zvexx_widen_narrow_helpers::sign_extend_bits(
+                    rs1_value.as_u64(),
+                    Vsew::from_xlen::<Reg>(),
+                )
+                .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _, _>(
@@ -611,9 +613,11 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                let scalar =
-                    zvexx_widen_narrow_helpers::sign_extend_bits(rs1_value.as_u64(), Reg::XLEN)
-                        .cast_unsigned();
+                let scalar = zvexx_widen_narrow_helpers::sign_extend_bits(
+                    rs1_value.as_u64(),
+                    Vsew::from_xlen::<Reg>(),
+                )
+                .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _, _>(
@@ -889,9 +893,11 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                let scalar =
-                    zvexx_widen_narrow_helpers::sign_extend_bits(rs1_value.as_u64(), Reg::XLEN)
-                        .cast_unsigned();
+                let scalar = zvexx_widen_narrow_helpers::sign_extend_bits(
+                    rs1_value.as_u64(),
+                    Vsew::from_xlen::<Reg>(),
+                )
+                .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _, _>(
@@ -1165,9 +1171,11 @@ where
                         address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     });
                 }
-                let scalar =
-                    zvexx_widen_narrow_helpers::sign_extend_bits(rs1_value.as_u64(), Reg::XLEN)
-                        .cast_unsigned();
+                let scalar = zvexx_widen_narrow_helpers::sign_extend_bits(
+                    rs1_value.as_u64(),
+                    Vsew::from_xlen::<Reg>(),
+                )
+                .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
                     zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _, _>(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
@@ -301,12 +301,12 @@ unsafe fn write_element_u64<const VLEN: Vlen>(
     dst.copy_from_slice(unsafe { buf.get_unchecked(..sew_bytes as usize) });
 }
 
-/// Sign-extend the low `bits` of `val` to `i64`.
+/// Sign-extend the low `sew.bits_width()` of `val` to `i64`.
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn sign_extend_bits(val: u64, bits: u8) -> i64 {
-    let shift = u64::BITS - u32::from(bits);
+pub fn sign_extend_bits(val: u64, sew: Vsew) -> i64 {
+    let shift = u64::BITS - u32::from(sew.bits_width());
     (val.cast_signed() << shift) >> shift
 }
 
@@ -332,8 +332,8 @@ pub fn sign_extend_bits(val: u64, bits: u8) -> i64 {
 /// This helper performs that SEW-width truncation without sign extension.
 #[inline(always)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-fn scalar_unsigned_for_sew(val: u64, sew_bits: u8) -> u64 {
-    val & (u64::MAX >> (u64::BITS - u32::from(sew_bits)))
+fn scalar_unsigned_for_sew(val: u64, sew: Vsew) -> u64 {
+    val & (u64::MAX >> (u64::BITS - u32::from(sew.bits_width())))
 }
 
 /// Interpret a scalar operand as a signed SEW-wide value.
@@ -359,8 +359,8 @@ fn scalar_unsigned_for_sew(val: u64, sew_bits: u8) -> u64 {
 /// as vwadd.vx and vwsub.vx.
 #[inline(always)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-fn scalar_signed_for_sew(val: u64, sew_bits: u8) -> u64 {
-    sign_extend_bits(val, sew_bits).cast_unsigned()
+fn scalar_signed_for_sew(val: u64, sew: Vsew) -> u64 {
+    sign_extend_bits(val, sew).cast_unsigned()
 }
 
 /// Execute a widening integer add/subtract.
@@ -417,7 +417,7 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, Custom
         let wide_a = if ZERO_EXTEND_AB {
             raw_a
         } else {
-            sign_extend_bits(raw_a, sew.bits_width()).cast_unsigned()
+            sign_extend_bits(raw_a, sew).cast_unsigned()
         };
         let wide_b = match src {
             OpSrc::Vreg(vs1_base) => {
@@ -426,14 +426,14 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, Custom
                 if ZERO_EXTEND_AB {
                     raw_b
                 } else {
-                    sign_extend_bits(raw_b, sew.bits_width()).cast_unsigned()
+                    sign_extend_bits(raw_b, sew).cast_unsigned()
                 }
             }
             OpSrc::Scalar(val) => {
                 if ZERO_EXTEND_AB {
-                    scalar_unsigned_for_sew(val, sew.bits_width())
+                    scalar_unsigned_for_sew(val, sew)
                 } else {
-                    scalar_signed_for_sew(val, sew.bits_width())
+                    scalar_signed_for_sew(val, sew)
                 }
             }
         };
@@ -505,14 +505,14 @@ pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, Custo
                 if ZERO_EXTEND_B {
                     raw_b
                 } else {
-                    sign_extend_bits(raw_b, sew.bits_width()).cast_unsigned()
+                    sign_extend_bits(raw_b, sew).cast_unsigned()
                 }
             }
             OpSrc::Scalar(val) => {
                 if ZERO_EXTEND_B {
-                    scalar_unsigned_for_sew(val, sew.bits_width())
+                    scalar_unsigned_for_sew(val, sew)
                 } else {
-                    scalar_signed_for_sew(val, sew.bits_width())
+                    scalar_signed_for_sew(val, sew)
                 }
             }
         };
@@ -589,7 +589,7 @@ pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, Custom
             // Sign-extend to i64 first, then shift arithmetically as i64 to
             // preserve sign bits, then cast back. Shifting u64 after cast_unsigned()
             // would be a logical shift and lose sign bits.
-            (sign_extend_bits(wide_val, wide_sew.bits_width()) >> shamt).cast_unsigned()
+            (sign_extend_bits(wide_val, wide_sew) >> shamt).cast_unsigned()
         } else {
             wide_val >> shamt
         };
@@ -650,7 +650,7 @@ pub unsafe fn execute_extension<const SIGN: bool, Reg, ExtState, CustomError>(
         // SAFETY: vs2 group covers `vl` narrow elements
         let raw = unsafe { read_element_u64(ext_state.read_vregs(), vs2, i, src_sew) };
         let result = if SIGN {
-            sign_extend_bits(raw, src_sew.bits_width()).cast_unsigned()
+            sign_extend_bits(raw, src_sew).cast_unsigned()
         } else {
             raw
         };

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
@@ -382,7 +382,7 @@ fn scalar_signed_for_sew(val: u64, sew: Vsew) -> u64 {
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -400,9 +400,8 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, Custom
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let wide_sew = sew
-        .double_width()
-        .expect("SEW < 64 is enforced by caller, hence this is always valid; qed");
+    // SAFETY: Caller guarantees SEW < 64, hence this is always valid
+    let wide_sew = unsafe { sew.double_width().unwrap_unchecked() };
 
     // SAFETY: `vl <= VLMAX <= VLEN`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
@@ -464,7 +463,7 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, Custom
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, CustomError, F>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -482,9 +481,8 @@ pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, Custo
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let wide_sew = sew
-        .double_width()
-        .expect("SEW < 64 is enforced by caller, hence this is always valid; qed");
+    // SAFETY: Caller guarantees SEW < 64, hence this is always valid
+    let wide_sew = unsafe { sew.double_width().unwrap_unchecked() };
 
     // SAFETY: `vl <= VLEN`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };
@@ -543,7 +541,7 @@ pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, Custo
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -559,9 +557,8 @@ pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, Custom
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let wide_sew = sew
-        .double_width()
-        .expect("SEW < 64 is enforced by caller, hence this is always valid; qed");
+    // SAFETY: Caller guarantees SEW < 64, hence this is always valid
+    let wide_sew = unsafe { sew.double_width().unwrap_unchecked() };
     // Shift amount mask: log2(2*SEW) bits = log2(SEW) + 1 bits
     let shamt_mask = u64::from(wide_sew.bits_width() - 1);
 
@@ -620,7 +617,7 @@ pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, Custom
 /// - When `vm=false`: `vd.to_bits() != 0`
 #[inline(always)]
 #[doc(hidden)]
-// TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub unsafe fn execute_extension<const SIGN: bool, Reg, ExtState, CustomError>(
     ext_state: &mut ExtState,
     vd: VReg,
@@ -636,9 +633,8 @@ pub unsafe fn execute_extension<const SIGN: bool, Reg, ExtState, CustomError>(
 {
     let vl = ext_state.vl();
     let vstart = ext_state.vstart();
-    let src_sew = sew
-        .divide_by_factor(factor)
-        .expect("SEW >= factor*8 and valid according to function contract; qed");
+    // SAFETY: Caller guarantees SEW >= factor*8 and valid according to function contract
+    let src_sew = unsafe { sew.divide_by_factor(factor).unwrap_unchecked() };
 
     // SAFETY: `vl <= VLEN`
     let mask_buf = unsafe { snapshot_mask(ext_state.read_vregs(), vm, vl) };

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -498,6 +498,26 @@ impl Vsew {
         }
     }
 
+    /// Create a selected element width that matches the register width
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    pub const fn from_xlen<Reg>() -> Self
+    where
+        Reg: [const] Register,
+    {
+        const {
+            match Reg::XLEN {
+                32 => Self::E32,
+                64 => Self::E64,
+                _ => {
+                    // TODO: Should have been `unreachable!()`:
+                    //  https://github.com/rust-lang/rust/issues/159645
+                    panic!("Invalid register width")
+                }
+            }
+        }
+    }
+
     /// Encode to the 3-bit vsew field
     #[inline(always)]
     pub const fn to_bits(self) -> u8 {


### PR DESCRIPTION
More things were already panic-free, just needed a higher inlining limits. Others required minor changes and clarifications to nudge compiler towards the correct conclusion.