### PR TITLE
RISC-V atomic instructions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -786,7 +786,7 @@ jobs:
 
   act4:
     env:
-      ACT4_REPO_REVISION: df4516ebd254eccbefdb5e395ac04f158390e178
+      ACT4_REPO_REVISION: e275a5cad3810f960bba751f6c9f3783930114d7
 
     strategy:
       matrix:

--- a/crates/execution/ab-riscv-act4-runner/Cargo.toml
+++ b/crates/execution/ab-riscv-act4-runner/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 all-features = true
 
 [dependencies]
-ab-riscv-interpreter = { workspace = true }
+ab-riscv-interpreter = { workspace = true, features = ["alloc"] }
 ab-riscv-macros = { workspace = true, features = ["proc-macro"] }
 ab-riscv-primitives = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/execution/ab-riscv-act4-runner/res/Dockerfile
+++ b/crates/execution/ab-riscv-act4-runner/res/Dockerfile
@@ -21,15 +21,15 @@
 # Global ARGs - declared before any FROM so they are overridable across all stages.
 # Each stage that uses them must redeclare them with a bare ARG (no default) to bring them into scope.
 ARG RISCV_TOOLCHAIN_PREFIX=/opt/riscv
-ARG SAIL_VERSION=0.11
-ARG RISCV_TOOLCHAIN_VERSION=2026.05.06
+ARG SAIL_VERSION=0.13
+ARG RISCV_TOOLCHAIN_VERSION=2026.07.15
 # Ice Lake (server) is the oldest CPU available in GitHub Actions right now
 ARG RISCV_TOOLCHAIN_HOST_MARCH_X86_64=icelake-server
 
 # Stage 1: build riscv-gnu-toolchain
 #
 # LDFLAGS=-static ensures no shared-lib dependencies survive into the final image.
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS toolchain-builder
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS toolchain-builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG RISCV_TOOLCHAIN_PREFIX
@@ -105,7 +105,7 @@ RUN git clone --depth 1 --branch "${RISCV_TOOLCHAIN_VERSION}" https://github.com
 #
 # HOME=/home/shared is used so all caches (mise, uv, udb, etc.) land in a single directory that is copied to the final
 # image.
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS mise-fetcher
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS mise-fetcher
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -151,7 +151,7 @@ RUN cd /act4 \
 RUN chmod -R 777 /act4 /home/shared
 
 # Stage 3: final runtime image
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS act4-build
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS act4-build
 
 LABEL description="RISC-V Architectural Certification Tests (ACT4) build env"
 LABEL org.opencontainers.image.source="https://github.com/riscv/riscv-arch-test"
@@ -202,7 +202,9 @@ COPY --from=mise-fetcher /act4/.venv /act4/.venv
 COPY --chmod=777 . /act4
 
 # TODO: `make vector-tests` is only needed temporarily before vector tests are enabled by default
-RUN make vector-tests \
+RUN make tests \
+  && make vector-tests \
+  && chown -R ubuntu:ubuntu tests \
   && chmod -R 777 /act4/.venv
 
 # Default user with ID 1000 matching typical desktop installation

--- a/crates/execution/ab-riscv-act4-runner/res/Dockerfile
+++ b/crates/execution/ab-riscv-act4-runner/res/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/riscv/riscv-arch-test (branch: act4)
 #
 # Includes:
-#   - riscv-gnu-toolchain  (GCC 15 / Binutils 2.44, built from source, statically linked)
+#   - riscv-none-elf-gcc   (xPack GNU RISC-V Embedded GCC)
 #   - mise                 (tool manager; installs uv/Python and Ruby automatically)
 #   - sail-riscv           (RISC-V reference model)
 #
@@ -22,81 +22,9 @@
 # Each stage that uses them must redeclare them with a bare ARG (no default) to bring them into scope.
 ARG RISCV_TOOLCHAIN_PREFIX=/opt/riscv
 ARG SAIL_VERSION=0.13
-ARG RISCV_TOOLCHAIN_VERSION=2026.07.15
-# Ice Lake (server) is the oldest CPU available in GitHub Actions right now
-ARG RISCV_TOOLCHAIN_HOST_MARCH_X86_64=icelake-server
+ARG XPACK_GCC_VERSION=15.2.0-1.1
 
-# Stage 1: build riscv-gnu-toolchain
-#
-# LDFLAGS=-static ensures no shared-lib dependencies survive into the final image.
-FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS toolchain-builder
-
-ARG DEBIAN_FRONTEND=noninteractive
-ARG RISCV_TOOLCHAIN_PREFIX
-ARG RISCV_TOOLCHAIN_VERSION
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  autoconf \
-  automake \
-  autotools-dev \
-  bc \
-  bison \
-  build-essential \
-  cmake \
-  ca-certificates \
-  curl \
-  flex \
-  gawk \
-  gperf \
-  git \
-  libexpat-dev \
-  libglib2.0-dev \
-  libgmp-dev \
-  libmpc-dev \
-  libmpfr-dev \
-  libncurses-dev \
-  libslirp-dev \
-  libtool \
-  ninja-build \
-  patchutils \
-  python3 \
-  python3-tomli \
-  texinfo \
-  zlib1g-dev
-
-RUN git clone --depth 1 --branch "${RISCV_TOOLCHAIN_VERSION}" https://github.com/riscv/riscv-gnu-toolchain /tmp/riscv-gnu-toolchain \
-  && cd /tmp/riscv-gnu-toolchain \
-  && sed -i 's/c,c++/c/g' Makefile.in \
-  && sed -i 's/c,c++,fortran/c/g' Makefile.in \
-  && if [ -n "${RISCV_TOOLCHAIN_HOST_MARCH_X86_64}" ] && [ "$(uname -m)" = "x86_64" ]; then \
-       export CFLAGS="-march=${RISCV_TOOLCHAIN_HOST_MARCH_X86_64}"; \
-       export CXXFLAGS="$CFLAGS"; \
-     fi \
-  && ./configure \
-  --prefix="${RISCV_TOOLCHAIN_PREFIX}" \
-  --disable-gdb \
-  --disable-qemu \
-  --disable-linux \
-  --disable-nls \
-  --enable-strip \
-  && GCC_EXTRA_CONFIGURE_FLAGS="\
-  --enable-languages=c \
-  --disable-gcov \
-  --disable-lto \
-  --disable-libgomp \
-  --disable-libssp \
-  --disable-libquadmath \
-  --disable-decimal-float \
-  --disable-libsanitizer \
-  --disable-libvtv \
-  --enable-static \
-  --disable-shared" \
-  BINUTILS_TARGET_FLAGS_EXTRA="--disable-gprof --disable-gprofng" \
-  LDFLAGS="-static -static-libgcc -static-libstdc++" \
-  make -j"$(nproc)" \
-  && rm -rf /tmp/riscv-gnu-toolchain
-
-# Stage 2: install mise, then use it to install uv (Python) and Ruby, and pre-install the riscv-unified-db Bundler gem,
+# Stage 1: install mise, then use it to install uv (Python) and Ruby, and pre-install the riscv-unified-db Bundler gem,
 # and pre-download all Python dependencies via uv sync.
 #
 # mise reads .mise.toml from the repo to pin exact tool versions.
@@ -105,7 +33,7 @@ RUN git clone --depth 1 --branch "${RISCV_TOOLCHAIN_VERSION}" https://github.com
 #
 # HOME=/home/shared is used so all caches (mise, uv, udb, etc.) land in a single directory that is copied to the final
 # image.
-FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS mise-fetcher
+FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb AS mise-fetcher
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -127,10 +55,10 @@ RUN curl -fsSL https://mise.jdx.dev/install.sh | sh
 
 # mise and bundler need .mise.toml and the Gemfile(s); uv needs .python-version / pyproject.toml / uv.lock.
 COPY \
-    .mise.toml \
-        framework/src/act/data/Gemfile framework/src/act/data/Gemfile.lock \
-        .python-version pyproject.toml uv.lock README.md \
-    /act4/
+  .mise.toml \
+  framework/src/act/data/Gemfile framework/src/act/data/Gemfile.lock \
+  .python-version pyproject.toml uv.lock README.md \
+  /act4/
 # Copy files of other workspace members
 COPY framework/pyproject.toml /act4/framework/pyproject.toml
 COPY framework/src/act/__init__.py /act4/framework/src/act/__init__.py
@@ -142,16 +70,48 @@ COPY generators/testgen/src/testgen/__init__.py /act4/generators/testgen/src/tes
 # Install uv and Ruby at the versions pinned in .mise.toml
 # Pre-install the riscv-unified-db gem into the mise-managed Ruby's gem dir so `bundle install` is a no-op at runtime.
 # Pre-download all Python dependencies so `uv sync` is a no-op at runtime.
+# The final chmod runs in the same layer so the whole tree is not duplicated into a second one.
 RUN cd /act4 \
   && mise install \
   && mise exec -- bundle install \
-  && mise exec -- uv sync
+  && mise exec -- uv sync \
+  && chmod -R 777 /act4 /home/shared
 
-# Fix permissions so that any user can use it
-RUN chmod -R 777 /act4 /home/shared
+# Stage 2: fetch riscv-none-elf-gcc (xPack GNU RISC-V Embedded GCC) via xpm.
+#
+# xpm resolves the host arch itself; under buildx this stage runs emulated as TARGETARCH, so no
+# manual arch-name mapping is needed here (contrast with the sail-riscv curl fetch below, which
+# needs one because it is a raw tar.gz per-arch download).
+FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb AS xpack-fetcher
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG RISCV_TOOLCHAIN_PREFIX
+ARG XPACK_GCC_VERSION
+
+# nodejs/npm from the stock archive are old, but xpm itself has no meaningful version
+# sensitivity here; it is only used once, non-interactively, to pull a binary release archive.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  nodejs \
+  npm \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV XPACKS_STORE_FOLDER=/opt/xpacks-store \
+  XPACKS_CACHE_FOLDER=/opt/xpacks-cache
+
+RUN npm install --global xpm@0.23.2 \
+  && xpm install --global "@xpack-dev-tools/riscv-none-elf-gcc@${XPACK_GCC_VERSION}"
+
+# xpm lays the extracted toolchain out as
+# ${XPACKS_STORE_FOLDER}/@xpack-dev-tools/riscv-none-elf-gcc/<version>/.content
+# It is moved (not symlinked) to RISCV_TOOLCHAIN_PREFIX because COPY --from in the next stage
+# copies symlinks as-is rather than dereferencing them; a symlink pointing back into
+# XPACKS_STORE_FOLDER would be copied as a dangling link once that folder is left behind.
+RUN toolchain_dir="$(find "${XPACKS_STORE_FOLDER}/@xpack-dev-tools/riscv-none-elf-gcc" -mindepth 1 -maxdepth 1 -type d)" \
+  && mv "${toolchain_dir}/.content" "${RISCV_TOOLCHAIN_PREFIX}"
 
 # Stage 3: final runtime image
-FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS act4-build
+FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb AS act4-build
 
 LABEL description="RISC-V Architectural Certification Tests (ACT4) build env"
 LABEL org.opencontainers.image.source="https://github.com/riscv/riscv-arch-test"
@@ -160,6 +120,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=UTC
 ARG RISCV_TOOLCHAIN_PREFIX
 ARG SAIL_VERSION
+ARG TARGETARCH
 
 ENV TZ="${TZ}" \
   SAIL_PREFIX=/opt/sail \
@@ -167,7 +128,7 @@ ENV TZ="${TZ}" \
   HOME=/home/shared
 ENV PATH="${RISCV_TOOLCHAIN_PREFIX}/bin:${SAIL_PREFIX}/bin:/home/shared/.local/bin:${PATH}"
 
-# Runtime-only packages:
+# Runtime packages:
 #   - make, ca-certificates: drive the ACT4 Makefile
 #   - curl: required to fetch the sail-riscv release archive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -177,18 +138,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Fetch and install sail-riscv directly into the final image
-RUN SAIL_OS="$(uname -s)" \
-  && SAIL_ARCH="$(uname -m)" \
+RUN case "${TARGETARCH}" in \
+    amd64) SAIL_ARCH=x86_64 ;; \
+    arm64) SAIL_ARCH=aarch64 ;; \
+    *) echo "unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+  esac \
   && mkdir -p "${SAIL_PREFIX}" \
   && curl --location --fail \
-  "https://github.com/riscv/sail-riscv/releases/download/${SAIL_VERSION}/sail-riscv-${SAIL_OS}-${SAIL_ARCH}.tar.gz" \
+  "https://github.com/riscv/sail-riscv/releases/download/${SAIL_VERSION}/sail-riscv-Linux-${SAIL_ARCH}.tar.gz" \
   | tar xz --directory="${SAIL_PREFIX}" --strip-components=1
 
-COPY --from=toolchain-builder "${RISCV_TOOLCHAIN_PREFIX}" "${RISCV_TOOLCHAIN_PREFIX}"
-COPY --from=mise-fetcher      /home/shared                /home/shared
+COPY --from=xpack-fetcher ${RISCV_TOOLCHAIN_PREFIX} ${RISCV_TOOLCHAIN_PREFIX}
+COPY --from=mise-fetcher /home/shared /home/shared
 
 # Smoke-test: verify all the binaries landed correctly (runs as root during build, before USER switch)
-RUN riscv64-unknown-elf-gcc --version \
+RUN riscv-none-elf-gcc --version \
   && sail_riscv_sim --version \
   && mise --version
 
@@ -198,14 +162,16 @@ CMD ["/bin/bash"]
 
 FROM act4-build AS act4
 
-COPY --from=mise-fetcher /act4/.venv /act4/.venv
+COPY --from=mise-fetcher --chmod=777 /act4/.venv /act4/.venv
 COPY --chmod=777 . /act4
 
 # TODO: `make vector-tests` is only needed temporarily before vector tests are enabled by default
+# make re-syncs the venv as root, so the fixup has to run after it; restricting it to inodes that
+# are actually missing bits keeps the copy-up (and therefore the layer) down to what uv rewrote
 RUN make tests \
   && make vector-tests \
-  && chown -R ubuntu:ubuntu tests \
-  && chmod -R 777 /act4/.venv
+  && find tests ! -perm -0777 -exec chmod 0777 {} + \
+  && find /act4/.venv ! -perm -0777 -exec chmod 0777 {} +
 
 # Default user with ID 1000 matching typical desktop installation
 USER ubuntu

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/abundance-rv32i-max.yaml
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/abundance-rv32i-max.yaml
@@ -9,7 +9,14 @@ description: Abundance RV32I-max core
 implemented_extensions:
   - { name: I,        version: "= 2.1" }
   - { name: M,        version: "= 2.0" }
+  - { name: A,        version: "= 2.1" }
   - { name: B,        version: "= 1.0.0" }
+  - { name: Zaamo,    version: "= 1.0.0" }
+  - { name: Zabha,    version: "= 1.0.0" }
+  - { name: Zacas,    version: "= 1.0.0" }
+  - { name: Zalasr,   version: "= 1.0.0" }
+  - { name: Zalrsc,   version: "= 1.0.0" }
+  - { name: Zawrs,    version: "= 1.0.0" }
   - { name: Zba,      version: "= 1.0.0" }
   - { name: Zbb,      version: "= 1.0.0" }
   - { name: Zbc,      version: "= 1.0.0" }
@@ -171,7 +178,23 @@ params:
   MISALIGNED_MAX_ATOMICITY_GRANULE_SIZE: 4096
   MISALIGNED_SPLIT_STRATEGY: sequential_bytes
 
+  # --- Atomics ---
+  # Misaligned AMOs and LR/SC are allowed, same as plain loads/stores above.
+  MISALIGNED_AMO: true
+  # Only used when MISALIGNED_AMO is false, which it never is here.
+  LRSC_MISALIGNED_BEHAVIOR: "always raise access fault"
+  # The interpreter tracks a single reservation address and requires an exact
+  # match for `sc` to succeed.
+  LRSC_RESERVATION_STRATEGY: "reserve exactly enough to cover the access"
+  LRSC_FAIL_ON_NON_EXACT_LRSC: true
+  # No address translation is implemented, so VA and PA are always identical
+  # and this is never actually observable.
+  LRSC_FAIL_ON_VA_SYNONYM: true
+  # Zawrs params
+  ZAWRS_NTO_IS_NOP: true
+
   # --- Extension mutability ---
+  MUTABLE_MISA_A: false
   MUTABLE_MISA_M: false
   MUTABLE_MISA_B: false
 

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/rvmodel_macros.h
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/rvmodel_macros.h
@@ -40,9 +40,13 @@
 // Emits a minimal direct-mode trap handler inline, branching over it, then
 // writes its address into mtvec (direct mode: low 2 bits = 0).
 //
-// Handler contract: skip the faulting instruction (mepc += 4) and return.
-// This covers reserved/hint encodings that the decoder rejects as illegal
-// rather than treating as nops. No register saving needed - the test
+// Handler contract: skip the faulting instruction and return. The faulting
+// instruction may be a 16-bit compressed encoding (Zca is enabled), so the
+// handler must not blindly add 4 - it reads the low halfword at mepc and
+// advances by 4 only if bits[1:0] == 0b11 (a 32-bit instruction), otherwise
+// by 2. This mirrors the framework's own default trap handler in
+// rvtest_trap_handler.h. mepc is always at least 2-byte aligned, so the lhu
+// cannot itself misalign-fault. No register saving needed - the test
 // framework doesn't inspect register state across a trap.
 // ---------------------------------------------------------------------------
 #define RVMODEL_BOOT                            \
@@ -54,7 +58,13 @@
     .global rvmodel_trap_handler;               \
     rvmodel_trap_handler:                       \
         csrr    t0, mepc;                       \
-        addi    t0, t0, 4;                      \
+        lhu     t1, 0(t0);                      \
+        andi    t1, t1, 3;                      \
+        addi    t1, t1, 1;                      \
+        srli    t1, t1, 2;                      \
+        addi    t1, t1, 1;                      \
+        slli    t1, t1, 1;                      \
+        add     t0, t0, t1;                     \
         csrw    mepc, t0;                       \
         mret;                                   \
     .align 2;                                   \
@@ -125,6 +135,14 @@
 #define RVMODEL_SET_SEXT_INT(_R1, _R2)
 #define RVMODEL_CLR_SEXT_INT(_R1, _R2)
 #define RVMODEL_CLR_STIMER_INT(_R1, _R2)
-#define RVMODEL_SET_VSW_INT(_R1, _R2)
-#define RVMODEL_CLR_VSW_INT(_R1, _R2)
+// RVMODEL_SET_VSW_INT / RVMODEL_CLR_VSW_INT are intentionally NOT defined
+// here: the framework invokes them bare, with no arguments (see
+// rvtest_trap_handler.h's `clr_Vsw_int` label), unlike their MSW/SSW
+// siblings. A function-like macro taking (_R1, _R2) never expands at a
+// parenthesis-less call site, so defining them like the others left the
+// literal macro name in the generated assembly and broke the build under
+// STANDARD_SM_SUPPORTED. Leaving them undefined lets the framework's own
+// `#ifndef` fallback (abort via RVTEST_DFLT_INT_HNDLR) apply, which is
+// correct since this core doesn't implement the H extension and should
+// never actually take a VS-mode software interrupt.
 #define RVMODEL_INTERRUPT_LATENCY

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/sail.json
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/sail.json
@@ -10,10 +10,55 @@
       // No writable HPM counters
       "value": "0x0"
     },
+    "mcounteren_writable_bits": {
+      "len": 32,
+      // No HPM counters, and no S-mode to observe mcounteren anyway
+      "value": "0x0"
+    },
     "scounteren_writable_bits": {
       "len": 32,
       // No S-mode counters
       "value": "0x0"
+    },
+    "privileged_isa_version": "Privileged_ISA_1_13",
+    // No traps can be delegated: there is no S-mode to delegate to.
+    "medeleg": {
+      "delegatable_bits": {
+        "len": 64,
+        "value": "0x0"
+      }
+    },
+    "mideleg": {
+      "delegatable_bits": {
+        "len": "xlen",
+        "value": "0x0"
+      }
+    },
+    "mstatus": {
+      // F is not implemented, so FS is read-only zero.
+      "fs_legal_states": "ExtContext_Off",
+      "vs_legal_states": "ExtContext_FourState"
+    },
+    "mtvec": {
+      "direct": {
+        "supported": true,
+        "base_alignment": 2
+      },
+      // MTVEC_MODES only allows mode 0 (direct).
+      "vectored": {
+        "supported": false,
+        "base_alignment": 2
+      }
+    },
+    // No S-mode, so stvec doesn't exist; values here are unobservable.
+    "stvec": {
+      "direct": {
+        "supported": false
+      },
+      "vectored": {
+        "supported": false,
+        "base_alignment": 2
+      }
     },
     // These settings control whether the specified exceptions
     // cause information to be written into the appropriate
@@ -66,6 +111,7 @@
     }
   },
   "memory": {
+    "physaddr_bits": 32,
     "pmp": {
       "grain": 0,
       // This specifies the number of PMP entries present.
@@ -106,19 +152,20 @@
         // whether it generates an access fault (use `"AccessFault"`)
         // or a misaligned exception (use `"AlignmentException"`).
         "lrsc": "AccessFault",
-        // Similarly, a misaligned AMO currently always faults, and this field
-        // can specify either `"AccessFault"` or `"AlignmentException"`.
-        "amo": "AccessFault"
+        // Misaligned AMOs are allowed, same as scalar/vector loads and stores above.
+        "amo": {
+          "None": null
+        }
       },
       // If a misaligned access was specified to have no fault in `exceptions` above, the
       // fields below specify how it is handled.
       //
       // Memory accesses that span multiple naturally aligned
-      // 2^allowed_within_exp sized regions will be split into multiple
+      // 2^default_allowed_within_exp sized regions will be split into multiple
       // memory operations. 0 means all misaligned accesses will be split.
       // The maximum value is 12 (one page).
-      "allowed_within_exp": 0,
-      // If the access gets split due to `allowed_within_exp` then the size
+      "default_allowed_within_exp": 0,
+      // If the access gets split due to `default_allowed_within_exp` then the size
       // of the operations will be one byte if `byte_by_byte` is set, otherwise
       // they will be the maximum size possible based on the alignment. For
       // example a 4-byte access to address 0x2 will use two 2-byte operations.
@@ -164,6 +211,8 @@
             "amo": "AccessFault"
           },
           "atomic_support": "AMONone",
+          "misaligned_atomicity_granule_size_exp": 0,
+          "vector_misaligned_atomicity_granule_size_exp": 0,
           "reservability": "RsrvNone",
           "supports_cbo_zero": false,
           "supports_pte_read": false,
@@ -179,7 +228,7 @@
         },
         "size": {
           "len": 64,
-          "value": "0x80000"
+          "value": "0x200000"
         },
         "attributes": {
           "mem_type": "MainMemory",
@@ -200,8 +249,12 @@
             },
             "amo": "AccessFault"
           },
-          "atomic_support": "AMONone",
-          "reservability": "RsrvNone",
+          // Supports Zaamo/Zalrsc, plus Zacas up to doubleword compare-and-swap.
+          // amocas.q does not exist on RV32 per the Zacas spec (it's RV64-only).
+          "atomic_support": "AMOCASD",
+          "misaligned_atomicity_granule_size_exp": 12,
+          "vector_misaligned_atomicity_granule_size_exp": 12,
+          "reservability": "RsrvEventual",
           "supports_cbo_zero": false,
           "supports_pte_read": false,
           "supports_pte_write": false
@@ -226,9 +279,13 @@
       // address as the matching Load-Reserve in order to succeed, regardless of the
       // configured reservation set size.  This controls whether such an exact address
       // match is required for a Store-Conditional to succeed.
-      "require_exact_reservation_addr": false
+      "require_exact_reservation_addr": false,
+      // The interpreter's reservation is only invalidated by a subsequent `lr` or `sc`,
+      // not by a plain store from the same hart.
+      "invalidate_on_same_hart_store": false
     },
     "clint": {
+      "supported": true,
       // This must be in a suitable memory region (see `memory.regions`)
       "base": 33554432,
       "size": 786432
@@ -236,6 +293,7 @@
     // Very simple MMIO device to generate interrupts for testing
     // purposes. See docs/SimpleInterruptGenerator.md for details.
     "simple_interrupt_generator": {
+      "supported": true,
       // This must be in a suitable IO memory region (see `memory.regions`)
       // and 4-byte aligned. The size is always 0x20.
       "base": 34078720
@@ -243,6 +301,8 @@
     "clock_frequency": 1000000000,
     "instructions_per_tick": 1,
     "wfi_is_nop": true,
+    // No U-mode is implemented.
+    "wfi_available_to_user_mode": false,
     // The maximum increment in the time CSR before a wait instruction
     // (e.g. WFI, WRS.NTO, WRS.STO) that is not a NOP expires its
     // wait. It is not possible to wait indefinitely.
@@ -258,7 +318,7 @@
   },
   "extensions": {
     "A": {
-      "supported": false
+      "supported": true
     },
     "B": {
       "supported": true
@@ -281,16 +341,40 @@
       "support_level": "Integer",
       "vlen_exp": 10,
       "elen_exp": 6,
-      "vl_use_ceil": false
+      "vl_use_ceil": false,
+      "reserved_behavior": {
+        "illegal_vtype": "IllegalVtype_SetVill",
+        "vstart_out_of_bounds": "Vstart_Illegal"
+      },
+      // Must not exceed the supported ELEN (2^elen_exp).
+      "max_index_eew_exp": 6,
+      "vstart": {
+        "zero_required": {
+          "arith": true,
+          "scalar_move": true
+        }
+      }
     },
     "Zaamo": {
-      "supported": false
+      "supported": true
     },
-    "Zalrsc": {
-      "supported": false
+    "Zabha": {
+      "supported": true
     },
     "Zacas": {
-      "supported": false
+      "supported": true
+    },
+    "Zalrsc": {
+      "supported": true
+    },
+    "Zawrs": {
+      "supported": true,
+      "nto": {
+        "is_nop": true
+      },
+      "sto": {
+        "is_nop": true
+      }
     },
     "Zba": {
       "supported": true
@@ -363,14 +447,35 @@
     "D": {
       "supported": false
     },
-    "F": {
+    // Not enabled: asserting this requires a 16-byte misaligned atomicity granule on
+    // every coherent/cacheable region, which is more than this core commits to.
+    "Zama16b": {
       "supported": false
+    },
+    "F": {
+      "supported": false,
+      "fflags_dirty_policy": "Fflags_Dirty_Precise"
     },
     "S": {
       "supported": false
     },
     "Smcntrpmf": {
       "supported": false
+    },
+    "Smmpm": {
+      "supported": false,
+      "supported_pmlen_7": false,
+      "supported_pmlen_16": false
+    },
+    "Smnpm": {
+      "supported": false,
+      "supported_pmlen_7": false,
+      "supported_pmlen_16": false
+    },
+    "Ssnpm": {
+      "supported": false,
+      "supported_pmlen_7": false,
+      "supported_pmlen_16": false
     },
     "Ssccptr": {
       "supported": false
@@ -441,18 +546,6 @@
     },
     "U": {
       "supported": false
-    },
-    "Zabha": {
-      "supported": false
-    },
-    "Zawrs": {
-      "supported": false,
-      "nto": {
-        "is_nop": false
-      },
-      "sto": {
-        "is_nop": false
-      }
     },
     "Zcd": {
       "supported": false

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/test_config.yaml
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/test_config.yaml
@@ -1,6 +1,6 @@
 # ACT4 framework top-level config for the abundance RV32I-max core.
 #
-# compiler_exe: riscv64-unknown-elf-gcc targeting ilp32 ABI (no F/D).
+# compiler_exe: riscv-none-elf-gcc targeting ilp32 ABI (no F/D).
 #   The march string must match the extensions in abundance-rv32i-max.yaml.
 #
 # ref_model_exe: sail_riscv_sim on $PATH.
@@ -12,8 +12,8 @@
 #   Enable only after you implement a machine-mode trap handler.
 
 name: abundance-rv32i-max
-compiler_exe: riscv64-unknown-elf-gcc
-objdump_exe: riscv64-unknown-elf-objdump
+compiler_exe: riscv-none-elf-gcc
+objdump_exe: riscv-none-elf-objdump
 ref_model_exe: sail_riscv_sim
 udb_config: abundance-rv32i-max.yaml
 linker_script: link.ld

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/abundance-rv64i-max.yaml
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/abundance-rv64i-max.yaml
@@ -9,7 +9,14 @@ description: Abundance RV64I-max core
 implemented_extensions:
   - { name: I,        version: "= 2.1" }
   - { name: M,        version: "= 2.0" }
+  - { name: A,        version: "= 2.1" }
   - { name: B,        version: "= 1.0.0" }
+  - { name: Zaamo,    version: "= 1.0.0" }
+  - { name: Zabha,    version: "= 1.0.0" }
+  - { name: Zacas,    version: "= 1.0.0" }
+  - { name: Zalasr,   version: "= 1.0.0" }
+  - { name: Zalrsc,   version: "= 1.0.0" }
+  - { name: Zawrs,    version: "= 1.0.0" }
   - { name: Zba,      version: "= 1.0.0" }
   - { name: Zbb,      version: "= 1.0.0" }
   - { name: Zbc,      version: "= 1.0.0" }
@@ -171,7 +178,23 @@ params:
   MISALIGNED_MAX_ATOMICITY_GRANULE_SIZE: 4096
   MISALIGNED_SPLIT_STRATEGY: sequential_bytes
 
+  # --- Atomics ---
+  # Misaligned AMOs and LR/SC are allowed, same as plain loads/stores above.
+  MISALIGNED_AMO: true
+  # Only used when MISALIGNED_AMO is false, which it never is here.
+  LRSC_MISALIGNED_BEHAVIOR: "always raise access fault"
+  # The interpreter tracks a single reservation address and requires an exact
+  # match for `sc` to succeed.
+  LRSC_RESERVATION_STRATEGY: "reserve exactly enough to cover the access"
+  LRSC_FAIL_ON_NON_EXACT_LRSC: true
+  # No address translation is implemented, so VA and PA are always identical
+  # and this is never actually observable.
+  LRSC_FAIL_ON_VA_SYNONYM: true
+  # Zawrs params
+  ZAWRS_NTO_IS_NOP: true
+
   # --- Extension mutability ---
+  MUTABLE_MISA_A: false
   MUTABLE_MISA_M: false
   MUTABLE_MISA_B: false
 

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/link.ld
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/link.ld
@@ -1,15 +1,52 @@
+/* Set these to match the DUT memory map and hart count. */
+RAM_ORIGIN = 0x80000000;
+RAM_LENGTH = 0x200000;
+TEST_BASE = RAM_ORIGIN;
+NUM_HARTS = 1;
+
+/* Most users should not need to modify anything below this line. */
+STACK_SIZE = 0x20000;
+
 OUTPUT_ARCH( "riscv" )
 ENTRY(rvtest_entry_point)
 
+MEMORY
+{
+  ram (rwx) : ORIGIN = RAM_ORIGIN, LENGTH = RAM_LENGTH
+}
+
+PROVIDE(__stack_size = STACK_SIZE);
+PROVIDE(__num_harts = NUM_HARTS);
+
 SECTIONS
 {
-  . = 0x80000000;
-  .text.init    : { *(.text.init) }
-  .text.rvtest  : { *(.text.rvtest) *(.text.rvtest.*) }
+  ASSERT(TEST_BASE >= ORIGIN(ram) && TEST_BASE < ORIGIN(ram) + LENGTH(ram), "TEST_BASE is outside RAM; update TEST_BASE and RAM_ORIGIN/RAM_LENGTH in link.ld, and the matching memory.regions entry in sail.json")
+
+  .text.init   TEST_BASE : { *(.text.init) } > ram
+  .text.rvtest . : { *(.text.rvtest) *(.text.rvtest.*) } > ram
+
   . = ALIGN(0x4000);
-  .data         : { *(.data) }
+  .rodata . : { *(.rodata) *(.rodata.*) *(.srodata) *(.srodata.*) } > ram
+  .data   . : { *(.data) *(.data.*) *(.sdata) *(.sdata.*) } > ram
+
+  . = ALIGN(16);
+  .bss . : {
+    __bss_start = .;
+    *(.sbss) *(.sbss.*) *(.bss) *(.bss.*) *(COMMON)
+    . = ALIGN(16);
+    __bss_end = .;
+  } > ram
+
+  . = ALIGN(16);
+  __stack_bottom = .;
+  . += __stack_size * __num_harts;
+  __stack_top = .;
+
   . = ALIGN(0x1000);
-  .text.rvmodel : { *(.text.rvmodel) *(.text.rvmodel.*) *(.text) *(.text.*) }
+  .text.rvmodel . : { *(.text.rvmodel) *(.text.rvmodel.*) *(.text) *(.text.*) } > ram
+
   . = ALIGN(0x1000);
   _end = .;
+
+  ASSERT(_end <= ORIGIN(ram) + LENGTH(ram), "ACT ELF exceeds RAM; increase RAM_LENGTH in link.ld and the matching memory.regions size in sail.json")
 }

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/rvmodel_macros.h
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/rvmodel_macros.h
@@ -41,9 +41,13 @@
 // writes its address into mtvec (direct mode: low 2 bits = 0, so 4-byte
 // alignment is sufficient).
 //
-// Handler contract: skip the faulting instruction (mepc += 4) and return.
-// This covers reserved/hint encodings that the decoder rejects as illegal
-// rather than treating as nops. No register saving needed - the test
+// Handler contract: skip the faulting instruction and return. The faulting
+// instruction may be a 16-bit compressed encoding (Zca is enabled), so the
+// handler must not blindly add 4 - it reads the low halfword at mepc and
+// advances by 4 only if bits[1:0] == 0b11 (a 32-bit instruction), otherwise
+// by 2. This mirrors the framework's own default trap handler in
+// rvtest_trap_handler.h. mepc is always at least 2-byte aligned, so the lhu
+// cannot itself misalign-fault. No register saving needed - the test
 // framework doesn't inspect register state across a trap.
 // ---------------------------------------------------------------------------
 #define RVMODEL_BOOT                            \
@@ -55,7 +59,13 @@
     .global rvmodel_trap_handler;               \
     rvmodel_trap_handler:                       \
         csrr    t0, mepc;                       \
-        addi    t0, t0, 4;                      \
+        lhu     t1, 0(t0);                      \
+        andi    t1, t1, 3;                      \
+        addi    t1, t1, 1;                      \
+        srli    t1, t1, 2;                      \
+        addi    t1, t1, 1;                      \
+        slli    t1, t1, 1;                      \
+        add     t0, t0, t1;                     \
         csrw    mepc, t0;                       \
         mret;                                   \
     .align 2;                                   \
@@ -126,6 +136,14 @@
 #define RVMODEL_SET_SEXT_INT(_R1, _R2)
 #define RVMODEL_CLR_SEXT_INT(_R1, _R2)
 #define RVMODEL_CLR_STIMER_INT(_R1, _R2)
-#define RVMODEL_SET_VSW_INT(_R1, _R2)
-#define RVMODEL_CLR_VSW_INT(_R1, _R2)
+// RVMODEL_SET_VSW_INT / RVMODEL_CLR_VSW_INT are intentionally NOT defined
+// here: the framework invokes them bare, with no arguments (see
+// rvtest_trap_handler.h's `clr_Vsw_int` label), unlike their MSW/SSW
+// siblings. A function-like macro taking (_R1, _R2) never expands at a
+// parenthesis-less call site, so defining them like the others left the
+// literal macro name in the generated assembly and broke the build under
+// STANDARD_SM_SUPPORTED. Leaving them undefined lets the framework's own
+// `#ifndef` fallback (abort via RVTEST_DFLT_INT_HNDLR) apply, which is
+// correct since this core doesn't implement the H extension and should
+// never actually take a VS-mode software interrupt.
 #define RVMODEL_INTERRUPT_LATENCY

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/sail.json
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/sail.json
@@ -10,10 +10,55 @@
       // No writable HPM counters
       "value": "0x0"
     },
+    "mcounteren_writable_bits": {
+      "len": 32,
+      // No HPM counters, and no S-mode to observe mcounteren anyway
+      "value": "0x0"
+    },
     "scounteren_writable_bits": {
       "len": 32,
       // No S-mode counters
       "value": "0x0"
+    },
+    "privileged_isa_version": "Privileged_ISA_1_13",
+    // No traps can be delegated: there is no S-mode to delegate to.
+    "medeleg": {
+      "delegatable_bits": {
+        "len": 64,
+        "value": "0x0"
+      }
+    },
+    "mideleg": {
+      "delegatable_bits": {
+        "len": "xlen",
+        "value": "0x0"
+      }
+    },
+    "mstatus": {
+      // F is not implemented, so FS is read-only zero.
+      "fs_legal_states": "ExtContext_Off",
+      "vs_legal_states": "ExtContext_FourState"
+    },
+    "mtvec": {
+      "direct": {
+        "supported": true,
+        "base_alignment": 2
+      },
+      // MTVEC_MODES only allows mode 0 (direct).
+      "vectored": {
+        "supported": false,
+        "base_alignment": 2
+      }
+    },
+    // No S-mode, so stvec doesn't exist; values here are unobservable.
+    "stvec": {
+      "direct": {
+        "supported": false
+      },
+      "vectored": {
+        "supported": false,
+        "base_alignment": 2
+      }
     },
     // These settings control whether the specified exceptions
     // cause information to be written into the appropriate
@@ -66,6 +111,7 @@
     }
   },
   "memory": {
+    "physaddr_bits": 64,
     "pmp": {
       "grain": 0,
       // This specifies the number of PMP entries present.
@@ -106,19 +152,20 @@
         // whether it generates an access fault (use `"AccessFault"`)
         // or a misaligned exception (use `"AlignmentException"`).
         "lrsc": "AccessFault",
-        // Similarly, a misaligned AMO currently always faults, and this field
-        // can specify either `"AccessFault"` or `"AlignmentException"`.
-        "amo": "AccessFault"
+        // Misaligned AMOs are allowed, same as scalar/vector loads and stores above.
+        "amo": {
+          "None": null
+        }
       },
       // If a misaligned access was specified to have no fault in `exceptions` above, the
       // fields below specify how it is handled.
       //
       // Memory accesses that span multiple naturally aligned
-      // 2^allowed_within_exp sized regions will be split into multiple
+      // 2^default_allowed_within_exp sized regions will be split into multiple
       // memory operations. 0 means all misaligned accesses will be split.
       // The maximum value is 12 (one page).
-      "allowed_within_exp": 0,
-      // If the access gets split due to `allowed_within_exp` then the size
+      "default_allowed_within_exp": 0,
+      // If the access gets split due to `default_allowed_within_exp` then the size
       // of the operations will be one byte if `byte_by_byte` is set, otherwise
       // they will be the maximum size possible based on the alignment. For
       // example a 4-byte access to address 0x2 will use two 2-byte operations.
@@ -164,6 +211,8 @@
             "amo": "AccessFault"
           },
           "atomic_support": "AMONone",
+          "misaligned_atomicity_granule_size_exp": 0,
+          "vector_misaligned_atomicity_granule_size_exp": 0,
           "reservability": "RsrvNone",
           "supports_cbo_zero": false,
           "supports_pte_read": false,
@@ -179,7 +228,7 @@
         },
         "size": {
           "len": 64,
-          "value": "0x80000"
+          "value": "0x200000"
         },
         "attributes": {
           "mem_type": "MainMemory",
@@ -200,8 +249,11 @@
             },
             "amo": "AccessFault"
           },
-          "atomic_support": "AMONone",
-          "reservability": "RsrvNone",
+          // Supports Zaamo/Zalrsc, plus Zacas.
+          "atomic_support": "AMOCASQ",
+          "misaligned_atomicity_granule_size_exp": 12,
+          "vector_misaligned_atomicity_granule_size_exp": 12,
+          "reservability": "RsrvEventual",
           "supports_cbo_zero": false,
           "supports_pte_read": false,
           "supports_pte_write": false
@@ -226,9 +278,13 @@
       // address as the matching Load-Reserve in order to succeed, regardless of the
       // configured reservation set size.  This controls whether such an exact address
       // match is required for a Store-Conditional to succeed.
-      "require_exact_reservation_addr": false
+      "require_exact_reservation_addr": false,
+      // The interpreter's reservation is only invalidated by a subsequent `lr` or `sc`,
+      // not by a plain store from the same hart.
+      "invalidate_on_same_hart_store": false
     },
     "clint": {
+      "supported": true,
       // This must be in a suitable memory region (see `memory.regions`)
       "base": 33554432,
       "size": 786432
@@ -236,6 +292,7 @@
     // Very simple MMIO device to generate interrupts for testing
     // purposes. See docs/SimpleInterruptGenerator.md for details.
     "simple_interrupt_generator": {
+      "supported": true,
       // This must be in a suitable IO memory region (see `memory.regions`)
       // and 4-byte aligned. The size is always 0x20.
       "base": 34078720
@@ -243,6 +300,8 @@
     "clock_frequency": 1000000000,
     "instructions_per_tick": 1,
     "wfi_is_nop": true,
+    // No U-mode is implemented.
+    "wfi_available_to_user_mode": false,
     // The maximum increment in the time CSR before a wait instruction
     // (e.g. WFI, WRS.NTO, WRS.STO) that is not a NOP expires its
     // wait. It is not possible to wait indefinitely.
@@ -258,7 +317,7 @@
   },
   "extensions": {
     "A": {
-      "supported": false
+      "supported": true
     },
     "B": {
       "supported": true
@@ -281,16 +340,40 @@
       "support_level": "Integer",
       "vlen_exp": 10,
       "elen_exp": 6,
-      "vl_use_ceil": false
+      "vl_use_ceil": false,
+      "reserved_behavior": {
+        "illegal_vtype": "IllegalVtype_SetVill",
+        "vstart_out_of_bounds": "Vstart_Illegal"
+      },
+      // Must not exceed the supported ELEN (2^elen_exp).
+      "max_index_eew_exp": 6,
+      "vstart": {
+        "zero_required": {
+          "arith": true,
+          "scalar_move": true
+        }
+      }
     },
     "Zaamo": {
-      "supported": false
+      "supported": true
     },
-    "Zalrsc": {
-      "supported": false
+    "Zabha": {
+      "supported": true
     },
     "Zacas": {
-      "supported": false
+      "supported": true
+    },
+    "Zalrsc": {
+      "supported": true
+    },
+    "Zawrs": {
+      "supported": true,
+      "nto": {
+        "is_nop": true
+      },
+      "sto": {
+        "is_nop": true
+      }
     },
     "Zba": {
       "supported": true
@@ -363,14 +446,35 @@
     "D": {
       "supported": false
     },
-    "F": {
+    // Not enabled: asserting this requires a 16-byte misaligned atomicity granule on
+    // every coherent/cacheable region, which is more than this core commits to.
+    "Zama16b": {
       "supported": false
+    },
+    "F": {
+      "supported": false,
+      "fflags_dirty_policy": "Fflags_Dirty_Precise"
     },
     "S": {
       "supported": false
     },
     "Smcntrpmf": {
       "supported": false
+    },
+    "Smmpm": {
+      "supported": false,
+      "supported_pmlen_7": false,
+      "supported_pmlen_16": false
+    },
+    "Smnpm": {
+      "supported": false,
+      "supported_pmlen_7": false,
+      "supported_pmlen_16": false
+    },
+    "Ssnpm": {
+      "supported": false,
+      "supported_pmlen_7": false,
+      "supported_pmlen_16": false
     },
     "Ssccptr": {
       "supported": false
@@ -441,18 +545,6 @@
     },
     "U": {
       "supported": false
-    },
-    "Zabha": {
-      "supported": false
-    },
-    "Zawrs": {
-      "supported": false,
-      "nto": {
-        "is_nop": false
-      },
-      "sto": {
-        "is_nop": false
-      }
     },
     "Zcd": {
       "supported": false

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/test_config.yaml
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/test_config.yaml
@@ -1,6 +1,6 @@
 # ACT4 framework top-level config for the abundance RV64I-max core.
 #
-# compiler_exe: riscv64-unknown-elf-gcc on $PATH, targeting lp64 ABI (no F/D).
+# compiler_exe: riscv-none-elf-gcc on $PATH, targeting lp64 ABI (no F/D).
 #   The march string must match the extensions in abundance-rv64i-max.yaml.
 #
 # ref_model_exe: sail_riscv_sim on $PATH.
@@ -12,8 +12,8 @@
 #   Enable only after you implement a machine-mode trap handler.
 
 name: abundance-rv64i-max
-compiler_exe: riscv64-unknown-elf-gcc
-objdump_exe: riscv64-unknown-elf-objdump
+compiler_exe: riscv-none-elf-gcc
+objdump_exe: riscv-none-elf-objdump
 ref_model_exe: sail_riscv_sim
 udb_config: abundance-rv64i-max.yaml
 linker_script: link.ld

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
@@ -12,8 +12,13 @@ pub(crate) type AbundanceRv32IMaxInstruction = AbundanceRv32IMaxInstructionProto
 #[instruction(
     inherit = [
         Rv32Instruction,
+        Rv32AInstruction,
         Rv32BInstruction,
         Rv32MInstruction,
+        Rv32ZabhaInstruction,
+        Rv32ZacasInstruction,
+        Rv32ZalasrInstruction,
+        Rv32ZawrsInstruction,
         Rv32ZbcInstruction,
         Rv32ZcaInstruction,
         Rv32ZcbInstruction,

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/interpreter.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 pub(crate) struct AbundanceRv32IMaxExtState {
     csrs: BTreeMap<u16, u32>,
     vregs: VectorRegisterFile<const { Self::VLEN }>,
+    reservation: Option<u32>,
 }
 
 impl AbundanceRv32IMaxExtState {
@@ -13,6 +14,7 @@ impl AbundanceRv32IMaxExtState {
         let mut s = Self {
             csrs: BTreeMap::new(),
             vregs: VectorRegisterFile::default(),
+            reservation: None,
         };
         // Vector CSRs
         s.init_csr(VectorCsr::Vstart.to_csr_index(), 0);
@@ -110,4 +112,20 @@ where
 impl VectorRegistersExt<<AbundanceRv32IMaxInstruction as Instruction>::Reg>
     for AbundanceRv32IMaxExtState
 {
+}
+
+impl ReservationSet<<AbundanceRv32IMaxInstruction as Instruction>::Reg>
+    for AbundanceRv32IMaxExtState
+{
+    fn reservation(&self) -> Option<u32> {
+        self.reservation
+    }
+
+    fn set_reservation(&mut self, address: u32) {
+        self.reservation = Some(address);
+    }
+
+    fn clear_reservation(&mut self) {
+        self.reservation = None;
+    }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
@@ -12,8 +12,13 @@ pub(crate) type AbundanceRv64IMaxInstruction = AbundanceRv64IMaxInstructionProto
 #[instruction(
     inherit = [
         Rv64Instruction,
+        Rv64AInstruction,
         Rv64BInstruction,
         Rv64MInstruction,
+        Rv64ZabhaInstruction,
+        Rv64ZacasInstruction,
+        Rv64ZalasrInstruction,
+        Rv64ZawrsInstruction,
         Rv64ZbcInstruction,
         Rv64ZcaInstruction,
         Rv64ZcbInstruction,

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/interpreter.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 pub(crate) struct AbundanceRv64IMaxExtState {
     csrs: BTreeMap<u16, u64>,
     vregs: VectorRegisterFile<const { Self::VLEN }>,
+    reservation: Option<u64>,
 }
 
 impl AbundanceRv64IMaxExtState {
@@ -13,6 +14,7 @@ impl AbundanceRv64IMaxExtState {
         let mut s = Self {
             csrs: BTreeMap::new(),
             vregs: VectorRegisterFile::default(),
+            reservation: None,
         };
         // Vector CSRs
         s.init_csr(VectorCsr::Vstart.to_csr_index(), 0);
@@ -113,4 +115,20 @@ where
 impl VectorRegistersExt<<AbundanceRv64IMaxInstruction as Instruction>::Reg>
     for AbundanceRv64IMaxExtState
 {
+}
+
+impl ReservationSet<<AbundanceRv64IMaxInstruction as Instruction>::Reg>
+    for AbundanceRv64IMaxExtState
+{
+    fn reservation(&self) -> Option<u64> {
+        self.reservation
+    }
+
+    fn set_reservation(&mut self, address: u64) {
+        self.reservation = Some(address);
+    }
+
+    fn clear_reservation(&mut self) {
+        self.reservation = None;
+    }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -43,7 +43,7 @@ compile_error!("Only little-endian platforms are supported");
 type RegisterType<I> = <<I as Instruction>::Reg as Register>::Type;
 
 const RAM_BASE: u64 = 0x8000_0000;
-const RAM_SIZE: usize = 0x80000;
+const RAM_SIZE: usize = 0x0020_0000;
 const MRET_INSTRUCTION: u32 = 0x3020_0073;
 
 const SIZE_OF<T>: usize = size_of::<T>();
@@ -325,7 +325,7 @@ fn run_rv32i_max_test(
 ) -> Result<(), TestError<RegisterType<AbundanceRv32IMaxInstruction>>> {
     let elf = ParsedElf::<<AbundanceRv32IMaxInstruction as Instruction>::Reg>::from_path(elf_path)?;
 
-    let mut ram = BasicMemory::<RAM_BASE, RAM_SIZE>::default();
+    let mut ram = BasicMemory::<RAM_BASE, RAM_SIZE>::new_boxed();
     for (vaddr, data) in &elf.segments {
         ram.write_slice(*vaddr, data)
             .map_err(ExecutionError::from)?;
@@ -458,7 +458,7 @@ fn run_rv64i_max_test(
 ) -> Result<(), TestError<RegisterType<AbundanceRv64IMaxInstruction>>> {
     let elf = ParsedElf::<<AbundanceRv64IMaxInstruction as Instruction>::Reg>::from_path(elf_path)?;
 
-    let mut ram = BasicMemory::<RAM_BASE, RAM_SIZE>::default();
+    let mut ram = BasicMemory::<RAM_BASE, RAM_SIZE>::new_boxed();
     for (vaddr, data) in &elf.segments {
         ram.write_slice(*vaddr, data)
             .map_err(ExecutionError::from)?;

--- a/crates/execution/ab-riscv-interpreter/Cargo.toml
+++ b/crates/execution/ab-riscv-interpreter/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = { workspace = true }
 ab-riscv-macros = { workspace = true, features = ["build"] }
 
 [features]
+alloc = []
 # TODO: no-panic coverage is limited very slightly:
 #  * Some `::execute()` methods do not have `no_panic_const::no_panic` macro applied due to unreasonable inlining limits
 #    required, but all helpers and other APIs used are guaranteed to not panic, and the rest of the code is trivially

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -7,7 +7,7 @@ use crate::{
     Address, BasicInt, CustomErrorPlaceholder, ExecutableInstruction, ExecutionError,
     FetchInstructionResult, InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
     Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    VirtualMemoryError, WrsHandler,
 };
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
@@ -524,3 +524,5 @@ where
         })
     }
 }
+
+const impl WrsHandler for IllegalEcallSystemInstructionHandler {}

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -10,6 +10,8 @@ use crate::{
     VirtualMemoryError, WrsHandler,
 };
 use ab_riscv_primitives::prelude::*;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 use core::hint::cold_path;
 use core::marker::PhantomData;
 use core::ops::ControlFlow;
@@ -363,6 +365,12 @@ impl<const BASE_ADDR: u64, const SIZE: usize> Default for BasicMemory<BASE_ADDR,
 }
 
 impl<const BASE_ADDR: u64, const SIZE: usize> BasicMemory<BASE_ADDR, SIZE> {
+    #[cfg(feature = "alloc")]
+    pub fn new_boxed() -> Box<Self> {
+        // SAFETY: Zeroed memory is a valid invariant
+        unsafe { Box::<Self>::new_zeroed().assume_init() }
+    }
+
     /// Get a mutable slice of memory.
     ///
     /// This is primarily useful for setting up the program and should not be used beyond that.

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -29,7 +29,11 @@
 //! * M (version 2.0)
 //! * B (version 1.0.0)
 //! * Zaamo (version 1.0.0)
+//! * Zabha (version 1.0.0)
+//! * Zacas (version 1.0.0)
+//! * (experimental) Zalasr (version 1.0.0)
 //! * Zalrsc (version 1.0.0)
+//! * Zawrs (version 1.0.0)
 //! * Zba (version 1.0.0)
 //! * Zbb (version 1.0.0)
 //! * Zbc (version 1.0.0)
@@ -59,8 +63,7 @@
 //!
 //! Any permutation of compatible extensions is supported.
 //!
-//! Experimental extensions are known to have bugs and need more work. They are not tested against
-//! ACTs yet.
+//! Experimental extensions may not have ACT4 tests yet and are not guaranteed to work correctly.
 //!
 //! ## Design choices
 //!
@@ -584,6 +587,24 @@ pub const trait SystemInstructionHandler<
         let _: &Regs = regs;
         let _: &mut Memory = memory;
         let _: Reg::Type = pc;
+        // NOP by default
+    }
+}
+
+/// Custom handler for `Zawrs` extension's `wrs.nto`/`wrs.sto` instructions.
+///
+/// These are hint instructions that may complete for any reason, so a no-op is a valid
+/// implementation for both.
+pub const trait WrsHandler {
+    /// Handle a `wrs.nto` instruction (Wait-on-Reservation-Set, no timeout)
+    #[inline(always)]
+    fn handle_wrs_nto(&mut self) {
+        // NOP by default
+    }
+
+    /// Handle a `wrs.sto` instruction (Wait-on-Reservation-Set, short timeout)
+    #[inline(always)]
+    fn handle_wrs_sto(&mut self) {
         // NOP by default
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -25,8 +25,11 @@
 //! * RV64E (version 2.0)
 //!
 //! Extensions:
+//! * A (version 2.1)
 //! * M (version 2.0)
 //! * B (version 1.0.0)
+//! * Zaamo (version 1.0.0)
+//! * Zalrsc (version 1.0.0)
 //! * Zba (version 1.0.0)
 //! * Zbb (version 1.0.0)
 //! * Zbc (version 1.0.0)
@@ -516,6 +519,25 @@ where
             }
         }
     }
+}
+
+/// Reservation set used to implement `Zalrsc` extension's `lr`/`sc` instruction pairs.
+///
+/// `lr` places a reservation on an address, and a subsequent `sc` succeeds only if the reservation
+/// is still held for the same address. Regardless of success or failure, executing `sc` always
+/// invalidates the reservation, as does a subsequent `lr`.
+pub const trait ReservationSet<Reg>
+where
+    Reg: [const] Register,
+{
+    /// Returns the address of the currently held reservation, if any
+    fn reservation(&self) -> Option<Reg::Type>;
+
+    /// Place a reservation on `address`, replacing any previously held reservation
+    fn set_reservation(&mut self, address: Reg::Type);
+
+    /// Clear any currently held reservation
+    fn clear_reservation(&mut self);
 }
 
 /// Custom handler for system instructions `ecall` and `ebreak`

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -164,8 +164,13 @@ pub mod zicsr;
 pub mod zvbb;
 pub mod zvbc;
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 use crate::private::BasicIntSealed;
 use ab_riscv_primitives::prelude::*;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
 use core::fmt;
 use core::hint::cold_path;
 use core::marker::Destruct;
@@ -254,6 +259,52 @@ pub const trait VirtualMemory {
 
     /// Write a contiguous byte slice to memory
     fn write_slice(&mut self, address: u64, data: &[u8]) -> Result<(), VirtualMemoryError>;
+}
+
+#[cfg(feature = "alloc")]
+impl<M> VirtualMemory for Box<M>
+where
+    M: VirtualMemory,
+{
+    #[inline(always)]
+    fn read<T>(&self, address: u64) -> Result<T, VirtualMemoryError>
+    where
+        T: BasicInt,
+    {
+        self.as_ref().read(address)
+    }
+
+    #[inline(always)]
+    unsafe fn read_unchecked<T>(&self, address: u64) -> T
+    where
+        T: BasicInt,
+    {
+        // SAFETY: Guaranteed by the caller
+        unsafe { self.as_ref().read_unchecked(address) }
+    }
+
+    #[inline(always)]
+    fn read_slice(&self, address: u64, len: u32) -> Result<&[u8], VirtualMemoryError> {
+        self.as_ref().read_slice(address, len)
+    }
+
+    #[inline(always)]
+    fn read_slice_up_to(&self, address: u64, len: u32) -> &[u8] {
+        self.as_ref().read_slice_up_to(address, len)
+    }
+
+    #[inline(always)]
+    fn write<T>(&mut self, address: u64, value: T) -> Result<(), VirtualMemoryError>
+    where
+        T: BasicInt,
+    {
+        self.as_mut().write(address, value)
+    }
+
+    #[inline(always)]
+    fn write_slice(&mut self, address: u64, data: &[u8]) -> Result<(), VirtualMemoryError> {
+        self.as_mut().write_slice(address, data)
+    }
 }
 
 /// Placeholder for custom errors in [`ExecutionError`]

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -37,5 +37,5 @@ pub use crate::{
     ExecutableInstructionOperands, ExecutableInstructionResult, ExecutionError,
     FetchInstructionResult, InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
     ReservationSet, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    VirtualMemoryError, WrsHandler,
 };

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -36,6 +36,6 @@ pub use crate::{
     BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
     ExecutableInstructionOperands, ExecutableInstructionResult, ExecutionError,
     FetchInstructionResult, InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ReservationSet, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
     VirtualMemoryError,
 };

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -1,5 +1,6 @@
 //! Base RISC-V RV32 instruction set
 
+pub mod a;
 pub mod b;
 pub mod c;
 pub mod m;

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -8,6 +8,10 @@ pub mod m;
 pub(crate) mod test_utils;
 #[cfg(test)]
 mod tests;
+pub mod zabha;
+pub mod zacas;
+pub mod zalasr;
+pub mod zawrs;
 pub mod zce;
 pub mod zk;
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
@@ -1,0 +1,55 @@
+//! RV32 A extension
+
+pub mod zaamo;
+pub mod zalrsc;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, ReservationSet, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv32AInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32AInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32AInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+    ExtState: [const] ReservationSet<Reg>,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        Ok(ControlFlow::Continue(Default::default()))
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
@@ -1,0 +1,165 @@
+//! RV32 Zaamo extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv32ZaamoInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZaamoInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZaamoInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::Amoswap {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                memory.write(u64::from(rs1_value), rs2_value)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::Amoadd {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                memory.write(u64::from(rs1_value), old.wrapping_add(rs2_value))?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::Amoxor {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                memory.write(u64::from(rs1_value), old ^ rs2_value)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::Amoand {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                memory.write(u64::from(rs1_value), old & rs2_value)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::Amoor {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                memory.write(u64::from(rs1_value), old | rs2_value)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::Amomin {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                let new = if old.cast_signed() < rs2_value.cast_signed() {
+                    old
+                } else {
+                    rs2_value
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::Amomax {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                let new = if old.cast_signed() > rs2_value.cast_signed() {
+                    old
+                } else {
+                    rs2_value
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::Amominu {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                let new = if old < rs2_value { old } else { rs2_value };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::Amomaxu {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u32>(u64::from(rs1_value))?;
+                let new = if old > rs2_value { old } else { rs2_value };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo/tests.rs
@@ -1,0 +1,246 @@
+use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_amoswap() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amoswap {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 222);
+}
+
+#[test]
+fn test_amoadd() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amoadd {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 10).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 32);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 10);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 42);
+}
+
+#[test]
+fn test_amoadd_wraps() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amoadd {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u32>(u64::from(addr), u32::MAX)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 1);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), u32::MAX);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 0);
+}
+
+#[test]
+fn test_amoxor() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amoxor {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 0b1010).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0b0110);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0b1010);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 0b1100);
+}
+
+#[test]
+fn test_amoand() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amoand {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 0b1010).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0b0110);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0b1010);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 0b0010);
+}
+
+#[test]
+fn test_amoor() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amoor {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 0b1010).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0b0110);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0b1010);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 0b1110);
+}
+
+#[test]
+fn test_amomin() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amomin {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u32>(u64::from(addr), (-5i32).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), (-5i32).cast_unsigned());
+    assert_eq!(
+        state.memory.read::<u32>(u64::from(addr)).unwrap(),
+        (-5i32).cast_unsigned()
+    );
+}
+
+#[test]
+fn test_amomax() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amomax {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u32>(u64::from(addr), (-5i32).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), (-5i32).cast_unsigned());
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 3);
+}
+
+#[test]
+fn test_amominu_treats_operands_as_unsigned() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amominu {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    // As unsigned, this is a very large number, larger than `3`
+    state
+        .memory
+        .write::<u32>(u64::from(addr), (-5i32).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), (-5i32).cast_unsigned());
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 3);
+}
+
+#[test]
+fn test_amomaxu_treats_operands_as_unsigned() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amomaxu {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u32>(u64::from(addr), (-5i32).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), (-5i32).cast_unsigned());
+    assert_eq!(
+        state.memory.read::<u32>(u64::from(addr)).unwrap(),
+        (-5i32).cast_unsigned()
+    );
+}
+
+#[test]
+fn test_amoswap_supports_misaligned_access() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amoswap {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // Not 4-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
+    state.memory.write::<u32>(u64::from(addr), 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 222);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
@@ -1,0 +1,83 @@
+//! RV32 Zalrsc extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, ReservationSet, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv32ZalrscInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZalrscInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZalrscInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+    ExtState: [const] ReservationSet<Reg>,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::Lr {
+                rd,
+                rs1: _,
+                aq: _,
+                rl: _,
+            } => {
+                let value = memory.read::<u32>(u64::from(rs1_value))?;
+                ext_state.set_reservation(rs1_value);
+                Ok(ControlFlow::Continue((rd, value)))
+            }
+            Self::Sc {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let success = ext_state.reservation() == Some(rs1_value);
+                ext_state.clear_reservation();
+
+                if success {
+                    memory.write(u64::from(rs1_value), rs2_value)?;
+                    Ok(ControlFlow::Continue((rd, 0)))
+                } else {
+                    Ok(ControlFlow::Continue((rd, 1)))
+                }
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc/tests.rs
@@ -1,0 +1,174 @@
+use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_lr_reads_value() {
+    let mut state = initialize_state([Rv32ZalrscInstruction::Lr {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        aq: false,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u32>(u64::from(addr), 0xDEAD_BEEF)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xDEAD_BEEF);
+}
+
+#[test]
+fn test_sc_succeeds_after_matching_lr() {
+    let mut state = initialize_state([
+        Rv32ZalrscInstruction::Lr {
+            rd: Reg::A1,
+            rs1: Reg::A0,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        },
+        Rv32ZalrscInstruction::Sc {
+            rd: Reg::A2,
+            rs1: Reg::A0,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+    ]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    // `sc` succeeds, so it returns 0 and stores the new value
+    assert_eq!(state.regs.read(Reg::A2), 0);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 42);
+}
+
+#[test]
+fn test_sc_fails_without_prior_lr() {
+    let mut state = initialize_state([Rv32ZalrscInstruction::Sc {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A3,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    // `sc` fails, so it returns a nonzero value and does not store
+    assert_eq!(state.regs.read(Reg::A2), 1);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 1);
+}
+
+#[test]
+fn test_sc_fails_for_different_address() {
+    let mut state = initialize_state([
+        Rv32ZalrscInstruction::Lr {
+            rd: Reg::A1,
+            rs1: Reg::A0,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        },
+        Rv32ZalrscInstruction::Sc {
+            rd: Reg::A2,
+            rs1: Reg::A4,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+    ]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    let other_addr = TEST_BASE_ADDR + 0x200;
+    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.memory.write::<u32>(u64::from(other_addr), 2).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A4, other_addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 1);
+    assert_eq!(state.memory.read::<u32>(u64::from(other_addr)).unwrap(), 2);
+}
+
+#[test]
+fn test_sc_fails_after_second_sc() {
+    let mut state = initialize_state([
+        Rv32ZalrscInstruction::Lr {
+            rd: Reg::A1,
+            rs1: Reg::A0,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        },
+        Rv32ZalrscInstruction::Sc {
+            rd: Reg::A2,
+            rs1: Reg::A0,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+        Rv32ZalrscInstruction::Sc {
+            rd: Reg::A5,
+            rs1: Reg::A0,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+    ]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    // First `sc` succeeds and invalidates the reservation, so the second `sc` fails
+    assert_eq!(state.regs.read(Reg::A2), 0);
+    assert_eq!(state.regs.read(Reg::A5), 1);
+}
+
+#[test]
+fn test_lr_sc_supports_misaligned_access() {
+    let mut state = initialize_state([
+        Rv32ZalrscInstruction::Lr {
+            rd: Reg::A1,
+            rs1: Reg::A0,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        },
+        Rv32ZalrscInstruction::Sc {
+            rd: Reg::A2,
+            rs1: Reg::A0,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+    ]);
+    // Not 4-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
+    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 42);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -3,8 +3,9 @@ extern crate alloc;
 use crate::basic::{BasicInterpreterState, BasicRegisters};
 use crate::{
     Address, BasicInt, ExecutableInstruction, ExecutionError, FetchInstructionResult,
-    InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile, ReservationSet,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::vec;
@@ -261,9 +262,31 @@ where
     }
 }
 
+/// Extended state used by RV32 tests.
+///
+/// Currently only holds the reservation set used by `Zalrsc`.
+#[derive(Default)]
+pub(crate) struct ExtState {
+    reservation: Option<u32>,
+}
+
+impl ReservationSet<Reg<u32>> for ExtState {
+    fn reservation(&self) -> Option<u32> {
+        self.reservation
+    }
+
+    fn set_reservation(&mut self, address: u32) {
+        self.reservation = Some(address);
+    }
+
+    fn clear_reservation(&mut self) {
+        self.reservation = None;
+    }
+}
+
 pub(crate) type TestInterpreterState<Instruction> = BasicInterpreterState<
     BasicRegisters<Reg<u32>>,
-    (),
+    ExtState,
     TestMemory,
     TestInstructionFetcher<Instruction>,
     TestInstructionHandler,
@@ -278,7 +301,7 @@ where
 {
     BasicInterpreterState {
         regs: BasicRegisters::default(),
-        ext_state: (),
+        ext_state: ExtState::default(),
         memory: TestMemory::new(8192, u64::from(TEST_BASE_ADDR)),
         instruction_fetcher: TestInstructionFetcher::new(
             instructions,
@@ -297,7 +320,7 @@ where
     I: Instruction<Reg = Reg<u32>>
         + ExecutableInstruction<
             BasicRegisters<Reg<u32>>,
-            (),
+            ExtState,
             TestMemory,
             TestInstructionFetcher<I>,
             TestInstructionHandler,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -5,7 +5,7 @@ use crate::{
     Address, BasicInt, ExecutableInstruction, ExecutionError, FetchInstructionResult,
     InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile, ReservationSet,
     Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    VirtualMemoryError, WrsHandler,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::vec;
@@ -261,6 +261,8 @@ where
         })
     }
 }
+
+impl WrsHandler for TestInstructionHandler {}
 
 /// Extended state used by RV32 tests.
 ///

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
@@ -1,0 +1,328 @@
+//! RV32 Zabha extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv32ZabhaInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZabhaInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZabhaInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::AmoswapB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                memory.write(u64::from(rs1_value), rs2_value as u8)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoswapH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                memory.write(u64::from(rs1_value), rs2_value as u16)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoaddB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                let new = old.cast_unsigned().wrapping_add(rs2_value as u8);
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoaddH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                let new = old.cast_unsigned().wrapping_add(rs2_value as u16);
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoxorB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                let new = old.cast_unsigned() ^ (rs2_value as u8);
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoxorH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                let new = old.cast_unsigned() ^ (rs2_value as u16);
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoandB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                let new = old.cast_unsigned() & (rs2_value as u8);
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoandH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                let new = old.cast_unsigned() & (rs2_value as u16);
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoorB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                let new = old.cast_unsigned() | (rs2_value as u8);
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmoorH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                let new = old.cast_unsigned() | (rs2_value as u16);
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmominB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                let new = if old < (rs2_value as u8).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u8
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmominH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                let new = if old < (rs2_value as u16).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u16
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmomaxB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                let new = if old > (rs2_value as u8).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u8
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmomaxH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                let new = if old > (rs2_value as u16).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u16
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmominuB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                let new = if old.cast_unsigned() < (rs2_value as u8) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u8
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmominuH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                let new = if old.cast_unsigned() < (rs2_value as u16) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u16
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmomaxuB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                let new = if old.cast_unsigned() > (rs2_value as u8) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u8
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmomaxuH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                let new = if old.cast_unsigned() > (rs2_value as u16) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u16
+                };
+                memory.write(u64::from(rs1_value), new)?;
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmocasB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let compare = regs.read(rd) as u8;
+                let old = memory.read::<i8>(u64::from(rs1_value))?;
+                if old.cast_unsigned() == compare {
+                    memory.write(u64::from(rs1_value), rs2_value as u8)?;
+                }
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+            Self::AmocasH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let compare = regs.read(rd) as u16;
+                let old = memory.read::<i16>(u64::from(rs1_value))?;
+                if old.cast_unsigned() == compare {
+                    memory.write(u64::from(rs1_value), rs2_value as u16)?;
+                }
+                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zabha/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zabha/tests.rs
@@ -1,0 +1,197 @@
+use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_amoswap_b_sign_extends() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmoswapB {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u8>(u64::from(addr), 0x80).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0x42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0xFFFF_FF80);
+    assert_eq!(state.memory.read::<u8>(u64::from(addr)).unwrap(), 0x42);
+}
+
+#[test]
+fn test_amoadd_h() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmoaddH {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u16>(u64::from(addr), 10).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 32);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 10);
+    assert_eq!(state.memory.read::<u16>(u64::from(addr)).unwrap(), 42);
+}
+
+#[test]
+fn test_amoadd_h_wraps_at_16_bits() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmoaddH {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u16>(u64::from(addr), u16::MAX)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 1);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0xFFFF_FFFF);
+    assert_eq!(state.memory.read::<u16>(u64::from(addr)).unwrap(), 0);
+}
+
+#[test]
+fn test_amoxor_b() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmoxorB {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u8>(u64::from(addr), 0b1010).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0b0110);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0b1010);
+    assert_eq!(state.memory.read::<u8>(u64::from(addr)).unwrap(), 0b1100);
+}
+
+#[test]
+fn test_amomin_b_signed_comparison() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmominB {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u8>(u64::from(addr), (-5i8).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0xFFFF_FFFB);
+    assert_eq!(
+        state.memory.read::<u8>(u64::from(addr)).unwrap(),
+        (-5i8).cast_unsigned()
+    );
+}
+
+#[test]
+fn test_amominu_h_unsigned_comparison() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmominuH {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u16>(u64::from(addr), (-5i16).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), i32::from(-5i16).cast_unsigned());
+    assert_eq!(state.memory.read::<u16>(u64::from(addr)).unwrap(), 3);
+}
+
+#[test]
+fn test_amocas_b_succeeds_on_match() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmocasB {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u8>(u64::from(addr), 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 111);
+    state.regs.write(Reg::A1, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u8>(u64::from(addr)).unwrap(), 42);
+}
+
+#[test]
+fn test_amocas_h_fails_on_mismatch() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmocasH {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u16>(u64::from(addr), 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 999);
+    state.regs.write(Reg::A1, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u16>(u64::from(addr)).unwrap(), 111);
+}
+
+#[test]
+fn test_amoadd_w_inherited_from_zaamo() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::Amoadd {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 10).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 32);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 10);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 42);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
@@ -1,0 +1,104 @@
+//! RV32 Zacas extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv32ZacasInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZacasInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZacasInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::AmocasW {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let addr = u64::from(rs1_value);
+                let compare = regs.read(rd);
+                let old = memory.read::<u32>(addr)?;
+                if old == compare {
+                    memory.write(addr, rs2_value)?;
+                }
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmocasD {
+                rd,
+                rs1: _,
+                rs2,
+                rd_hi,
+                rs2_hi,
+                aq: _,
+                rl: _,
+            } => {
+                let addr = u64::from(rs1_value);
+                // Per spec, when the first register of a pair is `x0`, BOTH halves of that pair
+                // read as zero - not just the literal `x0` half. `compare_lo`/`rs2_value` are
+                // already 0 in that case since `x0` is hardwired, but `compare_hi`/`swap_hi`
+                // need an explicit override since `rd_hi`/`rs2_hi` are real registers.
+                let compare_lo = regs.read(rd);
+                let compare_hi = if rd == Reg::ZERO { 0 } else { regs.read(rd_hi) };
+                let swap_hi = if rs2 == Reg::ZERO {
+                    0
+                } else {
+                    regs.read(rs2_hi)
+                };
+                let old_lo = memory.read::<u32>(addr)?;
+                let old_hi = memory.read::<u32>(addr + 4)?;
+                if old_lo == compare_lo && old_hi == compare_hi {
+                    memory.write(addr, rs2_value)?;
+                    memory.write(addr + 4, swap_hi)?;
+                }
+                // Per spec, when `rd == x0` the whole register-pair write (both halves) is
+                // skipped, not just the low half (which is a no-op anyway since x0 is
+                // hardwired). Only `rd_hi` needs an explicit guard since it's a real register.
+                if rd != Reg::ZERO {
+                    regs.write(rd_hi, old_hi);
+                }
+                Ok(ControlFlow::Continue((rd, old_lo)))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zacas/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zacas/tests.rs
@@ -1,0 +1,183 @@
+use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_amocas_w_succeeds_on_match() {
+    let mut state = initialize_state([Rv32ZacasInstruction::AmocasW {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 111);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 222);
+}
+
+#[test]
+fn test_amocas_w_fails_on_mismatch() {
+    let mut state = initialize_state([Rv32ZacasInstruction::AmocasW {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 999);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    // The old memory value is always returned into rd, whether the swap happens or not
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 111);
+}
+
+#[test]
+fn test_amocas_d_register_pair_succeeds() {
+    let mut state = initialize_state([Rv32ZacasInstruction::AmocasD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A4,
+        rd_hi: Reg::A3,
+        rs2_hi: Reg::A5,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.memory.write::<u32>(u64::from(addr + 4), 2).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 1);
+    state.regs.write(Reg::A3, 2);
+    state.regs.write(Reg::A4, 10);
+    state.regs.write(Reg::A5, 20);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 1);
+    assert_eq!(state.regs.read(Reg::A3), 2);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 10);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr + 4)).unwrap(), 20);
+}
+
+#[test]
+fn test_amocas_d_register_pair_fails_on_high_word_mismatch() {
+    let mut state = initialize_state([Rv32ZacasInstruction::AmocasD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A4,
+        rd_hi: Reg::A3,
+        rs2_hi: Reg::A5,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.memory.write::<u32>(u64::from(addr + 4), 2).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 1);
+    // Mismatched high word
+    state.regs.write(Reg::A3, 999);
+    state.regs.write(Reg::A4, 10);
+    state.regs.write(Reg::A5, 20);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 1);
+    assert_eq!(state.regs.read(Reg::A3), 2);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 1);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr + 4)).unwrap(), 2);
+}
+
+#[test]
+fn test_amocas_d_rd_zero_skips_whole_pair_write() {
+    // Per spec: when the first register of the *destination* pair is `x0`, the whole pair write
+    // is skipped (not just the `x0` half) - `rd_hi` must retain its original value even though
+    // the compare succeeds and the swap happens.
+    let mut state = initialize_state([Rv32ZacasInstruction::AmocasD {
+        rd: Reg::Zero,
+        rs1: Reg::A0,
+        rs2: Reg::A4,
+        rd_hi: Reg::Ra,
+        rs2_hi: Reg::A5,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    // Both compare halves are forced to 0 (rd == x0), so memory must hold 0/0 for the compare
+    // to succeed and the swap to actually happen.
+    state.memory.write::<u32>(u64::from(addr), 0).unwrap();
+    state.memory.write::<u32>(u64::from(addr + 4), 0).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::Ra, 777);
+    state.regs.write(Reg::A4, 10);
+    state.regs.write(Reg::A5, 20);
+
+    execute(&mut state).unwrap();
+
+    // The swap happened (memory now holds the new value), yet rd_hi (Ra) must be untouched.
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 10);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr + 4)).unwrap(), 20);
+    assert_eq!(state.regs.read(Reg::Ra), 777);
+}
+
+#[test]
+fn test_amocas_d_rs2_zero_forces_swap_high_to_zero() {
+    // Per spec: when the first register of the *source* pair is `x0`, BOTH halves of the swap
+    // value read as zero - `rs2_hi`'s actual register value must be ignored.
+    let mut state = initialize_state([Rv32ZacasInstruction::AmocasD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::Zero,
+        rd_hi: Reg::A3,
+        rs2_hi: Reg::Ra,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.memory.write::<u32>(u64::from(addr + 4), 2).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 1);
+    state.regs.write(Reg::A3, 2);
+    // rs2_hi holds a nonzero value, but must be ignored since rs2 (first of pair) is x0
+    state.regs.write(Reg::Ra, 999);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 0);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr + 4)).unwrap(), 0);
+}
+
+#[test]
+fn test_amoadd_inherited_from_zaamo() {
+    let mut state = initialize_state([Rv32ZacasInstruction::Amoadd {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(u64::from(addr), 10).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 32);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 10);
+    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 42);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
@@ -1,0 +1,96 @@
+//! RV32 Zalasr extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv32ZalasrInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZalasrInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZalasrInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::LbAq { rd, rs1: _, rl: _ } => {
+                let addr = u64::from(rs1_value);
+                let value = i32::from(memory.read::<i8>(addr)?);
+                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+            }
+            Self::LhAq { rd, rs1: _, rl: _ } => {
+                let addr = u64::from(rs1_value);
+                let value = i32::from(memory.read::<i16>(addr)?);
+                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+            }
+            Self::LwAq { rd, rs1: _, rl: _ } => {
+                let addr = u64::from(rs1_value);
+                let value = memory.read::<u32>(addr)?;
+                Ok(ControlFlow::Continue((rd, value)))
+            }
+            Self::SbRl {
+                rs1: _,
+                rs2: _,
+                aq: _,
+            } => {
+                let addr = u64::from(rs1_value);
+                memory.write(addr, rs2_value as u8)?;
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+            Self::ShRl {
+                rs1: _,
+                rs2: _,
+                aq: _,
+            } => {
+                let addr = u64::from(rs1_value);
+                memory.write(addr, rs2_value as u16)?;
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+            Self::SwRl {
+                rs1: _,
+                rs2: _,
+                aq: _,
+            } => {
+                let addr = u64::from(rs1_value);
+                memory.write(addr, rs2_value)?;
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zalasr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zalasr/tests.rs
@@ -1,0 +1,129 @@
+use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_lb_aq_sign_extends() {
+    let mut state = initialize_state([Rv32ZalasrInstruction::LbAq {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u8>(u64::from(addr), 0x80).unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xFFFF_FF80);
+}
+
+#[test]
+fn test_lh_aq_sign_extends() {
+    let mut state = initialize_state([Rv32ZalasrInstruction::LhAq {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u16>(u64::from(addr), 0x8000).unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xFFFF_8000);
+}
+
+#[test]
+fn test_lw_aq() {
+    let mut state = initialize_state([Rv32ZalasrInstruction::LwAq {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u32>(u64::from(addr), 0xDEAD_BEEF)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xDEAD_BEEF);
+}
+
+#[test]
+fn test_sb_rl() {
+    let mut state = initialize_state([Rv32ZalasrInstruction::SbRl {
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0x42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.memory.read::<u8>(u64::from(addr)).unwrap(), 0x42);
+}
+
+#[test]
+fn test_sh_rl() {
+    let mut state = initialize_state([Rv32ZalasrInstruction::ShRl {
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0x1234);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.memory.read::<u16>(u64::from(addr)).unwrap(), 0x1234);
+}
+
+#[test]
+fn test_sw_rl() {
+    let mut state = initialize_state([Rv32ZalasrInstruction::SwRl {
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0xDEAD_BEEF);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(
+        state.memory.read::<u32>(u64::from(addr)).unwrap(),
+        0xDEAD_BEEF
+    );
+}
+
+#[test]
+fn test_lw_aq_supports_misaligned_access() {
+    let mut state = initialize_state([Rv32ZalasrInstruction::LwAq {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    // Not 4-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
+    state
+        .memory
+        .write::<u32>(u64::from(addr), 0xDEAD_BEEF)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xDEAD_BEEF);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zawrs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zawrs.rs
@@ -1,0 +1,61 @@
+//! RV32 Zawrs extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, Rs1Rs2OperandValues, Rs1Rs2Operands, WrsHandler,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv32ZawrsInstruction<Reg> where
+    Reg: Register<Type = u32>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv32ZawrsInstruction<Reg>
+where
+    Reg: Register<Type = u32>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv32ZawrsInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+    InstructionHandler: [const] WrsHandler,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value: _,
+            rs2_value: _,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::WrsNto => {
+                system_instruction_handler.handle_wrs_nto();
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+            Self::WrsSto => {
+                system_instruction_handler.handle_wrs_sto();
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zawrs/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zawrs/tests.rs
@@ -1,0 +1,23 @@
+use crate::rv32::test_utils::{execute, initialize_state};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_wrs_nto_is_nop() {
+    let mut state = initialize_state([Rv32ZawrsInstruction::WrsNto {
+        rs1: Reg::Zero,
+        rs2: Reg::Zero,
+    }]);
+
+    // Should not error and should not hang
+    execute(&mut state).unwrap();
+}
+
+#[test]
+fn test_wrs_sto_is_nop() {
+    let mut state = initialize_state([Rv32ZawrsInstruction::WrsSto {
+        rs1: Reg::Zero,
+        rs2: Reg::Zero,
+    }]);
+
+    execute(&mut state).unwrap();
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -8,6 +8,10 @@ pub mod m;
 pub(crate) mod test_utils;
 #[cfg(test)]
 mod tests;
+pub mod zabha;
+pub mod zacas;
+pub mod zalasr;
+pub mod zawrs;
 pub mod zce;
 pub mod zk;
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -1,5 +1,6 @@
 //! Base RISC-V RV64 instruction set
 
+pub mod a;
 pub mod b;
 pub mod c;
 pub mod m;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
@@ -1,0 +1,55 @@
+//! RV64 A extension
+
+pub mod zaamo;
+pub mod zalrsc;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, ReservationSet, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv64AInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64AInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64AInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+    ExtState: [const] ReservationSet<Reg>,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        Ok(ControlFlow::Continue(Default::default()))
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
@@ -1,0 +1,289 @@
+//! RV64 Zaamo extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv64ZaamoInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZaamoInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZaamoInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::Amoswap {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                memory.write(rs1_value, rs2_value as u32)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::Amoadd {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                let new = (old.cast_unsigned()).wrapping_add(rs2_value as u32);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::Amoxor {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                let new = old.cast_unsigned() ^ (rs2_value as u32);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::Amoand {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                let new = old.cast_unsigned() & (rs2_value as u32);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::Amoor {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                let new = old.cast_unsigned() | (rs2_value as u32);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::Amomin {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                let new = if old < (rs2_value as u32).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u32
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::Amomax {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                let new = if old > (rs2_value as u32).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u32
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::Amominu {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                let new = if old.cast_unsigned() < (rs2_value as u32) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u32
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::Amomaxu {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i32>(rs1_value)?;
+                let new = if old.cast_unsigned() > (rs2_value as u32) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u32
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+
+            Self::AmoswapD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                memory.write(rs1_value, rs2_value)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmoaddD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                memory.write(rs1_value, old.wrapping_add(rs2_value))?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmoxorD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                memory.write(rs1_value, old ^ rs2_value)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmoandD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                memory.write(rs1_value, old & rs2_value)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmoorD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                memory.write(rs1_value, old | rs2_value)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmominD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                let new = if old.cast_signed() < rs2_value.cast_signed() {
+                    old
+                } else {
+                    rs2_value
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmomaxD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                let new = if old.cast_signed() > rs2_value.cast_signed() {
+                    old
+                } else {
+                    rs2_value
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmominuD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                let new = if old < rs2_value { old } else { rs2_value };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmomaxuD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<u64>(rs1_value)?;
+                let new = if old > rs2_value { old } else { rs2_value };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo/tests.rs
@@ -1,0 +1,185 @@
+use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_amoswap_w_sign_extends() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::Amoswap {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, 0x8000_0000).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    // Old 32-bit value is sign-extended to 64 bits
+    assert_eq!(state.regs.read(Reg::A2), 0xFFFF_FFFF_8000_0000);
+    assert_eq!(state.memory.read::<u32>(addr).unwrap(), 222);
+}
+
+#[test]
+fn test_amoadd_w_operates_on_32_bits() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::Amoadd {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, u32::MAX).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 1);
+
+    execute(&mut state).unwrap();
+
+    // Old value `0xFFFF_FFFF` is sign-extended to `0xFFFF_FFFF_FFFF_FFFF` (i.e. `-1i64`)
+    assert_eq!(state.regs.read(Reg::A2), u64::MAX);
+    // Result wraps at 32 bits, not 64
+    assert_eq!(state.memory.read::<u32>(addr).unwrap(), 0);
+}
+
+#[test]
+fn test_amomin_w_uses_32_bit_signed_comparison() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::Amomin {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u32>(addr, (-5i32).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0xFFFF_FFFF_FFFF_FFFB);
+    assert_eq!(
+        state.memory.read::<u32>(addr).unwrap(),
+        (-5i32).cast_unsigned()
+    );
+}
+
+#[test]
+fn test_amoswap_d() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::AmoswapD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u64>(addr, 0x1111_1111_1111_1111)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0x2222_2222_2222_2222);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0x1111_1111_1111_1111);
+    assert_eq!(
+        state.memory.read::<u64>(addr).unwrap(),
+        0x2222_2222_2222_2222
+    );
+}
+
+#[test]
+fn test_amoadd_d() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::AmoaddD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 10).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 32);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 10);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 42);
+}
+
+#[test]
+fn test_amoadd_d_wraps() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::AmoaddD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, u64::MAX).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 1);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), u64::MAX);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 0);
+}
+
+#[test]
+fn test_amomaxu_d_unsigned_comparison() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::AmomaxuD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u64>(addr, (-5i64).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), (-5i64).cast_unsigned());
+    assert_eq!(
+        state.memory.read::<u64>(addr).unwrap(),
+        (-5i64).cast_unsigned()
+    );
+}
+
+#[test]
+fn test_amoxor_d_supports_misaligned_access() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::AmoxorD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // Not 8-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
+    state.memory.write::<u64>(addr, 0b1010).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0b0110);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0b1010);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 0b1100);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
@@ -1,0 +1,113 @@
+//! RV64 Zalrsc extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, ReservationSet, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv64ZalrscInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZalrscInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZalrscInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+    ExtState: [const] ReservationSet<Reg>,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::Lr {
+                rd,
+                rs1: _,
+                aq: _,
+                rl: _,
+            } => {
+                let value = memory.read::<i32>(rs1_value)?;
+                ext_state.set_reservation(rs1_value);
+                Ok(ControlFlow::Continue((
+                    rd,
+                    i64::from(value).cast_unsigned(),
+                )))
+            }
+            Self::Sc {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let success = ext_state.reservation() == Some(rs1_value);
+                ext_state.clear_reservation();
+
+                if success {
+                    memory.write(rs1_value, rs2_value as u32)?;
+                    Ok(ControlFlow::Continue((rd, 0)))
+                } else {
+                    Ok(ControlFlow::Continue((rd, 1)))
+                }
+            }
+            Self::LrD {
+                rd,
+                rs1: _,
+                aq: _,
+                rl: _,
+            } => {
+                let value = memory.read::<u64>(rs1_value)?;
+                ext_state.set_reservation(rs1_value);
+                Ok(ControlFlow::Continue((rd, value)))
+            }
+            Self::ScD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let success = ext_state.reservation() == Some(rs1_value);
+                ext_state.clear_reservation();
+
+                if success {
+                    memory.write(rs1_value, rs2_value)?;
+                    Ok(ControlFlow::Continue((rd, 0)))
+                } else {
+                    Ok(ControlFlow::Continue((rd, 1)))
+                }
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc/tests.rs
@@ -1,0 +1,185 @@
+use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_lr_w_sign_extends() {
+    let mut state = initialize_state([Rv64ZalrscInstruction::Lr {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        aq: false,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, 0x8000_0000).unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xFFFF_FFFF_8000_0000);
+}
+
+#[test]
+fn test_sc_w_succeeds_after_matching_lr() {
+    let mut state = initialize_state([
+        Rv64ZalrscInstruction::Lr {
+            rd: Reg::A1,
+            rs1: Reg::A0,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        },
+        Rv64ZalrscInstruction::Sc {
+            rd: Reg::A2,
+            rs1: Reg::A0,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+    ]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0);
+    assert_eq!(state.memory.read::<u32>(addr).unwrap(), 42);
+}
+
+#[test]
+fn test_sc_w_fails_without_prior_lr() {
+    let mut state = initialize_state([Rv64ZalrscInstruction::Sc {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A3,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 1);
+    assert_eq!(state.memory.read::<u32>(addr).unwrap(), 1);
+}
+
+#[test]
+fn test_lr_d_reads_full_64_bits() {
+    let mut state = initialize_state([Rv64ZalrscInstruction::LrD {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        aq: false,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u64>(addr, 0xDEAD_BEEF_1234_5678)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xDEAD_BEEF_1234_5678);
+}
+
+#[test]
+fn test_sc_d_succeeds_after_matching_lr() {
+    let mut state = initialize_state([
+        Rv64ZalrscInstruction::LrD {
+            rd: Reg::A1,
+            rs1: Reg::A0,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        },
+        Rv64ZalrscInstruction::ScD {
+            rd: Reg::A2,
+            rs1: Reg::A0,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+    ]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 0xABCD_EF01_2345_6789);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0);
+    assert_eq!(
+        state.memory.read::<u64>(addr).unwrap(),
+        0xABCD_EF01_2345_6789
+    );
+}
+
+#[test]
+fn test_sc_d_fails_for_different_address() {
+    let mut state = initialize_state([
+        Rv64ZalrscInstruction::LrD {
+            rd: Reg::A1,
+            rs1: Reg::A0,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        },
+        Rv64ZalrscInstruction::ScD {
+            rd: Reg::A2,
+            rs1: Reg::A4,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+    ]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    let other_addr = TEST_BASE_ADDR + 0x200;
+    state.memory.write::<u64>(addr, 1).unwrap();
+    state.memory.write::<u64>(other_addr, 2).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A4, other_addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 1);
+    assert_eq!(state.memory.read::<u64>(other_addr).unwrap(), 2);
+}
+
+#[test]
+fn test_lr_d_sc_d_supports_misaligned_access() {
+    let mut state = initialize_state([
+        Rv64ZalrscInstruction::LrD {
+            rd: Reg::A1,
+            rs1: Reg::A0,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        },
+        Rv64ZalrscInstruction::ScD {
+            rd: Reg::A2,
+            rs1: Reg::A0,
+            rs2: Reg::A3,
+            aq: false,
+            rl: false,
+        },
+    ]);
+    // Not 8-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
+    state.memory.write::<u64>(addr, 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 42);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
     ExecutionError, FetchInstructionResult, InstructionFetcher, ProgramCounter,
     ProgramCounterError, RegisterFile, ReservationSet, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    SystemInstructionHandler, VirtualMemory, VirtualMemoryError, WrsHandler,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::collections::BTreeMap;
@@ -265,6 +265,8 @@ where
         })
     }
 }
+
+impl WrsHandler for TestInstructionHandler {}
 
 struct CsrExtState {
     privilege_level: PrivilegeLevel,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -7,7 +7,7 @@ use crate::v::vector_registers::{
 use crate::{
     Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
     ExecutionError, FetchInstructionResult, InstructionFetcher, ProgramCounter,
-    ProgramCounterError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ProgramCounterError, RegisterFile, ReservationSet, Rs1Rs2OperandValues, Rs1Rs2Operands,
     SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
@@ -304,6 +304,7 @@ impl Default for VectorExtState {
 pub(crate) struct ExtState {
     csr: CsrExtState,
     vector: VectorExtState,
+    reservation: Option<u64>,
 }
 
 impl Default for ExtState {
@@ -312,7 +313,22 @@ impl Default for ExtState {
         Self {
             csr: CsrExtState::default(),
             vector: VectorExtState::default(),
+            reservation: None,
         }
+    }
+}
+
+impl ReservationSet<Reg<u64>> for ExtState {
+    fn reservation(&self) -> Option<u64> {
+        self.reservation
+    }
+
+    fn set_reservation(&mut self, address: u64) {
+        self.reservation = Some(address);
+    }
+
+    fn clear_reservation(&mut self) {
+        self.reservation = None;
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
@@ -1,0 +1,328 @@
+//! RV64 Zabha extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv64ZabhaInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZabhaInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZabhaInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::AmoswapB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                memory.write(rs1_value, rs2_value as u8)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoswapH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                memory.write(rs1_value, rs2_value as u16)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoaddB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                let new = old.cast_unsigned().wrapping_add(rs2_value as u8);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoaddH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                let new = old.cast_unsigned().wrapping_add(rs2_value as u16);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoxorB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                let new = old.cast_unsigned() ^ (rs2_value as u8);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoxorH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                let new = old.cast_unsigned() ^ (rs2_value as u16);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoandB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                let new = old.cast_unsigned() & (rs2_value as u8);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoandH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                let new = old.cast_unsigned() & (rs2_value as u16);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoorB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                let new = old.cast_unsigned() | (rs2_value as u8);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmoorH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                let new = old.cast_unsigned() | (rs2_value as u16);
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmominB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                let new = if old < (rs2_value as u8).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u8
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmominH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                let new = if old < (rs2_value as u16).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u16
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmomaxB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                let new = if old > (rs2_value as u8).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u8
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmomaxH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                let new = if old > (rs2_value as u16).cast_signed() {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u16
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmominuB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                let new = if old.cast_unsigned() < (rs2_value as u8) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u8
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmominuH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                let new = if old.cast_unsigned() < (rs2_value as u16) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u16
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmomaxuB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i8>(rs1_value)?;
+                let new = if old.cast_unsigned() > (rs2_value as u8) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u8
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmomaxuH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let old = memory.read::<i16>(rs1_value)?;
+                let new = if old.cast_unsigned() > (rs2_value as u16) {
+                    old.cast_unsigned()
+                } else {
+                    rs2_value as u16
+                };
+                memory.write(rs1_value, new)?;
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmocasB {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let compare = regs.read(rd) as u8;
+                let old = memory.read::<i8>(rs1_value)?;
+                if old.cast_unsigned() == compare {
+                    memory.write(rs1_value, rs2_value as u8)?;
+                }
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmocasH {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let compare = regs.read(rd) as u16;
+                let old = memory.read::<i16>(rs1_value)?;
+                if old.cast_unsigned() == compare {
+                    memory.write(rs1_value, rs2_value as u16)?;
+                }
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zabha/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zabha/tests.rs
@@ -1,0 +1,128 @@
+use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_amoswap_b_sign_extends_to_64_bits() {
+    let mut state = initialize_state([Rv64ZabhaInstruction::AmoswapB {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u8>(addr, 0x80).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0x42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0xFFFF_FFFF_FFFF_FF80);
+    assert_eq!(state.memory.read::<u8>(addr).unwrap(), 0x42);
+}
+
+#[test]
+fn test_amoadd_h() {
+    let mut state = initialize_state([Rv64ZabhaInstruction::AmoaddH {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u16>(addr, 10).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 32);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 10);
+    assert_eq!(state.memory.read::<u16>(addr).unwrap(), 42);
+}
+
+#[test]
+fn test_amominu_b_unsigned_comparison() {
+    let mut state = initialize_state([Rv64ZabhaInstruction::AmominuB {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u8>(addr, (-5i8).cast_unsigned())
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 3);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), i64::from(-5i8).cast_unsigned());
+    assert_eq!(state.memory.read::<u8>(addr).unwrap(), 3);
+}
+
+#[test]
+fn test_amocas_h_succeeds_on_match() {
+    let mut state = initialize_state([Rv64ZabhaInstruction::AmocasH {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u16>(addr, 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 111);
+    state.regs.write(Reg::A1, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u16>(addr).unwrap(), 42);
+}
+
+#[test]
+fn test_amocas_b_fails_on_mismatch() {
+    let mut state = initialize_state([Rv64ZabhaInstruction::AmocasB {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u8>(addr, 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 999);
+    state.regs.write(Reg::A1, 42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u8>(addr).unwrap(), 111);
+}
+
+#[test]
+fn test_amoadd_d_inherited_from_zaamo() {
+    let mut state = initialize_state([Rv64ZabhaInstruction::AmoaddD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 10).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 32);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 10);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 42);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
@@ -1,0 +1,120 @@
+//! RV64 Zacas extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv64ZacasInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZacasInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZacasInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::AmocasW {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let addr = rs1_value;
+                // Ignore the upper bits of `rd` when comparing, per spec
+                let compare = regs.read(rd) as u32;
+                let old = memory.read::<i32>(addr)?;
+                if old.cast_unsigned() == compare {
+                    memory.write(addr, rs2_value as u32)?;
+                }
+                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+            }
+            Self::AmocasD {
+                rd,
+                rs1: _,
+                rs2: _,
+                aq: _,
+                rl: _,
+            } => {
+                let addr = rs1_value;
+                let compare = regs.read(rd);
+                let old = memory.read::<u64>(addr)?;
+                if old == compare {
+                    memory.write(addr, rs2_value)?;
+                }
+                Ok(ControlFlow::Continue((rd, old)))
+            }
+            Self::AmocasQ {
+                rd,
+                rs1: _,
+                rs2,
+                rd_hi,
+                rs2_hi,
+                aq: _,
+                rl: _,
+            } => {
+                let addr = rs1_value;
+                // Per spec, when the first register of a pair is `x0`, BOTH halves of that pair
+                // read as zero - not just the literal `x0` half. `compare_lo`/`rs2_value` are
+                // already 0 in that case since `x0` is hardwired, but `compare_hi`/`swap_hi`
+                // need an explicit override since `rd_hi`/`rs2_hi` are real registers.
+                let compare_lo = regs.read(rd);
+                let compare_hi = if rd == Reg::ZERO { 0 } else { regs.read(rd_hi) };
+                let swap_hi = if rs2 == Reg::ZERO {
+                    0
+                } else {
+                    regs.read(rs2_hi)
+                };
+                let old_lo = memory.read::<u64>(addr)?;
+                let old_hi = memory.read::<u64>(addr + 8)?;
+                if old_lo == compare_lo && old_hi == compare_hi {
+                    memory.write(addr, rs2_value)?;
+                    memory.write(addr + 8, swap_hi)?;
+                }
+                // Per spec, when `rd == x0` the whole register-pair write (both halves) is
+                // skipped, not just the low half (which is a no-op anyway since x0 is
+                // hardwired). Only `rd_hi` needs an explicit guard since it's a real register.
+                if rd != Reg::ZERO {
+                    regs.write(rd_hi, old_hi);
+                }
+                Ok(ControlFlow::Continue((rd, old_lo)))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zacas/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zacas/tests.rs
@@ -1,0 +1,249 @@
+use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_amocas_w_succeeds_and_sign_extends() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasW {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, 0x8000_0000).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 0xFFFF_FFFF_8000_0000);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 0xFFFF_FFFF_8000_0000);
+    assert_eq!(state.memory.read::<u32>(addr).unwrap(), 222);
+}
+
+#[test]
+fn test_amocas_w_ignores_upper_bits_of_rd() {
+    // Upper 32 bits of the compare value in `rd` must be ignored
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasW {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 0xDEAD_BEEF_0000_006F);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u32>(addr).unwrap(), 222);
+}
+
+#[test]
+fn test_amocas_w_fails_on_mismatch() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasW {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 999);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u32>(addr).unwrap(), 111);
+}
+
+#[test]
+fn test_amocas_d_succeeds() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 111);
+    state.regs.write(Reg::A1, 0xABCD_EF01_2345_6789);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(
+        state.memory.read::<u64>(addr).unwrap(),
+        0xABCD_EF01_2345_6789
+    );
+}
+
+#[test]
+fn test_amocas_d_fails_on_mismatch() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 111).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 999);
+    state.regs.write(Reg::A1, 222);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 111);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 111);
+}
+
+#[test]
+fn test_amocas_q_register_pair_succeeds() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasQ {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A4,
+        rd_hi: Reg::A3,
+        rs2_hi: Reg::A5,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 1).unwrap();
+    state.memory.write::<u64>(addr + 8, 2).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 1);
+    state.regs.write(Reg::A3, 2);
+    state.regs.write(Reg::A4, 10);
+    state.regs.write(Reg::A5, 20);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 1);
+    assert_eq!(state.regs.read(Reg::A3), 2);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 10);
+    assert_eq!(state.memory.read::<u64>(addr + 8).unwrap(), 20);
+}
+
+#[test]
+fn test_amocas_q_register_pair_fails_on_high_word_mismatch() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasQ {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A4,
+        rd_hi: Reg::A3,
+        rs2_hi: Reg::A5,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 1).unwrap();
+    state.memory.write::<u64>(addr + 8, 2).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 1);
+    // Mismatched high half
+    state.regs.write(Reg::A3, 999);
+    state.regs.write(Reg::A4, 10);
+    state.regs.write(Reg::A5, 20);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 1);
+    assert_eq!(state.regs.read(Reg::A3), 2);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 1);
+    assert_eq!(state.memory.read::<u64>(addr + 8).unwrap(), 2);
+}
+
+#[test]
+fn test_amocas_q_rd_zero_skips_whole_pair_write() {
+    // Per spec: when the first register of the *destination* pair is `x0`, the whole pair write
+    // is skipped (not just the `x0` half) - `rd_hi` must retain its original value even though
+    // the compare succeeds and the swap happens.
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasQ {
+        rd: Reg::Zero,
+        rs1: Reg::A0,
+        rs2: Reg::A4,
+        rd_hi: Reg::Ra,
+        rs2_hi: Reg::A5,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    // Both compare halves are forced to 0 (rd == x0), so memory must hold 0/0 for the compare
+    // to succeed and the swap to actually happen.
+    state.memory.write::<u64>(addr, 0).unwrap();
+    state.memory.write::<u64>(addr + 8, 0).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::Ra, 777);
+    state.regs.write(Reg::A4, 10);
+    state.regs.write(Reg::A5, 20);
+
+    execute(&mut state).unwrap();
+
+    // The swap happened (memory now holds the new value), yet rd_hi (Ra) must be untouched.
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 10);
+    assert_eq!(state.memory.read::<u64>(addr + 8).unwrap(), 20);
+    assert_eq!(state.regs.read(Reg::Ra), 777);
+}
+
+#[test]
+fn test_amocas_q_rs2_zero_forces_swap_high_to_zero() {
+    // Per spec: when the first register of the *source* pair is `x0`, BOTH halves of the swap
+    // value read as zero - `rs2_hi`'s actual register value must be ignored.
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasQ {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::Zero,
+        rd_hi: Reg::A3,
+        rs2_hi: Reg::Ra,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 1).unwrap();
+    state.memory.write::<u64>(addr + 8, 2).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A2, 1);
+    state.regs.write(Reg::A3, 2);
+    // rs2_hi holds a nonzero value, but must be ignored since rs2 (first of pair) is x0
+    state.regs.write(Reg::Ra, 999);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 0);
+    assert_eq!(state.memory.read::<u64>(addr + 8).unwrap(), 0);
+}
+
+#[test]
+fn test_amoaddd_inherited_from_zaamo() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmoaddD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u64>(addr, 10).unwrap();
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 32);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A2), 10);
+    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 42);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
@@ -1,0 +1,102 @@
+//! RV64 Zalasr extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv64ZalasrInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZalasrInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZalasrInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+    Regs: [const] RegisterFile<Reg>,
+    Memory: [const] VirtualMemory,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value,
+            rs2_value,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        memory: &mut Memory,
+        _program_counter: &mut PC,
+        _system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::LbAq { rd, rs1: _, rl: _ } => {
+                let value = i64::from(memory.read::<i8>(rs1_value)?);
+                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+            }
+            Self::LhAq { rd, rs1: _, rl: _ } => {
+                let value = i64::from(memory.read::<i16>(rs1_value)?);
+                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+            }
+            Self::LwAq { rd, rs1: _, rl: _ } => {
+                let value = i64::from(memory.read::<i32>(rs1_value)?);
+                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+            }
+            Self::LdAq { rd, rs1: _, rl: _ } => {
+                let value = memory.read::<u64>(rs1_value)?;
+                Ok(ControlFlow::Continue((rd, value)))
+            }
+            Self::SbRl {
+                rs1: _,
+                rs2: _,
+                aq: _,
+            } => {
+                memory.write(rs1_value, rs2_value as u8)?;
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+            Self::ShRl {
+                rs1: _,
+                rs2: _,
+                aq: _,
+            } => {
+                memory.write(rs1_value, rs2_value as u16)?;
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+            Self::SwRl {
+                rs1: _,
+                rs2: _,
+                aq: _,
+            } => {
+                memory.write(rs1_value, rs2_value as u32)?;
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+            Self::SdRl {
+                rs1: _,
+                rs2: _,
+                aq: _,
+            } => {
+                memory.write(rs1_value, rs2_value)?;
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zalasr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zalasr/tests.rs
@@ -1,0 +1,113 @@
+use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
+use crate::{RegisterFile, VirtualMemory};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_lb_aq_sign_extends() {
+    let mut state = initialize_state([Rv64ZalasrInstruction::LbAq {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u8>(addr, 0x80).unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xFFFF_FFFF_FFFF_FF80);
+}
+
+#[test]
+fn test_lw_aq_sign_extends() {
+    let mut state = initialize_state([Rv64ZalasrInstruction::LwAq {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.memory.write::<u32>(addr, 0x8000_0000).unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xFFFF_FFFF_8000_0000);
+}
+
+#[test]
+fn test_ld_aq() {
+    let mut state = initialize_state([Rv64ZalasrInstruction::LdAq {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state
+        .memory
+        .write::<u64>(addr, 0xDEAD_BEEF_1234_5678)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xDEAD_BEEF_1234_5678);
+}
+
+#[test]
+fn test_sb_rl() {
+    let mut state = initialize_state([Rv64ZalasrInstruction::SbRl {
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0x42);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.memory.read::<u8>(addr).unwrap(), 0x42);
+}
+
+#[test]
+fn test_sd_rl() {
+    let mut state = initialize_state([Rv64ZalasrInstruction::SdRl {
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+    }]);
+    let addr = TEST_BASE_ADDR + 0x100;
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A1, 0xDEAD_BEEF_1234_5678);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(
+        state.memory.read::<u64>(addr).unwrap(),
+        0xDEAD_BEEF_1234_5678
+    );
+}
+
+#[test]
+fn test_ld_aq_supports_misaligned_access() {
+    let mut state = initialize_state([Rv64ZalasrInstruction::LdAq {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    // Not 8-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
+    state
+        .memory
+        .write::<u64>(addr, 0xDEAD_BEEF_1234_5678)
+        .unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    execute(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A1), 0xDEAD_BEEF_1234_5678);
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zawrs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zawrs.rs
@@ -1,0 +1,61 @@
+//! RV64 Zawrs extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::{
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutableInstructionResult, Rs1Rs2OperandValues, Rs1Rs2Operands, WrsHandler,
+};
+use ab_riscv_macros::instruction_execution;
+use ab_riscv_primitives::prelude::*;
+use core::ops::ControlFlow;
+
+#[instruction_execution]
+const impl<Reg> ExecutableInstructionOperands for Rv64ZawrsInstruction<Reg> where
+    Reg: Register<Type = u64>
+{
+}
+
+#[instruction_execution]
+const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+    for Rv64ZawrsInstruction<Reg>
+where
+    Reg: Register<Type = u64>,
+{
+}
+
+#[instruction_execution]
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+    for Rv64ZawrsInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+    InstructionHandler: [const] WrsHandler,
+{
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn execute(
+        self,
+        Rs1Rs2OperandValues {
+            rs1_value: _,
+            rs2_value: _,
+        }: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
+        _regs: &mut Regs,
+        _ext_state: &mut ExtState,
+        _memory: &mut Memory,
+        _program_counter: &mut PC,
+        system_instruction_handler: &mut InstructionHandler,
+    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+        match self {
+            Self::WrsNto => {
+                system_instruction_handler.handle_wrs_nto();
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+            Self::WrsSto => {
+                system_instruction_handler.handle_wrs_sto();
+                Ok(ControlFlow::Continue(Default::default()))
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zawrs/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zawrs/tests.rs
@@ -1,0 +1,23 @@
+use crate::rv64::test_utils::{execute, initialize_state};
+use ab_riscv_primitives::prelude::*;
+
+#[test]
+fn test_wrs_nto_is_nop() {
+    let mut state = initialize_state([Rv64ZawrsInstruction::WrsNto {
+        rs1: Reg::Zero,
+        rs2: Reg::Zero,
+    }]);
+
+    // Should not error and should not hang
+    execute(&mut state).unwrap();
+}
+
+#[test]
+fn test_wrs_sto_is_nop() {
+    let mut state = initialize_state([Rv64ZawrsInstruction::WrsSto {
+        rs1: Reg::Zero,
+        rs2: Reg::Zero,
+    }]);
+
+    execute(&mut state).unwrap();
+}

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
@@ -1757,22 +1757,22 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: `vs2` and `vs1` alignment checked; `vd` is a single mask register,
-                // no alignment constraint; `vl <= VLMAX <= VLEN` so all element indices fit
-                // within the mask register. Mask-dest overlap rule (§11.8) checked above.
+                // SAFETY: `vs2`/`vs1` alignment and `vd` mask-destination overlap checked
+                // above; `vl <= VLMAX <= VLEN` so all element indices fit within the mask
+                // register
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -1812,7 +1812,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -1820,7 +1820,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -1855,7 +1855,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -1863,7 +1863,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = i64::from(imm).cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -1904,20 +1904,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -1957,7 +1957,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -1965,7 +1965,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2000,7 +2000,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2008,7 +2008,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = i64::from(imm).cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2049,20 +2049,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2102,7 +2102,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2110,7 +2110,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2151,20 +2151,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2204,7 +2204,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2212,7 +2212,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2253,20 +2253,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2306,7 +2306,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2314,7 +2314,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2349,7 +2349,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2364,7 +2364,7 @@ where
                 // zve64x_arith_helpers::sew_mask (the maximum SEW-wide unsigned value). This means
                 // vs2[i] <= imm is always true for SEW < XLEN when imm < 0.
                 let scalar = i64::from(imm).cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2405,20 +2405,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2458,7 +2458,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2466,7 +2466,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2501,7 +2501,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2509,7 +2509,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = i64::from(imm).cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2550,7 +2550,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2558,7 +2558,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2593,7 +2593,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2601,7 +2601,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = i64::from(imm).cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2642,7 +2642,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2650,7 +2650,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,
@@ -2685,7 +2685,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2693,7 +2693,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = i64::from(imm).cast_unsigned();
-                // SAFETY: see `VmseqVv`
+                // SAFETY: see `VmseqVv` (mask-destination overlap checked above)
                 unsafe {
                     zvexx_arith_helpers::execute_compare_op(
                         ext_state,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/tests.rs
@@ -1566,9 +1566,67 @@ fn every_instruction_marks_vs_dirty_exactly_once() {
 }
 
 #[test]
-fn error_compare_mask_dest_overlaps_vs2_lmul_gt_1() {
-    // vmseq.vv with LMUL=2 and vd inside the vs2 group [v2, v3] is reserved
-    let mut state = setup(Vl::new(8).unwrap(), Vsew::E32, Vlmul::M2);
+fn compare_mask_dest_may_overlap_vs2_base_lmul_gt_1() {
+    // vmseq.vv with LMUL=2 and vd equal to the *lowest-numbered* register of the vs2 group
+    // [v2, v3] is permitted by RVV §5.2's narrowing-overlap exception (destination is a mask
+    // register, EEW=1, narrower than any source EEW). vl=16 spans both registers of the group
+    // (8 elements/register at SEW=32/VLEN=256b) so elements actually read from the overlapping
+    // register (v3) are exercised, not just the non-overlapping one.
+    let mut state = setup(Vl::new(16).unwrap(), Vsew::E32, Vlmul::M2);
+    for i in 0..16usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E32, i as u64);
+        write_elem(&mut state, VReg::V6, i, Vsew::E32, i as u64);
+    }
+    exec(
+        &mut state,
+        ZveXxArithInstruction::VmseqVv {
+            vd: VReg::V2,
+            vs2: VReg::V2,
+            vs1: VReg::V6,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        state.ext_state.read_vregs().get(VReg::V2)[0..2],
+        [0xFF, 0xFF]
+    );
+}
+
+#[test]
+fn compare_mask_dest_may_overlap_vs1_base_lmul_gt_1() {
+    let mut state = setup(Vl::new(16).unwrap(), Vsew::E32, Vlmul::M2);
+    for i in 0..16usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E32, i as u64);
+        write_elem(&mut state, VReg::V6, i, Vsew::E32, i as u64);
+    }
+    exec(
+        &mut state,
+        ZveXxArithInstruction::VmseqVv {
+            vd: VReg::V6,
+            vs2: VReg::V2,
+            vs1: VReg::V6,
+            vm: true,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        state.ext_state.read_vregs().get(VReg::V6)[0..2],
+        [0xFF, 0xFF]
+    );
+}
+
+#[test]
+fn error_compare_mask_dest_overlaps_vs2_non_base_lmul_gt_1() {
+    // vd overlapping any register of the vs2 group *other than* the lowest-numbered one is
+    // reserved per RVV §5.2 and must be rejected: mask bits written while processing earlier
+    // elements (stored in v2) would otherwise clobber not-yet-read data of later elements that
+    // live in v3 (== vd).
+    let mut state = setup(Vl::new(16).unwrap(), Vsew::E32, Vlmul::M2);
     let result = exec(
         &mut state,
         ZveXxArithInstruction::VmseqVv {
@@ -1587,8 +1645,8 @@ fn error_compare_mask_dest_overlaps_vs2_lmul_gt_1() {
 }
 
 #[test]
-fn error_compare_mask_dest_overlaps_vs1_lmul_gt_1() {
-    let mut state = setup(Vl::new(8).unwrap(), Vsew::E32, Vlmul::M2);
+fn error_compare_mask_dest_overlaps_vs1_non_base_lmul_gt_1() {
+    let mut state = setup(Vl::new(16).unwrap(), Vsew::E32, Vlmul::M2);
     let result = exec(
         &mut state,
         ZveXxArithInstruction::VmseqVv {
@@ -1607,10 +1665,13 @@ fn error_compare_mask_dest_overlaps_vs1_lmul_gt_1() {
 }
 
 #[test]
-fn error_compare_mask_dest_overlaps_vs2_lmul_gt_1_vx() {
-    let mut state = setup(Vl::new(8).unwrap(), Vsew::E32, Vlmul::M2);
+fn compare_mask_dest_may_overlap_vs2_lmul_gt_1_vx() {
+    let mut state = setup(Vl::new(16).unwrap(), Vsew::E32, Vlmul::M2);
+    for i in 0..16usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E32, 0);
+    }
     state.regs.write(Reg::A0, 0);
-    let result = exec(
+    exec(
         &mut state,
         ZveXxArithInstruction::VmseqVx {
             vd: VReg::V2,
@@ -1619,11 +1680,12 @@ fn error_compare_mask_dest_overlaps_vs2_lmul_gt_1_vx() {
             vm: true,
             rs2: Reg::Zero,
         },
+    )
+    .unwrap();
+    assert_eq!(
+        state.ext_state.read_vregs().get(VReg::V2)[0..2],
+        [0xFF, 0xFF]
     );
-    assert!(matches!(
-        result,
-        Err(ExecutionError::IllegalInstruction { .. })
-    ));
 }
 
 #[test]

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
@@ -33,15 +33,24 @@ where
     Ok(())
 }
 
-/// Check mask-destination / source overlap constraint for compare instructions.
+/// Check mask-destination / source overlap constraint for compare/carry instructions.
 ///
-/// Per RVV §11.8: a mask destination register may overlap a source register group only when
-/// the source group occupies a single register (LMUL ≤ 1, i.e. `group_regs == 1`). Otherwise
-/// the encoding is reserved and raises an illegal instruction.
+/// Per RVV §5.2's narrowing-destination overlap rule (a mask destination has EEW=1, narrower
+/// than any source EEW), `vd` may overlap a multi-register source group only in the
+/// lowest-numbered register of that group. Overlapping any other register in the group is
+/// reserved: `execute_compare_op`/`execute_carry_*_mask` process elements in increasing index
+/// order and write one mask bit per element into `vd`. When `vd` is the group's base register,
+/// every mask byte written during the processing of register `base_reg` targets bytes that hold
+/// data from elements at or before the one just read (byte `b` can only be touched while
+/// processing elements `>= 8*b`, and it stores raw data for element `b / sew_bytes <= 8*b`, which
+/// is always read first). When `vd` is any later register in the group, that guarantee no longer
+/// holds: early elements from the group's *first* register write mask bits into byte 0 of `vd`,
+/// which is where the not-yet-read data of a later element (stored in `vd` itself) lives,
+/// corrupting it before it is read.
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_mask_dest_no_overlap<Reg, Memory, PC, CustomError>(
+pub fn check_mask_dest_overlap<Reg, Memory, PC, CustomError>(
     program_counter: &PC,
     vd: VReg,
     src_base: VReg,
@@ -55,7 +64,7 @@ where
     if group_regs > 1 {
         let vd_idx = vd.to_bits();
         let src = src_base.to_bits();
-        if vd_idx >= src && vd_idx < src + group_regs {
+        if vd_idx > src && vd_idx < src + group_regs {
             cold_path();
             return Err(ExecutionError::IllegalInstruction {
                 address: program_counter.old_pc(INSTRUCTION_SIZE),

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
@@ -218,20 +218,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _, _>(
                         ext_state,
@@ -262,7 +262,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -270,7 +270,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _, _>(
                         ext_state,
@@ -301,7 +301,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -309,7 +309,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = i64::from(imm).cast_unsigned();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _, _>(
                         ext_state,
@@ -345,20 +345,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _, _>(
                         ext_state,
@@ -389,7 +389,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -397,7 +397,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _, _>(
                         ext_state,
@@ -428,7 +428,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -436,7 +436,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = i64::from(imm).cast_unsigned();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _, _>(
                         ext_state,
@@ -566,20 +566,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_sub_mask::<true, Reg, _, _>(
                         ext_state,
@@ -610,7 +610,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -618,7 +618,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_sub_mask::<true, Reg, _, _>(
                         ext_state,
@@ -654,20 +654,20 @@ where
                     vs1,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs1,
                     group_regs,
                 )?;
                 let sew = vtype.vsew();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_sub_mask::<false, Reg, _, _>(
                         ext_state,
@@ -698,7 +698,7 @@ where
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_no_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -706,7 +706,7 @@ where
                 )?;
                 let sew = vtype.vsew();
                 let scalar = rs1_value.as_i64().cast_unsigned();
-                // SAFETY: alignments and overlap checked above
+                // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
                     zvexx_carry_helpers::execute_carry_sub_mask::<false, Reg, _, _>(
                         ext_state,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/tests.rs
@@ -648,8 +648,43 @@ fn error_vill_vtype() {
 }
 
 #[test]
-fn error_vmadc_vd_overlaps_vs2_lmul_gt_1() {
-    let mut state = setup(Vl::new(8).unwrap(), Vsew::E32, Vlmul::M2);
+fn vmadc_vd_may_overlap_vs2_base_lmul_gt_1() {
+    // `vd` equal to the *lowest-numbered* register of the vs2 group [v2, v3] is permitted by
+    // RVV §5.2's narrowing-overlap exception (destination is a mask register, EEW=1, narrower
+    // than any source EEW): sequential per-element processing always reads element `m`'s data
+    // (stored at byte `m * sew_bytes` of the base register) before any mask write can reach that
+    // byte, because a write to byte `b` only happens while processing elements `>= 8*b`, and
+    // `m * sew_bytes / 1 <= 8*b` always holds. `vl=16` spans both registers of the group (8
+    // elements/register at SEW=32/VLEN=256b) so this also exercises elements actually read from
+    // the overlapping register (`v3`), not just the non-overlapping one.
+    let mut state = setup(Vl::new(16).unwrap(), Vsew::E32, Vlmul::M2);
+    for i in 0..16usize {
+        write_elem(&mut state, VReg::V2, i, Vsew::E32, 0xFFFF_FFFF);
+        write_elem(&mut state, VReg::V6, i, Vsew::E32, 1);
+    }
+    exec(
+        &mut state,
+        ZveXxCarryInstruction::VmadcVvm {
+            vd: VReg::V2,
+            vs2: VReg::V2,
+            vs1: VReg::V6,
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        },
+    )
+    .unwrap();
+    for i in 0..16 {
+        assert!(read_mask_bit(&state, VReg::V2, i), "elem {i}");
+    }
+}
+
+#[test]
+fn error_vmadc_vd_overlaps_vs2_non_base_lmul_gt_1() {
+    // `vd` overlapping any register of the vs2 group *other than* the lowest-numbered one is
+    // reserved per RVV §5.2 and must be rejected: without this check, mask bits written while
+    // processing earlier elements (stored in `v2`) would clobber not-yet-read data of later
+    // elements that live in `v3` (== `vd`).
+    let mut state = setup(Vl::new(16).unwrap(), Vsew::E32, Vlmul::M2);
     let result = exec(
         &mut state,
         ZveXxCarryInstruction::VmadcVvm {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{
-    OpSrc, check_mask_dest_no_overlap, check_vreg_group_alignment,
+    OpSrc, check_mask_dest_overlap, check_vreg_group_alignment,
 };
 use crate::v::zvexx::arith::zvexx_arith_helpers::{
     read_element_u64, sew_mask, write_element_u64, write_mask_bit,

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
@@ -1,5 +1,6 @@
 //! Base RISC-V RV32 instruction set
 
+pub mod a;
 pub mod b;
 pub mod c;
 pub mod m;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
@@ -6,6 +6,10 @@ pub mod c;
 pub mod m;
 #[cfg(test)]
 mod tests;
+pub mod zabha;
+pub mod zacas;
+pub mod zalasr;
+pub mod zawrs;
 pub mod zce;
 pub mod zk;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/a.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/a.rs
@@ -1,0 +1,53 @@
+//! RV32 A extension
+
+pub mod zaamo;
+pub mod zalrsc;
+
+use crate::instructions::Instruction;
+use crate::instructions::rv32::a::zaamo::Rv32ZaamoInstruction;
+use crate::instructions::rv32::a::zalrsc::Rv32ZalrscInstruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV32 A (Zaamo + Zalrsc) instruction
+#[instruction(
+    inherit = [Rv32ZaamoInstruction, Rv32ZalrscInstruction]
+)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+pub enum Rv32AInstruction<Reg> {}
+
+#[instruction]
+const impl<Reg> Instruction for Rv32AInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        None
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32AInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {}
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zaamo.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zaamo.rs
@@ -1,0 +1,167 @@
+//! RV32 Zaamo extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV32 Zaamo instruction (Atomic memory operations)
+#[instruction]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum Rv32ZaamoInstruction<Reg> {
+    Amoswap { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amoadd { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amoxor { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amoand { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amoor { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amomin { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amomax { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amominu { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amomaxu { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv32ZaamoInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+
+        match (opcode, funct3) {
+            // AMO, word-sized (only size that exists in RV32)
+            (0b010_1111, 0b010) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let rs2 = Reg::from_bits(rs2_bits)?;
+                let funct5 = funct7 >> 2;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                match funct5 {
+                    0b00001 => Some(Self::Amoswap {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    0b00000 => Some(Self::Amoadd {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    0b00100 => Some(Self::Amoxor {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    0b01100 => Some(Self::Amoand {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    0b01000 => Some(Self::Amoor {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    0b10000 => Some(Self::Amomin {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    0b10100 => Some(Self::Amomax {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    0b11000 => Some(Self::Amominu {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    0b11100 => Some(Self::Amomaxu {
+                        rd,
+                        rs1,
+                        rs2,
+                        aq,
+                        rl,
+                    }),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format `aq`/`rl` suffix for display
+#[inline(always)]
+fn aq_rl_suffix(aq: &bool, rl: &bool) -> &'static str {
+    match (*aq, *rl) {
+        (false, false) => "",
+        (true, false) => ".aq",
+        (false, true) => ".rl",
+        (true, true) => ".aqrl",
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32ZaamoInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::Amoswap { rd, rs1, rs2, aq, rl } => write!(f, "amoswap.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amoadd { rd, rs1, rs2, aq, rl } => write!(f, "amoadd.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amoxor { rd, rs1, rs2, aq, rl } => write!(f, "amoxor.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amoand { rd, rs1, rs2, aq, rl } => write!(f, "amoand.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amoor { rd, rs1, rs2, aq, rl } => write!(f, "amoor.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amomin { rd, rs1, rs2, aq, rl } => write!(f, "amomin.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amomax { rd, rs1, rs2, aq, rl } => write!(f, "amomax.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amominu { rd, rs1, rs2, aq, rl } => write!(f, "amominu.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amomaxu { rd, rs1, rs2, aq, rl } => write!(f, "amomaxu.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zaamo/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zaamo/tests.rs
@@ -1,0 +1,225 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv32::a::zaamo::Rv32ZaamoInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT3_W: u8 = 0b010;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_amoswap_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00001, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amoswap {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoxor_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00100, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amoxor {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoand_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b01100, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amoand {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoor_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b01000, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amoor {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomin_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b10000, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amomin {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomax_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b10100, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amomax {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amominu_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b11000, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amominu {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomaxu_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b11100, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amomaxu {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_w_aq() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00000, true, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_w_rl() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00000, false, true));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: true,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_w_aqrl() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00000, true, true));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZaamoInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+            rl: true,
+        })
+    );
+}
+
+#[test]
+fn test_unknown_funct5_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(0b011_0011, 1, FUNCT3_W, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_funct3_returns_none() {
+    // RV32 Zaamo only supports word-sized (funct3 = 0b010) operations
+    let inst = make_r_type(OPCODE_AMO, 1, 0b011, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv32ZaamoInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zalrsc.rs
@@ -1,0 +1,100 @@
+//! RV32 Zalrsc extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV32 Zalrsc instruction (Load-Reserved/Store-Conditional)
+#[instruction]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum Rv32ZalrscInstruction<Reg> {
+    Lr { rd: Reg, rs1: Reg, aq: bool, rl: bool },
+    Sc { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv32ZalrscInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+
+        match (opcode, funct3) {
+            // AMO, word-sized (only size that exists in RV32)
+            (0b010_1111, 0b010) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let funct5 = funct7 >> 2;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                match (funct5, rs2_bits) {
+                    (0b00010, 0) => Some(Self::Lr { rd, rs1, aq, rl }),
+                    (0b00011, _) => {
+                        let rs2 = Reg::from_bits(rs2_bits)?;
+                        Some(Self::Sc {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        })
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format `aq`/`rl` suffix for display
+#[inline(always)]
+fn aq_rl_suffix(aq: &bool, rl: &bool) -> &'static str {
+    match (*aq, *rl) {
+        (false, false) => "",
+        (true, false) => ".aq",
+        (false, true) => ".rl",
+        (true, true) => ".aqrl",
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32ZalrscInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::Lr { rd, rs1, aq, rl } => write!(f, "lr.w{} {rd}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Sc { rd, rs1, rs2, aq, rl } => write!(f, "sc.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zalrsc/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zalrsc/tests.rs
@@ -1,0 +1,120 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv32::a::zalrsc::Rv32ZalrscInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT3_W: u8 = 0b010;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_lr_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 0, funct7(0b00010, false, false));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalrscInstruction::Lr {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_lr_w_aqrl() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 0, funct7(0b00010, true, true));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalrscInstruction::Lr {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            aq: true,
+            rl: true,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_lr_w_nonzero_rs2_returns_none() {
+    // `rs2` must be zero for `lr`, otherwise the encoding is reserved
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_sc_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00011, false, false));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalrscInstruction::Sc {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_sc_w_aq() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00011, true, false));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalrscInstruction::Sc {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_sc_w_rl() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00011, false, true));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalrscInstruction::Sc {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: true,
+        })
+    );
+}
+
+#[test]
+fn test_unknown_funct5_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00001, false, false));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(0b011_0011, 1, FUNCT3_W, 2, 0, funct7(0b00010, false, false));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_funct3_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b011, 2, 0, funct7(0b00010, false, false));
+    let decoded = Rv32ZalrscInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zabha.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zabha.rs
@@ -1,0 +1,277 @@
+//! RV32 Zabha extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::instructions::rv32::a::zaamo::Rv32ZaamoInstruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV32 Zabha instruction (Byte and Halfword Atomic Memory Operations)
+#[instruction(inherit = [Rv32ZaamoInstruction])]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum Rv32ZabhaInstruction<Reg> {
+    AmoswapB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoswapH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoaddB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoaddH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoxorB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoxorH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoandB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoandH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoorB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoorH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominuB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominuH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxuB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxuH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    /// Compare-and-swap byte. Only present when `Zacas` is also implemented.
+    #[instruction(if = [Rv32ZacasInstruction])]
+    AmocasB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    /// Compare-and-swap halfword. Only present when `Zacas` is also implemented.
+    #[instruction(if = [Rv32ZacasInstruction])]
+    AmocasH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv32ZabhaInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+
+        match (opcode, funct3) {
+            // AMO, byte- or halfword-sized
+            (0b010_1111, 0b000 | 0b001) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let rs2 = Reg::from_bits(rs2_bits)?;
+                let funct5 = funct7 >> 2;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                if funct3 == 0b000 {
+                    match funct5 {
+                        0b00001 => Some(Self::AmoswapB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00000 => Some(Self::AmoaddB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00100 => Some(Self::AmoxorB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01100 => Some(Self::AmoandB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01000 => Some(Self::AmoorB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10000 => Some(Self::AmominB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10100 => Some(Self::AmomaxB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11000 => Some(Self::AmominuB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11100 => Some(Self::AmomaxuB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00101 => Some(Self::AmocasB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        _ => None,
+                    }
+                } else {
+                    match funct5 {
+                        0b00001 => Some(Self::AmoswapH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00000 => Some(Self::AmoaddH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00100 => Some(Self::AmoxorH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01100 => Some(Self::AmoandH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01000 => Some(Self::AmoorH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10000 => Some(Self::AmominH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10100 => Some(Self::AmomaxH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11000 => Some(Self::AmominuH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11100 => Some(Self::AmomaxuH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00101 => Some(Self::AmocasH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        _ => None,
+                    }
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format `aq`/`rl` suffix for display
+#[inline(always)]
+fn aq_rl_suffix(aq: &bool, rl: &bool) -> &'static str {
+    match (*aq, *rl) {
+        (false, false) => "",
+        (true, false) => ".aq",
+        (false, true) => ".rl",
+        (true, true) => ".aqrl",
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32ZabhaInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::AmoswapB { rd, rs1, rs2, aq, rl } => write!(f, "amoswap.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoswapH { rd, rs1, rs2, aq, rl } => write!(f, "amoswap.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoaddB { rd, rs1, rs2, aq, rl } => write!(f, "amoadd.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoaddH { rd, rs1, rs2, aq, rl } => write!(f, "amoadd.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoxorB { rd, rs1, rs2, aq, rl } => write!(f, "amoxor.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoxorH { rd, rs1, rs2, aq, rl } => write!(f, "amoxor.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoandB { rd, rs1, rs2, aq, rl } => write!(f, "amoand.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoandH { rd, rs1, rs2, aq, rl } => write!(f, "amoand.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoorB { rd, rs1, rs2, aq, rl } => write!(f, "amoor.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoorH { rd, rs1, rs2, aq, rl } => write!(f, "amoor.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominB { rd, rs1, rs2, aq, rl } => write!(f, "amomin.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominH { rd, rs1, rs2, aq, rl } => write!(f, "amomin.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxB { rd, rs1, rs2, aq, rl } => write!(f, "amomax.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxH { rd, rs1, rs2, aq, rl } => write!(f, "amomax.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominuB { rd, rs1, rs2, aq, rl } => write!(f, "amominu.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominuH { rd, rs1, rs2, aq, rl } => write!(f, "amominu.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxuB { rd, rs1, rs2, aq, rl } => write!(f, "amomaxu.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxuH { rd, rs1, rs2, aq, rl } => write!(f, "amomaxu.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmocasB { rd, rs1, rs2, aq, rl } => write!(f, "amocas.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmocasH { rd, rs1, rs2, aq, rl } => write!(f, "amocas.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zabha/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zabha/tests.rs
@@ -1,0 +1,221 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv32::zabha::Rv32ZabhaInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT3_B: u8 = 0b000;
+const FUNCT3_H: u8 = 0b001;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_amoswap_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b00001, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmoswapB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmoaddH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoxor_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b00100, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmoxorB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoand_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b01100, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmoandH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoor_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b01000, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmoorB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomin_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b10000, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmominH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomax_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b10100, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmomaxB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amominu_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b11000, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmominuH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomaxu_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b11100, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmomaxuB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_b() {
+    // Zabha always defines amocas.b/h itself; whether it's pulled in further up the chain
+    // depends on whether Zacas is also present there
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b00101, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmocasB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b00101, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::AmocasH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_w_inherited_from_zaamo() {
+    // Zabha inherits Zaamo, so plain word-sized ops should also decode
+    let inst = make_r_type(OPCODE_AMO, 1, 0b010, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZabhaInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(0b011_0011, 1, FUNCT3_B, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_unknown_funct5_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv32ZabhaInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zacas.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zacas.rs
@@ -1,0 +1,132 @@
+//! RV32 Zacas extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::instructions::rv32::a::zaamo::Rv32ZaamoInstruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV32 Zacas instruction (Atomic Compare-and-Swap)
+#[instruction(inherit = [Rv32ZaamoInstruction])]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum Rv32ZacasInstruction<Reg> {
+    /// Compare-and-swap word
+    AmocasW { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    /// Compare-and-swap doubleword, using register pairs `(rd, rd_hi)` and `(rs2, rs2_hi)` since
+    /// RV32 registers are only 32 bits wide
+    AmocasD { rd: Reg, rs1: Reg, rs2: Reg, rd_hi: Reg, rs2_hi: Reg, aq: bool, rl: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv32ZacasInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+
+        match (opcode, funct3, funct7 >> 2) {
+            // AMOCAS.W
+            (0b010_1111, 0b010, 0b00101) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let rs2 = Reg::from_bits(rs2_bits)?;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                Some(Self::AmocasW {
+                    rd,
+                    rs1,
+                    rs2,
+                    aq,
+                    rl,
+                })
+            }
+            // AMOCAS.D, register-pair mode (RV32)
+            (0b010_1111, 0b011, 0b00101) => {
+                match (rd_bits & 1, rs2_bits & 1) {
+                    // Both halves of the register pairs must be even numbered, otherwise the
+                    // encoding is reserved
+                    (0, 0) => {
+                        let rs1 = Reg::from_bits(rs1_bits)?;
+                        let rd = Reg::from_bits(rd_bits)?;
+                        let rd_hi = Reg::from_bits(rd_bits + 1)?;
+                        let rs2 = Reg::from_bits(rs2_bits)?;
+                        let rs2_hi = Reg::from_bits(rs2_bits + 1)?;
+                        let aq = (funct7 & 0b10) != 0;
+                        let rl = (funct7 & 0b01) != 0;
+
+                        Some(Self::AmocasD {
+                            rd,
+                            rs1,
+                            rs2,
+                            rd_hi,
+                            rs2_hi,
+                            aq,
+                            rl,
+                        })
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format `aq`/`rl` suffix for display
+#[inline(always)]
+fn aq_rl_suffix(aq: &bool, rl: &bool) -> &'static str {
+    match (*aq, *rl) {
+        (false, false) => "",
+        (true, false) => ".aq",
+        (false, true) => ".rl",
+        (true, true) => ".aqrl",
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32ZacasInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::AmocasW { rd, rs1, rs2, aq, rl } => {
+                write!(f, "amocas.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl))
+            }
+            Self::AmocasD { rd, rs1, rs2, rd_hi, rs2_hi, aq, rl } => {
+                write!(
+                    f,
+                    "amocas.d{} {rd}, {rd_hi}, {rs2}, {rs2_hi}, ({rs1})",
+                    aq_rl_suffix(aq, rl)
+                )
+            }
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zacas/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zacas/tests.rs
@@ -1,0 +1,152 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv32::zacas::Rv32ZacasInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT3_W: u8 = 0b010;
+const FUNCT3_D: u8 = 0b011;
+const FUNCT5_AMOCAS: u8 = 0b00101;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_amocas_w() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        FUNCT3_W,
+        2,
+        3,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv32ZacasInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZacasInstruction::AmocasW {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_w_aqrl() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        FUNCT3_W,
+        2,
+        3,
+        funct7(FUNCT5_AMOCAS, true, true),
+    );
+    let decoded = Rv32ZacasInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZacasInstruction::AmocasW {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+            rl: true,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_d_register_pair() {
+    // rd=4 (t1), rs2=6 (t2): both even, valid register pair start
+    let inst = make_r_type(
+        OPCODE_AMO,
+        4,
+        FUNCT3_D,
+        2,
+        6,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv32ZacasInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZacasInstruction::AmocasD {
+            rd: Reg::Tp,
+            rs1: Reg::Sp,
+            rs2: Reg::T1,
+            rd_hi: Reg::T0,
+            rs2_hi: Reg::T2,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_d_odd_rd_reserved() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        5,
+        FUNCT3_D,
+        2,
+        6,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv32ZacasInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_amocas_d_odd_rs2_reserved() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        4,
+        FUNCT3_D,
+        2,
+        7,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv32ZacasInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_funct5_returns_none() {
+    // funct5=0b00010 is `lr`, not part of Zaamo or Zacas
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv32ZacasInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(
+        0b011_0011,
+        1,
+        FUNCT3_W,
+        2,
+        3,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv32ZacasInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_amoadd_inherited_from_zaamo() {
+    // Zacas inherits Zaamo, so plain amoadd.w should also decode
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv32ZacasInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZacasInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zalasr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zalasr.rs
@@ -1,0 +1,136 @@
+//! RV32 Zalasr extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV32 Zalasr instruction (Load-Acquire/Store-Release).
+///
+/// Load-acquire instructions always carry an acquire annotation (not stored as a field since it
+/// is always `true`), plus an optional release annotation stored in `rl`. Store-release
+/// instructions always carry a release annotation (not stored as a field since it is always
+/// `true`), plus an optional acquire annotation stored in `aq`.
+#[instruction]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+pub enum Rv32ZalasrInstruction<Reg> {
+    /// Load-acquire byte
+    LbAq { rd: Reg, rs1: Reg, rl: bool },
+    /// Load-acquire halfword
+    LhAq { rd: Reg, rs1: Reg, rl: bool },
+    /// Load-acquire word
+    LwAq { rd: Reg, rs1: Reg, rl: bool },
+    /// Store-release byte
+    SbRl { rs1: Reg, rs2: Reg, aq: bool },
+    /// Store-release halfword
+    ShRl { rs1: Reg, rs2: Reg, aq: bool },
+    /// Store-release word
+    SwRl { rs1: Reg, rs2: Reg, aq: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv32ZalasrInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+        let funct5 = funct7 >> 2;
+        let aq = (funct7 & 0b10) != 0;
+        let rl = (funct7 & 0b01) != 0;
+
+        match (opcode, funct5) {
+            // Load-acquire, `aq` bit is mandatory and `rs2` must be zero
+            (0b010_1111, 0b00110) => match (funct3, rs2_bits, aq) {
+                (0b000, 0, true) => {
+                    let rd = Reg::from_bits(rd_bits)?;
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    Some(Self::LbAq { rd, rs1, rl })
+                }
+                (0b001, 0, true) => {
+                    let rd = Reg::from_bits(rd_bits)?;
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    Some(Self::LhAq { rd, rs1, rl })
+                }
+                (0b010, 0, true) => {
+                    let rd = Reg::from_bits(rd_bits)?;
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    Some(Self::LwAq { rd, rs1, rl })
+                }
+                _ => None,
+            },
+            // Store-release, `rl` bit is mandatory and `rd` must be zero
+            (0b010_1111, 0b00111) => match (funct3, rd_bits, rl) {
+                (0b000, 0, true) => {
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    let rs2 = Reg::from_bits(rs2_bits)?;
+                    Some(Self::SbRl { rs1, rs2, aq })
+                }
+                (0b001, 0, true) => {
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    let rs2 = Reg::from_bits(rs2_bits)?;
+                    Some(Self::ShRl { rs1, rs2, aq })
+                }
+                (0b010, 0, true) => {
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    let rs2 = Reg::from_bits(rs2_bits)?;
+                    Some(Self::SwRl { rs1, rs2, aq })
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format optional `rl` suffix for load-acquire display
+#[inline(always)]
+fn rl_suffix(rl: &bool) -> &'static str {
+    if *rl { ".aqrl" } else { ".aq" }
+}
+
+/// Format optional `aq` suffix for store-release display
+#[inline(always)]
+fn aq_suffix(aq: &bool) -> &'static str {
+    if *aq { ".aqrl" } else { ".rl" }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32ZalasrInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LbAq { rd, rs1, rl } => write!(f, "lb{} {rd}, ({rs1})", rl_suffix(rl)),
+            Self::LhAq { rd, rs1, rl } => write!(f, "lh{} {rd}, ({rs1})", rl_suffix(rl)),
+            Self::LwAq { rd, rs1, rl } => write!(f, "lw{} {rd}, ({rs1})", rl_suffix(rl)),
+            Self::SbRl { rs1, rs2, aq } => write!(f, "sb{} {rs2}, ({rs1})", aq_suffix(aq)),
+            Self::ShRl { rs1, rs2, aq } => write!(f, "sh{} {rs2}, ({rs1})", aq_suffix(aq)),
+            Self::SwRl { rs1, rs2, aq } => write!(f, "sw{} {rs2}, ({rs1})", aq_suffix(aq)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zalasr/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zalasr/tests.rs
@@ -1,0 +1,178 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv32::zalasr::Rv32ZalasrInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT5_LOAD: u8 = 0b00110;
+const FUNCT5_STORE: u8 = 0b00111;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_lb_aq() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b000, 2, 0, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalasrInstruction::LbAq {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rl: false,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_lh_aq() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b001, 2, 0, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalasrInstruction::LhAq {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rl: false,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_lw_aqrl() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b010, 2, 0, funct7(FUNCT5_LOAD, true, true));
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalasrInstruction::LwAq {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rl: true,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_load_without_aq_bit_reserved() {
+    // `aq` is mandatory for load-acquire; without it the encoding is reserved
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        0b010,
+        2,
+        0,
+        funct7(FUNCT5_LOAD, false, false),
+    );
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_load_nonzero_rs2_reserved() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b010, 2, 3, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_sb_rl() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        0,
+        0b000,
+        2,
+        3,
+        funct7(FUNCT5_STORE, false, true),
+    );
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalasrInstruction::SbRl {
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+        })
+    );
+}
+
+#[test]
+fn test_sh_rl() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        0,
+        0b001,
+        2,
+        3,
+        funct7(FUNCT5_STORE, false, true),
+    );
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalasrInstruction::ShRl {
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+        })
+    );
+}
+
+#[test]
+fn test_sw_aqrl() {
+    let inst = make_r_type(OPCODE_AMO, 0, 0b010, 2, 3, funct7(FUNCT5_STORE, true, true));
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZalasrInstruction::SwRl {
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+        })
+    );
+}
+
+#[test]
+fn test_store_without_rl_bit_reserved() {
+    // `rl` is mandatory for store-release; without it the encoding is reserved
+    let inst = make_r_type(
+        OPCODE_AMO,
+        0,
+        0b010,
+        2,
+        3,
+        funct7(FUNCT5_STORE, false, false),
+    );
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_store_nonzero_rd_reserved() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        0b010,
+        2,
+        3,
+        funct7(FUNCT5_STORE, false, true),
+    );
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(0b011_0011, 1, 0b010, 2, 0, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_doubleword_size_not_available_on_rv32() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b011, 2, 0, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv32ZalasrInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zawrs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zawrs.rs
@@ -1,0 +1,67 @@
+//! RV32 Zawrs extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV32 Zawrs instruction (Wait-on-Reservation-Set)
+#[instruction]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+pub enum Rv32ZawrsInstruction<Reg> {
+    /// Wait-on-Reservation-Set, no timeout
+    WrsNto,
+    /// Wait-on-Reservation-Set, short timeout
+    WrsSto,
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv32ZawrsInstruction<Reg>
+where
+    Reg: [const] Register<Type = u32>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let imm = (instruction >> 20) & 0xfff;
+
+        match (opcode, funct3, rd_bits, rs1_bits, imm) {
+            (0b111_0011, 0b000, 0, 0, 0x00d) => Some(Self::WrsNto),
+            (0b111_0011, 0b000, 0, 0, 0x01d) => Some(Self::WrsSto),
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv32ZawrsInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrsNto => write!(f, "wrs.nto"),
+            Self::WrsSto => write!(f, "wrs.sto"),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zawrs/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zawrs/tests.rs
@@ -1,0 +1,72 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv32::zawrs::Rv32ZawrsInstruction;
+use crate::registers::general_purpose::Reg;
+
+fn make_system(rd: u8, funct3: u8, rs1: u8, imm: u16) -> u32 {
+    u32::from(0b111_0011u8)
+        | (u32::from(rd) << 7u8)
+        | (u32::from(funct3) << 12u8)
+        | (u32::from(rs1) << 15u8)
+        | (u32::from(imm) << 20u8)
+}
+
+#[test]
+fn test_wrs_nto() {
+    let inst = make_system(0, 0, 0, 0x00d);
+    let decoded = Rv32ZawrsInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZawrsInstruction::WrsNto {
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_wrs_sto() {
+    let inst = make_system(0, 0, 0, 0x01d);
+    let decoded = Rv32ZawrsInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv32ZawrsInstruction::WrsSto {
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_nonzero_rd_returns_none() {
+    let inst = make_system(1, 0, 0, 0x00d);
+    let decoded = Rv32ZawrsInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_nonzero_rs1_returns_none() {
+    let inst = make_system(0, 0, 1, 0x00d);
+    let decoded = Rv32ZawrsInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_funct3_returns_none() {
+    let inst = make_system(0, 1, 0, 0x00d);
+    let decoded = Rv32ZawrsInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_unknown_imm_returns_none() {
+    let inst = make_system(0, 0, 0, 0x000);
+    let decoded = Rv32ZawrsInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = (make_system(0, 0, 0, 0x00d) & !0b111_1111) | 0b011_0011;
+    let decoded = Rv32ZawrsInstruction::<Reg<u32>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
@@ -6,6 +6,10 @@ pub mod c;
 pub mod m;
 #[cfg(test)]
 mod tests;
+pub mod zabha;
+pub mod zacas;
+pub mod zalasr;
+pub mod zawrs;
 pub mod zce;
 pub mod zk;
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
@@ -1,5 +1,6 @@
 //! Base RISC-V RV64 instruction set
 
+pub mod a;
 pub mod b;
 pub mod c;
 pub mod m;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/a.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/a.rs
@@ -1,0 +1,53 @@
+//! RV64 A extension
+
+pub mod zaamo;
+pub mod zalrsc;
+
+use crate::instructions::Instruction;
+use crate::instructions::rv64::a::zaamo::Rv64ZaamoInstruction;
+use crate::instructions::rv64::a::zalrsc::Rv64ZalrscInstruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV64 A (Zaamo + Zalrsc) instruction
+#[instruction(
+    inherit = [Rv64ZaamoInstruction, Rv64ZalrscInstruction]
+)]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+pub enum Rv64AInstruction<Reg> {}
+
+#[instruction]
+const impl<Reg> Instruction for Rv64AInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        None
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64AInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {}
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zaamo.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zaamo.rs
@@ -1,0 +1,256 @@
+//! RV64 Zaamo extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV64 Zaamo instruction (Atomic memory operations)
+#[instruction]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum Rv64ZaamoInstruction<Reg> {
+    Amoswap { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amoadd { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amoxor { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amoand { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amoor { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amomin { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amomax { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amominu { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    Amomaxu { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+
+    AmoswapD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoaddD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoxorD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoandD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoorD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominuD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxuD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv64ZaamoInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+
+        match (opcode, funct3) {
+            // AMO, word- or doubleword-sized (the only sizes that exist in RV64)
+            (0b010_1111, 0b010 | 0b011) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let rs2 = Reg::from_bits(rs2_bits)?;
+                let funct5 = funct7 >> 2;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                if funct3 == 0b010 {
+                    match funct5 {
+                        0b00001 => Some(Self::Amoswap {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00000 => Some(Self::Amoadd {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00100 => Some(Self::Amoxor {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01100 => Some(Self::Amoand {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01000 => Some(Self::Amoor {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10000 => Some(Self::Amomin {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10100 => Some(Self::Amomax {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11000 => Some(Self::Amominu {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11100 => Some(Self::Amomaxu {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        _ => None,
+                    }
+                } else {
+                    match funct5 {
+                        0b00001 => Some(Self::AmoswapD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00000 => Some(Self::AmoaddD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00100 => Some(Self::AmoxorD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01100 => Some(Self::AmoandD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01000 => Some(Self::AmoorD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10000 => Some(Self::AmominD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10100 => Some(Self::AmomaxD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11000 => Some(Self::AmominuD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11100 => Some(Self::AmomaxuD {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        _ => None,
+                    }
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format `aq`/`rl` suffix for display
+#[inline(always)]
+fn aq_rl_suffix(aq: &bool, rl: &bool) -> &'static str {
+    match (*aq, *rl) {
+        (false, false) => "",
+        (true, false) => ".aq",
+        (false, true) => ".rl",
+        (true, true) => ".aqrl",
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64ZaamoInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::Amoswap { rd, rs1, rs2, aq, rl } => write!(f, "amoswap.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amoadd { rd, rs1, rs2, aq, rl } => write!(f, "amoadd.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amoxor { rd, rs1, rs2, aq, rl } => write!(f, "amoxor.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amoand { rd, rs1, rs2, aq, rl } => write!(f, "amoand.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amoor { rd, rs1, rs2, aq, rl } => write!(f, "amoor.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amomin { rd, rs1, rs2, aq, rl } => write!(f, "amomin.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amomax { rd, rs1, rs2, aq, rl } => write!(f, "amomax.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amominu { rd, rs1, rs2, aq, rl } => write!(f, "amominu.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Amomaxu { rd, rs1, rs2, aq, rl } => write!(f, "amomaxu.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+
+            Self::AmoswapD { rd, rs1, rs2, aq, rl } => write!(f, "amoswap.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoaddD { rd, rs1, rs2, aq, rl } => write!(f, "amoadd.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoxorD { rd, rs1, rs2, aq, rl } => write!(f, "amoxor.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoandD { rd, rs1, rs2, aq, rl } => write!(f, "amoand.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoorD { rd, rs1, rs2, aq, rl } => write!(f, "amoor.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominD { rd, rs1, rs2, aq, rl } => write!(f, "amomin.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxD { rd, rs1, rs2, aq, rl } => write!(f, "amomax.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominuD { rd, rs1, rs2, aq, rl } => write!(f, "amominu.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxuD { rd, rs1, rs2, aq, rl } => write!(f, "amomaxu.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zaamo/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zaamo/tests.rs
@@ -1,0 +1,337 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv64::a::zaamo::Rv64ZaamoInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT3_W: u8 = 0b010;
+const FUNCT3_D: u8 = 0b011;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_amoswap_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00001, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amoswap {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoxor_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00100, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amoxor {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoand_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b01100, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amoand {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoor_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b01000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amoor {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomin_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b10000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amomin {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomax_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b10100, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amomax {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amominu_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b11000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amominu {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomaxu_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b11100, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amomaxu {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoswap_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b00001, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmoswapD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmoaddD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoxor_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b00100, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmoxorD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoand_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b01100, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmoandD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoor_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b01000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmoorD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomin_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b10000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmominD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomax_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b10100, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmomaxD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amominu_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b11000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmominuD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomaxu_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b11100, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::AmomaxuD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_w_aqrl() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00000, true, true));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZaamoInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+            rl: true,
+        })
+    );
+}
+
+#[test]
+fn test_unknown_funct5_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(0b011_0011, 1, FUNCT3_W, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_funct3_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b001, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv64ZaamoInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zalrsc.rs
@@ -1,0 +1,122 @@
+//! RV64 Zalrsc extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV64 Zalrsc instruction (Load-Reserved/Store-Conditional)
+#[instruction]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum Rv64ZalrscInstruction<Reg> {
+    Lr { rd: Reg, rs1: Reg, aq: bool, rl: bool },
+    Sc { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+
+    LrD { rd: Reg, rs1: Reg, aq: bool, rl: bool },
+    ScD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv64ZalrscInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+
+        match (opcode, funct3) {
+            // AMO, word- or doubleword-sized (the only sizes that exist in RV64)
+            (0b010_1111, 0b010 | 0b011) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let funct5 = funct7 >> 2;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                if funct3 == 0b010 {
+                    match (funct5, rs2_bits) {
+                        (0b00010, 0) => Some(Self::Lr { rd, rs1, aq, rl }),
+                        (0b00011, _) => {
+                            let rs2 = Reg::from_bits(rs2_bits)?;
+                            Some(Self::Sc {
+                                rd,
+                                rs1,
+                                rs2,
+                                aq,
+                                rl,
+                            })
+                        }
+                        _ => None,
+                    }
+                } else {
+                    match (funct5, rs2_bits) {
+                        (0b00010, 0) => Some(Self::LrD { rd, rs1, aq, rl }),
+                        (0b00011, _) => {
+                            let rs2 = Reg::from_bits(rs2_bits)?;
+                            Some(Self::ScD {
+                                rd,
+                                rs1,
+                                rs2,
+                                aq,
+                                rl,
+                            })
+                        }
+                        _ => None,
+                    }
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format `aq`/`rl` suffix for display
+#[inline(always)]
+fn aq_rl_suffix(aq: &bool, rl: &bool) -> &'static str {
+    match (*aq, *rl) {
+        (false, false) => "",
+        (true, false) => ".aq",
+        (false, true) => ".rl",
+        (true, true) => ".aqrl",
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64ZalrscInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::Lr { rd, rs1, aq, rl } => write!(f, "lr.w{} {rd}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::Sc { rd, rs1, rs2, aq, rl } => write!(f, "sc.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::LrD { rd, rs1, aq, rl } => write!(f, "lr.d{} {rd}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::ScD { rd, rs1, rs2, aq, rl } => write!(f, "sc.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zalrsc/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zalrsc/tests.rs
@@ -1,0 +1,143 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv64::a::zalrsc::Rv64ZalrscInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT3_W: u8 = 0b010;
+const FUNCT3_D: u8 = 0b011;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_lr_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 0, funct7(0b00010, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalrscInstruction::Lr {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_lr_w_nonzero_rs2_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_sc_w() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00011, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalrscInstruction::Sc {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_lr_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 0, funct7(0b00010, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalrscInstruction::LrD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            aq: false,
+            rl: false,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_lr_d_aqrl() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 0, funct7(0b00010, true, true));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalrscInstruction::LrD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            aq: true,
+            rl: true,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_lr_d_nonzero_rs2_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_sc_d() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b00011, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalrscInstruction::ScD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_sc_d_aq() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b00011, true, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalrscInstruction::ScD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_unknown_funct5_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00001, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(0b011_0011, 1, FUNCT3_W, 2, 0, funct7(0b00010, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_funct3_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b001, 2, 0, funct7(0b00010, false, false));
+    let decoded = Rv64ZalrscInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zabha.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zabha.rs
@@ -1,0 +1,277 @@
+//! RV64 Zabha extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::instructions::rv64::a::zaamo::Rv64ZaamoInstruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV64 Zabha instruction (Byte and Halfword Atomic Memory Operations)
+#[instruction(inherit = [Rv64ZaamoInstruction])]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum Rv64ZabhaInstruction<Reg> {
+    AmoswapB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoswapH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoaddB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoaddH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoxorB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoxorH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoandB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoandH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoorB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmoorH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominuB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmominuH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxuB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    AmomaxuH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    /// Compare-and-swap byte. Only present when `Zacas` is also implemented.
+    #[instruction(if = [Rv64ZacasInstruction])]
+    AmocasB { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    /// Compare-and-swap halfword. Only present when `Zacas` is also implemented.
+    #[instruction(if = [Rv64ZacasInstruction])]
+    AmocasH { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv64ZabhaInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+
+        match (opcode, funct3) {
+            // AMO, byte- or halfword-sized
+            (0b010_1111, 0b000 | 0b001) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let rs2 = Reg::from_bits(rs2_bits)?;
+                let funct5 = funct7 >> 2;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                if funct3 == 0b000 {
+                    match funct5 {
+                        0b00001 => Some(Self::AmoswapB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00000 => Some(Self::AmoaddB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00100 => Some(Self::AmoxorB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01100 => Some(Self::AmoandB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01000 => Some(Self::AmoorB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10000 => Some(Self::AmominB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10100 => Some(Self::AmomaxB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11000 => Some(Self::AmominuB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11100 => Some(Self::AmomaxuB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00101 => Some(Self::AmocasB {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        _ => None,
+                    }
+                } else {
+                    match funct5 {
+                        0b00001 => Some(Self::AmoswapH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00000 => Some(Self::AmoaddH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00100 => Some(Self::AmoxorH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01100 => Some(Self::AmoandH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b01000 => Some(Self::AmoorH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10000 => Some(Self::AmominH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b10100 => Some(Self::AmomaxH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11000 => Some(Self::AmominuH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b11100 => Some(Self::AmomaxuH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        0b00101 => Some(Self::AmocasH {
+                            rd,
+                            rs1,
+                            rs2,
+                            aq,
+                            rl,
+                        }),
+                        _ => None,
+                    }
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format `aq`/`rl` suffix for display
+#[inline(always)]
+fn aq_rl_suffix(aq: &bool, rl: &bool) -> &'static str {
+    match (*aq, *rl) {
+        (false, false) => "",
+        (true, false) => ".aq",
+        (false, true) => ".rl",
+        (true, true) => ".aqrl",
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64ZabhaInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::AmoswapB { rd, rs1, rs2, aq, rl } => write!(f, "amoswap.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoswapH { rd, rs1, rs2, aq, rl } => write!(f, "amoswap.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoaddB { rd, rs1, rs2, aq, rl } => write!(f, "amoadd.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoaddH { rd, rs1, rs2, aq, rl } => write!(f, "amoadd.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoxorB { rd, rs1, rs2, aq, rl } => write!(f, "amoxor.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoxorH { rd, rs1, rs2, aq, rl } => write!(f, "amoxor.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoandB { rd, rs1, rs2, aq, rl } => write!(f, "amoand.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoandH { rd, rs1, rs2, aq, rl } => write!(f, "amoand.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoorB { rd, rs1, rs2, aq, rl } => write!(f, "amoor.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmoorH { rd, rs1, rs2, aq, rl } => write!(f, "amoor.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominB { rd, rs1, rs2, aq, rl } => write!(f, "amomin.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominH { rd, rs1, rs2, aq, rl } => write!(f, "amomin.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxB { rd, rs1, rs2, aq, rl } => write!(f, "amomax.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxH { rd, rs1, rs2, aq, rl } => write!(f, "amomax.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominuB { rd, rs1, rs2, aq, rl } => write!(f, "amominu.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmominuH { rd, rs1, rs2, aq, rl } => write!(f, "amominu.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxuB { rd, rs1, rs2, aq, rl } => write!(f, "amomaxu.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmomaxuH { rd, rs1, rs2, aq, rl } => write!(f, "amomaxu.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmocasB { rd, rs1, rs2, aq, rl } => write!(f, "amocas.b{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmocasH { rd, rs1, rs2, aq, rl } => write!(f, "amocas.h{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zabha/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zabha/tests.rs
@@ -1,0 +1,221 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv64::zabha::Rv64ZabhaInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT3_B: u8 = 0b000;
+const FUNCT3_H: u8 = 0b001;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_amoswap_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b00001, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmoswapB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmoaddH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoxor_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b00100, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmoxorB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoand_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b01100, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmoandH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoor_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b01000, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmoorB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomin_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b10000, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmominH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomax_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b10100, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmomaxB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amominu_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b11000, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmominuH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amomaxu_b() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b11100, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmomaxuB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_b() {
+    // Zabha always defines amocas.b/h itself; whether it's pulled in further up the chain
+    // depends on whether Zacas is also present there
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b00101, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmocasB {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_h() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_H, 2, 3, funct7(0b00101, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::AmocasH {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amoadd_w_inherited_from_zaamo() {
+    // Zabha inherits Zaamo, so plain word-sized ops should also decode
+    let inst = make_r_type(OPCODE_AMO, 1, 0b010, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZabhaInstruction::Amoadd {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(0b011_0011, 1, FUNCT3_B, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_unknown_funct5_returns_none() {
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_B, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv64ZabhaInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zacas.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zacas.rs
@@ -1,0 +1,143 @@
+//! RV64 Zacas extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::instructions::rv64::a::zaamo::Rv64ZaamoInstruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV64 Zacas instruction (Atomic Compare-and-Swap)
+#[instruction(inherit = [Rv64ZaamoInstruction])]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[rustfmt::skip]
+pub enum Rv64ZacasInstruction<Reg> {
+    /// Compare-and-swap word
+    AmocasW { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    /// Compare-and-swap doubleword
+    AmocasD { rd: Reg, rs1: Reg, rs2: Reg, aq: bool, rl: bool },
+    /// Compare-and-swap quadword, using register pairs `(rd, rd_hi)` and `(rs2, rs2_hi)` since
+    /// RV64 registers are only 64 bits wide.
+    AmocasQ { rd: Reg, rs1: Reg, rs2: Reg, rd_hi: Reg, rs2_hi: Reg, aq: bool, rl: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv64ZacasInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+
+        match (opcode, funct3, funct7 >> 2) {
+            // AMOCAS.W
+            (0b010_1111, 0b010, 0b00101) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let rs2 = Reg::from_bits(rs2_bits)?;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                Some(Self::AmocasW {
+                    rd,
+                    rs1,
+                    rs2,
+                    aq,
+                    rl,
+                })
+            }
+            // AMOCAS.D
+            (0b010_1111, 0b011, 0b00101) => {
+                let rd = Reg::from_bits(rd_bits)?;
+                let rs1 = Reg::from_bits(rs1_bits)?;
+                let rs2 = Reg::from_bits(rs2_bits)?;
+                let aq = (funct7 & 0b10) != 0;
+                let rl = (funct7 & 0b01) != 0;
+
+                Some(Self::AmocasD {
+                    rd,
+                    rs1,
+                    rs2,
+                    aq,
+                    rl,
+                })
+            }
+            // AMOCAS.Q, register-pair mode (RV64)
+            (0b010_1111, 0b100, 0b00101) => {
+                match (rd_bits & 1, rs2_bits & 1) {
+                    // Both halves of the register pairs must be even numbered, otherwise the
+                    // encoding is reserved
+                    (0, 0) => {
+                        let rs1 = Reg::from_bits(rs1_bits)?;
+                        let rd = Reg::from_bits(rd_bits)?;
+                        let rd_hi = Reg::from_bits(rd_bits + 1)?;
+                        let rs2 = Reg::from_bits(rs2_bits)?;
+                        let rs2_hi = Reg::from_bits(rs2_bits + 1)?;
+                        let aq = (funct7 & 0b10) != 0;
+                        let rl = (funct7 & 0b01) != 0;
+
+                        Some(Self::AmocasQ {
+                            rd,
+                            rs1,
+                            rs2,
+                            rd_hi,
+                            rs2_hi,
+                            aq,
+                            rl,
+                        })
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format `aq`/`rl` suffix for display
+#[inline(always)]
+fn aq_rl_suffix(aq: &bool, rl: &bool) -> &'static str {
+    match (*aq, *rl) {
+        (false, false) => "",
+        (true, false) => ".aq",
+        (false, true) => ".rl",
+        (true, true) => ".aqrl",
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64ZacasInstruction<Reg>
+where
+    Reg: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[rustfmt::skip]
+        match self {
+            Self::AmocasW { rd, rs1, rs2, aq, rl } => write!(f, "amocas.w{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmocasD { rd, rs1, rs2, aq, rl } => write!(f, "amocas.d{} {rd}, {rs2}, ({rs1})", aq_rl_suffix(aq, rl)),
+            Self::AmocasQ { rd, rs1, rs2, rd_hi, rs2_hi, aq, rl } => write!(f, "amocas.q{} {rd}, {rd_hi}, {rs2}, {rs2_hi}, ({rs1})", aq_rl_suffix(aq, rl)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zacas/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zacas/tests.rs
@@ -1,0 +1,200 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv64::zacas::Rv64ZacasInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT3_W: u8 = 0b010;
+const FUNCT3_D: u8 = 0b011;
+const FUNCT3_Q: u8 = 0b100;
+const FUNCT5_AMOCAS: u8 = 0b00101;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_amocas_w() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        FUNCT3_W,
+        2,
+        3,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZacasInstruction::AmocasW {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_d() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        FUNCT3_D,
+        2,
+        3,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZacasInstruction::AmocasD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_d_aqrl() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        FUNCT3_D,
+        2,
+        3,
+        funct7(FUNCT5_AMOCAS, true, true),
+    );
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZacasInstruction::AmocasD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+            rl: true,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_d_odd_registers_allowed_on_rv64() {
+    // On RV64, `amocas.d` uses single registers, not pairs, so odd registers are fine
+    let inst = make_r_type(
+        OPCODE_AMO,
+        5,
+        FUNCT3_D,
+        2,
+        7,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZacasInstruction::AmocasD {
+            rd: Reg::T0,
+            rs1: Reg::Sp,
+            rs2: Reg::T2,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_q_register_pair() {
+    // rd=4 (tp), rs2=6 (t1): both even, valid register pair start
+    let inst = make_r_type(
+        OPCODE_AMO,
+        4,
+        FUNCT3_Q,
+        2,
+        6,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZacasInstruction::AmocasQ {
+            rd: Reg::Tp,
+            rs1: Reg::Sp,
+            rs2: Reg::T1,
+            rd_hi: Reg::T0,
+            rs2_hi: Reg::T2,
+            aq: false,
+            rl: false,
+        })
+    );
+}
+
+#[test]
+fn test_amocas_q_odd_rd_reserved() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        5,
+        FUNCT3_Q,
+        2,
+        6,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_amocas_q_odd_rs2_reserved() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        4,
+        FUNCT3_Q,
+        2,
+        7,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_funct5_returns_none() {
+    // funct5=0b00010 is `lr`, not part of Zaamo or Zacas
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_W, 2, 3, funct7(0b00010, false, false));
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(
+        0b011_0011,
+        1,
+        FUNCT3_W,
+        2,
+        3,
+        funct7(FUNCT5_AMOCAS, false, false),
+    );
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_amoadd_d_inherited_from_zaamo() {
+    // Zacas inherits Zaamo, so plain amoadd.d should also decode
+    let inst = make_r_type(OPCODE_AMO, 1, FUNCT3_D, 2, 3, funct7(0b00000, false, false));
+    let decoded = Rv64ZacasInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZacasInstruction::AmoaddD {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+            rl: false,
+        })
+    );
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zalasr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zalasr.rs
@@ -1,0 +1,152 @@
+//! RV64 Zalasr extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV64 Zalasr instruction (Load-Acquire/Store-Release).
+///
+/// Load-acquire instructions always carry an acquire annotation (not stored as a field since it
+/// is always `true`), plus an optional release annotation stored in `rl`. Store-release
+/// instructions always carry a release annotation (not stored as a field since it is always
+/// `true`), plus an optional acquire annotation stored in `aq`.
+#[instruction]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+pub enum Rv64ZalasrInstruction<Reg> {
+    /// Load-acquire byte
+    LbAq { rd: Reg, rs1: Reg, rl: bool },
+    /// Load-acquire halfword
+    LhAq { rd: Reg, rs1: Reg, rl: bool },
+    /// Load-acquire word
+    LwAq { rd: Reg, rs1: Reg, rl: bool },
+    /// Load-acquire doubleword
+    LdAq { rd: Reg, rs1: Reg, rl: bool },
+    /// Store-release byte
+    SbRl { rs1: Reg, rs2: Reg, aq: bool },
+    /// Store-release halfword
+    ShRl { rs1: Reg, rs2: Reg, aq: bool },
+    /// Store-release word
+    SwRl { rs1: Reg, rs2: Reg, aq: bool },
+    /// Store-release doubleword
+    SdRl { rs1: Reg, rs2: Reg, aq: bool },
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv64ZalasrInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let rs2_bits = ((instruction >> 20) & 0x1f) as u8;
+        let funct7 = ((instruction >> 25) & 0b111_1111) as u8;
+        let funct5 = funct7 >> 2;
+        let aq = (funct7 & 0b10) != 0;
+        let rl = (funct7 & 0b01) != 0;
+
+        match (opcode, funct5) {
+            // Load-acquire, `aq` bit is mandatory and `rs2` must be zero
+            (0b010_1111, 0b00110) => match (funct3, rs2_bits, aq) {
+                (0b000, 0, true) => {
+                    let rd = Reg::from_bits(rd_bits)?;
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    Some(Self::LbAq { rd, rs1, rl })
+                }
+                (0b001, 0, true) => {
+                    let rd = Reg::from_bits(rd_bits)?;
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    Some(Self::LhAq { rd, rs1, rl })
+                }
+                (0b010, 0, true) => {
+                    let rd = Reg::from_bits(rd_bits)?;
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    Some(Self::LwAq { rd, rs1, rl })
+                }
+                (0b011, 0, true) => {
+                    let rd = Reg::from_bits(rd_bits)?;
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    Some(Self::LdAq { rd, rs1, rl })
+                }
+                _ => None,
+            },
+            // Store-release, `rl` bit is mandatory and `rd` must be zero
+            (0b010_1111, 0b00111) => match (funct3, rd_bits, rl) {
+                (0b000, 0, true) => {
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    let rs2 = Reg::from_bits(rs2_bits)?;
+                    Some(Self::SbRl { rs1, rs2, aq })
+                }
+                (0b001, 0, true) => {
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    let rs2 = Reg::from_bits(rs2_bits)?;
+                    Some(Self::ShRl { rs1, rs2, aq })
+                }
+                (0b010, 0, true) => {
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    let rs2 = Reg::from_bits(rs2_bits)?;
+                    Some(Self::SwRl { rs1, rs2, aq })
+                }
+                (0b011, 0, true) => {
+                    let rs1 = Reg::from_bits(rs1_bits)?;
+                    let rs2 = Reg::from_bits(rs2_bits)?;
+                    Some(Self::SdRl { rs1, rs2, aq })
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+/// Format optional `rl` suffix for load-acquire display
+#[inline(always)]
+fn rl_suffix(rl: &bool) -> &'static str {
+    if *rl { ".aqrl" } else { ".aq" }
+}
+
+/// Format optional `aq` suffix for store-release display
+#[inline(always)]
+fn aq_suffix(aq: &bool) -> &'static str {
+    if *aq { ".aqrl" } else { ".rl" }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64ZalasrInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LbAq { rd, rs1, rl } => write!(f, "lb{} {rd}, ({rs1})", rl_suffix(rl)),
+            Self::LhAq { rd, rs1, rl } => write!(f, "lh{} {rd}, ({rs1})", rl_suffix(rl)),
+            Self::LwAq { rd, rs1, rl } => write!(f, "lw{} {rd}, ({rs1})", rl_suffix(rl)),
+            Self::LdAq { rd, rs1, rl } => write!(f, "ld{} {rd}, ({rs1})", rl_suffix(rl)),
+            Self::SbRl { rs1, rs2, aq } => write!(f, "sb{} {rs2}, ({rs1})", aq_suffix(aq)),
+            Self::ShRl { rs1, rs2, aq } => write!(f, "sh{} {rs2}, ({rs1})", aq_suffix(aq)),
+            Self::SwRl { rs1, rs2, aq } => write!(f, "sw{} {rs2}, ({rs1})", aq_suffix(aq)),
+            Self::SdRl { rs1, rs2, aq } => write!(f, "sd{} {rs2}, ({rs1})", aq_suffix(aq)),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zalasr/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zalasr/tests.rs
@@ -1,0 +1,148 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv64::zalasr::Rv64ZalasrInstruction;
+use crate::instructions::test_utils::make_r_type;
+use crate::registers::general_purpose::Reg;
+
+const OPCODE_AMO: u8 = 0b010_1111;
+const FUNCT5_LOAD: u8 = 0b00110;
+const FUNCT5_STORE: u8 = 0b00111;
+
+fn funct7(funct5: u8, aq: bool, rl: bool) -> u8 {
+    (funct5 << 2) | (u8::from(aq) << 1) | u8::from(rl)
+}
+
+#[test]
+fn test_lb_aq() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b000, 2, 0, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalasrInstruction::LbAq {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rl: false,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_lw_aq() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b010, 2, 0, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalasrInstruction::LwAq {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rl: false,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_ld_aqrl() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b011, 2, 0, funct7(FUNCT5_LOAD, true, true));
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalasrInstruction::LdAq {
+            rd: Reg::Ra,
+            rs1: Reg::Sp,
+            rl: true,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_load_without_aq_bit_reserved() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        0b011,
+        2,
+        0,
+        funct7(FUNCT5_LOAD, false, false),
+    );
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_load_nonzero_rs2_reserved() {
+    let inst = make_r_type(OPCODE_AMO, 1, 0b011, 2, 3, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_sb_rl() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        0,
+        0b000,
+        2,
+        3,
+        funct7(FUNCT5_STORE, false, true),
+    );
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalasrInstruction::SbRl {
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: false,
+        })
+    );
+}
+
+#[test]
+fn test_sd_aqrl() {
+    let inst = make_r_type(OPCODE_AMO, 0, 0b011, 2, 3, funct7(FUNCT5_STORE, true, true));
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZalasrInstruction::SdRl {
+            rs1: Reg::Sp,
+            rs2: Reg::Gp,
+            aq: true,
+        })
+    );
+}
+
+#[test]
+fn test_store_without_rl_bit_reserved() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        0,
+        0b011,
+        2,
+        3,
+        funct7(FUNCT5_STORE, false, false),
+    );
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_store_nonzero_rd_reserved() {
+    let inst = make_r_type(
+        OPCODE_AMO,
+        1,
+        0b011,
+        2,
+        3,
+        funct7(FUNCT5_STORE, false, true),
+    );
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = make_r_type(0b011_0011, 1, 0b010, 2, 0, funct7(FUNCT5_LOAD, true, false));
+    let decoded = Rv64ZalasrInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zawrs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zawrs.rs
@@ -1,0 +1,67 @@
+//! RV64 Zawrs extension
+
+#[cfg(test)]
+mod tests;
+
+use crate::instructions::Instruction;
+use crate::registers::general_purpose::Register;
+use ab_riscv_macros::instruction;
+use core::fmt;
+
+/// RISC-V RV64 Zawrs instruction (Wait-on-Reservation-Set)
+#[instruction]
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+pub enum Rv64ZawrsInstruction<Reg> {
+    /// Wait-on-Reservation-Set, no timeout
+    WrsNto,
+    /// Wait-on-Reservation-Set, short timeout
+    WrsSto,
+}
+
+#[instruction]
+const impl<Reg> Instruction for Rv64ZawrsInstruction<Reg>
+where
+    Reg: [const] Register<Type = u64>,
+{
+    type Reg = Reg;
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn try_decode(instruction: u32) -> Option<Self> {
+        let opcode = (instruction & 0b111_1111) as u8;
+        let rd_bits = ((instruction >> 7) & 0x1f) as u8;
+        let funct3 = ((instruction >> 12) & 0b111) as u8;
+        let rs1_bits = ((instruction >> 15) & 0x1f) as u8;
+        let imm = (instruction >> 20) & 0xfff;
+
+        match (opcode, funct3, rd_bits, rs1_bits, imm) {
+            (0b111_0011, 0b000, 0, 0, 0x00d) => Some(Self::WrsNto),
+            (0b111_0011, 0b000, 0, 0, 0x01d) => Some(Self::WrsSto),
+            _ => None,
+        }
+    }
+
+    #[inline(always)]
+    fn alignment() -> u8 {
+        align_of::<u32>() as u8
+    }
+
+    #[inline(always)]
+    fn size(&self) -> u8 {
+        size_of::<u32>() as u8
+    }
+}
+
+#[instruction]
+impl<Reg> fmt::Display for Rv64ZawrsInstruction<Reg>
+where
+    Reg: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrsNto => write!(f, "wrs.nto"),
+            Self::WrsSto => write!(f, "wrs.sto"),
+        }
+    }
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zawrs/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zawrs/tests.rs
@@ -1,0 +1,72 @@
+use crate::instructions::Instruction;
+use crate::instructions::rv64::zawrs::Rv64ZawrsInstruction;
+use crate::registers::general_purpose::Reg;
+
+fn make_system(rd: u8, funct3: u8, rs1: u8, imm: u16) -> u32 {
+    u32::from(0b111_0011u8)
+        | (u32::from(rd) << 7u8)
+        | (u32::from(funct3) << 12u8)
+        | (u32::from(rs1) << 15u8)
+        | (u32::from(imm) << 20u8)
+}
+
+#[test]
+fn test_wrs_nto() {
+    let inst = make_system(0, 0, 0, 0x00d);
+    let decoded = Rv64ZawrsInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZawrsInstruction::WrsNto {
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_wrs_sto() {
+    let inst = make_system(0, 0, 0, 0x01d);
+    let decoded = Rv64ZawrsInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(
+        decoded,
+        Some(Rv64ZawrsInstruction::WrsSto {
+            rs1: Reg::Zero,
+            rs2: Reg::Zero,
+        })
+    );
+}
+
+#[test]
+fn test_nonzero_rd_returns_none() {
+    let inst = make_system(1, 0, 0, 0x00d);
+    let decoded = Rv64ZawrsInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_nonzero_rs1_returns_none() {
+    let inst = make_system(0, 0, 1, 0x00d);
+    let decoded = Rv64ZawrsInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_funct3_returns_none() {
+    let inst = make_system(0, 1, 0, 0x00d);
+    let decoded = Rv64ZawrsInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_unknown_imm_returns_none() {
+    let inst = make_system(0, 0, 0, 0x000);
+    let decoded = Rv64ZawrsInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}
+
+#[test]
+fn test_wrong_opcode_returns_none() {
+    let inst = (make_system(0, 0, 0, 0x00d) & !0b111_1111) | 0b011_0011;
+    let decoded = Rv64ZawrsInstruction::<Reg<u64>>::try_decode(inst);
+    assert_eq!(decoded, None);
+}

--- a/crates/execution/ab-riscv-primitives/src/lib.rs
+++ b/crates/execution/ab-riscv-primitives/src/lib.rs
@@ -31,7 +31,11 @@
 //! * M (version 2.0)
 //! * B (version 1.0.0)
 //! * Zaamo (version 1.0.0)
+//! * Zabha (version 1.0.0)
+//! * Zacas (version 1.0.0)
+//! * (experimental) Zalasr (version 1.0.0)
 //! * Zalrsc (version 1.0.0)
+//! * Zawrs (version 1.0.0)
 //! * Zba (version 1.0.0)
 //! * Zbb (version 1.0.0)
 //! * Zbc (version 1.0.0)
@@ -61,8 +65,7 @@
 //!
 //! Any permutation of compatible extensions is supported.
 //!
-//! Experimental extensions are known to have bugs and need more work. They are not tested against
-//! ACTs yet.
+//! Experimental extensions may not have ACT4 tests yet and are not guaranteed to work correctly.
 //!
 //! ## Design choices
 //!

--- a/crates/execution/ab-riscv-primitives/src/lib.rs
+++ b/crates/execution/ab-riscv-primitives/src/lib.rs
@@ -27,8 +27,11 @@
 //! * RV64E (version 2.0)
 //!
 //! Extensions:
+//! * A (version 2.1)
 //! * M (version 2.0)
 //! * B (version 1.0.0)
+//! * Zaamo (version 1.0.0)
+//! * Zalrsc (version 1.0.0)
 //! * Zba (version 1.0.0)
 //! * Zbb (version 1.0.0)
 //! * Zbc (version 1.0.0)

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -2,6 +2,9 @@
 
 pub use crate::instructions::Instruction;
 pub use crate::instructions::rv32::Rv32Instruction;
+pub use crate::instructions::rv32::a::Rv32AInstruction;
+pub use crate::instructions::rv32::a::zaamo::Rv32ZaamoInstruction;
+pub use crate::instructions::rv32::a::zalrsc::Rv32ZalrscInstruction;
 pub use crate::instructions::rv32::b::Rv32BInstruction;
 pub use crate::instructions::rv32::b::zba::Rv32ZbaInstruction;
 pub use crate::instructions::rv32::b::zbb::Rv32ZbbInstruction;
@@ -22,6 +25,9 @@ pub use crate::instructions::rv32::zk::zkn::zknd::{Rv32AesBs, Rv32ZkndInstructio
 pub use crate::instructions::rv32::zk::zkn::zkne::Rv32ZkneInstruction;
 pub use crate::instructions::rv32::zk::zkn::zknh::Rv32ZknhInstruction;
 pub use crate::instructions::rv64::Rv64Instruction;
+pub use crate::instructions::rv64::a::Rv64AInstruction;
+pub use crate::instructions::rv64::a::zaamo::Rv64ZaamoInstruction;
+pub use crate::instructions::rv64::a::zalrsc::Rv64ZalrscInstruction;
 pub use crate::instructions::rv64::b::Rv64BInstruction;
 pub use crate::instructions::rv64::b::zba::Rv64ZbaInstruction;
 pub use crate::instructions::rv64::b::zbb::Rv64ZbbInstruction;

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -13,6 +13,10 @@ pub use crate::instructions::rv32::b::zbs::Rv32ZbsInstruction;
 pub use crate::instructions::rv32::c::zca::Rv32ZcaInstruction;
 pub use crate::instructions::rv32::m::Rv32MInstruction;
 pub use crate::instructions::rv32::m::zmmul::Rv32ZmmulInstruction;
+pub use crate::instructions::rv32::zabha::Rv32ZabhaInstruction;
+pub use crate::instructions::rv32::zacas::Rv32ZacasInstruction;
+pub use crate::instructions::rv32::zalasr::Rv32ZalasrInstruction;
+pub use crate::instructions::rv32::zawrs::Rv32ZawrsInstruction;
 pub use crate::instructions::rv32::zce::zcb::{Rv32ZcbInstruction, Rv32ZcbOnlyInstruction};
 pub use crate::instructions::rv32::zce::zcmp::{
     Rv32ZcmpInstruction, Rv32ZcmpOnlyInstruction, ZcmpRegister, ZcmpUrlist,
@@ -36,6 +40,10 @@ pub use crate::instructions::rv64::b::zbs::Rv64ZbsInstruction;
 pub use crate::instructions::rv64::c::zca::Rv64ZcaInstruction;
 pub use crate::instructions::rv64::m::Rv64MInstruction;
 pub use crate::instructions::rv64::m::zmmul::Rv64ZmmulInstruction;
+pub use crate::instructions::rv64::zabha::Rv64ZabhaInstruction;
+pub use crate::instructions::rv64::zacas::Rv64ZacasInstruction;
+pub use crate::instructions::rv64::zalasr::Rv64ZalasrInstruction;
+pub use crate::instructions::rv64::zawrs::Rv64ZawrsInstruction;
 pub use crate::instructions::rv64::zce::zcb::{Rv64ZcbInstruction, Rv64ZcbOnlyInstruction};
 pub use crate::instructions::rv64::zce::zcmp::{Rv64ZcmpInstruction, Rv64ZcmpOnlyInstruction};
 pub use crate::instructions::rv64::zk::zbkb::Rv64ZbkbInstruction;


### PR DESCRIPTION
This implements following RISC-V extensions for atomics:
* A (Zaamo + Zalrsc)
* Zabha
* Zacas
* Zalasr
* Zawrs

There were issues with them when using previous ATC4 revision, so I had to update. That uncovered issues in vector implementations and required larger RAM size, which in turn prompted addition of `alloc` feature to `ab-riscv-interpreter` crate.

There were a few bugs in ACT4 too, which are finally fixed and all tests pass.