### PR TITLE
Update Rust toolchain to the latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "parity-scale-codec",
  "rayon",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -60,7 +60,7 @@ dependencies = [
  "ab-core-primitives",
  "ab-merkle-tree",
  "rclite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ dependencies = [
  "bytesize",
  "chacha20 0.10.1",
  "futures",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -107,7 +107,7 @@ dependencies = [
  "ab-core-primitives",
  "anyhow",
  "rclite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ dependencies = [
  "rclite",
  "send-future",
  "stable_deref_trait",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "yoke",
 ]
@@ -143,7 +143,7 @@ dependencies = [
  "anyhow",
  "rand 0.10.2",
  "rayon",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -157,7 +157,7 @@ dependencies = [
  "ab-merkle-tree",
  "blake3",
  "futures",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ dependencies = [
  "replace_with",
  "smallvec",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -221,7 +221,7 @@ dependencies = [
  "ab-riscv-primitives",
  "ouroboros",
  "replace_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -251,7 +251,7 @@ dependencies = [
  "derive_destructure2",
  "derive_more",
  "no-panic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ dependencies = [
  "replace_with",
  "serde",
  "serde-big-array",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "yoke",
 ]
 
@@ -350,7 +350,7 @@ dependencies = [
  "async-trait",
  "futures",
  "parity-scale-codec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -373,7 +373,7 @@ version = "0.1.0"
 dependencies = [
  "chacha20 0.10.1",
  "reed-solomon-simd",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ dependencies = [
  "ab-system-contract-state",
  "arrayvec",
  "halfbrown",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -497,7 +497,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -530,7 +530,7 @@ dependencies = [
  "rayon",
  "schnellru",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "windows",
@@ -607,7 +607,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -644,7 +644,7 @@ dependencies = [
  "mimalloc",
  "rclite",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -669,7 +669,7 @@ dependencies = [
  "parking_lot",
  "schnellru",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -711,7 +711,7 @@ dependencies = [
  "rayon",
  "rclite",
  "spirv-std",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "wgpu",
 ]
@@ -727,7 +727,7 @@ dependencies = [
  "cpufeatures 0.3.0",
  "criterion",
  "no-panic",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -780,7 +780,7 @@ dependencies = [
  "ab-riscv-primitives",
  "no-panic-const",
  "replace_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ dependencies = [
  "blake3",
  "no-panic",
  "schnorrkel",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -892,7 +892,7 @@ name = "ab-transaction-pool"
 version = "0.0.1"
 dependencies = [
  "ab-core-primitives",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1088,7 +1088,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -1176,7 +1176,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1504,7 +1504,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde-value",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "toml",
  "unicode-xid",
  "url",
@@ -1522,7 +1522,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1536,7 +1536,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2631,7 +2631,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2770,7 +2770,7 @@ dependencies = [
  "ipnet",
  "jni 0.22.4",
  "rand 0.10.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2791,7 +2791,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "url",
@@ -2818,7 +2818,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3212,7 +3212,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -3327,7 +3327,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3366,7 +3366,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3383,7 +3383,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3494,7 +3494,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3525,7 +3525,7 @@ dependencies = [
  "prost-codec",
  "rand 0.8.7",
  "rand_core 0.6.4",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "web-time",
 ]
@@ -3558,7 +3558,7 @@ dependencies = [
  "prost",
  "rand 0.8.7",
  "rw-stream-sink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "unsigned-varint",
  "web-time",
@@ -3625,7 +3625,7 @@ dependencies = [
  "prost",
  "prost-codec",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -3643,7 +3643,7 @@ dependencies = [
  "rand 0.8.7",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "zeroize",
 ]
@@ -3669,7 +3669,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "uint",
  "web-time",
@@ -3727,7 +3727,7 @@ dependencies = [
  "rand 0.8.7",
  "snow",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -3779,7 +3779,7 @@ dependencies = [
  "ring",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3877,7 +3877,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-webpki",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "x509-parser",
  "yasna 0.6.0",
 ]
@@ -3904,7 +3904,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.10",
@@ -4127,7 +4127,7 @@ dependencies = [
  "petgraph",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unicode-ident",
 ]
 
@@ -4140,7 +4140,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
  "rustc-hash 1.1.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4182,7 +4182,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4806,7 +4806,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "prost",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "unsigned-varint",
 ]
 
@@ -4838,7 +4838,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -4860,7 +4860,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5090,7 +5090,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5222,7 +5222,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spirv",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5712,7 +5712,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5904,11 +5904,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5924,9 +5924,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6597,7 +6597,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
@@ -6660,7 +6660,7 @@ dependencies = [
  "renderdoc-sys",
  "smallvec",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wgpu-naga-bridge",
  "wgpu-types",
  "windows",
@@ -7071,7 +7071,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ anyhow = { version = "1.0.104", default-features = false }
 arrayvec = { version = "0.7.8", default-features = false }
 async-lock = { version = "3.4.2", default-features = false }
 async-nats = { version = "0.50.0", default-features = false, features = ["ring"] }
-async-trait = "0.1.91"
+async-trait = "0.1.92"
 backon = { version = "1.6.0", default-features = false }
 bech32 = { version = "0.12.0", default-features = false }
 blake3 = { version = "1.8.5", default-features = false }
@@ -133,7 +133,7 @@ stable_deref_trait = { version = "1.2.1", default-features = false }
 strum = { version = "0.28.0", default-features = false, features = ["derive"] }
 syn = "3.0.3"
 tempfile = "3.27.0"
-thiserror = { version = "2.0.19", default-features = false }
+thiserror = { version = "2.0.20", default-features = false }
 tokio = { version = "1.53.1", default-features = false }
 tokio-stream = "0.1.19"
 tracing = "0.1.44"
@@ -174,7 +174,9 @@ rust_2018_idioms = "warn"
 missing_debug_implementations = "warn"
 # `spirv` target architecture is not upstream yet
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(target_arch, values("spirv"))'], priority = 1 }
-unreachable_pub = { level = "warn" }
+# TODO: Remove once rust-gpu's nightly is updated, this is triggered by `clippy::assert_is_empty`
+unknown_lints = { level = "allow", priority = -1 }
+unreachable_pub = "warn"
 
 [workspace.lints.clippy]
 # Enable very conservative/invasive lints by default, see https://billylevin.dev/posts/clippy-config/
@@ -187,6 +189,8 @@ absolute_paths = "allow"
 arbitrary_source_item_ordering = "allow"
 as_ptr_cast_mut = "deny"
 as_underscore = "allow"
+# TODO: Unusable for now: https://github.com/rust-lang/rust-clippy/issues/17523
+assert_is_empty = "allow"
 big_endian_bytes = "allow"
 cognitive_complexity = "allow"
 collapsible_else_if = "allow"
@@ -206,6 +210,8 @@ inline_always = "allow"
 integer_division = "allow"
 integer_division_remainder_used = "allow"
 little_endian_bytes = "allow"
+# TODO: Unusable for now: https://github.com/rust-lang/rust-clippy/issues/17524
+manual_assert_eq = "allow"
 match_same_arms = "allow"
 min_ident_chars = "allow"
 missing_docs_in_private_items = "allow"
@@ -307,7 +313,5 @@ redundant_type_annotations = "allow"
 semicolon_if_nothing_returned = "allow"
 # TODO: False-positives: https://github.com/rust-lang/rust-clippy/issues/11024
 tests_outside_test_module = "allow"
-# TODO: Re-enable once false-positive is resolved: https://github.com/rust-lang/rust-clippy/issues/17039
-unnecessary_safety_comment = "allow"
 # TODO: https://github.com/rust-lang/rust-clippy/issues/5368#issuecomment-4665479346
 verbose_file_reads = "allow"

--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -281,6 +281,10 @@ where
 impl<Reg> ContractInstruction<Reg> {
     /// Check if the instruction is a jump instruction of any kind (affects program counter)
     #[inline]
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not care about fields"
+    )]
     pub fn is_jump(&self) -> bool {
         matches!(
             self,

--- a/crates/contracts/core/ab-contract-file/src/lib.rs
+++ b/crates/contracts/core/ab-contract-file/src/lib.rs
@@ -504,6 +504,10 @@ impl<'a> ContractFile<'a> {
 
             // The instruction is an unconditional relative jump:
             //   jal x0, offset
+            #[expect(
+                clippy::rest_pattern_accessible_field,
+                reason = "Do not need other fields"
+            )]
             let matches_expected_pattern = match instruction {
                 ContractInstruction::Jal { rd, .. } => rd == Register::ZERO,
                 ContractInstruction::CJ { .. } => true,

--- a/crates/contracts/core/ab-contracts-common/src/metadata/decode.rs
+++ b/crates/contracts/core/ab-contracts-common/src/metadata/decode.rs
@@ -78,6 +78,10 @@ pub enum MetadataItem<'a, 'metadata> {
 impl<'a, 'metadata> MetadataItem<'a, 'metadata> {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     pub fn num_methods(&self) -> u8 {
         match self {
             MetadataItem::Contract { num_methods, .. }
@@ -87,6 +91,10 @@ impl<'a, 'metadata> MetadataItem<'a, 'metadata> {
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     pub fn into_decoder(self) -> MethodsMetadataDecoder<'a, 'metadata> {
         match self {
             MetadataItem::Contract { decoder, .. } | MetadataItem::Trait { decoder, .. } => decoder,

--- a/crates/contracts/core/cargo-ab-contract/src/main.rs
+++ b/crates/contracts/core/cargo-ab-contract/src/main.rs
@@ -128,7 +128,10 @@ pub fn main() -> anyhow::Result<()> {
             println!("Verification successful");
             Ok(())
         }
-        Cli::Recover { .. } => {
+        Cli::Recover {
+            input_file: _,
+            output_file: _,
+        } => {
             unimplemented!("Recovering of ELF files is not implemented yet");
         }
     }

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload.rs
@@ -766,6 +766,10 @@ impl<'tmp, 'decoder, const VERIFY: bool> TransactionPayloadDecoderInternal<'tmp,
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic::no_panic)]
     fn update_output_buffer_details(&mut self) {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         let TransactionPayloadDecoder {
             external_args_buffer,
             output_buffer_details,

--- a/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder.rs
+++ b/crates/contracts/system/ab-system-contract-simple-wallet-base/src/payload/builder.rs
@@ -148,6 +148,10 @@ impl TransactionPayloadBuilder {
                 .map_err(TransactionPayloadBuilderError::MetadataDecodingError)?;
         let mut metadata_decoder = metadata_decoder.without_auto_drain();
 
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         let MethodMetadataItem {
             method_kind,
             num_arguments,

--- a/crates/execution/ab-executor-native/src/context.rs
+++ b/crates/execution/ab-executor-native/src/context.rs
@@ -51,7 +51,7 @@ impl<'a> ExecutorContext for NativeExecutorContext<'a> {
             fingerprint,
             external_args,
             method_context,
-            ..
+            phantom: _,
         } = prepared_method;
 
         let env_state = EnvState {

--- a/crates/execution/ab-executor-native/src/context/ffi_call.rs
+++ b/crates/execution/ab-executor-native/src/context/ffi_call.rs
@@ -260,6 +260,10 @@ where
                 return Err(ContractError::InternalError);
             }
         };
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     let MethodMetadataItem {
         method_kind,
         num_arguments,

--- a/crates/execution/ab-executor-native/src/lib.rs
+++ b/crates/execution/ab-executor-native/src/lib.rs
@@ -150,6 +150,10 @@ impl NativeExecutorBuilder {
                     method_metadata,
                     ffi_fn,
                 } = native_executor_method;
+                #[expect(
+                    clippy::rest_pattern_accessible_field,
+                    reason = "Do not need other fields"
+                )]
                 let recommended_capacities = match MetadataDecoder::new(main_contract_metadata)
                     .decode_next()
                     .ok_or(NativeExecutorError::ContractMetadataNotFound)?

--- a/crates/execution/ab-executor-slots/src/lib.rs
+++ b/crates/execution/ab-executor-slots/src/lib.rs
@@ -1,3 +1,7 @@
+#![expect(
+    clippy::rest_pattern_accessible_field,
+    reason = "Intentionally not needing other fields, too verbose otherwise"
+)]
 #![no_std]
 
 extern crate alloc;
@@ -824,7 +828,7 @@ impl<'a> NestedSlots<'a> {
                 .1;
             replace_with_or_abort(slot, |slot| match slot {
                 SlotState::Original(_buffer) => {
-                    unreachable!("Slot can't be in `Original` state after being accessed; qed")
+                    unreachable!("Slot can't be in `Original` state after being accessed; qed");
                 }
                 SlotState::OriginalReadOnly(buffer) => SlotState::Original(buffer),
                 SlotState::Modified(buffer) => SlotState::Modified(buffer),

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -415,6 +415,10 @@ fn run_rv32i_max_test(
             rs2_value: state.regs.read(rs2),
         };
 
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match instruction.execute(
             rs1rs2_values,
             &mut state.regs,
@@ -594,6 +598,10 @@ fn run_rv64i_max_test(
             rs2_value: state.regs.read(rs2),
         };
 
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match instruction.execute(
             rs1rs2_values,
             &mut state.regs,

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -147,6 +147,13 @@
     ),
     feature(riscv_ext_intrinsics)
 )]
+#![cfg_attr(
+    test,
+    expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Too verbose for tests"
+    )
+)]
 #![no_std]
 
 pub mod basic;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -448,7 +448,7 @@ impl ExtState {
     /// [`ZkrSeedSource::poll_seed()`] calls. The last entry repeats once the sequence is
     /// exhausted.
     pub(crate) fn set_seed_poll_sequence(&mut self, sequence: Vec<ZkrSeedPoll>) {
-        assert!(!sequence.is_empty());
+        assert_ne!(sequence, []);
         self.seed.sequence = sequence;
         self.seed.index = 0;
     }

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -14,11 +14,10 @@ use quote::{ToTokens, format_ident, quote};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
-use std::{env, fs, iter, mem};
-use syn::token::DotDot;
+use std::{env, fs, iter};
 use syn::{
-    Block, Expr, Fields, FnArg, Ident, ImplItem, ItemImpl, Member, Pat, PatRest, Stmt, Type,
-    WherePredicate, parse_file, parse_quote, parse_str,
+    Block, Expr, FieldPat, Fields, FnArg, Ident, ImplItem, ItemImpl, Member, Pat, PatWild, Stmt,
+    Token, Type, WherePredicate, parse_file, parse_quote, parse_str,
 };
 
 const ORIGINAL_ENUM_DECODING_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_ORIGINAL_IMPL_PATH";
@@ -512,6 +511,11 @@ pub(super) fn process_enum_decoding_impl(
             }
 
             *size_block = parse_quote! {{
+                #[expect(clippy::allow_attributes, reason = "Attribute below")]
+                #[allow(
+                    clippy::rest_pattern_accessible_field,
+                    reason = "Generated code"
+                )]
                 match self {
                     #( #match_arms, )*
                 }
@@ -622,23 +626,14 @@ pub(super) fn process_enum_display_impl(
         }
 
         let Pat::Struct(pat_struct) = &mut arm.pat else {
-            // Must be path otherwise, replace it with a trivial struct
-            arm.pat = parse_quote! { #path { .. } };
+            // Must be path otherwise, ignore generated fields
+            arm.pat = parse_quote! { #path { rs1: _, rs2: _ } };
             return true;
         };
 
-        if pat_struct.rest.is_some() {
-            return true;
-        }
-
-        let mut has_ignore = false;
         let mut rs1_found = false;
         let mut rs2_found = false;
         for field in &pat_struct.fields {
-            if let Pat::Wild(_) = &*field.pat {
-                has_ignore = true;
-            }
-
             let Member::Named(ident) = &field.member else {
                 return false;
             };
@@ -650,23 +645,26 @@ pub(super) fn process_enum_display_impl(
             }
         }
 
-        if !rs1_found || !rs2_found {
-            if has_ignore {
-                // This prevents clippy warnings
-                pat_struct.fields = mem::take(&mut pat_struct.fields)
-                    .into_iter()
-                    .filter_map(|field| {
-                        if let Pat::Wild(_) = &*field.pat {
-                            return None;
-                        }
-
-                        Some(field)
-                    })
-                    .collect();
-            }
-            pat_struct.rest.replace(PatRest {
+        if !rs1_found {
+            pat_struct.fields.push(FieldPat {
                 attrs: vec![],
-                dot2_token: DotDot::default(),
+                member: Member::Named(format_ident!("rs1")),
+                colon_token: Some(<Token![:]>::default()),
+                pat: Box::new(Pat::Wild(PatWild {
+                    attrs: vec![],
+                    underscore_token: <Token![_]>::default(),
+                })),
+            });
+        }
+        if !rs2_found {
+            pat_struct.fields.push(FieldPat {
+                attrs: vec![],
+                member: Member::Named(format_ident!("rs2")),
+                colon_token: Some(<Token![:]>::default()),
+                pat: Box::new(Pat::Wild(PatWild {
+                    attrs: vec![],
+                    underscore_token: <Token![_]>::default(),
+                })),
             });
         }
 

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl/forbidden_checker.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl/forbidden_checker.rs
@@ -13,22 +13,35 @@ impl<'ast> Visit<'ast> for ForbiddenChecker<'ast> {
         }
 
         match i {
-            Expr::Return(ExprReturn { .. }) => {
+            Expr::Return(ExprReturn {
+                attrs: _,
+                return_token: _,
+                expr: _,
+            }) => {
                 self.found = true;
             }
 
             // Unit variant: `Enum::Foo` (qself must be None to avoid <T as Trait>::Assoc false
             // positives)
             Expr::Path(ExprPath {
-                qself: None, path, ..
+                attrs: _,
+                qself: None,
+                path,
             }) if is_forbidden_variant_path(path, self.enum_name) => {
                 self.found = true;
             }
 
             // Tuple variant: `Enum::Foo(...)`
-            Expr::Call(ExprCall { func, .. }) => {
+            Expr::Call(ExprCall {
+                attrs: _,
+                func,
+                paren_token: _,
+                args: _,
+            }) => {
                 if let Expr::Path(ExprPath {
-                    qself: None, path, ..
+                    attrs: _,
+                    qself: None,
+                    path,
                 }) = func.as_ref()
                     && is_forbidden_variant_path(path, self.enum_name)
                 {
@@ -37,9 +50,15 @@ impl<'ast> Visit<'ast> for ForbiddenChecker<'ast> {
             }
 
             // Struct variant: `Enum::Foo { .. }`
-            Expr::Struct(ExprStruct { path, .. })
-                if is_forbidden_variant_path(path, self.enum_name) =>
-            {
+            Expr::Struct(ExprStruct {
+                attrs: _,
+                qself: _,
+                path,
+                brace_token: _,
+                fields: _,
+                dot2_token: _,
+                rest: _,
+            }) if is_forbidden_variant_path(path, self.enum_name) => {
                 self.found = true;
             }
 

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl/ignored_variants_remover.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl/ignored_variants_remover.rs
@@ -4,15 +4,37 @@ use syn::{Block, Expr, ExprCall, ExprPath, ExprStruct, Ident};
 
 fn extract_self_variant_ident(expr: &Expr) -> Option<Ident> {
     let path = match expr {
-        Expr::Path(ExprPath { path, .. }) => path,
-        Expr::Call(ExprCall { func, .. }) => {
-            if let Expr::Path(ExprPath { path, .. }) = func.as_ref() {
+        Expr::Path(ExprPath {
+            attrs: _,
+            qself: _,
+            path,
+        }) => path,
+        Expr::Call(ExprCall {
+            attrs: _,
+            func,
+            paren_token: _,
+            args: _,
+        }) => {
+            if let Expr::Path(ExprPath {
+                attrs: _,
+                qself: _,
+                path,
+            }) = func.as_ref()
+            {
                 path
             } else {
                 return None;
             }
         }
-        Expr::Struct(ExprStruct { path, .. }) => path,
+        Expr::Struct(ExprStruct {
+            attrs: _,
+            qself: _,
+            path,
+            brace_token: _,
+            fields: _,
+            dot2_token: _,
+            rest: _,
+        }) => path,
         _ => return None,
     };
 

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -368,6 +368,9 @@ pub(super) fn process_enum_operands_impl(
 
         parse_quote! {
             #[inline(always)]
+            #[expect(clippy::allow_attributes, reason = "Attribute below")]
+            #[allow(clippy::rest_pattern_accessible_field, reason = "Generated code")]
+            #[allow(clippy::unnecessary_rest_pattern, reason = "Generated code")]
             fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg> {
                 match self {
                     #( Self::#all_instructions { rs1, rs2, .. } => Rs1Rs2Operands { rs1, rs2 }, )*

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
@@ -1,9 +1,9 @@
-use quote::{ToTokens, quote};
-use std::{iter, mem};
-use syn::token::{DotDot, Semi};
+use quote::{ToTokens, format_ident, quote};
+use std::iter;
+use syn::token::Semi;
 use syn::{
-    Arm, Block, Expr, ExprBlock, ExprMatch, Ident, Member, Pat, PatRest, PathArguments, Stmt,
-    parse_quote,
+    Arm, Block, Expr, ExprBlock, ExprMatch, FieldPat, Ident, Member, Pat, PatWild, PathArguments,
+    Stmt, Token, parse_quote,
 };
 
 fn is_exact_ok(expr: &Expr) -> bool {
@@ -54,56 +54,54 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
 
         // Fix up match pattern after `rs1`/`rs2` fields were added automatically
         if let Pat::Struct(pat_struct) = &mut arm.pat {
-            if pat_struct.rest.is_none() {
-                let mut has_ignore = false;
-                let mut rs1_found = false;
-                let mut rs2_found = false;
-                for field in &pat_struct.fields {
-                    if let Pat::Wild(_) = &*field.pat {
-                        has_ignore = true;
-                    }
+            let mut rs1_found = false;
+            let mut rs2_found = false;
+            for field in &pat_struct.fields {
+                let Member::Named(ident) = &field.member else {
+                    break;
+                };
 
-                    let Member::Named(ident) = &field.member else {
-                        break;
-                    };
-
-                    if ident == "rs1" {
-                        rs1_found = true;
-                    } else if ident == "rs2" {
-                        rs2_found = true;
-                    }
-                }
-
-                if !rs1_found || !rs2_found {
-                    if has_ignore {
-                        // This prevents clippy warnings
-                        pat_struct.fields = mem::take(&mut pat_struct.fields)
-                            .into_iter()
-                            .filter_map(|field| {
-                                // TODO: Ensure all fields correspond to those in the enum
-                                //  definition, right now this silently accepts non-existing ignored
-                                //  fields
-                                if let Pat::Wild(_) = &*field.pat {
-                                    return None;
-                                }
-
-                                Some(field)
-                            })
-                            .collect();
-                    }
-                    pat_struct.rest.replace(PatRest {
-                        attrs: vec![],
-                        dot2_token: DotDot::default(),
-                    });
+                if ident == "rs1" {
+                    rs1_found = true;
+                } else if ident == "rs2" {
+                    rs2_found = true;
                 }
             }
+
+            if !rs1_found {
+                pat_struct.fields.push(FieldPat {
+                    attrs: vec![],
+                    member: Member::Named(format_ident!("rs1")),
+                    colon_token: Some(<Token![:]>::default()),
+                    pat: Box::new(Pat::Wild(PatWild {
+                        attrs: vec![],
+                        underscore_token: <Token![_]>::default(),
+                    })),
+                });
+            }
+            if !rs2_found {
+                pat_struct.fields.push(FieldPat {
+                    attrs: vec![],
+                    member: Member::Named(format_ident!("rs2")),
+                    colon_token: Some(<Token![:]>::default()),
+                    pat: Box::new(Pat::Wild(PatWild {
+                        attrs: vec![],
+                        underscore_token: <Token![_]>::default(),
+                    })),
+                });
+            }
         } else {
-            // Must be path otherwise, replace it with a trivial struct
-            arm.pat = parse_quote! { #path { .. } };
+            // Must be path otherwise, ignore generated fields
+            arm.pat = parse_quote! { #path { rs1: _, rs2: _ } };
         }
 
         // If not a block then must be an expression, which we'll keep as is
-        if let Expr::Block(ExprBlock { block, .. }) = arm.body.as_mut() {
+        if let Expr::Block(ExprBlock {
+            attrs: _,
+            label: _,
+            block,
+        }) = arm.body.as_mut()
+        {
             let continue_expr = parse_quote! { Ok(ControlFlow::Continue(Default::default())) };
             if let Some(last_statement) = block.stmts.last_mut() {
                 // Has at least one statement

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/forbidden_checker.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/forbidden_checker.rs
@@ -11,7 +11,12 @@ impl Visit<'_> for ForbiddenChecker {
             return;
         }
 
-        if let Expr::Return(ExprReturn { .. }) = i {
+        if let Expr::Return(ExprReturn {
+            attrs: _,
+            return_token: _,
+            expr: _,
+        }) = i
+        {
             self.found = true;
         }
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zkne.rs
@@ -80,9 +80,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Aes64Es {
-                rd: rd1, rs1, rs2, ..
-            } => write!(f, "aes64es {rd1}, {rs1}, {rs2}"),
+            Self::Aes64Es { rd: rd1, rs1, rs2 } => write!(f, "aes64es {rd1}, {rs1}, {rs2}"),
             Self::Aes64Esm { rd, rs1, rs2 } => write!(f, "aes64esm {rd}, {rs1}, {rs2}"),
         }
     }

--- a/crates/execution/ab-riscv-primitives/src/lib.rs
+++ b/crates/execution/ab-riscv-primitives/src/lib.rs
@@ -111,6 +111,13 @@
     try_blocks
 )]
 #![cfg_attr(feature = "no-panic", feature(const_closures))]
+#![cfg_attr(
+    test,
+    expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Too verbose for tests"
+    )
+)]
 
 pub mod instructions;
 pub mod prelude;

--- a/crates/farmer/ab-farmer-components/src/proving.rs
+++ b/crates/farmer/ab-farmer-components/src/proving.rs
@@ -61,6 +61,10 @@ pub enum ProvingError {
 impl ProvingError {
     /// Whether this error is fatal and makes farm unusable
     pub fn is_fatal(&self) -> bool {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not care about fields"
+        )]
         match self {
             ProvingError::FailedToCreatePolynomialForRecord { .. } => false,
             ProvingError::FailedToDecodeSectorContentsMap(_) => false,

--- a/crates/farmer/ab-farmer-components/src/reading.rs
+++ b/crates/farmer/ab-farmer-components/src/reading.rs
@@ -76,6 +76,10 @@ pub enum ReadingError {
 impl ReadingError {
     /// Whether this error is fatal and renders farm unusable
     pub fn is_fatal(&self) -> bool {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not care about fields"
+        )]
         match self {
             ReadingError::FailedToReadChunk { .. } => false,
             ReadingError::MissingPosProof { .. } => false,

--- a/crates/farmer/ab-farmer/src/bin/ab-farmer/commands/benchmark.rs
+++ b/crates/farmer/ab-farmer/src/bin/ab-farmer/commands/benchmark.rs
@@ -131,6 +131,7 @@ fn audit(audit_options: AuditOptions) -> anyhow::Result<()> {
         }
     };
 
+    #[expect(clippy::rest_pattern_accessible_field, reason = "Intentional")]
     match single_disk_farm_info {
         SingleDiskFarmInfo::V0 { .. } => {
             audit_inner::<PosTable>(audit_options, single_disk_farm_info)
@@ -303,6 +304,7 @@ fn prove(prove_options: ProveOptions) -> anyhow::Result<()> {
         }
     };
 
+    #[expect(clippy::rest_pattern_accessible_field, reason = "Intentional")]
     match single_disk_farm_info {
         SingleDiskFarmInfo::V0 { .. } => {
             prove_inner::<PosTable>(prove_options, single_disk_farm_info)

--- a/crates/farmer/ab-farmer/src/cluster/controller/farms.rs
+++ b/crates/farmer/ab-farmer/src/cluster/controller/farms.rs
@@ -422,6 +422,10 @@ async fn initialize_farm(
         let plotted_sectors_buffer = Arc::clone(&plotted_sectors_buffer);
 
         move |(_sector_index, sector_update)| {
+            #[expect(
+                clippy::rest_pattern_accessible_field,
+                reason = "Do not need other fields"
+            )]
             if let SectorUpdate::Plotting(SectorPlottingDetails::Finished {
                 plotted_sector,
                 old_plotted_sector,

--- a/crates/farmer/ab-farmer/src/cluster/farmer.rs
+++ b/crates/farmer/ab-farmer/src/cluster/farmer.rs
@@ -345,6 +345,10 @@ impl ClusterFarm {
                 let mut solution_subscription = pin!(solution_subscription);
 
                 let sector_updates_fut = async {
+                    #[expect(
+                        clippy::rest_pattern_accessible_field,
+                        reason = "Do not need other fields"
+                    )]
                     while let Some(ClusterFarmerSectorUpdateBroadcast {
                         sector_index,
                         sector_update,
@@ -357,6 +361,10 @@ impl ClusterFarm {
                     }
                 };
                 let farming_notifications_fut = async {
+                    #[expect(
+                        clippy::rest_pattern_accessible_field,
+                        reason = "Do not need other fields"
+                    )]
                     while let Some(ClusterFarmerFarmingNotificationBroadcast {
                         farming_notification,
                         ..
@@ -368,6 +376,10 @@ impl ClusterFarm {
                     }
                 };
                 let solutions_fut = async {
+                    #[expect(
+                        clippy::rest_pattern_accessible_field,
+                        reason = "Do not need other fields"
+                    )]
                     while let Some(ClusterFarmerSolutionBroadcast {
                         solution_response, ..
                     }) = solution_subscription.next().await

--- a/crates/farmer/ab-farmer/src/cluster/nats_client.rs
+++ b/crates/farmer/ab-farmer/src/cluster/nats_client.rs
@@ -101,6 +101,10 @@ enum GenericStreamResponses<Response> {
 impl<Response> From<GenericStreamResponses<Response>> for VecDeque<Response> {
     #[inline]
     fn from(value: GenericStreamResponses<Response>) -> Self {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match value {
             GenericStreamResponses::Continue { responses, .. } => responses,
             GenericStreamResponses::Last { responses, .. } => responses,
@@ -110,6 +114,10 @@ impl<Response> From<GenericStreamResponses<Response>> for VecDeque<Response> {
 
 impl<Response> GenericStreamResponses<Response> {
     fn next(&mut self) -> Option<Response> {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             GenericStreamResponses::Continue { responses, .. } => responses.pop_front(),
             GenericStreamResponses::Last { responses, .. } => responses.pop_front(),
@@ -117,6 +125,10 @@ impl<Response> GenericStreamResponses<Response> {
     }
 
     fn index(&self) -> u32 {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             GenericStreamResponses::Continue { index, .. } => *index,
             GenericStreamResponses::Last { index, .. } => *index,
@@ -124,6 +136,10 @@ impl<Response> GenericStreamResponses<Response> {
     }
 
     fn ack_subject(&self) -> Option<&str> {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         if let GenericStreamResponses::Continue { ack_subject, .. } = self {
             Some(ack_subject)
         } else {
@@ -131,6 +147,10 @@ impl<Response> GenericStreamResponses<Response> {
         }
     }
 
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not care about fields"
+    )]
     fn is_last(&self) -> bool {
         matches!(self, Self::Last { .. })
     }

--- a/crates/farmer/ab-farmer/src/farm.rs
+++ b/crates/farmer/ab-farmer/src/farm.rs
@@ -364,6 +364,10 @@ impl FarmingError {
     /// String variant of the error, primarily for monitoring purposes
     #[inline]
     pub fn str_variant(&self) -> &str {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not care about fields"
+        )]
         match self {
             FarmingError::FailedToSubscribeSlotInfo { .. } => "FailedToSubscribeSlotInfo",
             FarmingError::FailedToGetFarmerInfo { .. } => "FailedToGetFarmerInfo",
@@ -377,6 +381,10 @@ impl FarmingError {
 
     /// Whether this error is fatal and makes farm unusable
     pub fn is_fatal(&self) -> bool {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not care about fields"
+        )]
         match self {
             FarmingError::FailedToSubscribeSlotInfo { .. } => true,
             FarmingError::FailedToGetFarmerInfo { .. } => true,

--- a/crates/farmer/ab-farmer/src/lib.rs
+++ b/crates/farmer/ab-farmer/src/lib.rs
@@ -6,6 +6,13 @@
     iter_collect_into,
     try_blocks
 )]
+#![cfg_attr(
+    test,
+    expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Too verbose for tests"
+    )
+)]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
 
 //! `ab-farmer` is both a library and an app for everything related to farming.

--- a/crates/farmer/ab-farmer/src/plotter/cpu.rs
+++ b/crates/farmer/ab-farmer/src/plotter/cpu.rs
@@ -487,6 +487,10 @@ impl ProgressUpdater {
         PS::Error: Error,
     {
         if let Some(metrics) = &self.metrics {
+            #[expect(
+                clippy::rest_pattern_accessible_field,
+                reason = "Just counting occurrences"
+            )]
             match &progress {
                 SectorPlottingProgress::Downloading => {
                     metrics.sector_downloading.inc();

--- a/crates/farmer/ab-farmer/src/plotter/gpu.rs
+++ b/crates/farmer/ab-farmer/src/plotter/gpu.rs
@@ -456,6 +456,10 @@ impl ProgressUpdater {
         PS::Error: Error,
     {
         if let Some(metrics) = &self.metrics {
+            #[expect(
+                clippy::rest_pattern_accessible_field,
+                reason = "Do not need other fields"
+            )]
             match &progress {
                 SectorPlottingProgress::Downloading => {
                     metrics.sector_downloading.inc();

--- a/crates/farmer/ab-farmer/src/single_disk_farm.rs
+++ b/crates/farmer/ab-farmer/src/single_disk_farm.rs
@@ -201,24 +201,40 @@ impl SingleDiskFarmInfo {
     }
 
     /// ID of the farm
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     pub fn id(&self) -> &FarmId {
         let Self::V0 { id, .. } = self;
         id
     }
 
     /// Genesis hash of the chain used for farm creation
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     pub fn genesis_root(&self) -> &BlockRoot {
         let Self::V0 { genesis_root, .. } = self;
         genesis_root
     }
 
     /// Public key of identity used for farm creation
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     pub fn public_key(&self) -> &Ed25519PublicKey {
         let Self::V0 { public_key, .. } = self;
         public_key
     }
 
     /// Seed used for deriving shard commitments
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     pub fn shard_commitments_seed(&self) -> &Blake3Hash {
         let Self::V0 {
             shard_commitments_seed,
@@ -227,7 +243,11 @@ impl SingleDiskFarmInfo {
         shard_commitments_seed
     }
 
-    /// How many pieces does one sector contain.
+    /// How many pieces does one sector contain
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     pub fn pieces_in_sector(&self) -> u16 {
         match self {
             SingleDiskFarmInfo::V0 {
@@ -237,6 +257,10 @@ impl SingleDiskFarmInfo {
     }
 
     /// How much space in bytes is allocated for this farm
+    #[expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Do not need other fields"
+    )]
     pub fn allocated_space(&self) -> u64 {
         match self {
             SingleDiskFarmInfo::V0 {
@@ -1315,6 +1339,10 @@ impl SingleDiskFarm {
                 );
 
                 let new_allocated_space = allocated_space;
+                #[expect(
+                    clippy::rest_pattern_accessible_field,
+                    reason = "Do not need other fields"
+                )]
                 match &mut single_disk_farm_info {
                     SingleDiskFarmInfo::V0 {
                         allocated_space, ..

--- a/crates/farmer/ab-farmer/src/single_disk_farm/plot_cache/tests.rs
+++ b/crates/farmer/ab-farmer/src/single_disk_farm/plot_cache/tests.rs
@@ -112,10 +112,7 @@ async fn basic() {
         disk_plot_cache.is_piece_maybe_stored(&record_key_0),
         MaybePieceStoredResult::Yes
     );
-    #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-    {
-        assert!(disk_plot_cache.read_piece(&record_key_0).await.unwrap() == piece_0);
-    }
+    assert!(disk_plot_cache.read_piece(&record_key_0).await.unwrap() == piece_0);
 
     // Store two more pieces and make sure they can be read
     assert_matches!(
@@ -132,10 +129,7 @@ async fn basic() {
         disk_plot_cache.is_piece_maybe_stored(&record_key_1),
         MaybePieceStoredResult::Yes
     );
-    #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-    {
-        assert!(disk_plot_cache.read_piece(&record_key_1).await.unwrap() == piece_1);
-    }
+    assert!(disk_plot_cache.read_piece(&record_key_1).await.unwrap() == piece_1);
 
     assert_matches!(
         disk_plot_cache.is_piece_maybe_stored(&record_key_2),
@@ -151,10 +145,7 @@ async fn basic() {
         disk_plot_cache.is_piece_maybe_stored(&record_key_2),
         MaybePieceStoredResult::Yes
     );
-    #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-    {
-        assert!(disk_plot_cache.read_piece(&record_key_2).await.unwrap() == piece_2);
-    }
+    assert!(disk_plot_cache.read_piece(&record_key_2).await.unwrap() == piece_2);
 
     // Write almost all sectors even without updating metadata, this will result in internal piece
     // read error due to checksum mismatch and eviction of the piece from cache
@@ -187,10 +178,7 @@ async fn basic() {
     );
 
     // Closing file will render cache unusable
-    #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-    {
-        assert!(disk_plot_cache.read_piece(&record_key_0).await.unwrap() == piece_0);
-    }
+    assert!(disk_plot_cache.read_piece(&record_key_0).await.unwrap() == piece_0);
     drop(file);
     assert_matches!(disk_plot_cache.read_piece(&record_key_0).await, None);
 }

--- a/crates/farmer/ab-farmer/src/single_disk_farm/plotting.rs
+++ b/crates/farmer/ab-farmer/src/single_disk_farm/plotting.rs
@@ -1039,7 +1039,13 @@ where
 
         let sectors_queued = sectors_to_replot.len();
         sectors_to_replot.sort_by_key(|sector_to_replot| sector_to_replot.expires_at);
-        for (index, SectorToReplot { sector_index, .. }) in sectors_to_replot.drain(..).enumerate()
+        for (
+            index,
+            SectorToReplot {
+                sector_index,
+                expires_at: _,
+            },
+        ) in sectors_to_replot.drain(..).enumerate()
         {
             let (acknowledgement_sender, acknowledgement_receiver) = oneshot::channel();
             if let Err(error) = sectors_to_plot_sender

--- a/crates/farmer/ab-proof-of-space-gpu/build.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/build.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let path_to_spv = if env::var("CLIPPY_ARGS").is_ok() {
         match spirv_builder.clippy() {
             Ok(compile_result) => compile_result.module.unwrap_single().to_path_buf(),
-            Err(SpirvBuilderError::NoArtifactProduced { .. }) => {
+            Err(SpirvBuilderError::NoArtifactProduced { stdout: _ }) => {
                 let empty_file = out_dir.join("empty.bin");
                 fs::write(&empty_file, [])?;
                 empty_file

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f2/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f2/cpu_tests.rs
@@ -39,7 +39,6 @@ pub(super) fn find_matches_and_compute_f2_correct<
         for (index, ((m, match_positions), match_metadata)) in
             matches.iter().zip(positions).zip(metadatas).enumerate()
         {
-            // SAFETY: Guaranteed by function contract
             let (bucket_offset, r_target, positions_offset) = m.split();
 
             let left_position_r = left_bucket[bucket_offset as usize];

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f2/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f2/gpu_tests.rs
@@ -184,10 +184,7 @@ async fn find_matches_and_compute_f2(
 
         match &result {
             Some(result) => {
-                #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-                {
-                    assert!(result == &adapter_result);
-                }
+                assert!(result == &adapter_result);
             }
             None => {
                 result.replace(adapter_result);

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7/cpu_tests.rs
@@ -31,7 +31,6 @@ pub(super) fn find_matches_and_compute_f7_correct<'a>(
         );
 
         for m in matches {
-            // SAFETY: Guaranteed by function contract
             let (bucket_offset, r_target, positions_offset) = m.split();
 
             let left_position_r = left_bucket[bucket_offset as usize];

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_f7/gpu_tests.rs
@@ -173,10 +173,7 @@ async fn find_matches_and_compute_f7(
 
         match &result {
             Some(result) => {
-                #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-                {
-                    assert!(result == &adapter_result);
-                }
+                assert!(result == &adapter_result);
             }
             None => {
                 result.replace(adapter_result);

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/cpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/cpu_tests.rs
@@ -41,7 +41,6 @@ pub(super) fn find_matches_and_compute_fn_correct<
         for (index, ((m, match_positions), match_metadata)) in
             matches.iter().zip(positions).zip(metadatas).enumerate()
         {
-            // SAFETY: Guaranteed by function contract
             let (bucket_offset, r_target, positions_offset) = m.split();
 
             let left_position_r = left_bucket[bucket_offset as usize];

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_and_compute_fn/gpu_tests.rs
@@ -226,10 +226,7 @@ async fn find_matches_and_compute_fn<const TABLE_NUMBER: u8>(
 
         match &result {
             Some(result) => {
-                #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-                {
-                    assert!(result == &adapter_result);
-                }
+                assert!(result == &adapter_result);
             }
             None => {
                 result.replace(adapter_result);

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_matches_in_buckets/gpu_tests.rs
@@ -103,10 +103,7 @@ async fn find_matches_in_buckets(
 
         match &result {
             Some(result) => {
-                #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-                {
-                    assert!(result == &adapter_result);
-                }
+                assert!(result == &adapter_result);
             }
             None => {
                 result.replace(adapter_result);

--- a/crates/farmer/ab-proof-of-space-gpu/src/shader/find_proofs/gpu_tests.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/shader/find_proofs/gpu_tests.rs
@@ -195,10 +195,7 @@ async fn find_proofs(
 
         match &result {
             Some(result) => {
-                #[expect(clippy::manual_assert_eq, reason = "Value is too large")]
-                {
-                    assert!(result == &adapter_result);
-                }
+                assert!(result == &adapter_result);
             }
             None => {
                 result.replace(adapter_result);

--- a/crates/node/ab-client-api/src/lib.rs
+++ b/crates/node/ab-client-api/src/lib.rs
@@ -298,7 +298,6 @@ pub trait BeaconChainInfoWrite: BeaconChainInfo + ChainInfoWrite<OwnedBeaconChai
     /// Persist a new super segment header.
     ///
     /// Returns `Ok(true)` if the header was inserted, `Ok(false)` if it was already present.
-    #[must_use]
     fn persist_super_segment_header(
         &self,
         super_segment_header: SuperSegmentHeader,

--- a/crates/node/ab-client-block-import/src/beacon_chain.rs
+++ b/crates/node/ab-client-block-import/src/beacon_chain.rs
@@ -262,6 +262,10 @@ where
         let header = block.header.header();
         let body = block.body.body();
 
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not care about fields"
+        )]
         let log_block_import = match origin {
             BlockOrigin::LocalBlockBuilder { .. } => true,
             BlockOrigin::Sync => false,

--- a/crates/node/ab-client-database/src/lib.rs
+++ b/crates/node/ab-client-database/src/lib.rs
@@ -451,6 +451,10 @@ where
 {
     #[inline(always)]
     fn header(&self) -> &Block::Header {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             Self::InMemory { block, .. } => block.header(),
             Self::Persisted { header, .. } | Self::PersistedConfirmed { header, .. } => header,
@@ -459,6 +463,10 @@ where
 
     #[inline(always)]
     fn full_block(&self) -> FullBlock<'_, Block> {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             Self::InMemory { block, .. } => FullBlock::InMemory(block),
             Self::Persisted {
@@ -479,6 +487,10 @@ where
 
     #[inline(always)]
     fn block_details(&self) -> Option<&BlockDetails> {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             Self::InMemory { block_details, .. } | Self::Persisted { block_details, .. } => {
                 Some(block_details)
@@ -489,6 +501,10 @@ where
 
     #[inline(always)]
     fn beacon_chain_block_details(&self) -> Option<&BeaconChainBlockDetails> {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             Self::InMemory {
                 beacon_chain_block_details,
@@ -1804,6 +1820,10 @@ where
                 .iter()
                 .enumerate()
                 .filter_map(|(fork_offset, client_database_block)| {
+                    #[expect(
+                        clippy::rest_pattern_accessible_field,
+                        reason = "Do not need other fields"
+                    )]
                     match client_database_block {
                         ClientDatabaseBlock::InMemory {
                             block,
@@ -2065,6 +2085,10 @@ where
             }
 
             // Blocks that are already persisted
+            #[expect(
+                clippy::rest_pattern_accessible_field,
+                reason = "Do not care about fields"
+            )]
             match block {
                 ClientDatabaseBlock::InMemory { .. } => {
                     // Prune
@@ -2115,35 +2139,41 @@ where
                 return;
             };
 
-            replace_with_or_abort(canonical_block, |block| match block {
-                ClientDatabaseBlock::InMemory { .. } => {
-                    error!(
-                        %best_number,
-                        block_offset,
-                        header = ?block.header(),
-                        "Block to be confirmed must not be in memory, this is an implementation bug"
-                    );
-                    block
-                }
-                ClientDatabaseBlock::Persisted {
-                    header,
-                    block_details: _,
-                    beacon_chain_block_details,
-                    write_location,
-                } => ClientDatabaseBlock::PersistedConfirmed {
-                    header,
-                    beacon_chain_block_details,
-                    write_location,
-                },
-                ClientDatabaseBlock::PersistedConfirmed { .. } => {
-                    error!(
-                        %best_number,
-                        block_offset,
-                        header = ?block.header(),
-                        "Block to be confirmed must not be confirmed yet, this is an \
-                        implementation bug"
-                    );
-                    block
+            replace_with_or_abort(canonical_block, |block| {
+                #[expect(
+                    clippy::rest_pattern_accessible_field,
+                    reason = "Do not need other fields"
+                )]
+                match block {
+                    ClientDatabaseBlock::InMemory { .. } => {
+                        error!(
+                            %best_number,
+                            block_offset,
+                            header = ?block.header(),
+                            "Block to be confirmed must not be in memory, this is an implementation bug"
+                        );
+                        block
+                    }
+                    ClientDatabaseBlock::Persisted {
+                        header,
+                        block_details: _,
+                        beacon_chain_block_details,
+                        write_location,
+                    } => ClientDatabaseBlock::PersistedConfirmed {
+                        header,
+                        beacon_chain_block_details,
+                        write_location,
+                    },
+                    ClientDatabaseBlock::PersistedConfirmed { .. } => {
+                        error!(
+                            %best_number,
+                            block_offset,
+                            header = ?block.header(),
+                            "Block to be confirmed must not be confirmed yet, this is an \
+                            implementation bug"
+                        );
+                        block
+                    }
                 }
             });
         }

--- a/crates/node/ab-node-rpc-server/src/lib.rs
+++ b/crates/node/ab-node-rpc-server/src/lib.rs
@@ -80,6 +80,10 @@ pub enum Error {
 
 impl From<Error> for ErrorObjectOwned {
     fn from(error: Error) -> Self {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Only extracting error code"
+        )]
         let code = match &error {
             Error::SolutionWasIgnored { .. } => 0,
             Error::SuperSegmentHeadersLengthExceeded { .. } => 1,

--- a/crates/shared/ab-archiving/src/archiver.rs
+++ b/crates/shared/ab-archiving/src/archiver.rs
@@ -512,6 +512,10 @@ impl Archiver {
                         }
                     }
                 }
+                #[expect(
+                    clippy::rest_pattern_accessible_field,
+                    reason = "Do not care about fields"
+                )]
                 SegmentItem::BlockStart { .. } => {
                     unreachable!("Buffer never contains SegmentItem::BlockStart; qed");
                 }

--- a/crates/shared/ab-archiving/src/reconstructor.rs
+++ b/crates/shared/ab-archiving/src/reconstructor.rs
@@ -146,6 +146,10 @@ impl Reconstructor {
         let mut partial_block = self.partial_block.take().unwrap_or_default();
 
         for segment_item in segment.items {
+            #[expect(
+                clippy::rest_pattern_accessible_field,
+                reason = "Do not need other fields"
+            )]
             match segment_item {
                 SegmentItem::Padding => {
                     // Doesn't contain anything

--- a/crates/shared/ab-archiving/tests/integration/archiver.rs
+++ b/crates/shared/ab-archiving/tests/integration/archiver.rs
@@ -557,17 +557,11 @@ fn invalid_usage() {
 
         assert_matches!(
             result,
-            Err(ArchiverInstantiationError::InvalidBlockSmallSize { .. }),
+            Err(ArchiverInstantiationError::InvalidBlockSmallSize {
+                block_bytes: 6,
+                archived_block_bytes: 10,
+            }),
         );
-
-        if let Err(ArchiverInstantiationError::InvalidBlockSmallSize {
-            block_bytes,
-            archived_block_bytes,
-        }) = result
-        {
-            assert_eq!(block_bytes, 6);
-            assert_eq!(archived_block_bytes, 10);
-        }
     }
 }
 

--- a/crates/shared/ab-erasure-coding/tests/integration.rs
+++ b/crates/shared/ab-erasure-coding/tests/integration.rs
@@ -102,8 +102,10 @@ fn basic_data() {
                 num_shards / 4..num_shards * 2 / 4,
             ),
         ),
-        Err(ErasureCodingError::DecoderError(
-            Error::NotEnoughShards { .. }
-        ))
+        Err(ErasureCodingError::DecoderError(Error::NotEnoughShards {
+            original_count: _,
+            original_received_count: _,
+            recovery_received_count: _,
+        }))
     );
 }

--- a/crates/shared/ab-networking/src/lib.rs
+++ b/crates/shared/ab-networking/src/lib.rs
@@ -3,6 +3,13 @@
 
 #![feature(duration_constructors, exact_size_is_empty, ip, trivial_bounds)]
 #![warn(missing_docs)]
+#![cfg_attr(
+    test,
+    expect(
+        clippy::rest_pattern_accessible_field,
+        reason = "Too verbose for tests"
+    )
+)]
 
 mod behavior;
 mod constructor;

--- a/crates/shared/ab-networking/src/node_runner.rs
+++ b/crates/shared/ab-networking/src/node_runner.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::rest_pattern_accessible_field,
+    reason = "Too verbose otherwise"
+)]
+
 use crate::behavior::persistent_parameters::{
     KnownPeersRegistry, PeerAddressRemovedEvent, append_p2p_suffix, remove_p2p_suffix,
 };
@@ -857,7 +862,7 @@ impl NodeRunner {
 
         match event {
             KademliaEvent::InboundRequest {
-                request: InboundRequest::AddProvider { record, .. },
+                request: InboundRequest::AddProvider { record },
             } => {
                 debug!("Unexpected AddProvider request received: {:?}", record);
             }

--- a/crates/shared/ab-networking/src/protocols/request_response/request_response_factory.rs
+++ b/crates/shared/ab-networking/src/protocols/request_response/request_response_factory.rs
@@ -673,7 +673,11 @@ impl NetworkBehaviour for RequestResponseFactoryBehaviour {
                     request_id,
                     protocol: protocol_name,
                     inner_channel,
-                    response: OutgoingResponse { result, .. },
+                    response:
+                        OutgoingResponse {
+                            result,
+                            sent_feedback: _,
+                        },
                 }) = outcome
                 else {
                     // The response builder was too busy, or handling the request failed. This is
@@ -766,6 +770,10 @@ impl NetworkBehaviour for RequestResponseFactoryBehaviour {
                         }
                     };
 
+                    #[expect(
+                        clippy::rest_pattern_accessible_field,
+                        reason = "Do not care about other fields"
+                    )]
                     match event {
                         // Received a request from a remote.
                         RequestResponseEvent::Message {

--- a/crates/shared/ab-networking/src/protocols/reserved_peers.rs
+++ b/crates/shared/ab-networking/src/protocols/reserved_peers.rs
@@ -168,6 +168,10 @@ impl NetworkBehaviour for Behaviour {
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm<'_>) {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not care about other fields"
+        )]
         match event {
             FromSwarm::ConnectionEstablished(ConnectionEstablished { peer_id, .. }) => {
                 if let Some(state) = self.reserved_peers_state.get_mut(&peer_id) {

--- a/crates/shared/ab-networking/src/shared.rs
+++ b/crates/shared/ab-networking/src/shared.rs
@@ -36,6 +36,10 @@ pub enum PeerDiscovered {
 impl PeerDiscovered {
     /// Extracts peer ID from event.
     pub fn peer_id(&self) -> PeerId {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             PeerDiscovered::UnroutablePeer { peer_id } => *peer_id,
             PeerDiscovered::RoutablePeer { peer_id, .. } => *peer_id,

--- a/crates/shared/ab-proof-of-space/src/chiapos/table.rs
+++ b/crates/shared/ab-proof-of-space/src/chiapos/table.rs
@@ -897,12 +897,12 @@ impl<const K: u8, const TABLE_NUMBER: u8> PrunedTable<K, TABLE_NUMBER> {
             Self::First => {
                 unreachable!("Not the first table");
             }
-            Self::Other { positions, .. } => {
+            Self::Other { positions } => {
                 // SAFETY: All non-sentinel positions returned by [`Self::buckets()`] are valid
                 unsafe { positions.get_unchecked(usize::from(position)).assume_init() }
             }
             #[cfg(feature = "parallel")]
-            Self::OtherBuckets { positions, .. } => {
+            Self::OtherBuckets { positions } => {
                 // SAFETY: All non-sentinel positions returned by [`Self::buckets()`] are valid
                 unsafe {
                     positions
@@ -1300,6 +1300,10 @@ where
     /// [`PrunedTable::position()`] and not be a sentinel value.
     #[inline(always)]
     pub(super) unsafe fn position(&self, position: Position) -> [Position; 2] {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             Self::First { .. } => {
                 unreachable!("Not the first table");
@@ -1565,6 +1569,10 @@ where
     /// `position` must come from [`Self::buckets()`] and not be a sentinel value.
     #[inline(always)]
     unsafe fn metadata(&self, position: Position) -> Metadata<K, TABLE_NUMBER> {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             Self::First { .. } => {
                 // X matches position
@@ -1592,6 +1600,10 @@ where
 impl<const K: u8, const TABLE_NUMBER: u8> Table<K, TABLE_NUMBER> {
     #[inline(always)]
     fn prune(self) -> PrunedTable<K, TABLE_NUMBER> {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
             Self::First { .. } => PrunedTable::First,
             Self::Other { positions, .. } => PrunedTable::Other { positions },
@@ -1603,8 +1615,12 @@ impl<const K: u8, const TABLE_NUMBER: u8> Table<K, TABLE_NUMBER> {
     /// Positions of `y`s grouped by the bucket they belong to
     #[inline(always)]
     pub(super) fn buckets(&self) -> &[[(Position, Y); REDUCED_BUCKET_SIZE]; NUM_BUCKETS::<K>] {
+        #[expect(
+            clippy::rest_pattern_accessible_field,
+            reason = "Do not need other fields"
+        )]
         match self {
-            Self::First { buckets, .. } => buckets,
+            Self::First { buckets } => buckets,
             Self::Other { buckets, .. } => buckets,
             #[cfg(feature = "parallel")]
             Self::OtherBuckets { buckets, .. } => buckets,

--- a/crates/shared/ab-proof-of-time/src/aes.rs
+++ b/crates/shared/ab-proof-of-time/src/aes.rs
@@ -1,4 +1,4 @@
-//! AES related functionality.
+//! AES related functionality
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64;

--- a/crates/shared/ab-proof-of-time/src/lib.rs
+++ b/crates/shared/ab-proof-of-time/src/lib.rs
@@ -4,6 +4,11 @@
     any(target_arch = "aarch64", target_arch = "x86_64"),
     feature(portable_simd)
 )]
+// TODO: Remove once https://github.com/RustCrypto/utils/issues/1514 is resolved
+#![cfg_attr(
+    any(target_arch = "aarch64", target_arch = "x86_64"),
+    expect(deprecated, reason = "https://github.com/RustCrypto/utils/issues/1514")
+)]
 #![no_std]
 
 mod aes;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-08-03"
+channel = "nightly-2026-08-08"
 components = ["miri", "rust-src"]
 targets = []
 profile = "default"


### PR DESCRIPTION
A few crate updates were needed to fix clippy lints. Overall quite a lot of suppressions due to new clippy lints. RISC-V macros were modified to avoid lints in some cases and suppressed suppressed them in others.