### PR TITLE
Support running RISC-V interpreter in const environment with several extensions

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -264,10 +264,7 @@ const unsafe impl ZcmpRegister for ContractRegister {
 pub enum ContractInstruction<Reg = ContractRegister> {}
 
 #[instruction]
-const impl<Reg> Instruction for ContractInstruction<Reg>
-where
-    Reg: [const] Register<Type = u64>,
-{
+const impl<Reg> Instruction for ContractInstruction<Reg> {
     type Reg = Reg;
 
     #[inline(always)]
@@ -297,10 +294,10 @@ where
 }
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ContractInstruction<Reg> {}
+const impl<Reg> ExecutableInstructionOperands for ContractInstruction<Reg> {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ContractInstruction<Reg>
 {
 }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
@@ -30,10 +30,7 @@ pub(crate) type AbundanceRv32IMaxInstruction = AbundanceRv32IMaxInstructionProto
 pub(crate) enum AbundanceRv32IMaxInstructionPrototype<Reg> {}
 
 #[instruction]
-const impl<Reg> Instruction for AbundanceRv32IMaxInstructionPrototype<Reg>
-where
-    Reg: [const] Register<Type = u32>,
-{
+const impl<Reg> Instruction for AbundanceRv32IMaxInstructionPrototype<Reg> {
     type Reg = Reg;
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
@@ -30,10 +30,7 @@ pub(crate) type AbundanceRv64IMaxInstruction = AbundanceRv64IMaxInstructionProto
 pub(crate) enum AbundanceRv64IMaxInstructionPrototype<Reg> {}
 
 #[instruction]
-const impl<Reg> Instruction for AbundanceRv64IMaxInstructionPrototype<Reg>
-where
-    Reg: [const] Register<Type = u64>,
-{
+const impl<Reg> Instruction for AbundanceRv64IMaxInstructionPrototype<Reg> {
     type Reg = Reg;
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-act4-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/instruction.rs
@@ -14,10 +14,7 @@ use std::ops::ControlFlow;
 pub(crate) enum MachineModePlaceholder<Reg> {}
 
 #[instruction]
-const impl<Reg> Instruction for MachineModePlaceholder<Reg>
-where
-    Reg: [const] Register,
-{
+const impl<Reg> Instruction for MachineModePlaceholder<Reg> {
     type Reg = Reg;
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
@@ -21,10 +21,7 @@ type CoremarkRegister = Reg<u64>;
 pub(crate) enum CoremarkInstruction<Reg = CoremarkRegister> {}
 
 #[instruction]
-const impl<Reg> Instruction for CoremarkInstruction<Reg>
-where
-    Reg: [const] Register<Type = u64>,
-{
+const impl<Reg> Instruction for CoremarkInstruction<Reg> {
     type Reg = Reg;
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -67,10 +67,7 @@ impl TimeCsrState {
 pub(crate) enum TimeCsrInstruction<Reg> {}
 
 #[instruction]
-const impl<Reg> Instruction for TimeCsrInstruction<Reg>
-where
-    Reg: [const] Register,
-{
+const impl<Reg> Instruction for TimeCsrInstruction<Reg> {
     type Reg = Reg;
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-interpreter/Cargo.toml
+++ b/crates/execution/ab-riscv-interpreter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ab-riscv-interpreter"
 description = "Composable and generic RISC-V interpreter"
-keywords = ["riscv", "risc-v", "interpreter", "no-std"]
+keywords = ["riscv", "risc-v", "interpreter", "no-std", "const"]
 repository = "https://github.com/nazar-pc/abundance"
 homepage = "https://github.com/nazar-pc/abundance/tree/main/crates/execution/ab-riscv-interpreter"
 license = "0BSD"

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -220,9 +220,9 @@ pub struct BasicMemory<const BASE_ADDR: u64, const SIZE: usize> {
     data: [u8; SIZE],
 }
 
-impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE_ADDR, SIZE> {
+const impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE_ADDR, SIZE> {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn read<T>(&self, address: u64) -> Result<T, VirtualMemoryError>
     where
         T: BasicInt,
@@ -249,7 +249,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
     }
 
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     unsafe fn read_unchecked<T>(&self, address: u64) -> T
     where
         T: BasicInt,
@@ -265,7 +265,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
         }
     }
 
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn read_slice(&self, address: u64, len: u32) -> Result<&[u8], VirtualMemoryError> {
         let Some(offset) = address.checked_sub(BASE_ADDR) else {
             cold_path();
@@ -279,11 +279,11 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
 
         self.data
             .get(offset as usize..)
-            .and_then(|data| data.get(..len as usize))
+            .and_then(const |data| data.get(..len as usize))
             .ok_or(VirtualMemoryError::OutOfBoundsRead { address })
     }
 
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn read_slice_up_to(&self, address: u64, len: u32) -> &[u8] {
         let Some(offset) = address.checked_sub(BASE_ADDR) else {
             cold_path();
@@ -300,7 +300,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
     }
 
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn write<T>(&mut self, address: u64, value: T) -> Result<(), VirtualMemoryError>
     where
         T: BasicInt,
@@ -327,7 +327,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
         Ok(())
     }
 
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn write_slice(&mut self, address: u64, data: &[u8]) -> Result<(), VirtualMemoryError> {
         let Some(offset) = address.checked_sub(BASE_ADDR) else {
             cold_path();
@@ -343,7 +343,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> VirtualMemory for BasicMemory<BASE
         let Some(target_data) = self
             .data
             .get_mut(offset as usize..)
-            .and_then(|data| data.get_mut(..len))
+            .and_then(const |data| data.get_mut(..len))
         else {
             cold_path();
             return Err(VirtualMemoryError::OutOfBoundsWrite { address });
@@ -367,7 +367,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> BasicMemory<BASE_ADDR, SIZE> {
     ///
     /// This is primarily useful for setting up the program and should not be used beyond that.
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    pub fn get_mut_bytes(
+    pub const fn get_mut_bytes(
         &mut self,
         address: u64,
         size: usize,
@@ -381,7 +381,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> BasicMemory<BASE_ADDR, SIZE> {
         let Some(slice) = self
             .data
             .get_mut(offset..)
-            .and_then(|data| data.get_mut(..size))
+            .and_then(const |data| data.get_mut(..size))
         else {
             cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address });
@@ -409,11 +409,11 @@ where
     _phantom: PhantomData<CustomError>,
 }
 
-impl<I, Memory, CustomError> ProgramCounter<Address<I>, Memory, CustomError>
+const impl<I, Memory, CustomError> ProgramCounter<Address<I>, Memory, CustomError>
     for BasicInstructionFetcher<I, CustomError>
 where
-    I: Instruction,
-    Memory: VirtualMemory,
+    I: [const] Instruction,
+    Memory: [const] VirtualMemory,
 {
     #[inline(always)]
     fn get_pc(&self) -> Address<I> {
@@ -421,7 +421,7 @@ where
     }
 
     #[inline]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn set_pc(
         &mut self,
         _memory: &Memory,
@@ -443,19 +443,19 @@ where
     }
 }
 
-impl<I, Memory, CustomError> InstructionFetcher<I, Memory, CustomError>
+const impl<I, Memory, CustomError> InstructionFetcher<I, Memory, CustomError>
     for BasicInstructionFetcher<I, CustomError>
 where
-    I: Instruction,
-    Memory: VirtualMemory,
+    I: [const] Instruction,
+    Memory: [const] VirtualMemory,
 {
     #[inline]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn fetch_instruction(
         &mut self,
         memory: &Memory,
     ) -> Result<FetchInstructionResult<I>, ExecutionError<Address<I>, CustomError>> {
-        let instruction = match memory.read(self.pc.as_u64()).or_else(|error| {
+        let instruction = match memory.read(self.pc.as_u64()).or_else(const |error| {
             cold_path();
             // Attempt to read a 16-bit compressed instruction
             if let Ok(instruction) = memory.read::<u16>(self.pc.as_u64())
@@ -491,7 +491,7 @@ where
     /// `return_trap_address` is the address at which the interpreter will stop execution
     /// (gracefully).
     #[inline(always)]
-    pub fn new(return_trap_address: Address<I>, pc: Address<I>) -> Self {
+    pub const fn new(return_trap_address: Address<I>, pc: Address<I>) -> Self {
         Self {
             return_trap_address,
             pc,
@@ -505,15 +505,14 @@ where
 #[derive(Debug, Default, Clone, Copy)]
 pub struct IllegalEcallSystemInstructionHandler;
 
-impl<Reg, Regs, Memory, PC, CustomError>
+const impl<Reg, Regs, Memory, PC, CustomError>
     SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>
     for IllegalEcallSystemInstructionHandler
 where
-    Reg: Register,
-    Regs: RegisterFile<Reg>,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    Reg: [const] Register,
+    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
 {
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn handle_ecall(
         &mut self,
         _regs: &mut Regs,

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -13,7 +13,8 @@
 //! Certification Tests runner for <https://github.com/riscv-non-isa/riscv-arch-test> that ensures
 //! correct implementation.
 //!
-//! Does not require a standard library (`no_std`) or an allocator, never panics.
+//! Does not require a standard library (`no_std`) or an allocator, never panics, almost 100% of the
+//! API abstractions are usable in const, including several extensions beyond base ISA.
 //!
 //! ## Supported ISA variants and extensions
 //!
@@ -61,11 +62,17 @@
 #![expect(incomplete_features, reason = "generic_const_*")]
 #![feature(
     adt_const_params,
+    const_closures,
     const_cmp,
     const_convert,
     const_default,
+    const_destruct,
     const_index,
+    const_ops,
+    const_option_ops,
+    const_result_trait_fn,
     const_trait_impl,
+    const_try,
     generic_const_args,
     generic_const_items,
     inherent_associated_types,
@@ -75,7 +82,6 @@
     signed_bigint_helpers,
     widening_mul
 )]
-#![cfg_attr(feature = "no-panic", feature(const_closures))]
 #![cfg_attr(
     not(any(
         all(target_arch = "riscv32", target_feature = "zbkx"),
@@ -135,6 +141,7 @@ use crate::private::BasicIntSealed;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 use core::hint::cold_path;
+use core::marker::Destruct;
 use core::ops::{ControlFlow, Sub};
 
 type RegisterType<I> = <<I as Instruction>::Reg as Register>::Type;
@@ -191,7 +198,7 @@ impl BasicInt for i32 {}
 impl BasicInt for i64 {}
 
 /// Virtual memory interface
-pub trait VirtualMemory {
+pub const trait VirtualMemory {
     /// Read a value from memory at the specified address
     fn read<T>(&self, address: u64) -> Result<T, VirtualMemoryError>
     where
@@ -250,7 +257,7 @@ pub enum ProgramCounterError<Address, CustomError = CustomErrorPlaceholder> {
 }
 
 /// Generic program counter
-pub trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder> {
+pub const trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder> {
     /// Get the current value of the program counter
     fn get_pc(&self) -> Address;
 
@@ -260,10 +267,10 @@ pub trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder> 
     /// advanced during instruction fetching. As such, `pc - instruction_size` is expected to never
     /// underflow.
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn old_pc(&self, instruction_size: u8) -> Address
     where
-        Address: From<u8> + Sub<Output = Address>,
+        Address: [const] From<u8> + [const] Sub<Output = Address>,
     {
         // TODO: Wrapping subtraction would be nice, but causes a lot of additional generic bounds
         //  that are bad for ergonomics
@@ -283,10 +290,10 @@ pub trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder> 
 pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder> {
     /// Program counter error
     #[error("Program counter error: {0}")]
-    ProgramCounter(#[from] ProgramCounterError<Address, CustomError>),
+    ProgramCounter(ProgramCounterError<Address, CustomError>),
     /// Memory access error
     #[error("Memory access error: {0}")]
-    MemoryAccess(#[from] VirtualMemoryError),
+    MemoryAccess(VirtualMemoryError),
     /// Unsupported `ecall` instruction
     #[error("Unsupported `ecall` instruction at address {address:#x}")]
     EcallUnsupported {
@@ -309,10 +316,35 @@ pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder> {
     },
     /// CSR error
     #[error("CSR error: {0}")]
-    CsrError(#[from] CsrError<CustomError>),
+    CsrError(CsrError<CustomError>),
     /// Custom error
     #[error("Custom error: {0}")]
     Custom(CustomError),
+}
+
+const impl<Address, CustomError> From<ProgramCounterError<Address, CustomError>>
+    for ExecutionError<Address, CustomError>
+{
+    #[inline(always)]
+    fn from(value: ProgramCounterError<Address, CustomError>) -> Self {
+        Self::ProgramCounter(value)
+    }
+}
+
+const impl<Address, CustomError> From<VirtualMemoryError> for ExecutionError<Address, CustomError> {
+    #[inline(always)]
+    fn from(value: VirtualMemoryError) -> Self {
+        Self::MemoryAccess(value)
+    }
+}
+
+const impl<Address, CustomError> From<CsrError<CustomError>>
+    for ExecutionError<Address, CustomError>
+{
+    #[inline(always)]
+    fn from(value: CsrError<CustomError>) -> Self {
+        Self::CsrError(value)
+    }
 }
 
 /// Result of [`InstructionFetcher::fetch_instruction()`] call
@@ -325,7 +357,7 @@ pub enum FetchInstructionResult<Instruction> {
 }
 
 /// Generic instruction fetcher
-pub trait InstructionFetcher<I, Memory, CustomError = CustomErrorPlaceholder>
+pub const trait InstructionFetcher<I, Memory, CustomError = CustomErrorPlaceholder>
 where
     Self: ProgramCounter<Address<I>, Memory, CustomError>,
     I: Instruction,
@@ -384,9 +416,10 @@ pub enum CsrError<CustomError = CustomErrorPlaceholder> {
 }
 
 /// CSRs (Control and Status Registers)
-pub trait Csrs<Reg, CustomError = CustomErrorPlaceholder>
+pub const trait Csrs<Reg, CustomError = CustomErrorPlaceholder>
 where
-    Reg: Register,
+    Reg: [const] Register,
+    CustomError: [const] Destruct,
 {
     /// Current privilege level
     #[inline(always)]
@@ -408,14 +441,14 @@ where
     /// fine most of the time but can be overridden in special cases or for testing purposes.
     #[doc(hidden)]
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn process_csr_read<I>(
         &self,
         csr_index: u16,
         raw_value: Reg::Type,
     ) -> Result<Reg::Type, CsrError<CustomError>>
     where
-        I: ExecutableInstructionCsr<Self, CustomError, Reg = Reg>,
+        I: [const] ExecutableInstructionCsr<Self, CustomError, Reg = Reg>,
     {
         let mut out = Reg::Type::default();
         match I::prepare_csr_read(self, csr_index, raw_value, &mut out) {
@@ -440,14 +473,14 @@ where
     /// purposes.
     #[doc(hidden)]
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn process_csr_write<I>(
         &mut self,
         csr_index: u16,
         write_value: Reg::Type,
     ) -> Result<Reg::Type, CsrError<CustomError>>
     where
-        I: ExecutableInstructionCsr<Self, CustomError, Reg = Reg>,
+        I: [const] ExecutableInstructionCsr<Self, CustomError, Reg = Reg>,
     {
         let mut out = Reg::Type::default();
         match I::prepare_csr_write(self, csr_index, write_value, &mut out) {
@@ -465,10 +498,14 @@ where
 }
 
 /// Custom handler for system instructions `ecall` and `ebreak`
-pub trait SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError = CustomErrorPlaceholder>
-where
+pub const trait SystemInstructionHandler<
+    Reg,
+    Regs,
+    Memory,
+    PC,
+    CustomError = CustomErrorPlaceholder,
+> where
     Reg: Register,
-    Regs: RegisterFile<Reg>,
 {
     // TODO: Figure out the correct API for this method
     /// Handle a `fence` instruction
@@ -535,7 +572,7 @@ pub struct Rs1Rs2OperandValues<RegType> {
 }
 
 /// `rs1`/`rs2` instruction operands
-pub trait ExecutableInstructionOperands
+pub const trait ExecutableInstructionOperands
 where
     Self: Instruction,
 {
@@ -546,7 +583,7 @@ where
     fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg>;
 }
 
-pub trait ExecutableInstructionCsr<ExtState, CustomError = CustomErrorPlaceholder>
+pub const trait ExecutableInstructionCsr<ExtState, CustomError = CustomErrorPlaceholder>
 where
     Self: Instruction,
     ExtState: ?Sized,
@@ -623,7 +660,7 @@ pub type ExecutableInstructionResult<T, I, CustomError> = Result<
 >;
 
 /// Trait for executable instructions
-pub trait ExecutableInstruction<
+pub const trait ExecutableInstruction<
     Regs,
     ExtState,
     Memory,

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -17,13 +17,17 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
+use core::marker::Destruct;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32Instruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32Instruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32Instruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -31,18 +35,19 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32Instruction<Reg>
 where
-    Reg: Register<Type = u32>,
-    Regs: RegisterFile<Reg>,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
+    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    CustomError: [const] Destruct,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {
@@ -166,10 +171,14 @@ where
             Self::Jalr { rd, rs1: _, imm } => {
                 let target = (rs1_value.wrapping_add(i32::from(imm).cast_unsigned())) & !1u32;
                 regs.write(rd, program_counter.get_pc());
-                return program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from);
+
+                match program_counter.set_pc(memory, target) {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::from(err)),
+                }
             }
 
             Self::Sb {
@@ -207,10 +216,15 @@ where
             } => {
                 if rs1_value == rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -222,10 +236,15 @@ where
             } => {
                 if rs1_value != rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -237,10 +256,15 @@ where
             } => {
                 if rs1_value.cast_signed() < rs2_value.cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -252,10 +276,15 @@ where
             } => {
                 if rs1_value.cast_signed() >= rs2_value.cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -267,10 +296,15 @@ where
             } => {
                 if rs1_value < rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -282,10 +316,15 @@ where
             } => {
                 if rs1_value >= rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -305,10 +344,16 @@ where
                 let pc = program_counter.get_pc();
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 regs.write(rd, pc);
-                return program_counter
+
+                match program_counter
                     .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from);
+                {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::ProgramCounter(err)),
+                }
             }
 
             Self::Fence { pred, succ } => {
@@ -321,9 +366,13 @@ where
             }
 
             Self::Ecall => {
-                return system_instruction_handler
-                    .handle_ecall(regs, memory, program_counter)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()));
+                match system_instruction_handler.handle_ecall(regs, memory, program_counter) {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(err),
+                }
             }
             Self::Ebreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
@@ -332,7 +381,7 @@ where
 
             Self::Unimp => {
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                return Err(ExecutionError::IllegalInstruction { address: old_pc });
+                Err(ExecutionError::IllegalInstruction { address: old_pc })
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
@@ -15,10 +15,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32BInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32BInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32BInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
@@ -12,10 +12,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZbaInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZbaInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZbaInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -23,15 +26,15 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32ZbaInstruction<Reg>
 where
-    Reg: Register<Type = u32>,
-    Regs: RegisterFile<Reg>,
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZbbInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZbbInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZbbInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZbcInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZbcInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZbcInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
@@ -12,10 +12,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZbsInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZbsInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZbsInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -23,15 +26,15 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32ZbsInstruction<Reg>
 where
-    Reg: Register<Type = u32>,
-    Regs: RegisterFile<Reg>,
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -10,13 +10,17 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
+use core::marker::Destruct;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZcaInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZcaInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZcaInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -24,18 +28,19 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32ZcaInstruction<Reg>
 where
-    Reg: Register<Type = u32>,
-    Regs: RegisterFile<Reg>,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
+    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    CustomError: [const] Destruct,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {
@@ -82,10 +87,15 @@ where
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                program_counter
+                match program_counter
                     .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from)
+                {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::from(err)),
+                }
             }
             Self::CLi { rd, imm } => {
                 Ok(ControlFlow::Continue((rd, i32::from(imm).cast_unsigned())))
@@ -129,18 +139,28 @@ where
             }
             Self::CJ { imm } => {
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                program_counter
+                match program_counter
                     .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from)
+                {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::from(err)),
+                }
             }
             Self::CBeqz { rs1: _, imm } => {
                 if rs1_value == 0 {
                     let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -148,10 +168,15 @@ where
             Self::CBnez { rs1: _, imm } => {
                 if rs1_value != 0 {
                     let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -169,10 +194,13 @@ where
             }
             Self::CJr { rs1: _ } => {
                 let target = rs1_value & !1;
-                program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from)
+                match program_counter.set_pc(memory, target) {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::from(err)),
+                }
             }
             Self::CMv { rd, rs2: _ } => Ok(ControlFlow::Continue((rd, rs2_value))),
             Self::CEbreak => {
@@ -183,10 +211,13 @@ where
                 let target = rs1_value & !1;
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
-                return program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from);
+                return match program_counter.set_pc(memory, target) {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::from(err)),
+                };
             }
             Self::CAdd { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_add(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32MInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32MInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32MInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -24,15 +27,15 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32MInstruction<Reg>
 where
-    Reg: Register<Type = u32>,
-    Regs: RegisterFile<Reg>,
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
@@ -9,11 +9,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZmmulInstruction<Reg> where Reg: Register<Type = u32>
-{}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZmmulInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZmmulInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -21,14 +23,14 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv32ZmmulInstruction<Reg>
 where
-    Reg: Register<Type = u32>,
+    Reg: [const] Register<Type = u32>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -241,7 +241,6 @@ impl<Regs, I> SystemInstructionHandler<Reg<u32>, Regs, TestMemory, TestInstructi
     for TestInstructionHandler
 where
     I: Instruction<Reg = Reg<u32>>,
-    Regs: RegisterFile<Reg<u32>>,
 {
     #[inline(always)]
     fn handle_ecall(

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -15,10 +15,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZcbInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZcbInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZcbInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -51,13 +54,13 @@ where
 }
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZcbOnlyInstruction<Reg> where
+const impl<Reg> ExecutableInstructionOperands for Rv32ZcbOnlyInstruction<Reg> where
     Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZcbOnlyInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -14,13 +14,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZcmpInstruction<Reg> where
+const impl<Reg> ExecutableInstructionOperands for Rv32ZcmpInstruction<Reg> where
     Reg: ZcmpRegister<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZcmpInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u32>,
@@ -53,13 +53,13 @@ where
 }
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZcmpOnlyInstruction<Reg> where
+const impl<Reg> ExecutableInstructionOperands for Rv32ZcmpOnlyInstruction<Reg> where
     Reg: ZcmpRegister<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZcmpOnlyInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZbkbInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZbkbInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZbkbInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
@@ -10,10 +10,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZbkcInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZbkcInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZbkcInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZbkxInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZbkxInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZbkxInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
@@ -19,10 +19,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZknInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZknInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZknInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZkndInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZkndInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZkndInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZkneInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZkneInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZkneInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv32ZknhInstruction<Reg> where Reg: Register<Type = u32> {}
+const impl<Reg> ExecutableInstructionOperands for Rv32ZknhInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv32ZknhInstruction<Reg>
 where
     Reg: Register<Type = u32>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -17,13 +17,17 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
+use core::marker::Destruct;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64Instruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64Instruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64Instruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -31,18 +35,19 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64Instruction<Reg>
 where
-    Reg: Register<Type = u64>,
-    Regs: RegisterFile<Reg>,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
+    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    CustomError: [const] Destruct,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {
@@ -235,10 +240,14 @@ where
             Self::Jalr { rd, rs1: _, imm } => {
                 let target = (rs1_value.wrapping_add(i64::from(imm).cast_unsigned())) & !1u64;
                 regs.write(rd, program_counter.get_pc());
-                return program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from);
+
+                match program_counter.set_pc(memory, target) {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::from(err)),
+                }
             }
 
             Self::Sb {
@@ -285,10 +294,15 @@ where
             } => {
                 if rs1_value == rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -300,10 +314,15 @@ where
             } => {
                 if rs1_value != rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -315,10 +334,15 @@ where
             } => {
                 if rs1_value.cast_signed() < rs2_value.cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -330,10 +354,15 @@ where
             } => {
                 if rs1_value.cast_signed() >= rs2_value.cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -345,10 +374,15 @@ where
             } => {
                 if rs1_value < rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -360,10 +394,15 @@ where
             } => {
                 if rs1_value >= rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::from(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -385,10 +424,16 @@ where
                 let pc = program_counter.get_pc();
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 regs.write(rd, pc);
-                return program_counter
+
+                match program_counter
                     .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from);
+                {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::from(err)),
+                }
             }
 
             Self::Fence { pred, succ } => {
@@ -401,9 +446,13 @@ where
             }
 
             Self::Ecall => {
-                return system_instruction_handler
-                    .handle_ecall(regs, memory, program_counter)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()));
+                match system_instruction_handler.handle_ecall(regs, memory, program_counter) {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(err),
+                }
             }
             Self::Ebreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
@@ -412,7 +461,7 @@ where
 
             Self::Unimp => {
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                return Err(ExecutionError::IllegalInstruction { address: old_pc });
+                Err(ExecutionError::IllegalInstruction { address: old_pc })
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
@@ -15,10 +15,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64BInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64BInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64BInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
@@ -12,10 +12,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZbaInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZbaInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZbaInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -23,15 +26,15 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64ZbaInstruction<Reg>
 where
-    Reg: Register<Type = u64>,
-    Regs: RegisterFile<Reg>,
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZbbInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZbbInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZbbInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZbcInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZbcInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZbcInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
@@ -12,10 +12,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZbsInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZbsInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZbsInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -23,15 +26,15 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64ZbsInstruction<Reg>
 where
-    Reg: Register<Type = u64>,
-    Regs: RegisterFile<Reg>,
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -10,13 +10,17 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
+use core::marker::Destruct;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZcaInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZcaInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZcaInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -24,18 +28,19 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64ZcaInstruction<Reg>
 where
-    Reg: Register<Type = u64>,
-    Regs: RegisterFile<Reg>,
-    Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
+    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    CustomError: [const] Destruct,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {
@@ -147,18 +152,28 @@ where
             }
             Self::CJ { imm } => {
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                return program_counter
+                match program_counter
                     .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from);
+                {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::ProgramCounter(err)),
+                }
             }
             Self::CBeqz { rs1: _, imm } => {
                 if rs1_value == 0 {
                     let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::ProgramCounter(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -166,10 +181,15 @@ where
             Self::CBnez { rs1: _, imm } => {
                 if rs1_value != 0 {
                     let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return program_counter
+                    return match program_counter
                         .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                        .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                        .map_err(ExecutionError::from);
+                    {
+                        Ok(control_flow) => Ok(match control_flow {
+                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                            ControlFlow::Break(()) => ControlFlow::Break(()),
+                        }),
+                        Err(err) => Err(ExecutionError::ProgramCounter(err)),
+                    };
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -192,10 +212,13 @@ where
             }
             Self::CJr { rs1: _ } => {
                 let target = rs1_value & !1;
-                return program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from);
+                match program_counter.set_pc(memory, target) {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::ProgramCounter(err)),
+                }
             }
             Self::CMv { rd, rs2: _ } => Ok(ControlFlow::Continue((rd, rs2_value))),
             Self::CEbreak => {
@@ -206,10 +229,13 @@ where
                 let target = rs1_value & !1;
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
-                return program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from);
+                match program_counter.set_pc(memory, target) {
+                    Ok(control_flow) => Ok(match control_flow {
+                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                        ControlFlow::Break(()) => ControlFlow::Break(()),
+                    }),
+                    Err(err) => Err(ExecutionError::ProgramCounter(err)),
+                }
             }
             Self::CAdd { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_add(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64MInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64MInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64MInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -24,15 +27,15 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64MInstruction<Reg>
 where
-    Reg: Register<Type = u64>,
-    Regs: RegisterFile<Reg>,
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {
@@ -134,9 +137,10 @@ where
             Self::Divuw { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value as u32;
                 let divisor = rs2_value as u32;
-                let value = dividend.checked_div(divisor).map_or(u64::MAX, |value| {
-                    i64::from(value.cast_signed()).cast_unsigned()
-                });
+                let value = match dividend.checked_div(divisor) {
+                    Some(value) => i64::from(value.cast_signed()).cast_unsigned(),
+                    None => u64::MAX,
+                };
                 Ok(ControlFlow::Continue((rd, value)))
             }
             Self::Remw { rd, rs1: _, rs2: _ } => {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
@@ -9,11 +9,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZmmulInstruction<Reg> where Reg: Register<Type = u64>
-{}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZmmulInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZmmulInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -21,14 +23,14 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for Rv64ZmmulInstruction<Reg>
 where
-    Reg: Register<Type = u64>,
+    Reg: [const] Register<Type = u64>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -246,7 +246,6 @@ impl<Regs, I> SystemInstructionHandler<Reg<u64>, Regs, TestMemory, TestInstructi
     for TestInstructionHandler
 where
     I: Instruction<Reg = Reg<u64>>,
-    Regs: RegisterFile<Reg<u64>>,
 {
     #[inline(always)]
     fn handle_ecall(
@@ -355,12 +354,12 @@ impl Csrs<Reg<u64>> for ExtState {
     }
 }
 
-impl VectorRegistersBase for ExtState {
+const impl VectorRegistersBase for ExtState {
     const ELEN: Elen = Elen::L64;
     const VLEN: Vlen = Vlen::L256;
 }
 
-impl VectorRegisters for ExtState
+const impl VectorRegisters for ExtState
 where
     Self: Csrs<Reg<u64>>,
 {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZcbInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZcbInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZcbInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -49,13 +52,13 @@ where
 }
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZcbOnlyInstruction<Reg> where
+const impl<Reg> ExecutableInstructionOperands for Rv64ZcbOnlyInstruction<Reg> where
     Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZcbOnlyInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -14,13 +14,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZcmpInstruction<Reg> where
+const impl<Reg> ExecutableInstructionOperands for Rv64ZcmpInstruction<Reg> where
     Reg: ZcmpRegister<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZcmpInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u64>,
@@ -53,13 +53,13 @@ where
 }
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZcmpOnlyInstruction<Reg> where
+const impl<Reg> ExecutableInstructionOperands for Rv64ZcmpOnlyInstruction<Reg> where
     Reg: ZcmpRegister<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZcmpOnlyInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
@@ -12,10 +12,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZbkbInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZbkbInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZbkbInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
@@ -10,10 +10,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZbkcInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZbkcInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZbkcInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZbkxInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZbkxInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZbkxInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
@@ -18,10 +18,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZknInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZknInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZknInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZkndInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZkndInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZkndInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
@@ -17,10 +17,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZkneInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZkneInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZkneInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
@@ -13,10 +13,13 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for Rv64ZknhInstruction<Reg> where Reg: Register<Type = u64> {}
+const impl<Reg> ExecutableInstructionOperands for Rv64ZknhInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for Rv64ZknhInstruction<Reg>
 where
     Reg: Register<Type = u64>,

--- a/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
@@ -3,6 +3,7 @@
 use crate::{Csrs, CustomErrorPlaceholder};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
+use core::marker::Destruct;
 
 pub(crate) const VLENB_USIZE<const VLEN: Vlen>: usize = VLEN.bytes() as usize;
 
@@ -23,16 +24,16 @@ const impl<const VLEN: Vlen> Default for VectorRegisterFile<VLEN> {
 impl<const VLEN: Vlen> VectorRegisterFile<VLEN> {
     /// Get reference to a vector register
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    pub fn get(&self, index: VReg) -> &[u8; VLENB_USIZE::<VLEN>] {
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    pub const fn get(&self, index: VReg) -> &[u8; VLENB_USIZE::<VLEN>] {
         // SAFETY: Always in-range
         unsafe { self.0.get_unchecked(usize::from(index.to_bits())) }
     }
 
     /// Get mutable reference to a vector register
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    pub fn get_mut(&mut self, index: VReg) -> &mut [u8; VLENB_USIZE::<VLEN>] {
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    pub const fn get_mut(&mut self, index: VReg) -> &mut [u8; VLENB_USIZE::<VLEN>] {
         // SAFETY: Always in-range
         unsafe { self.0.get_unchecked_mut(usize::from(index.to_bits())) }
     }
@@ -41,7 +42,7 @@ impl<const VLEN: Vlen> VectorRegisterFile<VLEN> {
 /// Base for [`VectorRegisters`].
 ///
 /// This is primarily a workaround for type system cycles.
-pub trait VectorRegistersBase {
+pub const trait VectorRegistersBase {
     /// Maximum vector element width `ELEN` in bits
     const ELEN: Elen;
     /// Vector register width `VLEN` in bits
@@ -64,9 +65,9 @@ pub trait VectorRegistersBase {
 /// loads.
 ///
 /// `ELEN` is the maximum element width in bits.
-pub trait VectorRegisters<CustomError = CustomErrorPlaceholder>
+pub const trait VectorRegisters<CustomError = CustomErrorPlaceholder>
 where
-    Self: VectorRegistersBase,
+    Self: [const] VectorRegistersBase,
     [(); SUPPORTED_ELEN_VLEN::<{ Self::ELEN }, { Self::VLEN }>]:,
 {
     /// Read the vector register file
@@ -93,14 +94,14 @@ where
     /// sophisticated implementations may return values in `[ceil(AVL/2), VLMAX]` for
     /// `AVL < 2*VLMAX`, but this simple strategy satisfies all three spec requirements.
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn compute_vl(&self, avl: Vl, vlmax: Vl) -> Vl {
         avl.min(vlmax)
     }
 
     /// Compute `VLMAX` for a given vtype
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn vlmax_for_vtype(&self, vtype: Vtype<{ Self::ELEN }, { Self::VLEN }>) -> Vl {
         vtype.vlmul().vlmax::<{ Self::VLEN }>(vtype.vsew())
     }
@@ -115,19 +116,19 @@ where
 /// higher-performance implementations are often possible by overriding them and, for example,
 /// caching various CSRs as separate pre-decoded values rather than going through a generic code
 /// path with XLEN-sized raw CSR values during reads.
-pub trait VectorRegistersExt<Reg, CustomError = CustomErrorPlaceholder>
+pub const trait VectorRegistersExt<Reg, CustomError = CustomErrorPlaceholder>
 where
-    Self: Csrs<Reg, CustomError> + VectorRegisters<CustomError>,
+    Self: [const] Csrs<Reg, CustomError> + [const] VectorRegisters<CustomError>,
     [(); SUPPORTED_ELEN_VLEN::<{ Self::ELEN }, { Self::VLEN }>]:,
-    Reg: Register,
-    CustomError: fmt::Debug,
+    Reg: [const] Register,
+    CustomError: [const] Destruct + fmt::Debug,
 {
     /// Initialize the vector state to the recommended default configuration.
     ///
     /// Per spec: `vtype.vill` = 1, remaining `vtype` bits = `0`, `vl` = 0.
     /// `vstart`, `vxrm`, `vxsat` may have arbitrary values at reset but are zeroed here for
     /// deterministic behavior.
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn initialize_vector_state(&mut self) {
         self.set_vtype(None);
         self.set_vl(Vl::ZERO);
@@ -138,7 +139,7 @@ where
 
     /// Get current `vstart`
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn vstart(&self) -> Vstart {
         let raw = self
             .read_csr(VectorCsr::Vstart.to_csr_index())
@@ -152,7 +153,7 @@ where
     /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
     /// debug.
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn set_vstart(&mut self, vstart: Vstart) {
         let result = self.write_csr(
             VectorCsr::Vstart.to_csr_index(),
@@ -168,14 +169,14 @@ where
     ///
     /// Per spec, all vector instructions reset `vstart` to zero at the end of execution.
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn reset_vstart(&mut self) {
         self.set_vstart(Vstart::ZERO);
     }
 
     /// Get `vxsat` (single bit)
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn vxsat(&self) -> bool {
         let raw = self
             .read_csr(VectorCsr::Vxsat.to_csr_index())
@@ -189,7 +190,7 @@ where
     /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
     /// debug.
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn set_vxsat(&mut self, vxsat: bool) {
         let masked = Reg::Type::from(u8::from(vxsat));
         let result = self.write_csr(VectorCsr::Vxsat.to_csr_index(), masked);
@@ -205,7 +206,7 @@ where
 
     /// Get `vxrm`
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn vxrm(&self) -> Vxrm {
         let raw = self
             .read_csr(VectorCsr::Vxrm.to_csr_index())
@@ -219,7 +220,7 @@ where
     /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
     /// debug.
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn set_vxrm(&mut self, vxrm: Vxrm) {
         let masked = Reg::Type::from(vxrm.to_bits());
         let result = self.write_csr(VectorCsr::Vxrm.to_csr_index(), masked);
@@ -235,7 +236,7 @@ where
 
     /// Get the current vl
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn vl(&self) -> Vl {
         let vl = self
             .read_csr(VectorCsr::Vl.to_csr_index())
@@ -253,7 +254,7 @@ where
     /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
     /// debug.
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn set_vl(&mut self, vl: Vl) {
         let result = self.write_csr(VectorCsr::Vl.to_csr_index(), Reg::Type::from(u32::from(vl)));
         debug_assert!(result.is_ok(), "Implementation must initialize `vl` CSR");
@@ -261,7 +262,7 @@ where
 
     /// Get the current decoded vtype
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn vtype(&self) -> Option<Vtype<{ Self::ELEN }, { Self::VLEN }>> {
         self.read_csr(VectorCsr::Vtype.to_csr_index())
             .ok()
@@ -276,7 +277,7 @@ where
     /// The default implementation ignores writes to uninitialized CSR in release mode and panics in
     /// debug.
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn set_vtype(&mut self, vtype: Option<Vtype<{ Self::ELEN }, { Self::VLEN }>>) {
         let vtype_raw = if let Some(vt) = vtype {
             vt.to_raw::<Reg>()

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
@@ -37,7 +37,7 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
 impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
@@ -17,10 +17,10 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxArithInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxArithInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxArithInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
@@ -17,10 +17,10 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxCarryInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxCarryInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxCarryInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
@@ -15,7 +15,7 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxConfigInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxConfigInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
 impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
@@ -17,10 +17,11 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxFixedPointInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxFixedPointInstruction<Reg> where Reg: Register
+{}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxFixedPointInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -17,10 +17,10 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxLoadInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxLoadInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxLoadInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -17,10 +17,10 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxMaskInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxMaskInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxMaskInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
@@ -17,10 +17,10 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxMulDivInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxMulDivInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxMulDivInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -17,10 +17,10 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxPermInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxPermInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxPermInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
@@ -18,10 +18,10 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxReductionInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxReductionInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxReductionInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -18,10 +18,10 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxStoreInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxStoreInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxStoreInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -17,10 +17,13 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZveXxWidenNarrowInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZveXxWidenNarrowInstruction<Reg> where
+    Reg: Register
+{
+}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZveXxWidenNarrowInstruction<Reg>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/zicond.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicond.rs
@@ -12,10 +12,10 @@ use ab_riscv_primitives::prelude::*;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZicondInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZicondInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZicondInstruction<Reg>
 where
     Reg: Register,
@@ -23,15 +23,15 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for ZicondInstruction<Reg>
 where
-    Reg: Register,
-    Regs: RegisterFile<Reg>,
+    Reg: [const] Register,
+    Regs: [const] RegisterFile<Reg>,
 {
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -10,13 +10,14 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
+use core::marker::Destruct;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZicsrInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZicsrInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
     for ZicsrInstruction<Reg>
 where
     Reg: Register,
@@ -24,13 +25,14 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
     for ZicsrInstruction<Reg>
 where
-    Reg: Register,
-    Regs: RegisterFile<Reg>,
-    ExtState: Csrs<Reg, CustomError>,
+    Reg: [const] Register,
+    Regs: [const] RegisterFile<Reg>,
+    ExtState: [const] Csrs<Reg, CustomError>,
+    CustomError: [const] Destruct,
 {
     #[inline(always)]
     // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/zicsr_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/zicsr_helpers.rs
@@ -3,6 +3,7 @@
 use crate::{CsrError, Csrs};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
+use core::marker::Destruct;
 
 /// CSR privilege level check helper.
 ///
@@ -12,13 +13,14 @@ use core::hint::cold_path;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_csr_privilege_level<Reg, C, CustomError>(
+pub const fn check_csr_privilege_level<Reg, C, CustomError>(
     csrs: &C,
     csr_index: u16,
 ) -> Result<(), CsrError<CustomError>>
 where
-    Reg: Register,
-    C: Csrs<Reg, CustomError>,
+    Reg: [const] Register,
+    C: [const] Csrs<Reg, CustomError>,
+    CustomError: [const] Destruct,
 {
     let current = csrs.privilege_level();
     let required_bits = ((csr_index >> 8u8) & 0b11) as u8;

--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -31,7 +31,7 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZvbbInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZvbbInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
 impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -29,7 +29,7 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZvkbInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZvkbInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
 impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>

--- a/crates/execution/ab-riscv-interpreter/src/zvbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc.rs
@@ -29,7 +29,7 @@ use core::fmt;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
-impl<Reg> ExecutableInstructionOperands for ZvbcInstruction<Reg> where Reg: Register {}
+const impl<Reg> ExecutableInstructionOperands for ZvbcInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
 impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>

--- a/crates/execution/ab-riscv-macros-common/src/code_utils.rs
+++ b/crates/execution/ab-riscv-macros-common/src/code_utils.rs
@@ -28,6 +28,10 @@ const FROM_BRACKETS_CONST_1: &str = "[const] ";
 const TO_BRACKETS_CONST_1: &str = "BRCONST+";
 const FROM_BRACKETS_CONST_2: &str = " [const] ";
 const TO_BRACKETS_CONST_2: &str = "BRCONST +";
+const FROM_BRACKETS_CONST_3: &str = ": [const]\n        ";
+const TO_BRACKETS_CONST_3: &str = ": BRCONST\n       +";
+const FROM_BRACKETS_CONST_4: &str = ": [const]\n         ";
+const TO_BRACKETS_CONST_4: &str = ": BRCONST\n        +";
 
 /// Replace bits of Rust nightly syntax with something that is technically valid in stable Rust, so
 /// `syn` can parse it
@@ -45,6 +49,8 @@ pub fn pre_process_rust_code(s: &mut str) {
     replace_inplace(s, FROM_IMPL_CONST_REVERT_5, TO_IMPL_CONST_REVERT_5);
     replace_inplace(s, FROM_BRACKETS_CONST_1, TO_BRACKETS_CONST_1);
     replace_inplace(s, FROM_BRACKETS_CONST_2, TO_BRACKETS_CONST_2);
+    replace_inplace(s, FROM_BRACKETS_CONST_3, TO_BRACKETS_CONST_3);
+    replace_inplace(s, FROM_BRACKETS_CONST_4, TO_BRACKETS_CONST_4);
 }
 
 /// The inverse of [`pre_process_rust_code()`]
@@ -57,6 +63,8 @@ pub fn post_process_rust_code(s: &mut str) {
     replace_inplace(s, TO_IMPL_CONST_4, FROM_IMPL_CONST_4);
     replace_inplace(s, TO_BRACKETS_CONST_1, FROM_BRACKETS_CONST_1);
     replace_inplace(s, TO_BRACKETS_CONST_2, FROM_BRACKETS_CONST_2);
+    replace_inplace(s, TO_BRACKETS_CONST_3, FROM_BRACKETS_CONST_3);
+    replace_inplace(s, TO_BRACKETS_CONST_4, FROM_BRACKETS_CONST_4);
 }
 
 fn replace_inplace(mut s: &mut str, from: &str, to: &str) {

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -16,7 +16,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 use std::{env, fs, iter};
-use syn::{Ident, ImplItem, ImplItemFn, ItemImpl, parse_file, parse_quote, parse_str};
+use syn::{
+    Ident, ImplItem, ImplItemFn, ItemImpl, WherePredicate, parse_file, parse_quote, parse_str,
+};
 
 const ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_EXECUTION_IMPL_PATH";
 const ENUM_CSR_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_CSR_IMPL_PATH";
@@ -532,14 +534,18 @@ pub(super) fn process_enum_csr_impl(
     }
 
     // Comments will be stripped, this will suppress some of the lints that are caused by it
-    item_impl.attrs.extend([
+    item_impl.attrs.insert(
+        0,
         parse_quote! { #[expect(clippy::allow_attributes, reason = "Attribute below")] },
+    );
+    item_impl.attrs.insert(
+        1,
         parse_quote! { #[allow(
             clippy::undocumented_unsafe_blocks,
             reason = "Comments will be stripped, this will suppress some of the lints that are \
             caused by it"
         )] },
-    ]);
+    );
 
     output_processed_enum_csr_impl(&enum_name, item_impl, out_dir, state)
 }
@@ -620,6 +626,39 @@ pub(super) fn process_enum_execution_impl(
             already_inserted.insert(predicate.clone());
             where_clause.predicates.push(predicate);
         }
+
+        // TODO: This is a massive hack for implementations that strips `[const]` for non-const
+        //  instructions that inherit const instructions. `Destruct` is a special case here that is
+        //  avoided altogether for non-const implementations to improve downstream user experience.
+        if item_impl.attrs.last() != Some(&parse_quote! { #[cst] }) {
+            where_clause.predicates = where_clause
+                .predicates
+                .clone()
+                .into_iter()
+                .filter_map(|mut predicate| match &mut predicate {
+                    WherePredicate::Type(predicate_type) => {
+                        // TODO: Remove `Destruct` hack once stabilized:
+                        //  https://github.com/rust-lang/rust/issues/133214
+                        if predicate_type.bounds.to_token_stream().to_string()
+                            == "BRCONST + Destruct"
+                        {
+                            return None;
+                        }
+
+                        // TODO: `BRCONST` is a hack that allows `syn` to parse unstable Rust syntax
+                        //  around const traits and such. It will change to a proper modifier once
+                        //  stabilized
+                        if predicate_type.bounds.first() == Some(&parse_quote! { BRCONST }) {
+                            predicate_type.bounds =
+                                predicate_type.bounds.clone().into_iter().skip(1).collect();
+                        }
+
+                        Some(predicate)
+                    }
+                    _ => Some(predicate),
+                })
+                .collect();
+        }
     } else {
         return Err(anyhow::anyhow!(
             "Missing where clause on `#[instruction_execution] impl ExecutableInstruction for \
@@ -659,14 +698,18 @@ pub(super) fn process_enum_execution_impl(
     }};
 
     // Comments will be stripped, this will suppress some of the lints that are caused by it
-    item_impl.attrs.extend([
+    item_impl.attrs.insert(
+        0,
         parse_quote! { #[expect(clippy::allow_attributes, reason = "Attribute below")] },
+    );
+    item_impl.attrs.insert(
+        1,
         parse_quote! { #[allow(
             clippy::undocumented_unsafe_blocks,
             reason = "Comments will be stripped, this will suppress some of the lints that are \
             caused by it"
         )] },
-    ]);
+    );
 
     output_processed_enum_execution_impl(&enum_name, item_impl, out_dir, state)
 }

--- a/crates/execution/ab-riscv-primitives/Cargo.toml
+++ b/crates/execution/ab-riscv-primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ab-riscv-primitives"
 description = "Composable RISC-V primitives (instructions, registers) and abstractions around them"
-keywords = ["riscv", "risc-v", "decoder", "no-std"]
+keywords = ["riscv", "risc-v", "decoder", "no-std", "const"]
 repository = "https://github.com/nazar-pc/abundance"
 homepage = "https://github.com/nazar-pc/abundance/tree/main/crates/execution/ab-riscv-primitives"
 license = "0BSD"

--- a/crates/execution/ab-riscv-primitives/src/instructions.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions.rs
@@ -20,7 +20,7 @@ pub const trait Instruction:
     fmt::Display + fmt::Debug + [const] Destruct + Copy + Send + Sync + Sized
 {
     /// A register type used by the instruction
-    type Reg: Register;
+    type Reg: [const] Register;
 
     /// Try to decode a single valid instruction
     fn try_decode(instruction: u32) -> Option<Self>;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
@@ -16,7 +16,8 @@ use core::fmt;
 
 /// RISC-V RV32 instruction
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32Instruction<Reg> {
     // R-type
     Add { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b.rs
@@ -17,7 +17,8 @@ use core::fmt;
 #[instruction(
     inherit = [Rv32ZbaInstruction, Rv32ZbbInstruction, Rv32ZbsInstruction]
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32BInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zba.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV32 Zba instruction (Address generation)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZbaInstruction<Reg> {
     Sh1add { rd: Reg, rs1: Reg, rs2: Reg },
     Sh2add { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbb.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV32 Zbb instruction (Basic bit manipulation)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZbbInstruction<Reg> {
     Andn { rd: Reg, rs1: Reg, rs2: Reg },
     Orn { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbc.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV32 Zbc instruction (Carryless multiplication)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZbcInstruction<Reg> {
     Clmul { rd: Reg, rs1: Reg, rs2: Reg },
     Clmulh { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbs.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV32 Zbs instruction (Single-bit instructions)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZbsInstruction<Reg> {
     // Single-Bit Set
     Bset { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
@@ -11,7 +11,8 @@ use core::fmt;
 
 /// RISC-V RV32 Zca compressed instruction set
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 pub enum Rv32ZcaInstruction<Reg> {
     // Quadrant 00

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/m.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/m.rs
@@ -11,7 +11,8 @@ use core::fmt;
 
 /// RISC-V RV32 M instruction
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32MInstruction<Reg> {
     Mul { rd: Reg, rs1: Reg, rs2: Reg },
     Mulh { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/m/zmmul.rs
@@ -12,7 +12,8 @@ use core::fmt;
     ignore = [Rv32MInstruction],
     inherit = [Rv32MInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZmmulInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb.rs
@@ -16,7 +16,8 @@ use core::fmt;
 #[instruction(
     inherit = [Rv32ZcaInstruction, Rv32ZcbOnlyInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZcbInstruction<Reg> {}
 
 #[instruction]
@@ -55,7 +56,8 @@ where
 
 /// Instruction that contains isolated Zcb instructions without inheriting Zca for testing purposes
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum Rv32ZcbOnlyInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
@@ -48,7 +48,8 @@ const unsafe impl ZcmpRegister for EReg<u64> {
 
 /// Values 0..=3 are reserved by the spec; only 4..=15 are valid.
 /// Construct via [`ZcmpUrlist::try_from_raw`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 enum ZcmpUrlistInner {
     /// {ra}
@@ -83,11 +84,20 @@ enum ZcmpUrlistInner {
 ///
 /// Only valid values (4..=15, further restricted to 4..=6 for RVE) are
 /// representable; construct via [`ZcmpUrlist::try_from_raw`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub struct ZcmpUrlist<Reg> {
     inner: ZcmpUrlistInner,
     reg: PhantomData<Reg>,
 }
+
+const impl<Reg> PartialEq<ZcmpUrlist<Reg>> for ZcmpUrlist<Reg> {
+    #[inline(always)]
+    fn eq(&self, other: &ZcmpUrlist<Reg>) -> bool {
+        self.inner == other.inner
+    }
+}
+
+const impl<Reg> Eq for ZcmpUrlist<Reg> {}
 
 impl<Reg> ZcmpUrlist<Reg>
 where
@@ -152,6 +162,7 @@ where
         self.inner as u8
     }
 
+    // TODO: Map iterator isn't const or else this method would be const too
     /// Iterator over the absolute register numbers in this list.
     ///
     /// Order matches the spec push/pop order: ra first, then s0 ascending.
@@ -248,7 +259,8 @@ impl<Reg> fmt::Display for ZcmpUrlist<Reg> {
 #[instruction(
     inherit = [Rv32ZcaInstruction, Rv32ZcmpOnlyInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZcmpInstruction<Reg> {}
 
 #[instruction]
@@ -287,7 +299,8 @@ where
 
 /// Instruction that contains isolated Zcmp instructions without inheriting Zca for testing purposes
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[doc(hidden)]
 pub enum Rv32ZcmpOnlyInstruction<Reg> {
     /// CM.PUSH - push reg_list, decrement sp by `stack_adj`

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkb.rs
@@ -15,7 +15,8 @@ use core::fmt;
     ignore = [Rv32ZbbInstruction],
     inherit = [Rv32ZbbInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZbkbInstruction<Reg> {
     /// Pack low 16 bits of `rs1` into `rd[15:0]`, low 16 bits of `rs2` into `rd[31:16]`
     Pack { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkc.rs
@@ -12,7 +12,8 @@ use core::fmt;
     ignore = [Rv32ZbcInstruction],
     inherit = [Rv32ZbcInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZbkcInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkx.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV32 Zbkx instruction (Crossbar permutations)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZbkxInstruction<Reg> {
     Xperm4 { rd: Reg, rs1: Reg, rs2: Reg },
     Xperm8 { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn.rs
@@ -27,7 +27,8 @@ use core::fmt;
         Rv32ZknhInstruction,
     ]
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZknInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknd.rs
@@ -11,7 +11,8 @@ use core::fmt;
 /// 2-bit byte-select immediate for RV32 AES instructions.
 ///
 /// Selects which byte of `rs2` is fed into the S-box: `bs ∈ {0,1,2,3}`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum Rv32AesBs {
     B0 = 0,
@@ -56,7 +57,8 @@ impl Rv32AesBs {
 
 /// RISC-V RV32 Zknd instructions (AES decryption)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZkndInstruction<Reg> {
     /// AES final round decryption step: InvSubBytes on one byte of rs2,
     /// rotated to the byte lane selected by bs, XOR'd into rs1.

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zkne.rs
@@ -11,7 +11,8 @@ use core::fmt;
 
 /// RISC-V RV32 Zkne instructions (AES encryption)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZkneInstruction<Reg> {
     /// AES final round encryption step: SubBytes on one byte of rs2, rotated to the byte lane
     /// selected by bs, XOR'd into rs1.

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknh.rs
@@ -23,7 +23,8 @@ use core::fmt;
 /// `x[63:32] = X(rs2), x[31:0] = X(rs1)` (rs2 is the HIGH half) and writes the low 32 bits of the
 /// result to `rd`.
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv32ZknhInstruction<Reg> {
     // SHA-256 (single-register, identical encoding to RV64)
     Sha256Sig0 { rd: Reg, rs1: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
@@ -16,7 +16,8 @@ use core::fmt;
 
 /// RISC-V RV64 instruction
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64Instruction<Reg> {
     // R-type
     Add { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b.rs
@@ -17,7 +17,8 @@ use core::fmt;
 #[instruction(
     inherit = [Rv64ZbaInstruction, Rv64ZbbInstruction, Rv64ZbsInstruction]
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64BInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zba.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV64 Zba instruction (Address generation)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZbaInstruction<Reg> {
     AddUw { rd: Reg, rs1: Reg, rs2: Reg },
     Sh1add { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbb.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV64 Zbb instruction (Basic bit manipulation)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZbbInstruction<Reg> {
     // RV64 Zbb instructions
     Andn { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbc.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV64 Zbc instruction (Carryless multiplication)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZbcInstruction<Reg> {
     Clmul { rd: Reg, rs1: Reg, rs2: Reg },
     Clmulh { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbs.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV64 Zbs instruction (Single-bit instructions)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZbsInstruction<Reg> {
     // Single-Bit Set
     Bset { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
@@ -11,7 +11,8 @@ use core::fmt;
 
 /// RISC-V RV64 Zca compressed instruction set
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 pub enum Rv64ZcaInstruction<Reg> {
     // Quadrant 00

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/m.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/m.rs
@@ -11,7 +11,8 @@ use core::fmt;
 
 /// RISC-V RV64 M instruction
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64MInstruction<Reg> {
     Mul { rd: Reg, rs1: Reg, rs2: Reg },
     Mulh { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/m/zmmul.rs
@@ -12,7 +12,8 @@ use core::fmt;
     ignore = [Rv64MInstruction],
     inherit = [Rv64MInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZmmulInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb.rs
@@ -16,7 +16,8 @@ use core::fmt;
 #[instruction(
     inherit = [Rv64ZcaInstruction, Rv64ZcbOnlyInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZcbInstruction<Reg> {}
 
 #[instruction]
@@ -55,7 +56,8 @@ where
 
 /// Instruction that contains isolated Zcb instructions without inheriting Zca for testing purposes
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum Rv64ZcbOnlyInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
@@ -15,7 +15,8 @@ use core::fmt;
 #[instruction(
     inherit = [Rv64ZcaInstruction, Rv64ZcmpOnlyInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZcmpInstruction<Reg> {}
 
 #[instruction]
@@ -54,7 +55,8 @@ where
 
 /// Instruction that contains isolated Zcmp instructions without inheriting Zca for testing purposes
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[doc(hidden)]
 pub enum Rv64ZcmpOnlyInstruction<Reg> {
     /// CM.PUSH - push reg_list, decrement sp by `stack_adj`

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkb.rs
@@ -15,7 +15,8 @@ use core::fmt;
     ignore = [Rv64ZbbInstruction],
     inherit = [Rv64ZbbInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZbkbInstruction<Reg> {
     /// Pack low 32 bits of `rs1` and `rs2` into `rd`
     Pack { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkc.rs
@@ -12,7 +12,8 @@ use core::fmt;
     ignore = [Rv64ZbcInstruction],
     inherit = [Rv64ZbcInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZbkcInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkx.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV64 Zbkx instruction (Crossbar permutations)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZbkxInstruction<Reg> {
     Xperm4 { rd: Reg, rs1: Reg, rs2: Reg },
     Xperm8 { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn.rs
@@ -27,7 +27,8 @@ use core::fmt;
         Rv64ZknhInstruction,
     ]
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZknInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknd.rs
@@ -9,7 +9,8 @@ use ab_riscv_macros::instruction;
 use core::{fmt, mem};
 
 /// AES key schedule round constant number
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum Rv64ZkndKsRnum {
     R0 = 0x0,
@@ -76,7 +77,8 @@ impl Rv64ZkndKsRnum {
 
 /// RISC-V RV64 Zknd instructions (AES decryption and key schedule)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZkndInstruction<Reg> {
     /// AES final round decryption: InvShiftRows + InvSubBytes, no MixColumns
     Aes64Ds { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zkne.rs
@@ -15,7 +15,8 @@ use core::fmt;
     ignore = [Rv64ZkndInstruction],
     inherit = [Rv64ZkndInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZkneInstruction<Reg> {
     /// AES final round encryption: ShiftRows + SubBytes, no MixColumns
     Aes64Es { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknh.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V RV64 Zknh instruction (SHA-256 and SHA-512 sigma functions)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum Rv64ZknhInstruction<Reg> {
     Sha256Sig0 { rd: Reg, rs1: Reg },
     Sha256Sig1 { rd: Reg, rs1: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/utils.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/utils.rs
@@ -7,8 +7,16 @@ use core::fmt;
 use core::ops::{Shl, Shr};
 
 /// New type for unsigned integers that stores 24-bit numbers
-#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Hash)]
+#[derive_const(PartialEq, Eq)]
 pub struct U24([u8; 3]);
+
+const impl Default for U24 {
+    #[inline(always)]
+    fn default() -> Self {
+        Self([0; _])
+    }
+}
 
 impl fmt::Debug for U24 {
     #[inline(always)]
@@ -74,14 +82,14 @@ const impl Shr<u8> for &U24 {
     }
 }
 
-impl From<U24> for u32 {
+const impl From<U24> for u32 {
     #[inline(always)]
     fn from(v: U24) -> Self {
         v.to_u32()
     }
 }
 
-impl From<U24> for u64 {
+const impl From<U24> for u64 {
     #[inline(always)]
     fn from(v: U24) -> Self {
         u64::from(v.to_u32())
@@ -113,8 +121,16 @@ impl U24 {
 }
 
 /// New type for signed integers that stores 24-bit numbers
-#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Hash)]
+#[derive_const(PartialEq, Eq)]
 pub struct I24([u8; 3]);
+
+const impl Default for I24 {
+    #[inline(always)]
+    fn default() -> Self {
+        Self([0; _])
+    }
+}
 
 impl fmt::Debug for I24 {
     #[inline(always)]
@@ -180,14 +196,14 @@ const impl Shr<u8> for &I24 {
     }
 }
 
-impl From<I24> for i32 {
+const impl From<I24> for i32 {
     #[inline(always)]
     fn from(v: I24) -> Self {
         v.to_i32()
     }
 }
 
-impl From<I24> for i64 {
+const impl From<I24> for i64 {
     #[inline(always)]
     fn from(v: I24) -> Self {
         i64::from(v.to_i32())
@@ -221,8 +237,16 @@ impl I24 {
 
 /// New type for signed integers that stores 32-bit numbers with `LOW_ZEROED_BITS` low bits zeroed
 /// and truncated to 24-bits
-#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Hash)]
+#[derive_const(PartialEq, Eq)]
 pub struct I24WithZeroedBits<const LOW_ZEROED_BITS: u8>([u8; 3]);
+
+const impl<const LOW_ZEROED_BITS: u8> Default for I24WithZeroedBits<LOW_ZEROED_BITS> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self([0; _])
+    }
+}
 
 impl<const LOW_ZEROED_BITS: u8> fmt::Debug for I24WithZeroedBits<LOW_ZEROED_BITS> {
     #[inline(always)]
@@ -252,14 +276,14 @@ impl<const LOW_ZEROED_BITS: u8> fmt::UpperHex for I24WithZeroedBits<LOW_ZEROED_B
     }
 }
 
-impl<const LOW_ZEROED_BITS: u8> From<I24WithZeroedBits<LOW_ZEROED_BITS>> for i32 {
+const impl<const LOW_ZEROED_BITS: u8> From<I24WithZeroedBits<LOW_ZEROED_BITS>> for i32 {
     #[inline(always)]
     fn from(v: I24WithZeroedBits<LOW_ZEROED_BITS>) -> Self {
         v.to_i32()
     }
 }
 
-impl<const LOW_ZEROED_BITS: u8> From<I24WithZeroedBits<LOW_ZEROED_BITS>> for i64 {
+const impl<const LOW_ZEROED_BITS: u8> From<I24WithZeroedBits<LOW_ZEROED_BITS>> for i64 {
     #[inline(always)]
     fn from(v: I24WithZeroedBits<LOW_ZEROED_BITS>) -> Self {
         i64::from(v.to_i32())

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -10,7 +10,8 @@ use core::ops::RangeInclusive;
 use core::{cmp, fmt};
 
 /// Vector start element index
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(Default, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Vstart(u16);
 
 impl fmt::Display for Vstart {
@@ -69,7 +70,8 @@ impl Vstart {
 }
 
 /// Vector length
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(Default, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Vl(u32);
 
 impl fmt::Display for Vl {
@@ -150,7 +152,8 @@ impl Vl {
 }
 
 /// Element length
-#[derive(ConstParamTy, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(ConstParamTy, Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u32)]
 pub enum Elen {
     /// Element length is 8 bits
@@ -191,7 +194,8 @@ const impl From<Elen> for u32 {
 }
 
 /// Vector length
-#[derive(ConstParamTy, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(ConstParamTy, Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u32)]
 pub enum Vlen {
     /// Vector length is 8 bits
@@ -253,7 +257,8 @@ pub const SUPPORTED_ELEN_VLEN<const ELEN: Elen, const VLEN: Vlen>: usize = {
 ///
 /// Context status for the vector extension, analogous to `mstatus.FS`.
 /// Located at bits `[10:9]` in the respective status registers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum VsStatus {
     /// Vector unit is off; any vector instruction or CSR access raises illegal instruction
@@ -290,7 +295,8 @@ impl VsStatus {
 /// Encoded in `vtype[2:0]` as a signed 3-bit value.
 /// `LMUL = 2^vlmul` where `vlmul` is sign-extended. Positive values give integer multipliers,
 /// negative values give fractional.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum Vlmul {
     /// LMUL = 1 (`vlmul` encoding 0b000)
@@ -447,7 +453,8 @@ impl fmt::Display for Vlmul {
 }
 
 /// Factor by which Vsew width is divided
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum VsewFactor {
     /// Divide width by 2
@@ -469,7 +476,8 @@ impl VsewFactor {
 /// Selected element width (SEW).
 ///
 /// Encoded in `vtype[5:3]` as `vsew`. `SEW = 8 * 2^vsew`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum Vsew {
     /// SEW = 8 bits (vsew = 0b000)
@@ -612,7 +620,8 @@ impl fmt::Display for Vsew {
 }
 
 /// Effective element width for vector memory operations
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum Eew {
     /// 8-bit elements
@@ -690,7 +699,8 @@ impl fmt::Display for Eew {
 /// Vector fixed-point rounding mode.
 ///
 /// Encoded in the `vxrm` CSR bits `[1:0]` and mirrored in `vcsr[2:1]`.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(Default, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Vxrm {
     /// Round-to-nearest-up (rnu)
@@ -730,7 +740,8 @@ impl Vxrm {
 ///
 /// The raw encoding is XLEN-dependent (vill is at bit XLEN-1), but this decoded form is
 /// XLEN-independent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub struct Vtype<const ELEN: Elen, const VLEN: Vlen>
 where
     [(); SUPPORTED_ELEN_VLEN::<ELEN, VLEN>]:,

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx.rs
@@ -63,7 +63,8 @@ use core::fmt;
         ZicsrInstruction,
     ],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum ZveXxInstruction<Reg> {}
 
 #[instruction]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/arith.rs
@@ -22,7 +22,8 @@ use core::fmt;
 /// - OPIVX = 0b100: vector-scalar (x register)
 /// - OPIVI = 0b011: vector-immediate (5-bit signed or unsigned)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxArithInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/carry.rs
@@ -22,7 +22,8 @@ use core::fmt;
 /// vadc/vsbc produce SEW-wide data results written to vd.
 /// vmadc/vmsbc produce one mask bit per element (carry-out/borrow-out) written to vd.
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxCarryInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/config.rs
@@ -13,7 +13,8 @@ use core::fmt;
 /// These instructions set the vector type (`vtype`) and vector length (`vl`) registers. They use
 /// the OP-V major opcode (0b101_0111) with funct3=0b111 (OPCFG).
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxConfigInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/fixed_point.rs
@@ -14,7 +14,8 @@ use core::fmt;
 /// Includes saturating add/subtract, averaging add/subtract, fractional multiply, scaling shifts,
 /// and narrowing clips. All use the OP-V major opcode (0b101_0111).
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxFixedPointInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/load.rs
@@ -11,7 +11,8 @@ use ab_riscv_macros::instruction;
 use core::fmt;
 
 /// Number of fields per segment for load/store instructions
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum Nf {
     /// 1 field per segment
@@ -74,7 +75,8 @@ impl Nf {
 ///
 /// This is a more compact representation that fits within a single byte rather than two when
 /// storing these separately.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub struct SegVmNf(u8);
 
 impl SegVmNf {
@@ -101,7 +103,8 @@ impl SegVmNf {
 }
 
 /// `nreg` field for load/store instructions
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum LoadStoreNreg {
     /// 1 register
@@ -146,7 +149,8 @@ impl LoadStoreNreg {
 /// Encoded under the LOAD-FP major opcode (0x07). All loads use rs1 (GPR) as a base address and vd
 /// (vector register) as a destination.
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxLoadInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/mask.rs
@@ -17,7 +17,8 @@ use core::fmt;
 ///
 /// All use the OP-V major opcode (0b101_0111).
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxMaskInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/muldiv.rs
@@ -19,7 +19,8 @@ use core::fmt;
 /// require a 128-bit multiplier). The decoder still recognizes these encodings; the SEW
 /// restriction is enforced at execution time via `vtype`.
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxMulDivInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/perm.rs
@@ -17,7 +17,8 @@ use core::fmt;
 ///
 /// All instructions use the OP-V major opcode (0b101_0111).
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxPermInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/reduction.rs
@@ -16,7 +16,8 @@ use core::fmt;
 ///
 /// Single-width reductions use OPMVV (funct3=0b010). Widening reductions use OPIVV (funct3=0b000).
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxReductionInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/store.rs
@@ -16,7 +16,8 @@ use core::fmt;
 /// Encoded under the STORE-FP major opcode (0x27). All stores use rs1 (GPR) as a base address and
 /// vs3 (vector register) as a source.
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxStoreInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/widen_narrow.rs
@@ -19,7 +19,8 @@ use core::fmt;
 ///
 /// All instructions use the OP-V major opcode (0b101_0111).
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 #[doc(hidden)]
 pub enum ZveXxWidenNarrowInstruction<Reg> {

--- a/crates/execution/ab-riscv-primitives/src/instructions/zicond.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zicond.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V Zicond instruction (Integer Conditional Operations)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum ZicondInstruction<Reg> {
     /// `czero.eqz rd, rs1, rs2` - move zero to `rd` if `rs2 == 0`, else move `rs1`
     CzeroEqz { rd: Reg, rs1: Reg, rs2: Reg },

--- a/crates/execution/ab-riscv-primitives/src/instructions/zicsr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zicsr.rs
@@ -10,7 +10,8 @@ use core::fmt;
 
 /// RISC-V Zicsr instruction (Control and Status Register)
 #[instruction]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum ZicsrInstruction<Reg> {
     Csrrw { rd: Reg, rs1: Reg, csr_index: u16 },
     Csrrs { rd: Reg, rs1: Reg, csr_index: u16 },

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbb.rs
@@ -51,7 +51,8 @@ use core::fmt;
 #[instruction(
     inherit = [ZvkbInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 pub enum ZvbbInstruction<Reg> {
     // vbrev: bit-reverse within each SEW-wide element (element granularity, unlike vbrev8's byte granularity)

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbb/zvkb.rs
@@ -39,7 +39,8 @@ use core::fmt;
 #[instruction(
     inherit = [ZveXxInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 pub enum ZvkbInstruction<Reg> {
     // vandn: vd[i] = ~vs1[i] & vs2[i]  (or ~rs1 & vs2[i])

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbc.rs
@@ -39,7 +39,8 @@ use core::fmt;
 #[instruction(
     inherit = [ZveXxInstruction],
 )]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[rustfmt::skip]
 pub enum ZvbcInstruction<Reg> {
     // vclmul: lower SEW bits of the carry-less 2*SEW product

--- a/crates/execution/ab-riscv-primitives/src/lib.rs
+++ b/crates/execution/ab-riscv-primitives/src/lib.rs
@@ -15,7 +15,8 @@
 //! Certification Tests runner for <https://github.com/riscv-non-isa/riscv-arch-test> that ensures
 //! correct implementation.
 //!
-//! Does not require a standard library (`no_std`) or an allocator, never panics.
+//! Does not require a standard library (`no_std`) or an allocator, never panics, almost 100% of the
+//! API is usable in const.
 //!
 //! ## Supported ISA variants and extensions
 //!
@@ -72,6 +73,7 @@
     const_trait_impl,
     const_try,
     const_try_residual,
+    derive_const,
     exact_div,
     generic_const_args,
     generic_const_items,

--- a/crates/execution/ab-riscv-primitives/src/privilege.rs
+++ b/crates/execution/ab-riscv-primitives/src/privilege.rs
@@ -7,7 +7,8 @@
 /// `[9:8]` and in `mstatus`/`sstatus` privilege fields.
 ///
 /// The encoding `0b10` is architecturally reserved and is therefore absent.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum PrivilegeLevel {
     /// User / application mode (least privileged)
@@ -22,7 +23,7 @@ pub enum PrivilegeLevel {
 impl PrivilegeLevel {
     /// Create a privilege level from its bit representation
     #[inline(always)]
-    pub fn from_bits(bits: u8) -> Option<Self> {
+    pub const fn from_bits(bits: u8) -> Option<Self> {
         match bits {
             0b00 => Some(Self::User),
             0b01 => Some(Self::Supervisor),

--- a/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
@@ -17,6 +17,7 @@ use core::ops::{
 pub const trait RegType
 where
     Self: [const] Default
+        + [const] Destruct
         + [const] From<bool>
         + [const] From<u8>
         + [const] From<u16>

--- a/crates/execution/ab-riscv-primitives/src/registers/machine.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/machine.rs
@@ -4,7 +4,8 @@ use crate::registers::general_purpose::{RegType, Register};
 
 // TODO: CSR composition?
 /// Machine CSR addresses (core mandatory registers from the Privileged Spec)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u16)]
 pub enum MCsr {
     /// Machine vendor ID register (MRO)
@@ -61,7 +62,8 @@ impl MCsr {
 }
 
 /// Machine exception causes (`mcause[XLEN‑1] = 0`)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u32)]
 pub enum MCauseException {
     /// Instruction address misaligned
@@ -130,7 +132,8 @@ impl MCauseException {
 }
 
 /// Machine interrupt causes (`mcause[XLEN‑1] = 1`)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u32)]
 pub enum MCauseInterrupt {
     /// User software interrupt
@@ -184,7 +187,8 @@ impl MCauseInterrupt {
 }
 
 /// Combined `mcause` CSR value
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum MCause {
     Exception(MCauseException),
     Interrupt(MCauseInterrupt),

--- a/crates/execution/ab-riscv-primitives/src/registers/vector.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/vector.rs
@@ -3,7 +3,8 @@
 use core::fmt;
 
 /// RISC-V vector register (v0-v31)
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum VReg {
     /// Vector register v0 (also used as mask register)
@@ -134,7 +135,8 @@ impl fmt::Debug for VReg {
 
 // TODO: CSR composition?
 /// Vector CSR addresses
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
 pub enum VectorCsr {
     /// Vector start element index (URW)
     Vstart,


### PR DESCRIPTION
Now it is possible to interpret RISC-V binaries for targets like RV64IMC in `const fn` end-to-end