### PR TITLE
Remove `blake3` workarounds for rust-gpu that are no longer needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
  "anyhow",
  "async-lock",
  "futures",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rclite",
  "send-future",
  "stable_deref_trait",
@@ -203,7 +203,7 @@ dependencies = [
  "derive_more",
  "futures",
  "parity-scale-codec",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rclite",
  "schnellru",
  "tokio",
@@ -362,7 +362,7 @@ dependencies = [
  "chacha20 0.10.1",
  "fs4",
  "libc",
- "parking_lot 0.12.5",
+ "parking_lot",
  "tempfile",
  "windows",
 ]
@@ -489,7 +489,7 @@ dependencies = [
  "num_cpus",
  "ouroboros",
  "parity-scale-codec",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project",
  "prometheus-client",
  "rand 0.10.2",
@@ -526,7 +526,7 @@ dependencies = [
  "futures",
  "libc",
  "parity-scale-codec",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rayon",
  "schnellru",
  "serde",
@@ -600,7 +600,7 @@ dependencies = [
  "multihash",
  "nohash-hasher",
  "parity-scale-codec",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project",
  "prometheus-client",
  "rand 0.10.2",
@@ -666,7 +666,7 @@ dependencies = [
  "async-lock",
  "futures",
  "jsonrpsee",
- "parking_lot 0.12.5",
+ "parking_lot",
  "schnellru",
  "serde_json",
  "thiserror 2.0.19",
@@ -706,7 +706,7 @@ dependencies = [
  "chacha20 0.10.1",
  "derive_more",
  "futures",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rand 0.10.2",
  "rayon",
  "rclite",
@@ -1301,12 +1301,6 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -1471,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "cargo-gpu-install"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=99abecb20ab5d343bc661c8934daa44a8492ca93#99abecb20ab5d343bc661c8934daa44a8492ca93"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.21.0",
@@ -2156,7 +2150,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "objc2",
 ]
 
@@ -2296,12 +2290,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener-primitives"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5384093b4255393cc8c42f0fc3dd4f19977ad3b1025f968257854895a993028c"
+checksum = "9898d3d58792ab69f451ad08e5a5b62371296a4877674fb8471a7992c5aab835"
 dependencies = [
  "nohash-hasher",
- "parking_lot 0.11.2",
+ "parking_lot",
  "smallvec",
 ]
 
@@ -2532,7 +2526,7 @@ version = "0.2606.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60f6baf9eb03f64b3b2c0ab79160b535c7460f12252e9965a4a67e22c518c27"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "libc",
  "raw-cpuid",
  "windows",
@@ -2819,7 +2813,7 @@ dependencies = [
  "moka",
  "ndk-context",
  "once_cell",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rand 0.10.2",
  "resolv-conf",
  "smallvec",
@@ -3139,15 +3133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3336,7 +3321,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "jsonrpsee-types",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project",
  "rand 0.9.5",
  "rustc-hash 2.1.3",
@@ -3568,7 +3553,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "multistream-select",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project",
  "prost",
  "rand 0.8.7",
@@ -3588,7 +3573,7 @@ dependencies = [
  "hickory-resolver",
  "libp2p-core",
  "libp2p-identity",
- "parking_lot 0.12.5",
+ "parking_lot",
  "smallvec",
  "tracing",
 ]
@@ -4056,7 +4041,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "parking_lot 0.12.5",
+ "parking_lot",
  "portable-atomic",
  "smallvec",
  "tagptr",
@@ -4127,7 +4112,7 @@ checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.13.1",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -4179,7 +4164,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "libc",
  "log",
  "netlink-packet-core",
@@ -4219,7 +4204,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4332,7 +4317,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "dispatch2",
  "objc2",
 ]
@@ -4361,7 +4346,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4372,7 +4357,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4383,7 +4368,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -4395,7 +4380,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -4550,37 +4535,12 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -4591,7 +4551,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -4813,7 +4773,7 @@ checksum = "ba70bf887030e45213b4a95c9b08d5a450b157f87c1d63661ed0847a12fa2aad"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.5",
+ "parking_lot",
  "prometheus-client-derive-encode",
 ]
 
@@ -5038,7 +4998,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -5115,20 +5075,11 @@ checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -5264,7 +5215,7 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 [[package]]
 name = "rustc_codegen_spirv-types"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=99abecb20ab5d343bc661c8934daa44a8492ca93#99abecb20ab5d343bc661c8934daa44a8492ca93"
 dependencies = [
  "rspirv",
  "semver",
@@ -5298,7 +5249,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5455,7 +5406,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5744,14 +5695,14 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "serde",
 ]
 
 [[package]]
 name = "spirv-builder"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=99abecb20ab5d343bc661c8934daa44a8492ca93#99abecb20ab5d343bc661c8934daa44a8492ca93"
 dependencies = [
  "cargo_metadata 0.21.0",
  "log",
@@ -5767,9 +5718,9 @@ dependencies = [
 [[package]]
 name = "spirv-std"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=99abecb20ab5d343bc661c8934daa44a8492ca93#99abecb20ab5d343bc661c8934daa44a8492ca93"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "glam",
  "libm",
  "num-traits",
@@ -5780,7 +5731,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-macros"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=99abecb20ab5d343bc661c8934daa44a8492ca93#99abecb20ab5d343bc661c8934daa44a8492ca93"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5791,7 +5742,7 @@ dependencies = [
 [[package]]
 name = "spirv-std-types"
 version = "0.10.0-alpha.1"
-source = "git+https://github.com/Rust-GPU/rust-gpu?rev=63d5a41422010cd3f732b587b9dcd1d1a2b42de7#63d5a41422010cd3f732b587b9dcd1d1a2b42de7"
+source = "git+https://github.com/Rust-GPU/rust-gpu?rev=99abecb20ab5d343bc661c8934daa44a8492ca93#99abecb20ab5d343bc661c8934daa44a8492ca93"
 
 [[package]]
 name = "spki"
@@ -5893,7 +5844,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -6065,7 +6016,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -6598,7 +6549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
 dependencies = [
  "arrayvec",
- "bitflags 2.13.1",
+ "bitflags",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -6607,7 +6558,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.5",
+ "parking_lot",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
@@ -6630,7 +6581,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.13.1",
+ "bitflags",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -6640,7 +6591,7 @@ dependencies = [
  "naga",
  "naga-types",
  "once_cell",
- "parking_lot 0.12.5",
+ "parking_lot",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
@@ -6681,7 +6632,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bitflags 2.13.1",
+ "bitflags",
  "block2",
  "bytemuck",
  "cfg-if",
@@ -6700,7 +6651,7 @@ dependencies = [
  "objc2-metal",
  "objc2-quartz-core",
  "ordered-float 5.3.0",
- "parking_lot 0.12.5",
+ "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
  "profiling",
@@ -6731,7 +6682,7 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "bytemuck",
  "js-sys",
  "log",
@@ -7148,7 +7099,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project",
  "rand 0.8.7",
  "static_assertions",
@@ -7163,7 +7114,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project",
  "rand 0.9.5",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ bech32 = { version = "0.12.0", default-features = false }
 blake3 = { version = "1.8.5", default-features = false }
 bytes = { version = "1.12.1", default-features = false }
 bytesize = { version = "2.6.0", default-features = false }
-cargo-gpu-install = { version = "=0.10.0-alpha.1", git = "https://github.com/Rust-GPU/rust-gpu", rev = "63d5a41422010cd3f732b587b9dcd1d1a2b42de7" }
+cargo-gpu-install = { version = "=0.10.0-alpha.1", git = "https://github.com/Rust-GPU/rust-gpu", rev = "99abecb20ab5d343bc661c8934daa44a8492ca93" }
 cargo_metadata = { version = "0.23.1" }
 chacha20 = { version = "0.10.1", default-features = false }
 clap = { version = "4.6.5", features = ["derive"] }
@@ -84,7 +84,7 @@ dirs = { version = "6.0.0" }
 ed25519-dalek = { version = "3.0.0", default-features = false }
 enum-map = "3.1.0"
 event-listener = "5.4.2"
-event-listener-primitives = "2.0.1"
+event-listener-primitives = "2.0.2"
 fdlimit = "0.3.0"
 fs4 = "1.1.0"
 futures = { version = "0.3.33", default-features = false, features = ["async-await"] }
@@ -128,7 +128,7 @@ serde_json = "1.0.151"
 serde-big-array = "0.5.1"
 sha2 = { version = "0.11.0", default-features = false }
 smallvec = { version = "1.15.2", features = ["union"] }
-spirv-std = { version = "=0.10.0-alpha.1", git = "https://github.com/Rust-GPU/rust-gpu", rev = "63d5a41422010cd3f732b587b9dcd1d1a2b42de7" }
+spirv-std = { version = "=0.10.0-alpha.1", git = "https://github.com/Rust-GPU/rust-gpu", rev = "99abecb20ab5d343bc661c8934daa44a8492ca93" }
 stable_deref_trait = { version = "1.2.1", default-features = false }
 strum = { version = "0.28.0", default-features = false, features = ["derive"] }
 syn = "3.0.3"

--- a/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
+++ b/crates/farmer/ab-proof-of-space-gpu/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 wgpu = { workspace = true }
 
-[target.'cfg(not(target_arch = "spirv"))'.dev-dependencies]
+[dev-dependencies]
 chacha20 = { workspace = true, features = ["rng"] }
 futures = { workspace = true, features = ["executor"] }
 rand = { workspace = true }

--- a/crates/shared/ab-blake3/Cargo.toml
+++ b/crates/shared/ab-blake3/Cargo.toml
@@ -24,20 +24,15 @@ all-features = true
 # TODO: Would be nice to have benchmarks here
 
 [dependencies]
-# NOTE: `blake3` is here only for `no-panic` feature
-blake3 = { workspace = true, optional = true }
-no-panic = { workspace = true, optional = true }
-
-# TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-[target.'cfg(not(target_arch = "spirv"))'.dependencies]
 blake3 = { workspace = true }
+no-panic = { workspace = true, optional = true }
 
 [features]
 # Check that code can't panic under any conditions
 no-panic = [
     "dep:no-panic",
     # Helps with testing on CPUs without AVX512 support
-    "blake3?/no_avx512",
+    "blake3/no_avx512",
 ]
 
 [lints]

--- a/crates/shared/ab-blake3/src/lib.rs
+++ b/crates/shared/ab-blake3/src/lib.rs
@@ -6,33 +6,18 @@
 
 #![no_std]
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 mod const_fn;
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 mod platform;
 mod portable;
 mod single_block;
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 mod single_chunk;
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 pub use const_fn::{const_derive_key, const_hash, const_keyed_hash};
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 pub use platform::{le_bytes_from_words_32, words_from_le_bytes_32, words_from_le_bytes_64};
-pub use single_block::single_block_hash_portable_words;
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 pub use single_block::{
     single_block_derive_key, single_block_hash, single_block_hash_many_exact,
-    single_block_keyed_hash, single_block_keyed_hash_many_exact,
+    single_block_hash_portable_words, single_block_keyed_hash, single_block_keyed_hash_many_exact,
 };
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 pub use single_chunk::{single_chunk_derive_key, single_chunk_hash, single_chunk_keyed_hash};
 
 /// The number of bytes in a hash
@@ -46,8 +31,6 @@ pub const BLOCK_LEN: usize = 64;
 ///
 /// You don't usually need to think about this number, but it often comes up in benchmarks, because
 /// the maximum degree of parallelism used by the implementation equals the number of chunks.
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 pub const CHUNK_LEN: usize = 1024;
 
 // While iterating the compression function within a chunk, the CV is
@@ -56,12 +39,8 @@ pub const CHUNK_LEN: usize = 1024;
 // needs to hash both input bytes and parent nodes, so its better for its
 // output CVs to be represented as bytes.
 type CVWords = [u32; 8];
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 type CVBytes = [u8; 32]; // little-endian
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 type BlockBytes = [u8; BLOCK_LEN];
 type BlockWords = [u32; 16];
 
@@ -92,16 +71,8 @@ const MSG_SCHEDULE: [[usize; 16]; 7] = [
 // high and go down.
 const CHUNK_START: u8 = 1 << 0;
 const CHUNK_END: u8 = 1 << 1;
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 const PARENT: u8 = 1 << 2;
 const ROOT: u8 = 1 << 3;
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 const KEYED_HASH: u8 = 1 << 4;
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 const DERIVE_KEY_CONTEXT: u8 = 1 << 5;
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 const DERIVE_KEY_MATERIAL: u8 = 1 << 6;

--- a/crates/shared/ab-blake3/src/portable.rs
+++ b/crates/shared/ab-blake3/src/portable.rs
@@ -1,12 +1,5 @@
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 use crate::platform::{le_bytes_from_words_32, words_from_le_bytes_64};
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
-use crate::{BLOCK_LEN, BlockBytes, CVBytes, OUT_LEN};
-use crate::{BlockWords, CVWords, IV, MSG_SCHEDULE};
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
+use crate::{BLOCK_LEN, BlockBytes, BlockWords, CVBytes, CVWords, IV, MSG_SCHEDULE, OUT_LEN};
 use blake3::IncrementCounter;
 
 #[inline(always)]
@@ -40,22 +33,16 @@ const fn round(state: &mut BlockWords, msg: &BlockWords, round: usize) {
     g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
 }
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline]
 const fn counter_low(counter: u64) -> u32 {
     counter as u32
 }
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline]
 const fn counter_high(counter: u64) -> u32 {
     (counter >> 32) as u32
 }
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline(always)]
 const fn compress_pre(
     cv: &CVWords,
@@ -94,8 +81,6 @@ const fn compress_pre(
     state
 }
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 pub(crate) const fn compress_in_place(
     cv: &mut CVWords,
     block_words: &BlockWords,
@@ -177,8 +162,6 @@ pub(crate) const fn compress_in_place_u32(
     cv[7] = state[7] ^ state[15];
 }
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 const fn hash1<const N: usize>(
     input: &[u8; N],
     key: &CVWords,
@@ -217,8 +200,6 @@ const fn hash1<const N: usize>(
     *out = *le_bytes_from_words_32(&cv);
 }
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[expect(clippy::too_many_arguments, reason = "Internal")]
 pub(crate) const fn hash_many<const N: usize>(
     mut inputs: &[&[u8; N]],

--- a/crates/shared/ab-blake3/src/single_block.rs
+++ b/crates/shared/ab-blake3/src/single_block.rs
@@ -6,25 +6,15 @@
 #[cfg(test)]
 mod tests;
 
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 use crate::platform::{le_bytes_from_words_32, words_from_le_bytes_32};
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 use crate::{
-    BLOCK_LEN, BlockBytes, DERIVE_KEY_CONTEXT, DERIVE_KEY_MATERIAL, KEY_LEN, KEYED_HASH, OUT_LEN,
+    BLOCK_LEN, BlockBytes, BlockWords, CHUNK_END, CHUNK_START, CVWords, DERIVE_KEY_CONTEXT,
+    DERIVE_KEY_MATERIAL, IV, KEY_LEN, KEYED_HASH, OUT_LEN, ROOT, portable,
 };
-use crate::{BlockWords, CHUNK_END, CHUNK_START, CVWords, IV, ROOT, portable};
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 use blake3::IncrementCounter;
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 use blake3::platform::Platform;
 
 /// Hash single block worth of values
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline(always)]
 fn hash_block(input: &[u8], key: CVWords, flags: u8) -> Option<[u8; OUT_LEN]> {
     // If the whole subtree is one block, hash it directly with a ChunkState.
@@ -48,8 +38,6 @@ fn hash_block(input: &[u8], key: CVWords, flags: u8) -> Option<[u8; OUT_LEN]> {
 }
 
 /// Hash multiple single block-sized inputs
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline(always)]
 fn hash_block_many_exact<const NUM_BLOCKS: usize>(
     inputs: &[BlockBytes; NUM_BLOCKS],
@@ -97,8 +85,6 @@ fn hash_block_many_exact<const NUM_BLOCKS: usize>(
 /// Hashing function for at most single block worth of bytes.
 ///
 /// Returns `None` if the input length exceeds one block.
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_block_hash(input: &[u8]) -> Option<[u8; OUT_LEN]> {
@@ -106,8 +92,6 @@ pub fn single_block_hash(input: &[u8]) -> Option<[u8; OUT_LEN]> {
 }
 
 /// Hashing function for many single-block inputs
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_block_hash_many_exact<const NUM_BLOCKS: usize>(
@@ -122,8 +106,6 @@ pub fn single_block_hash_many_exact<const NUM_BLOCKS: usize>(
 /// The keyed hash function for at most single block worth of bytes.
 ///
 /// Returns `None` if the input length exceeds one block.
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_block_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Option<[u8; OUT_LEN]> {
@@ -132,8 +114,6 @@ pub fn single_block_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Option<[u8;
 }
 
 /// Keyed hash function for many single-block inputs
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_block_keyed_hash_many_exact<const NUM_BLOCKS: usize>(
@@ -150,8 +130,6 @@ pub fn single_block_keyed_hash_many_exact<const NUM_BLOCKS: usize>(
 // The key derivation function for at most a single block worth of bytes.
 //
 // Returns `None` if either context or key material length exceed one block.
-// TODO: Workaround for https://github.com/Rust-GPU/rust-gpu/issues/312
-#[cfg(not(target_arch = "spirv"))]
 #[inline]
 #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
 pub fn single_block_derive_key(context: &str, key_material: &[u8]) -> Option<[u8; OUT_LEN]> {


### PR DESCRIPTION
Updating rust-gpu also allowed to remove old versions of some dependencies