### PR TITLE
RISC-V refactoring

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -2,7 +2,6 @@ use ab_riscv_interpreter::prelude::*;
 use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
-use core::ops::ControlFlow;
 
 /// Registers used by contracts
 #[derive(Debug, Default, Clone, Copy)]
@@ -273,8 +272,8 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }
 

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
@@ -97,7 +97,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
@@ -93,7 +93,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/instruction.rs
@@ -2,7 +2,6 @@ use ab_riscv_interpreter::prelude::*;
 use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;
 use std::fmt;
-use std::ops::ControlFlow;
 
 /// First `mhpmeventN` CSR index (`N` starts at 3, the first non-reserved HPM event selector).
 pub(crate) const MHPMEVENT3_CSR_INDEX: u16 = 0x323;
@@ -152,7 +151,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -355,16 +355,16 @@ fn run_rv32i_max_test(
 
     loop {
         let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
-            Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+            FetchInstructionResult::Instruction(instruction) => instruction,
+            FetchInstructionResult::Break => {
                 break;
             }
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+            FetchInstructionResult::Continue => {
                 continue;
             }
             // TODO: This custom handling is temporary until interpreter has abstractions and
             //  support for privileged instructions
-            Err(ExecutionError::IllegalInstruction { address }) => {
+            FetchInstructionResult::Err(ExecutionError::IllegalInstruction { address }) => {
                 let address = address.get();
                 // Check for mret before treating as a trap - mret is a privileged instruction the
                 // interpreter doesn't implement, so it arrives here as an illegal instruction
@@ -407,7 +407,7 @@ fn run_rv32i_max_test(
                     }
                 }
             }
-            Err(error) => {
+            FetchInstructionResult::Err(error) => {
                 if state
                     .memory
                     .tohost_value::<RegisterType<AbundanceRv32IMaxInstruction>>(elf.tohost_addr)?
@@ -560,16 +560,16 @@ fn run_rv64i_max_test(
 
     loop {
         let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
-            Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+            FetchInstructionResult::Instruction(instruction) => instruction,
+            FetchInstructionResult::Break => {
                 break;
             }
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+            FetchInstructionResult::Continue => {
                 continue;
             }
             // TODO: This custom handling is temporary until interpreter has abstractions and
             //  support for privileged instructions
-            Err(ExecutionError::IllegalInstruction { address }) => {
+            FetchInstructionResult::Err(ExecutionError::IllegalInstruction { address }) => {
                 let address = address.get();
                 // Check for mret before treating as a trap - mret is a privileged instruction the
                 // interpreter doesn't implement, so it arrives here as an illegal instruction
@@ -612,7 +612,7 @@ fn run_rv64i_max_test(
                     }
                 }
             }
-            Err(error) => {
+            FetchInstructionResult::Err(error) => {
                 if state
                     .memory
                     .tohost_value::<RegisterType<AbundanceRv64IMaxInstruction>>(elf.tohost_addr)?

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -117,7 +117,9 @@ where
         for segment in elf.segments() {
             let data = match segment.data() {
                 Ok(d) if !d.is_empty() => d,
-                _ => continue,
+                _ => {
+                    continue;
+                }
             };
             let vaddr = segment.address();
             if vaddr < RAM_BASE {
@@ -178,31 +180,40 @@ where
 }
 
 #[derive(Debug)]
-enum TestError<RegType> {
+enum TestError<Address>
+where
+    Address: Copy,
+{
     HtifFail {
         exit_code: u64,
         detail: String,
     },
     SignatureMismatch {
         word: usize,
-        actual: RegType,
-        expected: RegType,
+        actual: Address,
+        expected: Address,
     },
     LengthMismatch {
         actual_bytes: usize,
         expected_bytes: usize,
     },
-    Execution(ExecutionError<RegType>),
+    Execution(ExecutionError<Address>),
     Test(anyhow::Error),
 }
 
-impl<RegType> From<ExecutionError<RegType>> for TestError<RegType> {
-    fn from(error: ExecutionError<RegType>) -> Self {
+impl<Address> From<ExecutionError<Address>> for TestError<Address>
+where
+    Address: Copy,
+{
+    fn from(error: ExecutionError<Address>) -> Self {
         Self::Execution(error)
     }
 }
 
-impl<RegType> From<anyhow::Error> for TestError<RegType> {
+impl<Address> From<anyhow::Error> for TestError<Address>
+where
+    Address: Copy,
+{
     fn from(error: anyhow::Error) -> Self {
         Self::Test(error)
     }
@@ -345,11 +356,16 @@ fn run_rv32i_max_test(
     loop {
         let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
             Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => break,
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => continue,
+            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+                break;
+            }
+            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+                continue;
+            }
             // TODO: This custom handling is temporary until interpreter has abstractions and
             //  support for privileged instructions
             Err(ExecutionError::IllegalInstruction { address }) => {
+                let address = address.get();
                 // Check for mret before treating as a trap - mret is a privileged instruction the
                 // interpreter doesn't implement, so it arrives here as an illegal instruction
                 let raw_instruction = state
@@ -379,7 +395,9 @@ fn run_rv32i_max_test(
                         address,
                         raw_instruction,
                     )
-                    .ok_or(ExecutionError::IllegalInstruction { address })?;
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(address),
+                    })?;
                 match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
                     ControlFlow::Continue(()) => {
                         continue;
@@ -419,8 +437,8 @@ fn run_rv32i_max_test(
             &mut state.instruction_fetcher,
             &mut state.system_instruction_handler,
         ) {
-            Ok(ControlFlow::Continue((rd, rd_value))) => {
-                state.regs.write(rd, rd_value);
+            ExecutionResult::Continue { rd, value } => {
+                state.regs.write(rd, value);
                 if state
                     .memory
                     .tohost_value::<RegisterType<AbundanceRv32IMaxInstruction>>(elf.tohost_addr)?
@@ -429,7 +447,27 @@ fn run_rv32i_max_test(
                     break;
                 }
             }
-            Ok(ControlFlow::Break(())) => {
+            ExecutionResult::Branch { offset } => {
+                match state.instruction_fetcher.set_pc_relative(
+                    &state.memory,
+                    instruction.size(),
+                    offset,
+                )? {
+                    ControlFlow::Continue(()) => {}
+                    ControlFlow::Break(()) => {
+                        break;
+                    }
+                }
+            }
+            ExecutionResult::Jump { target } => {
+                match state.instruction_fetcher.set_pc(&state.memory, target)? {
+                    ControlFlow::Continue(()) => {}
+                    ControlFlow::Break(()) => {
+                        break;
+                    }
+                }
+            }
+            ExecutionResult::Break => {
                 break;
             }
             // TODO: This custom handling is temporary until interpreter has abstractions and
@@ -445,7 +483,7 @@ fn run_rv32i_max_test(
             //   illegal, currently only `ecall` (IllegalEcallSystemInstructionHandler always
             //   rejects it - the interpreter has no other way to support it yet). Unlike the
             //   decode-time case, this one already carries the correct address.
-            Err(
+            ExecutionResult::Err(
                 error @ (ExecutionError::CsrReadOnly { .. }
                 | ExecutionError::CsrIllegalRead { .. }
                 | ExecutionError::CsrIllegalWrite { .. }
@@ -454,7 +492,7 @@ fn run_rv32i_max_test(
                 | ExecutionError::IllegalInstruction { .. }),
             ) => {
                 let address = match error {
-                    ExecutionError::IllegalInstruction { address } => address,
+                    ExecutionError::IllegalInstruction { address } => address.get(),
                     _ => ProgramCounter::<u32, BasicMemory<RAM_BASE, RAM_SIZE>>::old_pc(
                         &state.instruction_fetcher,
                         instruction.size(),
@@ -471,7 +509,9 @@ fn run_rv32i_max_test(
                         address,
                         raw_instruction,
                     )
-                    .ok_or(ExecutionError::IllegalInstruction { address })?;
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(address),
+                    })?;
                 match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
                     ControlFlow::Continue(()) => {}
                     ControlFlow::Break(()) => {
@@ -479,7 +519,7 @@ fn run_rv32i_max_test(
                     }
                 }
             }
-            Err(error) => {
+            ExecutionResult::Err(error) => {
                 if state
                     .memory
                     .tohost_value::<RegisterType<AbundanceRv32IMaxInstruction>>(elf.tohost_addr)?
@@ -521,11 +561,16 @@ fn run_rv64i_max_test(
     loop {
         let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
             Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => break,
-            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => continue,
+            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+                break;
+            }
+            Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+                continue;
+            }
             // TODO: This custom handling is temporary until interpreter has abstractions and
             //  support for privileged instructions
             Err(ExecutionError::IllegalInstruction { address }) => {
+                let address = address.get();
                 // Check for mret before treating as a trap - mret is a privileged instruction the
                 // interpreter doesn't implement, so it arrives here as an illegal instruction
                 let raw_instruction = state
@@ -555,7 +600,9 @@ fn run_rv64i_max_test(
                         address,
                         u64::from(raw_instruction),
                     )
-                    .ok_or(ExecutionError::IllegalInstruction { address })?;
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(address),
+                    })?;
                 match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
                     ControlFlow::Continue(()) => {
                         continue;
@@ -595,8 +642,8 @@ fn run_rv64i_max_test(
             &mut state.instruction_fetcher,
             &mut state.system_instruction_handler,
         ) {
-            Ok(ControlFlow::Continue((rd, rd_value))) => {
-                state.regs.write(rd, rd_value);
+            ExecutionResult::Continue { rd, value } => {
+                state.regs.write(rd, value);
                 if state
                     .memory
                     .tohost_value::<RegisterType<AbundanceRv64IMaxInstruction>>(elf.tohost_addr)?
@@ -605,7 +652,27 @@ fn run_rv64i_max_test(
                     break;
                 }
             }
-            Ok(ControlFlow::Break(())) => {
+            ExecutionResult::Branch { offset } => {
+                match state.instruction_fetcher.set_pc_relative(
+                    &state.memory,
+                    instruction.size(),
+                    offset,
+                )? {
+                    ControlFlow::Continue(()) => {}
+                    ControlFlow::Break(()) => {
+                        break;
+                    }
+                }
+            }
+            ExecutionResult::Jump { target } => {
+                match state.instruction_fetcher.set_pc(&state.memory, target)? {
+                    ControlFlow::Continue(()) => {}
+                    ControlFlow::Break(()) => {
+                        break;
+                    }
+                }
+            }
+            ExecutionResult::Break => {
                 break;
             }
             // TODO: This custom handling is temporary until interpreter has abstractions and
@@ -621,7 +688,7 @@ fn run_rv64i_max_test(
             //   illegal, currently only `ecall` (IllegalEcallSystemInstructionHandler always
             //   rejects it - the interpreter has no other way to support it yet). Unlike the
             //   decode-time case, this one already carries the correct address.
-            Err(
+            ExecutionResult::Err(
                 error @ (ExecutionError::CsrReadOnly { .. }
                 | ExecutionError::CsrIllegalRead { .. }
                 | ExecutionError::CsrIllegalWrite { .. }
@@ -630,7 +697,7 @@ fn run_rv64i_max_test(
                 | ExecutionError::IllegalInstruction { .. }),
             ) => {
                 let address = match error {
-                    ExecutionError::IllegalInstruction { address } => address,
+                    ExecutionError::IllegalInstruction { address } => address.get(),
                     _ => ProgramCounter::<u64, BasicMemory<RAM_BASE, RAM_SIZE>>::old_pc(
                         &state.instruction_fetcher,
                         instruction.size(),
@@ -647,7 +714,9 @@ fn run_rv64i_max_test(
                         address,
                         u64::from(raw_instruction),
                     )
-                    .ok_or(ExecutionError::IllegalInstruction { address })?;
+                    .ok_or(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(address),
+                    })?;
                 match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
                     ControlFlow::Continue(()) => {}
                     ControlFlow::Break(()) => {
@@ -655,7 +724,7 @@ fn run_rv64i_max_test(
                     }
                 }
             }
-            Err(error) => {
+            ExecutionResult::Err(error) => {
                 if state
                     .memory
                     .tohost_value::<RegisterType<AbundanceRv64IMaxInstruction>>(elf.tohost_addr)?

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -361,11 +361,7 @@ fn run_rv32i_max_test(
                         .ext_state
                         .read_csr(MCsr::Mepc as u16)
                         .map_err(ExecutionError::from)?;
-                    match state
-                        .instruction_fetcher
-                        .set_pc(&state.memory, mepc)
-                        .map_err(ExecutionError::from)?
-                    {
+                    match state.instruction_fetcher.set_pc(&state.memory, mepc)? {
                         ControlFlow::Continue(()) => {
                             continue;
                         }
@@ -384,11 +380,7 @@ fn run_rv32i_max_test(
                         raw_instruction,
                     )
                     .ok_or(ExecutionError::IllegalInstruction { address })?;
-                match state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, trap_pc)
-                    .map_err(ExecutionError::from)?
-                {
+                match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
                     ControlFlow::Continue(()) => {
                         continue;
                     }
@@ -454,7 +446,12 @@ fn run_rv32i_max_test(
             //   rejects it - the interpreter has no other way to support it yet). Unlike the
             //   decode-time case, this one already carries the correct address.
             Err(
-                error @ (ExecutionError::CsrError(_) | ExecutionError::IllegalInstruction { .. }),
+                error @ (ExecutionError::CsrReadOnly { .. }
+                | ExecutionError::CsrIllegalRead { .. }
+                | ExecutionError::CsrIllegalWrite { .. }
+                | ExecutionError::CsrUnknown { .. }
+                | ExecutionError::CsrInsufficientPrivilege { .. }
+                | ExecutionError::IllegalInstruction { .. }),
             ) => {
                 let address = match error {
                     ExecutionError::IllegalInstruction { address } => address,
@@ -475,11 +472,7 @@ fn run_rv32i_max_test(
                         raw_instruction,
                     )
                     .ok_or(ExecutionError::IllegalInstruction { address })?;
-                match state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, trap_pc)
-                    .map_err(ExecutionError::from)?
-                {
+                match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
                     ControlFlow::Continue(()) => {}
                     ControlFlow::Break(()) => {
                         break;
@@ -544,11 +537,7 @@ fn run_rv64i_max_test(
                         .ext_state
                         .read_csr(MCsr::Mepc as u16)
                         .map_err(ExecutionError::from)?;
-                    match state
-                        .instruction_fetcher
-                        .set_pc(&state.memory, mepc)
-                        .map_err(ExecutionError::from)?
-                    {
+                    match state.instruction_fetcher.set_pc(&state.memory, mepc)? {
                         ControlFlow::Continue(()) => {
                             continue;
                         }
@@ -567,11 +556,7 @@ fn run_rv64i_max_test(
                         u64::from(raw_instruction),
                     )
                     .ok_or(ExecutionError::IllegalInstruction { address })?;
-                match state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, trap_pc)
-                    .map_err(ExecutionError::from)?
-                {
+                match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
                     ControlFlow::Continue(()) => {
                         continue;
                     }
@@ -637,7 +622,12 @@ fn run_rv64i_max_test(
             //   rejects it - the interpreter has no other way to support it yet). Unlike the
             //   decode-time case, this one already carries the correct address.
             Err(
-                error @ (ExecutionError::CsrError(_) | ExecutionError::IllegalInstruction { .. }),
+                error @ (ExecutionError::CsrReadOnly { .. }
+                | ExecutionError::CsrIllegalRead { .. }
+                | ExecutionError::CsrIllegalWrite { .. }
+                | ExecutionError::CsrUnknown { .. }
+                | ExecutionError::CsrInsufficientPrivilege { .. }
+                | ExecutionError::IllegalInstruction { .. }),
             ) => {
                 let address = match error {
                     ExecutionError::IllegalInstruction { address } => address,
@@ -658,11 +648,7 @@ fn run_rv64i_max_test(
                         u64::from(raw_instruction),
                     )
                     .ok_or(ExecutionError::IllegalInstruction { address })?;
-                match state
-                    .instruction_fetcher
-                    .set_pc(&state.memory, trap_pc)
-                    .map_err(ExecutionError::from)?
-                {
+                match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
                     ControlFlow::Continue(()) => {}
                     ControlFlow::Break(()) => {
                         break;

--- a/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
+++ b/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
@@ -185,7 +185,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .instruction_fetcher
                     .set_pc(&lazy_state.memory, benchmarks_blake3_hash_chunk_addr)
                     .unwrap()
-                    .continue_ok()
+                    .continue_value()
                     .unwrap();
                 lazy_state.regs.write(Register::A0, internal_args_addr);
                 // Stack is between internal arguments and contract memory
@@ -201,7 +201,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .instruction_fetcher
                     .set_pc(&eager_state.memory, benchmarks_blake3_hash_chunk_addr)
                     .unwrap()
-                    .continue_ok()
+                    .continue_value()
                     .unwrap();
                 eager_state.regs.write(Register::A0, internal_args_addr);
                 // Stack is between internal arguments and contract memory
@@ -259,7 +259,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .instruction_fetcher
                     .set_pc(&lazy_state.memory, benchmarks_ed25519_verify_addr)
                     .unwrap()
-                    .continue_ok()
+                    .continue_value()
                     .unwrap();
                 lazy_state.regs.write(Register::A0, internal_args_addr);
                 // Stack is between internal arguments and contract memory
@@ -275,7 +275,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     .instruction_fetcher
                     .set_pc(&eager_state.memory, benchmarks_ed25519_verify_addr)
                     .unwrap()
-                    .continue_ok()
+                    .continue_value()
                     .unwrap();
                 eager_state.regs.write(Register::A0, internal_args_addr);
                 // Stack is between internal arguments and contract memory

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -280,6 +280,17 @@ where
         self.pc
     }
 
+    #[inline(always)]
+    fn set_pc_relative(
+        &mut self,
+        memory: &Memory,
+        instruction_size: u8,
+        offset: i32,
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+        let old_pc = <Self as ProgramCounter<_, Memory, _>>::old_pc(self, instruction_size);
+        self.set_pc(memory, old_pc.wrapping_add_signed(i64::from(offset)))
+    }
+
     #[inline]
     fn set_pc(&mut self, memory: &Memory, pc: u64) -> Result<ControlFlow<()>, ExecutionError<u64>> {
         if pc == self.return_trap_address {
@@ -291,7 +302,9 @@ where
             ContractInstruction::<ContractRegister>::alignment(),
         )) {
             cold_path();
-            return Err(ExecutionError::UnalignedInstruction { address: pc });
+            return Err(ExecutionError::UnalignedInstruction {
+                address: PackedAddress::new(pc),
+            });
         }
 
         // Note: This will not allow reading a 16-bit instruction at the very end of memory range,
@@ -372,6 +385,52 @@ where
                 / size_of::<ContractInstruction>() as u64
     }
 
+    /// Moves within the decoded stream instead of resolving an address and converting it back,
+    /// which is what going through [`Self::set_pc()`] would do.
+    ///
+    /// One comparison and one test are all this needs to hand every case it does not handle itself
+    /// over to [`Self::set_pc()`]: a target past the end of the decoded stream, a backwards branch
+    /// that ran off its start, and an unaligned target. The return trap sits outside the decoded
+    /// stream, so a branch to it fails the bounds check here and is stopped by [`Self::set_pc()`]
+    /// like any other jump to it.
+    #[inline(always)]
+    fn set_pc_relative(
+        &mut self,
+        memory: &Memory,
+        instruction_size: u8,
+        offset: i32,
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+        // Byte offset from the instruction being executed to the branch target. The program counter
+        // is advanced during instruction fetching, so that instruction starts `instruction_size`
+        // bytes back.
+        let offset = offset as isize - isize::from(instruction_size);
+        // Every `size_of::<u16>()` of guest code owns one decoded instruction, so the target is
+        // reached by moving within the decoded stream
+        let decoded_instruction_byte_offset =
+            self.decoded_instruction_byte_offset.wrapping_add_signed(
+                offset * (size_of::<ContractInstruction>() / size_of::<u16>()).cast_signed(),
+            );
+
+        // A target that does not land on a decoded instruction sits between two guest
+        // instructions, which makes it an unaligned instruction rather than something to round to
+        // the start of one. That rule lives in `set_pc()`, so rather than restating it here, where
+        // it could drift, such a target simply fails to qualify for the fast path, as does one past
+        // the end of the decoded stream, which a backwards branch that ran off its start wraps
+        // around into.
+        if decoded_instruction_byte_offset
+            >= self.instructions.len() * size_of::<ContractInstruction>()
+            || !decoded_instruction_byte_offset.is_multiple_of(size_of::<ContractInstruction>())
+        {
+            cold_path();
+            let pc = <Self as ProgramCounter<_, Memory>>::get_pc(self);
+            return self.set_pc(memory, pc.wrapping_add_signed(offset as i64));
+        }
+
+        self.decoded_instruction_byte_offset = decoded_instruction_byte_offset;
+
+        Ok(ControlFlow::Continue(()))
+    }
+
     #[inline]
     fn set_pc(
         &mut self,
@@ -387,12 +446,16 @@ where
 
         if !address.is_multiple_of(size_of::<u16>() as u64) {
             cold_path();
-            return Err(ExecutionError::UnalignedInstruction { address });
+            return Err(ExecutionError::UnalignedInstruction {
+                address: PackedAddress::new(address),
+            });
         }
 
         let Some(offset) = address.checked_sub(self.base_addr) else {
             cold_path();
-            return Err(ExecutionError::OutOfBoundsRead { address });
+            return Err(ExecutionError::OutOfBoundsRead {
+                address: PackedAddress::new(address),
+            });
         };
         let offset = offset as usize;
         let instruction_offset = offset / size_of::<u16>();
@@ -447,7 +510,9 @@ impl EagerTestInstructionFetcher {
     ///
     /// # Safety
     /// The program counter must be valid and aligned, the instructions processed must end with a
-    /// jump instruction.
+    /// jump instruction, and `return_trap_address` must not fall inside them. Instruction fetching
+    /// does not compare against the return trap, so an address inside the instructions would stop
+    /// execution when jumped to but not when reached by falling through.
     #[inline(always)]
     pub unsafe fn new(
         instructions: &[u8],
@@ -527,10 +592,11 @@ impl EagerTestInstructionFetcher {
             ));
         }
 
+        let instructions = decoded_instructions.into_boxed_slice();
         Self {
             decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
                 * size_of::<ContractInstruction>(),
-            instructions: decoded_instructions.into_boxed_slice(),
+            instructions,
             base_addr,
             return_trap_address,
         }

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -329,7 +329,7 @@ where
     fn fetch_instruction(
         &mut self,
         memory: &Memory,
-    ) -> Result<FetchInstructionResult<ContractInstruction>, ExecutionError<u64>> {
+    ) -> FetchInstructionResult<ContractInstruction> {
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
         // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
@@ -340,7 +340,7 @@ where
 
         self.pc += u64::from(instruction.size());
 
-        Ok(FetchInstructionResult::Instruction(instruction))
+        FetchInstructionResult::Instruction(instruction)
     }
 }
 
@@ -480,7 +480,7 @@ where
     fn fetch_instruction(
         &mut self,
         _memory: &Memory,
-    ) -> Result<FetchInstructionResult<ContractInstruction>, ExecutionError<u64>> {
+    ) -> FetchInstructionResult<ContractInstruction> {
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
         // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
@@ -495,7 +495,7 @@ where
         self.decoded_instruction_byte_offset +=
             usize::from(instruction.size()) / size_of::<u16>() * size_of::<ContractInstruction>();
 
-        Ok(FetchInstructionResult::Instruction(instruction))
+        FetchInstructionResult::Instruction(instruction)
     }
 }
 

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -281,11 +281,7 @@ where
     }
 
     #[inline]
-    fn set_pc(
-        &mut self,
-        memory: &Memory,
-        pc: u64,
-    ) -> Result<ControlFlow<()>, ProgramCounterError<u64>> {
+    fn set_pc(&mut self, memory: &Memory, pc: u64) -> Result<ControlFlow<()>, ExecutionError<u64>> {
         if pc == self.return_trap_address {
             cold_path();
             return Ok(ControlFlow::Break(()));
@@ -295,7 +291,7 @@ where
             ContractInstruction::<ContractRegister>::alignment(),
         )) {
             cold_path();
-            return Err(ProgramCounterError::UnalignedInstruction { address: pc });
+            return Err(ExecutionError::UnalignedInstruction { address: pc });
         }
 
         // Note: This will not allow reading a 16-bit instruction at the very end of memory range,
@@ -381,7 +377,7 @@ where
         &mut self,
         _memory: &Memory,
         pc: u64,
-    ) -> Result<ControlFlow<()>, ProgramCounterError<u64>> {
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
         let address = pc;
 
         if address == self.return_trap_address {
@@ -391,14 +387,12 @@ where
 
         if !address.is_multiple_of(size_of::<u16>() as u64) {
             cold_path();
-            return Err(ProgramCounterError::UnalignedInstruction { address });
+            return Err(ExecutionError::UnalignedInstruction { address });
         }
 
         let Some(offset) = address.checked_sub(self.base_addr) else {
             cold_path();
-            return Err(ProgramCounterError::MemoryAccess(
-                VirtualMemoryError::OutOfBoundsRead { address },
-            ));
+            return Err(ExecutionError::OutOfBoundsRead { address });
         };
         let offset = offset as usize;
         let instruction_offset = offset / size_of::<u16>();

--- a/crates/execution/ab-riscv-benchmarks/tests/instruction_fetcher.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/instruction_fetcher.rs
@@ -1,0 +1,162 @@
+//! Tests for [`EagerTestInstructionFetcher`]'s relative branch handling.
+//!
+//! [`ProgramCounter::set_pc_relative()`] moves within the decoded instruction stream rather than
+//! resolving an address and converting it back, and its fast path deliberately skips the checks
+//! [`ProgramCounter::set_pc()`] does. These tests pin down that the cases it skips are still
+//! handled: the return trap, branches past the end of the stream, branches off its start and
+//! unaligned targets.
+
+use ab_riscv_benchmarks::host_utils::{EagerTestInstructionFetcher, TestMemory};
+use ab_riscv_interpreter::prelude::*;
+use core::ops::ControlFlow;
+
+const MEMORY_BASE_ADDRESS: u64 = 0x1000;
+const MEMORY_SIZE: usize = 4 * 1024;
+/// Address of the first instruction of [`code()`]
+const BASE_ADDR: u64 = MEMORY_BASE_ADDRESS;
+
+type Memory = TestMemory<MEMORY_BASE_ADDRESS, MEMORY_SIZE>;
+
+/// `addi x0, x0, 0`, the canonical `nop`
+const NOP: u32 = 0x0000_0013;
+/// `jalr x0, 0(x1)`, the canonical `ret`, so that the stream ends with a jump as the constructor
+/// requires
+const RET: u32 = 0x0000_8067;
+
+/// Five 4-byte instructions at `BASE_ADDR`, `BASE_ADDR + 4`, ... `BASE_ADDR + 16`
+fn code() -> Vec<u8> {
+    [NOP, NOP, NOP, NOP, RET]
+        .iter()
+        .flat_map(|instruction| instruction.to_le_bytes())
+        .collect()
+}
+
+/// Address one past the last instruction
+const END_ADDR: u64 = BASE_ADDR + 5 * 4;
+
+/// Build a fetcher whose program counter sits just after the instruction at `BASE_ADDR + 4`, which
+/// is the state relative branches are resolved from: the program counter is advanced during
+/// instruction fetching, so `set_pc_relative(_, 4, offset)` branches from `BASE_ADDR + 4`
+fn new_fetcher(return_trap_address: u64) -> EagerTestInstructionFetcher {
+    // SAFETY: Program counter is valid and aligned, the instruction stream ends with a jump
+    unsafe {
+        EagerTestInstructionFetcher::new(&code(), return_trap_address, BASE_ADDR, BASE_ADDR + 8)
+    }
+}
+
+/// Branch by `offset` from the instruction at `BASE_ADDR + 4`
+fn branch(
+    fetcher: &mut EagerTestInstructionFetcher,
+    offset: i32,
+) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+    let memory = Memory::default();
+    fetcher.set_pc_relative(&memory, 4, offset)
+}
+
+#[test]
+fn forward_and_backward_branches_move_within_the_stream() {
+    let mut fetcher = new_fetcher(0);
+
+    assert!(
+        matches!(branch(&mut fetcher, 8), Ok(ControlFlow::Continue(()))),
+        "Expected Continue"
+    );
+    assert_eq!(
+        ProgramCounter::<u64, Memory>::get_pc(&fetcher),
+        BASE_ADDR + 12
+    );
+
+    // Now branching from `BASE_ADDR + 8`, back to the very first instruction
+    assert!(
+        matches!(branch(&mut fetcher, -8), Ok(ControlFlow::Continue(()))),
+        "Expected Continue"
+    );
+    assert_eq!(ProgramCounter::<u64, Memory>::get_pc(&fetcher), BASE_ADDR);
+}
+
+#[test]
+fn branch_to_the_last_instruction_stays_in_bounds() {
+    let mut fetcher = new_fetcher(0);
+
+    assert!(
+        matches!(branch(&mut fetcher, 12), Ok(ControlFlow::Continue(()))),
+        "Expected Continue"
+    );
+    assert_eq!(
+        ProgramCounter::<u64, Memory>::get_pc(&fetcher),
+        END_ADDR - 4
+    );
+}
+
+#[test]
+fn branch_to_a_trap_below_the_stream_stops_execution() {
+    // The usual arrangement: the trap sentinel sits outside the guest's code
+    let mut fetcher = new_fetcher(0);
+
+    // From `BASE_ADDR + 4` down to address 0
+    let offset = -i32::try_from(BASE_ADDR + 4).unwrap();
+    assert!(
+        matches!(branch(&mut fetcher, offset), Ok(ControlFlow::Break(()))),
+        "Expected Break"
+    );
+}
+
+#[test]
+fn branch_to_a_trap_above_the_stream_stops_execution() {
+    let mut fetcher = new_fetcher(END_ADDR + 4);
+
+    let offset = i32::try_from(END_ADDR + 4 - (BASE_ADDR + 4)).unwrap();
+    assert!(
+        matches!(branch(&mut fetcher, offset), Ok(ControlFlow::Break(()))),
+        "Expected Break"
+    );
+}
+
+#[test]
+fn branch_past_the_end_of_the_stream_is_out_of_bounds() {
+    let mut fetcher = new_fetcher(0);
+
+    let error = branch(&mut fetcher, 1024).unwrap_err();
+    assert!(
+        matches!(error, ExecutionError::OutOfBoundsRead { address } if address.get() == BASE_ADDR + 4 + 1024),
+        "Unexpected error {error:?}"
+    );
+}
+
+#[test]
+fn branch_off_the_start_of_the_stream_is_out_of_bounds() {
+    let mut fetcher = new_fetcher(0);
+
+    // Lands below `BASE_ADDR`, which underflows the stream rather than wrapping into it
+    let error = branch(&mut fetcher, -1024).unwrap_err();
+    assert!(
+        matches!(error, ExecutionError::OutOfBoundsRead { address } if address.get() == BASE_ADDR + 4 - 1024),
+        "Unexpected error {error:?}"
+    );
+}
+
+#[test]
+fn branch_to_an_unaligned_target_is_rejected() {
+    // Branch immediates encode a halfword count, so the decoder cannot produce an odd offset and
+    // this is not reachable through instruction execution. It is still the rule `set_pc()` applies,
+    // and the fast path must not quietly round such a target to a slot boundary instead.
+    let mut fetcher = new_fetcher(0);
+
+    let error = branch(&mut fetcher, 3).unwrap_err();
+    assert!(
+        matches!(error, ExecutionError::UnalignedInstruction { address } if address.get() == BASE_ADDR + 7),
+        "Unexpected error {error:?}"
+    );
+}
+
+#[test]
+fn branch_that_wraps_around_the_address_space_is_out_of_bounds() {
+    let mut fetcher = new_fetcher(0);
+
+    // Far enough back that the guest address itself wraps around zero
+    let error = branch(&mut fetcher, i32::MIN).unwrap_err();
+    assert!(
+        matches!(error, ExecutionError::OutOfBoundsRead { address: _ }),
+        "Unexpected error {error:?}"
+    );
+}

--- a/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
@@ -78,7 +78,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -154,6 +154,52 @@ where
                 / size_of::<CoremarkInstruction>() as u64
     }
 
+    /// Moves within the decoded stream instead of resolving an address and converting it back,
+    /// which is what going through [`Self::set_pc()`] would do.
+    ///
+    /// One comparison and one test are all this needs to hand every case it does not handle itself
+    /// over to [`Self::set_pc()`]: a target past the end of the decoded stream, a backwards branch
+    /// that ran off its start, and an unaligned target. The return trap sits outside the decoded
+    /// stream, so a branch to it fails the bounds check here and is stopped by [`Self::set_pc()`]
+    /// like any other jump to it.
+    #[inline(always)]
+    fn set_pc_relative(
+        &mut self,
+        memory: &Memory,
+        instruction_size: u8,
+        offset: i32,
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+        // Byte offset from the instruction being executed to the branch target. The program counter
+        // is advanced during instruction fetching, so that instruction starts `instruction_size`
+        // bytes back.
+        let offset = offset as isize - isize::from(instruction_size);
+        // Every `size_of::<u16>()` of guest code owns one decoded instruction, so the target is
+        // reached by moving within the decoded stream
+        let decoded_instruction_byte_offset =
+            self.decoded_instruction_byte_offset.wrapping_add_signed(
+                offset * (size_of::<CoremarkInstruction>() / size_of::<u16>()).cast_signed(),
+            );
+
+        // A target that does not land on a decoded instruction sits between two guest
+        // instructions, which makes it an unaligned instruction rather than something to round to
+        // the start of one. That rule lives in `set_pc()`, so rather than restating it here, where
+        // it could drift, such a target simply fails to qualify for the fast path, as does one past
+        // the end of the decoded stream, which a backwards branch that ran off its start wraps
+        // around into.
+        if decoded_instruction_byte_offset
+            >= self.instructions.len() * size_of::<CoremarkInstruction>()
+            || !decoded_instruction_byte_offset.is_multiple_of(size_of::<CoremarkInstruction>())
+        {
+            cold_path();
+            let pc = <Self as ProgramCounter<_, Memory>>::get_pc(self);
+            return self.set_pc(memory, pc.wrapping_add_signed(offset as i64));
+        }
+
+        self.decoded_instruction_byte_offset = decoded_instruction_byte_offset;
+
+        Ok(ControlFlow::Continue(()))
+    }
+
     #[inline]
     fn set_pc(
         &mut self,
@@ -169,12 +215,16 @@ where
 
         if !address.is_multiple_of(size_of::<u16>() as u64) {
             cold_path();
-            return Err(ExecutionError::UnalignedInstruction { address });
+            return Err(ExecutionError::UnalignedInstruction {
+                address: PackedAddress::new(address),
+            });
         }
 
         let Some(offset) = address.checked_sub(self.base_addr) else {
             cold_path();
-            return Err(ExecutionError::OutOfBoundsRead { address });
+            return Err(ExecutionError::OutOfBoundsRead {
+                address: PackedAddress::new(address),
+            });
         };
         let offset = offset as usize;
         let instruction_offset = offset / size_of::<u16>();
@@ -226,7 +276,9 @@ impl EagerInstructionFetcher {
     ///
     /// # Safety
     /// The program counter must be valid and aligned, the instructions processed must end with a
-    /// jump instruction.
+    /// jump instruction, and `return_trap_address` must not fall inside them. Instruction fetching
+    /// does not compare against the return trap, so an address inside the instructions would stop
+    /// execution when jumped to but not when reached by falling through.
     #[inline(always)]
     pub(super) unsafe fn new(
         instructions: &[u8],
@@ -306,10 +358,11 @@ impl EagerInstructionFetcher {
             ));
         }
 
+        let instructions = decoded_instructions.into_boxed_slice();
         Self {
             decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
                 * size_of::<CoremarkInstruction>(),
-            instructions: decoded_instructions.into_boxed_slice(),
+            instructions,
             base_addr,
             return_trap_address,
         }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -159,7 +159,7 @@ where
         &mut self,
         _memory: &Memory,
         pc: u64,
-    ) -> Result<ControlFlow<()>, ProgramCounterError<u64>> {
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
         let address = pc;
 
         if address == self.return_trap_address {
@@ -169,14 +169,12 @@ where
 
         if !address.is_multiple_of(size_of::<u16>() as u64) {
             cold_path();
-            return Err(ProgramCounterError::UnalignedInstruction { address });
+            return Err(ExecutionError::UnalignedInstruction { address });
         }
 
         let Some(offset) = address.checked_sub(self.base_addr) else {
             cold_path();
-            return Err(ProgramCounterError::MemoryAccess(
-                VirtualMemoryError::OutOfBoundsRead { address },
-            ));
+            return Err(ExecutionError::OutOfBoundsRead { address });
         };
         let offset = offset as usize;
         let instruction_offset = offset / size_of::<u16>();

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -249,7 +249,7 @@ where
     fn fetch_instruction(
         &mut self,
         _memory: &Memory,
-    ) -> Result<FetchInstructionResult<CoremarkInstruction>, ExecutionError<u64>> {
+    ) -> FetchInstructionResult<CoremarkInstruction> {
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
         // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
@@ -264,7 +264,7 @@ where
         self.decoded_instruction_byte_offset +=
             usize::from(instruction.size()) / size_of::<u16>() * size_of::<CoremarkInstruction>();
 
-        Ok(FetchInstructionResult::Instruction(instruction))
+        FetchInstructionResult::Instruction(instruction)
     }
 }
 

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -4,7 +4,6 @@ use ab_riscv_interpreter::prelude::*;
 use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
-use core::ops::ControlFlow;
 use std::time::Instant;
 
 /// State for the counter CSR (time-only)
@@ -157,7 +156,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -155,16 +155,16 @@ impl<Regs, ExtState, Memory, IF, InstructionHandler>
             |mut instruction_fetcher| {
                 loop {
                     let instruction = match instruction_fetcher.fetch_instruction(&self.memory) {
-                        Ok(FetchInstructionResult::Instruction(instruction)) => instruction,
-                        Ok(FetchInstructionResult::ControlFlow(ControlFlow::Continue(()))) => {
+                        FetchInstructionResult::Instruction(instruction) => instruction,
+                        FetchInstructionResult::Continue => {
                             cold_path();
                             continue;
                         }
-                        Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(()))) => {
+                        FetchInstructionResult::Break => {
                             cold_path();
                             break;
                         }
-                        Err(error) => {
+                        FetchInstructionResult::Err(error) => {
                             cold_path();
                             return (Err(error), instruction_fetcher);
                         }
@@ -494,10 +494,7 @@ where
 {
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
-    fn fetch_instruction(
-        &mut self,
-        memory: &Memory,
-    ) -> Result<FetchInstructionResult<I>, ExecutionError<Address<I>, CustomError>> {
+    fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I, CustomError> {
         let instruction = match memory.read(self.pc.as_u64()).or_else(const |error| {
             cold_path();
             // Attempt to read a 16-bit compressed instruction
@@ -511,19 +508,19 @@ where
             Ok(instruction) => instruction,
             Err(error) => {
                 cold_path();
-                return Err(ExecutionError::from(error));
+                return FetchInstructionResult::Err(ExecutionError::from(error));
             }
         };
 
         let Some(instruction) = I::try_decode(instruction) else {
             cold_path();
-            return Err(ExecutionError::IllegalInstruction {
+            return FetchInstructionResult::Err(ExecutionError::IllegalInstruction {
                 address: PackedAddress::new(self.pc),
             });
         };
         self.pc += instruction.size().into();
 
-        Ok(FetchInstructionResult::Instruction(instruction))
+        FetchInstructionResult::Instruction(instruction)
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -6,9 +6,8 @@ mod tests;
 use crate::zawrs::WrsHandler;
 use crate::{
     Address, BasicInt, CustomErrorPlaceholder, ExecutableInstruction, ExecutionError,
-    FetchInstructionResult, InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 #[cfg(feature = "alloc")]
@@ -435,7 +434,7 @@ where
         &mut self,
         _memory: &Memory,
         pc: Address<I>,
-    ) -> Result<ControlFlow<()>, ProgramCounterError<Address<I>, CustomError>> {
+    ) -> Result<ControlFlow<()>, ExecutionError<Address<I>, CustomError>> {
         if pc == self.return_trap_address {
             cold_path();
             return Ok(ControlFlow::Break(()));
@@ -443,7 +442,7 @@ where
 
         if !pc.as_u64().is_multiple_of(u64::from(I::alignment())) {
             cold_path();
-            return Err(ProgramCounterError::UnalignedInstruction { address: pc });
+            return Err(ExecutionError::UnalignedInstruction { address: pc });
         }
 
         self.pc = pc;
@@ -477,7 +476,7 @@ where
             Ok(instruction) => instruction,
             Err(error) => {
                 cold_path();
-                return Err(ExecutionError::MemoryAccess(error));
+                return Err(ExecutionError::from(error));
             }
         };
 

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -6,8 +6,9 @@ mod tests;
 use crate::zawrs::WrsHandler;
 use crate::{
     Address, BasicInt, CustomErrorPlaceholder, ExecutableInstruction, ExecutionError,
-    FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 #[cfg(feature = "alloc")]
@@ -175,17 +176,38 @@ impl<Regs, ExtState, Memory, IF, InstructionHandler>
                         rs2_value: self.regs.read(rs2),
                     };
 
-                    match instruction.execute(
+                    let outcome = instruction.execute(
                         rs1rs2_values,
                         &mut self.regs,
                         &mut self.ext_state,
                         &mut self.memory,
                         &mut instruction_fetcher,
                         &mut self.system_instruction_handler,
-                    ) {
-                        Ok(ControlFlow::Continue((rd, rd_value))) => {
-                            self.regs.write(rd, rd_value);
-                        }
+                    );
+
+                    let control_flow =
+                        match outcome {
+                            ExecutionResult::Continue { rd, value } => {
+                                self.regs.write(rd, value);
+                                continue;
+                            }
+                            ExecutionResult::Branch { offset } => instruction_fetcher
+                                .set_pc_relative(&self.memory, instruction.size(), offset),
+                            ExecutionResult::Jump { target } => {
+                                instruction_fetcher.set_pc(&self.memory, target)
+                            }
+                            ExecutionResult::Break => {
+                                cold_path();
+                                break;
+                            }
+                            ExecutionResult::Err(error) => {
+                                cold_path();
+                                return (Err(error), instruction_fetcher);
+                            }
+                        };
+
+                    match control_flow {
+                        Ok(ControlFlow::Continue(())) => {}
                         Ok(ControlFlow::Break(())) => {
                             cold_path();
                             break;
@@ -428,6 +450,17 @@ where
         self.pc
     }
 
+    #[inline(always)]
+    fn set_pc_relative(
+        &mut self,
+        memory: &Memory,
+        instruction_size: u8,
+        offset: i32,
+    ) -> Result<ControlFlow<()>, ExecutionError<Address<I>, CustomError>> {
+        let old_pc = <Self as ProgramCounter<_, Memory, _>>::old_pc(self, instruction_size);
+        self.set_pc(memory, old_pc.wrapping_add_signed(offset))
+    }
+
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn set_pc(
@@ -442,7 +475,9 @@ where
 
         if !pc.as_u64().is_multiple_of(u64::from(I::alignment())) {
             cold_path();
-            return Err(ExecutionError::UnalignedInstruction { address: pc });
+            return Err(ExecutionError::UnalignedInstruction {
+                address: PackedAddress::new(pc),
+            });
         }
 
         self.pc = pc;
@@ -482,7 +517,9 @@ where
 
         let Some(instruction) = I::try_decode(instruction) else {
             cold_path();
-            return Err(ExecutionError::IllegalInstruction { address: self.pc });
+            return Err(ExecutionError::IllegalInstruction {
+                address: PackedAddress::new(self.pc),
+            });
         };
         self.pc += instruction.size().into();
 
@@ -528,7 +565,7 @@ where
         program_counter: &mut PC,
     ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
         Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(size_of::<u32>() as u8),
+            address: PackedAddress::new(program_counter.old_pc(size_of::<u32>() as u8)),
         })
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -695,12 +695,19 @@ where
 }
 
 /// Result of [`InstructionFetcher::fetch_instruction()`] call
-#[derive(Debug, Copy, Clone)]
-pub enum FetchInstructionResult<Instruction> {
-    /// Instruction fetched successfully
-    Instruction(Instruction),
-    /// Control flow instruction encountered
-    ControlFlow(ControlFlow<()>),
+#[derive(Debug)]
+pub enum FetchInstructionResult<I, CustomError = CustomErrorPlaceholder>
+where
+    I: Instruction,
+{
+    /// Instruction to execute
+    Instruction(I),
+    /// Nothing to execute here, carry on from wherever the program counter now points
+    Continue,
+    /// Stop execution
+    Break,
+    /// Fetching failed
+    Err(ExecutionError<Address<I>, CustomError>),
 }
 
 /// Generic instruction fetcher
@@ -711,10 +718,7 @@ where
 {
     /// Fetch a single instruction at a specified address and advance the program counter on
     /// successful fetch
-    fn fetch_instruction(
-        &mut self,
-        memory: &Memory,
-    ) -> Result<FetchInstructionResult<I>, ExecutionError<Address<I>, CustomError>>;
+    fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I, CustomError>;
 }
 
 /// CSR error

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -108,6 +108,7 @@
     macroless_generic_const_args,
     min_generic_const_args,
     signed_bigint_helpers,
+    try_trait_v2,
     widening_mul
 )]
 #![cfg_attr(test, feature(try_blocks))]
@@ -162,6 +163,8 @@ pub mod prelude;
 mod private;
 pub mod rv32;
 pub mod rv64;
+#[cfg(test)]
+mod tests;
 pub mod v;
 pub mod zawrs;
 pub mod zicond;
@@ -177,9 +180,11 @@ use crate::private::BasicIntSealed;
 use ab_riscv_primitives::prelude::*;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+use core::convert::Infallible;
 use core::fmt;
+use core::hint::cold_path;
 use core::marker::Destruct;
-use core::ops::{ControlFlow, Sub};
+use core::ops::{ControlFlow, FromResidual, Sub};
 
 type RegisterType<I> = <<I as Instruction>::Reg as Register>::Type;
 type Address<I> = RegisterType<I>;
@@ -323,7 +328,10 @@ impl fmt::Display for CustomErrorPlaceholder {
 }
 
 /// Generic program counter
-pub const trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder> {
+pub const trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder>
+where
+    Address: Copy,
+{
     /// Get the current value of the program counter
     fn get_pc(&self) -> Address;
 
@@ -343,12 +351,91 @@ pub const trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceho
         self.get_pc() - Address::from(instruction_size)
     }
 
+    /// Apply [`ExecutionResult::Branch`], continuing `offset` bytes from the instruction being
+    /// executed.
+    ///
+    /// A simple implementation can resolve the offset against the program counter and call
+    /// [`Self::set_pc()`]. Implementation that keeps the program counter as a position in an
+    /// already decoded instruction stream can move within that stream directly, which avoids
+    /// converting an address back into a position.
+    fn set_pc_relative(
+        &mut self,
+        memory: &Memory,
+        instruction_size: u8,
+        offset: i32,
+    ) -> Result<ControlFlow<()>, ExecutionError<Address, CustomError>>;
+
     /// Set the current value of the program counter
     fn set_pc(
         &mut self,
         memory: &Memory,
         pc: Address,
     ) -> Result<ControlFlow<()>, ExecutionError<Address, CustomError>>;
+}
+
+/// Address wrapper for [`ExecutionError`] with an alignment of 4 rather than its natural one.
+///
+/// This is needed for [`ExecutionResult`] that contains [`ExecutionError`] to fit within 16 bytes
+/// or two native registers on 64-bit platforms.
+#[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(C, packed(4))]
+pub struct PackedAddress<Address>(Address);
+
+impl<Address> PackedAddress<Address>
+where
+    Address: Copy,
+{
+    /// Create a new instance
+    #[inline(always)]
+    pub const fn new(address: Address) -> Self {
+        Self(address)
+    }
+
+    /// Read the address back
+    #[inline(always)]
+    pub const fn get(self) -> Address {
+        self.0
+    }
+}
+
+const impl<Address> From<Address> for PackedAddress<Address>
+where
+    Address: Copy + [const] Destruct,
+{
+    #[inline(always)]
+    fn from(address: Address) -> Self {
+        Self(address)
+    }
+}
+
+impl<Address> fmt::Debug for PackedAddress<Address>
+where
+    Address: fmt::Debug + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let address = self.0;
+        fmt::Debug::fmt(&address, f)
+    }
+}
+
+impl<Address> fmt::Display for PackedAddress<Address>
+where
+    Address: fmt::Display + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let address = self.0;
+        fmt::Display::fmt(&address, f)
+    }
+}
+
+impl<Address> fmt::LowerHex for PackedAddress<Address>
+where
+    Address: fmt::LowerHex + Copy,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let address = self.0;
+        fmt::LowerHex::fmt(&address, f)
+    }
 }
 
 /// Execution errors.
@@ -361,44 +448,39 @@ pub const trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceho
 ///
 /// Note that a large `CustomError` will grow this type past that threshold again.
 #[derive(Debug, thiserror::Error)]
-pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder> {
+pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder>
+where
+    Address: Copy,
+{
     /// Unaligned instruction
     #[error("Unaligned instruction at address {address}")]
     UnalignedInstruction {
         /// Address of the unaligned instruction fetch
-        address: Address,
+        address: PackedAddress<Address>,
     },
     /// Out-of-bounds read
     #[error("Out-of-bounds read at address {address}")]
     OutOfBoundsRead {
         /// Address of the out-of-bounds read
-        address: u64,
+        address: PackedAddress<u64>,
     },
     /// Out-of-bounds write
     #[error("Out-of-bounds write at address {address}")]
     OutOfBoundsWrite {
         /// Address of the out-of-bounds write
-        address: u64,
+        address: PackedAddress<u64>,
     },
     /// Unsupported `ecall` instruction
     #[error("Unsupported `ecall` instruction at address {address:#x}")]
     EcallUnsupported {
         /// Address of the unsupported instruction
-        address: Address,
+        address: PackedAddress<Address>,
     },
     /// Unimplemented/illegal instruction
     #[error("Unimplemented/illegal instruction at address {address:#x}")]
     IllegalInstruction {
         /// Address of the `unimp` instruction
-        address: Address,
-    },
-    /// Invalid instruction
-    #[error("Invalid instruction at address {address:#x}: {instruction:#010x}")]
-    InvalidInstruction {
-        /// Address of the invalid instruction
-        address: Address,
-        /// Instruction that caused the error
-        instruction: u32,
+        address: PackedAddress<Address>,
     },
     /// Read only CSR
     #[error("Read only CSR {csr_index:#x}")]
@@ -442,17 +524,145 @@ pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder> {
     Custom(CustomError),
 }
 
-const {
-    // Ensure error type retains its size
-    assert!(size_of::<ExecutionError<u64>>() == 16);
+/// Where execution continues after an instruction, or why it could not.
+///
+/// Instructions describe control flow rather than performing it: they say where execution goes next
+/// instead of moving the program counter themselves. This keeps instruction bodies independent of
+/// how the program counter is represented, which is what allows the same bodies to drive both an
+/// interpreter loop that owns a program counter and one that carries it in a register.
+#[derive(Debug)]
+pub enum ExecutionResult<Reg, CustomError = CustomErrorPlaceholder>
+where
+    Reg: Register,
+{
+    /// Write the register and continue with the instruction that follows this one.
+    ///
+    /// `rd` being the zero register writes nothing, see [`Self::CONTINUE_ZERO`].
+    Continue {
+        /// Register to write
+        rd: Reg,
+        /// Value to write into it
+        value: Reg::Type,
+    },
+    /// Continue `offset` bytes away from the address of *this* instruction.
+    ///
+    /// Keeping it relative rather than resolving it against the program counter here means a
+    /// pre-decoded interpreter can reach the target by moving within the decoded stream instead of
+    /// converting an address back into a position.
+    Branch {
+        /// Signed byte offset from this instruction
+        offset: i32,
+    },
+    /// Continue at an absolute guest address, as `jalr`-style jumps produce
+    Jump {
+        /// Address to continue at
+        target: Reg::Type,
+    },
+    /// Stop execution
+    Break,
+    /// Execution failed
+    Err(ExecutionError<Reg::Type, CustomError>),
 }
 
-const impl<Address, CustomError> From<VirtualMemoryError> for ExecutionError<Address, CustomError> {
+const {
+    // Ensure result type retains its size
+    assert!(size_of::<ExecutionResult<Reg<u64>>>() <= 16);
+    assert!(size_of::<ExecutionResult<Reg<u32>>>() <= 16);
+}
+
+impl<Reg, CustomError> ExecutionResult<Reg, CustomError>
+where
+    Reg: Register,
+{
+    /// Continue with the instruction that follows this one without writing a register.
+    ///
+    /// The zero register discards whatever is written to it, so this is what an instruction whose
+    /// only effect is elsewhere returns.
+    pub const CONTINUE_ZERO: Self = Self::Continue {
+        rd: Reg::ZERO,
+        value: Reg::Type::from(0u8),
+    };
+}
+
+const impl<Reg, CustomError> From<ExecutionError<Reg::Type, CustomError>>
+    for ExecutionResult<Reg, CustomError>
+where
+    Reg: Register,
+{
+    #[inline(always)]
+    fn from(error: ExecutionError<Reg::Type, CustomError>) -> Self {
+        cold_path();
+        Self::Err(error)
+    }
+}
+
+const impl<Reg, CustomError>
+    FromResidual<Result<Infallible, ExecutionError<Reg::Type, CustomError>>>
+    for ExecutionResult<Reg, CustomError>
+where
+    Reg: Register,
+    CustomError: [const] Destruct,
+{
+    #[inline(always)]
+    fn from_residual(residual: Result<Infallible, ExecutionError<Reg::Type, CustomError>>) -> Self {
+        match residual {
+            Ok(never) => match never {},
+            Err(error) => {
+                cold_path();
+                Self::Err(error)
+            }
+        }
+    }
+}
+
+const impl<Reg, CustomError> FromResidual<Result<Infallible, VirtualMemoryError>>
+    for ExecutionResult<Reg, CustomError>
+where
+    Reg: Register,
+{
+    #[inline(always)]
+    fn from_residual(residual: Result<Infallible, VirtualMemoryError>) -> Self {
+        match residual {
+            Ok(never) => match never {},
+            Err(error) => {
+                cold_path();
+                Self::Err(ExecutionError::from(error))
+            }
+        }
+    }
+}
+
+const impl<Reg, CustomError> FromResidual<Result<Infallible, CsrError<CustomError>>>
+    for ExecutionResult<Reg, CustomError>
+where
+    Reg: Register,
+    CustomError: [const] Destruct,
+{
+    #[inline(always)]
+    fn from_residual(residual: Result<Infallible, CsrError<CustomError>>) -> Self {
+        match residual {
+            Ok(never) => match never {},
+            Err(error) => {
+                cold_path();
+                Self::Err(ExecutionError::from(error))
+            }
+        }
+    }
+}
+
+const impl<Address, CustomError> From<VirtualMemoryError> for ExecutionError<Address, CustomError>
+where
+    Address: Copy,
+{
     #[inline(always)]
     fn from(value: VirtualMemoryError) -> Self {
         match value {
-            VirtualMemoryError::OutOfBoundsRead { address } => Self::OutOfBoundsRead { address },
-            VirtualMemoryError::OutOfBoundsWrite { address } => Self::OutOfBoundsWrite { address },
+            VirtualMemoryError::OutOfBoundsRead { address } => Self::OutOfBoundsRead {
+                address: PackedAddress::new(address),
+            },
+            VirtualMemoryError::OutOfBoundsWrite { address } => Self::OutOfBoundsWrite {
+                address: PackedAddress::new(address),
+            },
         }
     }
 }
@@ -460,6 +670,7 @@ const impl<Address, CustomError> From<VirtualMemoryError> for ExecutionError<Add
 const impl<Address, CustomError> From<CsrError<CustomError>>
     for ExecutionError<Address, CustomError>
 where
+    Address: Copy,
     CustomError: [const] Destruct,
 {
     #[inline(always)]
@@ -728,18 +939,6 @@ where
     }
 }
 
-/// Type alias for the result returned by [`ExecutableInstruction::execute`]
-pub type ExecutableInstructionResult<T, I, CustomError> = Result<
-    ControlFlow<
-        T,
-        (
-            <I as Instruction>::Reg,
-            <<I as Instruction>::Reg as Register>::Type,
-        ),
-    >,
-    ExecutionError<Address<I>, CustomError>,
->;
-
 /// Trait for executable instructions
 pub const trait ExecutableInstruction<
     Regs,
@@ -757,10 +956,11 @@ pub const trait ExecutableInstruction<
     /// registers or other resources. If no such constraint is used, `()` can be used as a
     /// placeholder.
     ///
-    /// On success `Ok(ControlFlow::Continue((rd, rd_value)))` is returned, which will be written
-    /// into the register file. In most cases this is the only register that needs to be written. If
-    /// no value needs to be written, `Ok(ControlFlow::Continue(Default::default()))` should be
-    /// returned, which corresponds to `Ok(ControlFlow::Continue(Reg::ZERO, 0))` and is no-op.
+    /// On success `ExecutionResult::Continue { rd: rd, value: rd_value }` is returned, which will
+    /// be written into the register file. In most cases this is the only register that needs to
+    /// be written. If no value needs to be written,
+    /// `ExecutionResult::CONTINUE_ZERO` should be returned, which corresponds
+    /// to `Ok(ControlFlow::Continue(Reg::ZERO, 0))` and is no-op.
     fn execute(
         self,
         rs1rs2_values: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,
@@ -769,5 +969,5 @@ pub const trait ExecutableInstruction<
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError>;
+    ) -> ExecutionResult<Self::Reg, CustomError>;
 }

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -89,6 +89,7 @@
 #![expect(incomplete_features, reason = "generic_const_*")]
 #![feature(
     adt_const_params,
+    const_block_items,
     const_closures,
     const_cmp,
     const_convert,
@@ -109,7 +110,7 @@
     signed_bigint_helpers,
     widening_mul
 )]
-#![cfg_attr(test, feature(const_block_items, try_blocks))]
+#![cfg_attr(test, feature(try_blocks))]
 #![cfg_attr(
     not(any(
         all(target_arch = "riscv32", target_feature = "zbkx"),
@@ -321,23 +322,6 @@ impl fmt::Display for CustomErrorPlaceholder {
     }
 }
 
-/// Program counter errors
-#[derive(Debug, thiserror::Error)]
-pub enum ProgramCounterError<Address, CustomError = CustomErrorPlaceholder> {
-    /// Unaligned instruction
-    #[error("Unaligned instruction at address {address}")]
-    UnalignedInstruction {
-        /// Address of the unaligned instruction fetch
-        address: Address,
-    },
-    /// Memory access error
-    #[error("Memory access error: {0}")]
-    MemoryAccess(#[from] VirtualMemoryError),
-    /// Custom error
-    #[error("Custom error: {0}")]
-    Custom(CustomError),
-}
-
 /// Generic program counter
 pub const trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder> {
     /// Get the current value of the program counter
@@ -364,18 +348,38 @@ pub const trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceho
         &mut self,
         memory: &Memory,
         pc: Address,
-    ) -> Result<ControlFlow<()>, ProgramCounterError<Address, CustomError>>;
+    ) -> Result<ControlFlow<()>, ExecutionError<Address, CustomError>>;
 }
 
-/// Execution errors
+/// Execution errors.
+///
+/// The variants of [`VirtualMemoryError`] and [`CsrError`] are inlined
+/// here rather than nested. Nesting cost an extra discriminant per level, which made this type 24
+/// bytes; flattened it is 16, which is what lets `Result<_, ExecutionError>` be returned in
+/// registers instead of through a hidden out-pointer. `From` implementations for all three are
+/// provided, so `?` on them keeps working unchanged.
+///
+/// Note that a large `CustomError` will grow this type past that threshold again.
 #[derive(Debug, thiserror::Error)]
 pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder> {
-    /// Program counter error
-    #[error("Program counter error: {0}")]
-    ProgramCounter(ProgramCounterError<Address, CustomError>),
-    /// Memory access error
-    #[error("Memory access error: {0}")]
-    MemoryAccess(VirtualMemoryError),
+    /// Unaligned instruction
+    #[error("Unaligned instruction at address {address}")]
+    UnalignedInstruction {
+        /// Address of the unaligned instruction fetch
+        address: Address,
+    },
+    /// Out-of-bounds read
+    #[error("Out-of-bounds read at address {address}")]
+    OutOfBoundsRead {
+        /// Address of the out-of-bounds read
+        address: u64,
+    },
+    /// Out-of-bounds write
+    #[error("Out-of-bounds write at address {address}")]
+    OutOfBoundsWrite {
+        /// Address of the out-of-bounds write
+        address: u64,
+    },
     /// Unsupported `ecall` instruction
     #[error("Unsupported `ecall` instruction at address {address:#x}")]
     EcallUnsupported {
@@ -396,36 +400,86 @@ pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder> {
         /// Instruction that caused the error
         instruction: u32,
     },
-    /// CSR error
-    #[error("CSR error: {0}")]
-    CsrError(CsrError<CustomError>),
+    /// Read only CSR
+    #[error("Read only CSR {csr_index:#x}")]
+    CsrReadOnly {
+        /// Index of CSR where write was attempted
+        csr_index: u16,
+    },
+    /// Illegal read access
+    #[error("Illegal read access to CSR {csr_index:#x}")]
+    CsrIllegalRead {
+        /// Index of the accessed CSR
+        csr_index: u16,
+    },
+    /// Illegal write access
+    #[error("Illegal write access to CSR {csr_index:#x}")]
+    CsrIllegalWrite {
+        /// Index of the accessed CSR
+        csr_index: u16,
+    },
+    /// Unknown CSR
+    #[error("Unknown CSR {csr_index:#x}")]
+    CsrUnknown {
+        /// Index of the accessed CSR
+        csr_index: u16,
+    },
+    /// Insufficient privilege level
+    #[error(
+        "Insufficient privilege level for CSR {csr_index:#x}: required {required:?}, \
+        current {current:?}"
+    )]
+    CsrInsufficientPrivilege {
+        /// Index of the accessed CSR
+        csr_index: u16,
+        /// Required privilege level
+        required: PrivilegeLevel,
+        /// Current privilege level
+        current: PrivilegeLevel,
+    },
     /// Custom error
     #[error("Custom error: {0}")]
     Custom(CustomError),
 }
 
-const impl<Address, CustomError> From<ProgramCounterError<Address, CustomError>>
-    for ExecutionError<Address, CustomError>
-{
-    #[inline(always)]
-    fn from(value: ProgramCounterError<Address, CustomError>) -> Self {
-        Self::ProgramCounter(value)
-    }
+const {
+    // Ensure error type retains its size
+    assert!(size_of::<ExecutionError<u64>>() == 16);
 }
 
 const impl<Address, CustomError> From<VirtualMemoryError> for ExecutionError<Address, CustomError> {
     #[inline(always)]
     fn from(value: VirtualMemoryError) -> Self {
-        Self::MemoryAccess(value)
+        match value {
+            VirtualMemoryError::OutOfBoundsRead { address } => Self::OutOfBoundsRead { address },
+            VirtualMemoryError::OutOfBoundsWrite { address } => Self::OutOfBoundsWrite { address },
+        }
     }
 }
 
 const impl<Address, CustomError> From<CsrError<CustomError>>
     for ExecutionError<Address, CustomError>
+where
+    CustomError: [const] Destruct,
 {
     #[inline(always)]
     fn from(value: CsrError<CustomError>) -> Self {
-        Self::CsrError(value)
+        match value {
+            CsrError::ReadOnly { csr_index } => Self::CsrReadOnly { csr_index },
+            CsrError::IllegalRead { csr_index } => Self::CsrIllegalRead { csr_index },
+            CsrError::IllegalWrite { csr_index } => Self::CsrIllegalWrite { csr_index },
+            CsrError::Unknown { csr_index } => Self::CsrUnknown { csr_index },
+            CsrError::InsufficientPrivilege {
+                csr_index,
+                required,
+                current,
+            } => Self::CsrInsufficientPrivilege {
+                csr_index,
+                required,
+                current,
+            },
+            CsrError::Custom(error) => Self::Custom(error),
+        }
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -38,7 +38,6 @@ pub use crate::zvbc::zvbc_helpers;
 pub use crate::{
     BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
     ExecutableInstructionOperands, ExecutableInstructionResult, ExecutionError,
-    FetchInstructionResult, InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -37,7 +37,7 @@ pub use crate::zvbb::zvkb::zvkb_helpers;
 pub use crate::zvbc::zvbc_helpers;
 pub use crate::{
     BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
-    ExecutableInstructionOperands, ExecutableInstructionResult, ExecutionError,
-    FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstructionOperands, ExecutionError, ExecutionResult, FetchInstructionResult,
+    InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -15,8 +15,8 @@ pub mod zce;
 pub mod zk;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
@@ -63,123 +63,150 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Add { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sub { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_sub(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sll { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x1f;
                 let value = rs1_value << shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Slt { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.cast_signed() < rs2_value.cast_signed();
-                Ok(ControlFlow::Continue((rd, u32::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from(value),
+                }
             }
             Self::Sltu { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value < rs2_value;
-                Ok(ControlFlow::Continue((rd, u32::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from(value),
+                }
             }
             Self::Xor { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value ^ rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Srl { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x1f;
                 let value = rs1_value >> shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sra { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x1f;
                 let value = rs1_value.cast_signed() >> shamt;
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Or { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value | rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::And { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value & rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
 
             Self::Addi { rd, rs1: _, imm } => {
                 let value = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Slti { rd, rs1: _, imm } => {
                 let value = rs1_value.cast_signed() < i32::from(imm);
-                Ok(ControlFlow::Continue((rd, u32::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from(value),
+                }
             }
             Self::Sltiu { rd, rs1: _, imm } => {
                 let value = rs1_value < i32::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, u32::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from(value),
+                }
             }
             Self::Xori { rd, rs1: _, imm } => {
                 let value = rs1_value ^ i32::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Ori { rd, rs1: _, imm } => {
                 let value = rs1_value | i32::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Andi { rd, rs1: _, imm } => {
                 let value = rs1_value & i32::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Slli { rd, rs1: _, shamt } => {
                 let value = rs1_value << shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Srli { rd, rs1: _, shamt } => {
                 let value = rs1_value >> shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Srai { rd, rs1: _, shamt } => {
                 let value = rs1_value.cast_signed() >> shamt;
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
 
             Self::Lb { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 let value = i32::from(memory.read::<i8>(u64::from(addr))?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Lh { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 let value = i32::from(memory.read::<i16>(u64::from(addr))?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Lw { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 let value = memory.read::<u32>(u64::from(addr))?;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Lbu { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 let value = memory.read::<u8>(u64::from(addr))?;
-                Ok(ControlFlow::Continue((rd, u32::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from(value),
+                }
             }
             Self::Lhu { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 let value = memory.read::<u16>(u64::from(addr))?;
-                Ok(ControlFlow::Continue((rd, u32::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from(value),
+                }
             }
 
             Self::Jalr { rd, rs1: _, imm } => {
                 let target = (rs1_value.wrapping_add(i32::from(imm).cast_unsigned())) & !1u32;
                 regs.write(rd, program_counter.get_pc());
 
-                Ok(match program_counter.set_pc(memory, target)? {
-                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                    ControlFlow::Break(()) => ControlFlow::Break(()),
-                })
+                ExecutionResult::Jump { target }
             }
 
             Self::Sb {
@@ -189,7 +216,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 memory.write(u64::from(addr), rs2_value as u8)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Sh {
                 rs2: _,
@@ -198,7 +225,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 memory.write(u64::from(addr), rs2_value as u16)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Sw {
                 rs2: _,
@@ -207,7 +234,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 memory.write(u64::from(addr), rs2_value)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             Self::Beq {
@@ -216,18 +243,12 @@ where
                 imm,
             } => {
                 if rs1_value == rs2_value {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: imm.to_i32(),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Bne {
                 rs1: _,
@@ -235,18 +256,12 @@ where
                 imm,
             } => {
                 if rs1_value != rs2_value {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: imm.to_i32(),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Blt {
                 rs1: _,
@@ -254,18 +269,12 @@ where
                 imm,
             } => {
                 if rs1_value.cast_signed() < rs2_value.cast_signed() {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: imm.to_i32(),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Bge {
                 rs1: _,
@@ -273,18 +282,12 @@ where
                 imm,
             } => {
                 if rs1_value.cast_signed() >= rs2_value.cast_signed() {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: imm.to_i32(),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Bltu {
                 rs1: _,
@@ -292,18 +295,12 @@ where
                 imm,
             } => {
                 if rs1_value < rs2_value {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: imm.to_i32(),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Bgeu {
                 rs1: _,
@@ -311,71 +308,61 @@ where
                 imm,
             } => {
                 if rs1_value >= rs2_value {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: imm.to_i32(),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
-            Self::Lui { rd, imm } => Ok(ControlFlow::Continue((rd, imm.to_i32().cast_unsigned()))),
+            Self::Lui { rd, imm } => ExecutionResult::Continue {
+                rd,
+                value: imm.to_i32().cast_unsigned(),
+            },
 
             Self::Auipc { rd, imm } => {
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    old_pc.wrapping_add(imm.to_i32().cast_unsigned()),
-                )))
+                    value: old_pc.wrapping_add(imm.to_i32().cast_unsigned()),
+                }
             }
 
             Self::Jal { rd, imm } => {
                 let pc = program_counter.get_pc();
-                let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 regs.write(rd, pc);
 
-                Ok(
-                    match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
-                    {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    },
-                )
+                ExecutionResult::Branch {
+                    offset: imm.to_i32(),
+                }
             }
 
             Self::Fence { pred, succ } => {
                 system_instruction_handler.handle_fence(pred, succ);
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::FenceTso => {
                 system_instruction_handler.handle_fence_tso();
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             Self::Ecall => {
-                match system_instruction_handler.handle_ecall(regs, memory, program_counter) {
-                    Ok(control_flow) => Ok(match control_flow {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(err),
+                match system_instruction_handler.handle_ecall(regs, memory, program_counter)? {
+                    ControlFlow::Continue(()) => ExecutionResult::CONTINUE_ZERO,
+                    ControlFlow::Break(()) => ExecutionResult::Break,
                 }
             }
             Self::Ebreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             Self::Unimp => {
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                Err(ExecutionError::IllegalInstruction { address: old_pc })
+                ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                    address: PackedAddress::new(old_pc),
+                })
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -176,13 +176,10 @@ where
                 let target = (rs1_value.wrapping_add(i32::from(imm).cast_unsigned())) & !1u32;
                 regs.write(rd, program_counter.get_pc());
 
-                match program_counter.set_pc(memory, target) {
-                    Ok(control_flow) => Ok(match control_flow {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::from(err)),
-                }
+                Ok(match program_counter.set_pc(memory, target)? {
+                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                    ControlFlow::Break(()) => ControlFlow::Break(()),
+                })
             }
 
             Self::Sb {
@@ -220,15 +217,14 @@ where
             } => {
                 if rs1_value == rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -240,15 +236,14 @@ where
             } => {
                 if rs1_value != rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -260,15 +255,14 @@ where
             } => {
                 if rs1_value.cast_signed() < rs2_value.cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -280,15 +274,14 @@ where
             } => {
                 if rs1_value.cast_signed() >= rs2_value.cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -300,15 +293,14 @@ where
             } => {
                 if rs1_value < rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -320,15 +312,14 @@ where
             } => {
                 if rs1_value >= rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -349,15 +340,14 @@ where
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 regs.write(rd, pc);
 
-                match program_counter
-                    .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))
-                {
-                    Ok(control_flow) => Ok(match control_flow {
+                Ok(
+                    match program_counter
+                        .set_pc(memory, old_pc.wrapping_add(imm.to_i32().cast_unsigned()))?
+                    {
                         ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                         ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::ProgramCounter(err)),
-                }
+                    },
+                )
             }
 
             Self::Fence { pred, succ } => {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
@@ -5,11 +5,10 @@ pub mod zalrsc;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 /// Reservation set used to implement `Zalrsc` extension's `lr`/`sc` instruction pairs.
 ///
@@ -67,7 +66,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZaamoInstruction<Reg> where
@@ -47,7 +46,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Amoswap {
                 rd,
@@ -58,7 +57,7 @@ where
             } => {
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), rs2_value)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::Amoadd {
                 rd,
@@ -69,7 +68,7 @@ where
             } => {
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), old.wrapping_add(rs2_value))?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::Amoxor {
                 rd,
@@ -80,7 +79,7 @@ where
             } => {
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), old ^ rs2_value)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::Amoand {
                 rd,
@@ -91,7 +90,7 @@ where
             } => {
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), old & rs2_value)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::Amoor {
                 rd,
@@ -102,7 +101,7 @@ where
             } => {
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), old | rs2_value)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::Amomin {
                 rd,
@@ -118,7 +117,7 @@ where
                     rs2_value
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::Amomax {
                 rd,
@@ -134,7 +133,7 @@ where
                     rs2_value
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::Amominu {
                 rd,
@@ -146,7 +145,7 @@ where
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 let new = if old < rs2_value { old } else { rs2_value };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::Amomaxu {
                 rd,
@@ -158,7 +157,7 @@ where
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 let new = if old > rs2_value { old } else { rs2_value };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
@@ -6,11 +6,10 @@ mod tests;
 use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZalrscInstruction<Reg> where
@@ -49,7 +48,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Lr {
                 rd,
@@ -59,7 +58,7 @@ where
             } => {
                 let value = memory.read::<u32>(u64::from(rs1_value))?;
                 ext_state.set_reservation(rs1_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sc {
                 rd,
@@ -73,9 +72,9 @@ where
 
                 if success {
                     memory.write(u64::from(rs1_value), rs2_value)?;
-                    Ok(ControlFlow::Continue((rd, 0)))
+                    ExecutionResult::Continue { rd, value: 0 }
                 } else {
-                    Ok(ControlFlow::Continue((rd, 1)))
+                    ExecutionResult::Continue { rd, value: 1 }
                 }
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
@@ -8,11 +8,10 @@ pub mod zbs;
 use crate::rv32::b::zbb::rv32_zbb_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32BInstruction<Reg> where
@@ -48,7 +47,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZbaInstruction<Reg> where
@@ -46,19 +45,19 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Sh1add { rd, rs1: _, rs2: _ } => {
                 let value = (rs1_value << 1).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sh2add { rd, rs1: _, rs2: _ } => {
                 let value = (rs1_value << 2).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sh3add { rd, rs1: _, rs2: _ } => {
                 let value = (rs1_value << 3).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZbbInstruction<Reg> where
@@ -47,86 +46,89 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Andn { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value & !rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Orn { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value | !rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Xnor { rd, rs1: _, rs2: _ } => {
                 let value = !(rs1_value ^ rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Clz { rd, rs1: _ } => {
                 let value = rs1_value.leading_zeros();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Ctz { rd, rs1: _ } => {
                 let value = rs1_value.trailing_zeros();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Cpop { rd, rs1: _ } => {
                 let value = rs1_value.count_ones();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Max { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value.cast_signed();
                 let b = rs2_value.cast_signed();
                 let value = a.max(b).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Maxu { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.max(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Min { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value.cast_signed();
                 let b = rs2_value.cast_signed();
                 let value = a.min(b).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Minu { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.min(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sextb { rd, rs1: _ } => {
                 let value = i32::from(rs1_value as i8).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sexth { rd, rs1: _ } => {
                 let value = i32::from(rs1_value as i16).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Zexth { rd, rs1: _ } => {
                 let value = u32::from(rs1_value as u16);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Rol { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x1f;
                 let value = rs1_value.rotate_left(shamt);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Ror { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x1f;
                 let value = rs1_value.rotate_right(shamt);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Rori { rd, rs1: _, shamt } => {
                 let value = rs1_value.rotate_right(u32::from(shamt & 0x1f));
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Orcb { rd, rs1: _ } => {
                 let src = rs1_value;
 
-                Ok(ControlFlow::Continue((rd, rv32_zbb_helpers::orc_b(src))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv32_zbb_helpers::orc_b(src),
+                }
             }
             Self::Rev8 { rd, rs1: _ } => {
                 let value = rs1_value.swap_bytes();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZbcInstruction<Reg> where
@@ -47,25 +46,34 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Clmul { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value;
                 let b = rs2_value;
 
-                Ok(ControlFlow::Continue((rd, rv32_zbc_helpers::clmul(a, b))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv32_zbc_helpers::clmul(a, b),
+                }
             }
             Self::Clmulh { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value;
                 let b = rs2_value;
 
-                Ok(ControlFlow::Continue((rd, rv32_zbc_helpers::clmulh(a, b))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv32_zbc_helpers::clmulh(a, b),
+                }
             }
             Self::Clmulr { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value;
                 let b = rs2_value;
 
-                Ok(ControlFlow::Continue((rd, rv32_zbc_helpers::clmulr(a, b))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv32_zbc_helpers::clmulr(a, b),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZbsInstruction<Reg> where
@@ -46,48 +45,48 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Bset { rd, rs1: _, rs2: _ } => {
                 // Only the bottom 5 bits for RV32
                 let index = rs2_value & 0x1f;
                 let result = rs1_value | (1u32 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bseti { rd, rs1: _, shamt } => {
                 let index = shamt;
                 let result = rs1_value | (1u32 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bclr { rd, rs1: _, rs2: _ } => {
                 let index = rs2_value & 0x1f;
                 let result = rs1_value & !(1u32 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bclri { rd, rs1: _, shamt } => {
                 let index = shamt;
                 let result = rs1_value & !(1u32 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Binv { rd, rs1: _, rs2: _ } => {
                 let index = rs2_value & 0x1f;
                 let result = rs1_value ^ (1u32 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Binvi { rd, rs1: _, shamt } => {
                 let index = shamt;
                 let result = rs1_value ^ (1u32 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bext { rd, rs1: _, rs2: _ } => {
                 let index = rs2_value & 0x1f;
                 let result = (rs1_value >> index) & 1;
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bexti { rd, rs1: _, shamt } => {
                 let index = shamt;
                 let result = (rs1_value >> index) & 1;
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -4,14 +4,13 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZcaInstruction<Reg> where
@@ -52,20 +51,20 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // Quadrant 00
             Self::CAddi4spn { rd, nzuimm } => {
                 let sp_val = regs.read(Reg::SP);
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    sp_val.wrapping_add(u32::from(nzuimm)),
-                )))
+                    value: sp_val.wrapping_add(u32::from(nzuimm)),
+                }
             }
             Self::CLw { rd, rs1: _, uimm } => {
                 let addr = rs1_value.wrapping_add(u32::from(uimm));
                 let value = memory.read::<i32>(u64::from(addr))?.cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSw {
                 rs1: _,
@@ -74,153 +73,131 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(u32::from(uimm));
                 memory.write(u64::from(addr), rs2_value)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             // Quadrant 01
-            Self::CNop => Ok(ControlFlow::Continue(Default::default())),
+            Self::CNop => ExecutionResult::CONTINUE_ZERO,
             Self::CAddi { rd, nzimm } => {
                 let value = regs.read(rd).wrapping_add(i32::from(nzimm).cast_unsigned());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CJal { imm } => {
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
-                let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                Ok(
-                    match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))?
-                    {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    },
-                )
+                ExecutionResult::Branch {
+                    offset: i32::from(imm),
+                }
             }
-            Self::CLi { rd, imm } => {
-                Ok(ControlFlow::Continue((rd, i32::from(imm).cast_unsigned())))
-            }
+            Self::CLi { rd, imm } => ExecutionResult::Continue {
+                rd,
+                value: i32::from(imm).cast_unsigned(),
+            },
             Self::CAddi16sp { nzimm } => {
                 let value = regs
                     .read(Reg::SP)
                     .wrapping_add(i32::from(nzimm).cast_unsigned());
-                Ok(ControlFlow::Continue((Reg::SP, value)))
+                ExecutionResult::Continue { rd: Reg::SP, value }
             }
-            Self::CLui { rd, nzimm } => {
-                Ok(ControlFlow::Continue((rd, nzimm.to_i32().cast_unsigned())))
-            }
+            Self::CLui { rd, nzimm } => ExecutionResult::Continue {
+                rd,
+                value: nzimm.to_i32().cast_unsigned(),
+            },
             Self::CSrli { rd, shamt } => {
                 let value = regs.read(rd) >> shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSrai { rd, shamt } => {
                 let value = regs.read(rd).cast_signed() >> shamt;
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CAndi { rd, imm } => {
                 let value = regs.read(rd) & i32::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSub { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_sub(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CXor { rd, rs2: _ } => {
                 let value = regs.read(rd) ^ rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::COr { rd, rs2: _ } => {
                 let value = regs.read(rd) | rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CAnd { rd, rs2: _ } => {
                 let value = regs.read(rd) & rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
-            Self::CJ { imm } => {
-                let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                Ok(
-                    match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))?
-                    {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    },
-                )
-            }
+            Self::CJ { imm } => ExecutionResult::Branch {
+                offset: i32::from(imm),
+            },
             Self::CBeqz { rs1: _, imm } => {
                 if rs1_value == 0 {
-                    let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CBnez { rs1: _, imm } => {
                 if rs1_value != 0 {
-                    let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             // Quadrant 10
             Self::CSlli { rd, shamt } => {
                 let value = regs.read(rd) << shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CLwsp { rd, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u32::from(uimm));
                 let value = memory.read::<i32>(u64::from(addr))?.cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CJr { rs1: _ } => {
                 let target = rs1_value & !1;
-                Ok(match program_counter.set_pc(memory, target)? {
-                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                    ControlFlow::Break(()) => ControlFlow::Break(()),
-                })
+                ExecutionResult::Jump { target }
             }
-            Self::CMv { rd, rs2: _ } => Ok(ControlFlow::Continue((rd, rs2_value))),
+            Self::CMv { rd, rs2: _ } => ExecutionResult::Continue {
+                rd,
+                value: rs2_value,
+            },
             Self::CEbreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CJalr { rs1: _ } => {
                 let target = rs1_value & !1;
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
-                Ok(match program_counter.set_pc(memory, target)? {
-                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                    ControlFlow::Break(()) => ControlFlow::Break(()),
-                })
+                return ExecutionResult::Jump { target };
             }
             Self::CAdd { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSwsp { rs2: _, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u32::from(uimm));
                 memory.write(u64::from(addr), rs2_value)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CUnimp => {
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                Err(ExecutionError::IllegalInstruction { address: old_pc })
+                ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                    address: PackedAddress::new(old_pc),
+                })
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -87,15 +87,14 @@ where
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                match program_counter
-                    .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
-                {
-                    Ok(control_flow) => Ok(match control_flow {
+                Ok(
+                    match program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))?
+                    {
                         ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                         ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::from(err)),
-                }
+                    },
+                )
             }
             Self::CLi { rd, imm } => {
                 Ok(ControlFlow::Continue((rd, i32::from(imm).cast_unsigned())))
@@ -139,28 +138,26 @@ where
             }
             Self::CJ { imm } => {
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                match program_counter
-                    .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
-                {
-                    Ok(control_flow) => Ok(match control_flow {
+                Ok(
+                    match program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))?
+                    {
                         ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                         ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::from(err)),
-                }
+                    },
+                )
             }
             Self::CBeqz { rs1: _, imm } => {
                 if rs1_value == 0 {
                     let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -168,15 +165,14 @@ where
             Self::CBnez { rs1: _, imm } => {
                 if rs1_value != 0 {
                     let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i32::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -194,13 +190,10 @@ where
             }
             Self::CJr { rs1: _ } => {
                 let target = rs1_value & !1;
-                match program_counter.set_pc(memory, target) {
-                    Ok(control_flow) => Ok(match control_flow {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::from(err)),
-                }
+                Ok(match program_counter.set_pc(memory, target)? {
+                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                    ControlFlow::Break(()) => ControlFlow::Break(()),
+                })
             }
             Self::CMv { rd, rs2: _ } => Ok(ControlFlow::Continue((rd, rs2_value))),
             Self::CEbreak => {
@@ -211,13 +204,10 @@ where
                 let target = rs1_value & !1;
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
-                return match program_counter.set_pc(memory, target) {
-                    Ok(control_flow) => Ok(match control_flow {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::from(err)),
-                };
+                Ok(match program_counter.set_pc(memory, target)? {
+                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                    ControlFlow::Break(()) => ControlFlow::Break(()),
+                })
             }
             Self::CAdd { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_add(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
@@ -1,9 +1,10 @@
 use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    VirtualMemory,
+    ExecutableInstruction, ExecutionError, ExecutionResult, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 // C.ADDI4SPN
 
@@ -109,23 +110,27 @@ fn test_cjal_negative_offset() {
             .instruction_fetcher
             .set_pc(&state.memory, pc_before + u32::from(instruction.size()))
             .unwrap()
-            .continue_ok()
+            .continue_value()
             .unwrap();
         instruction
     };
-    let (rd, rd_value) = instruction
-        .execute(
-            Rs1Rs2OperandValues::default(),
-            &mut state.regs,
-            &mut state.ext_state,
-            &mut state.memory,
-            &mut state.instruction_fetcher,
-            &mut state.system_instruction_handler,
-        )
+    // `c.jal` writes `ra` itself and asks to continue at an offset from this instruction, which the
+    // interpreter loop applies
+    let next = instruction.execute(
+        Rs1Rs2OperandValues::default(),
+        &mut state.regs,
+        &mut state.ext_state,
+        &mut state.memory,
+        &mut state.instruction_fetcher,
+        &mut state.system_instruction_handler,
+    );
+    assert_matches!(next, ExecutionResult::Branch { offset: -4 });
+    state
+        .instruction_fetcher
+        .set_pc_relative(&state.memory, instruction.size(), -4)
         .unwrap()
-        .continue_ok()
+        .continue_value()
         .unwrap();
-    state.regs.write(rd, rd_value);
     assert_eq!(state.regs.read(Reg::Ra), pc_before + 2);
     assert_eq!(
         state.instruction_fetcher.get_pc(),

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca/tests.rs
@@ -560,6 +560,6 @@ fn test_clw_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsRead { .. })
     ));
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
@@ -6,11 +6,10 @@ pub mod zmmul;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32MInstruction<Reg> where
@@ -47,30 +46,39 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Mul { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_mul(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Mulh { rd, rs1: _, rs2: _ } => {
                 // Signed × signed: multiply and take upper 32 bits
                 let (_lo, prod) = rs1_value
                     .cast_signed()
                     .carrying_mul(rs2_value.cast_signed(), 0);
-                Ok(ControlFlow::Continue((rd, prod.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: prod.cast_unsigned(),
+                }
             }
             Self::Mulhsu { rd, rs1: _, rs2: _ } => {
                 // Signed × unsigned: widen to i64, take upper 32 bits
                 let prod = i64::from(rs1_value.cast_signed()) * i64::from(rs2_value);
                 let value = prod >> 32;
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned() as u32)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned() as u32,
+                }
             }
             Self::Mulhu { rd, rs1: _, rs2: _ } => {
                 // Unsigned × unsigned: widen to u64, take upper 32 bits
                 let prod = u64::from(rs1_value) * u64::from(rs2_value);
                 let value = prod >> 32;
-                Ok(ControlFlow::Continue((rd, value as u32)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value as u32,
+                }
             }
             Self::Div { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value.cast_signed();
@@ -82,13 +90,16 @@ where
                 } else {
                     dividend / divisor
                 };
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Divu { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value;
                 let divisor = rs2_value;
                 let value = dividend.checked_div(divisor).unwrap_or(u32::MAX);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Rem { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value.cast_signed();
@@ -104,7 +115,10 @@ where
                 } else {
                     dividend % divisor
                 };
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Remu { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value;
@@ -114,7 +128,7 @@ where
                 } else {
                     dividend % divisor
                 };
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
@@ -2,11 +2,10 @@
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZmmulInstruction<Reg> where
@@ -42,7 +41,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -5,8 +5,8 @@ use crate::rv32::a::ReservationSet;
 use crate::zawrs::WrsHandler;
 use crate::{
     Address, BasicInt, ExecutableInstruction, ExecutionError, FetchInstructionResult,
-    InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    InstructionFetcher, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::vec;
@@ -163,7 +163,7 @@ where
         &mut self,
         _memory: &TestMemory,
         pc: u32,
-    ) -> Result<ControlFlow<()>, ProgramCounterError<u32>> {
+    ) -> Result<ControlFlow<()>, ExecutionError<u32>> {
         self.pc = pc;
 
         Ok(ControlFlow::Continue(()))

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -187,29 +187,26 @@ where
     I: Instruction<Reg = Reg<u32>>,
 {
     #[inline]
-    fn fetch_instruction(
-        &mut self,
-        _memory: &TestMemory,
-    ) -> Result<FetchInstructionResult<I>, ExecutionError<Address<I>>> {
+    fn fetch_instruction(&mut self, _memory: &TestMemory) -> FetchInstructionResult<I> {
         if self.pc == self.return_trap_address {
-            return Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(())));
+            return FetchInstructionResult::Break;
         }
 
         let Some(&maybe_instruction) = self
             .instructions
             .get((self.pc - self.base_address) as usize / size_of::<u16>())
         else {
-            return Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(())));
+            return FetchInstructionResult::Break;
         };
 
         let Some(instruction) = maybe_instruction else {
-            return Err(ExecutionError::IllegalInstruction {
+            return FetchInstructionResult::Err(ExecutionError::IllegalInstruction {
                 address: PackedAddress::new(self.pc),
             });
         };
         self.pc += u32::from(instruction.size());
 
-        Ok(FetchInstructionResult::Instruction(instruction))
+        FetchInstructionResult::Instruction(instruction)
     }
 }
 
@@ -346,13 +343,16 @@ where
         >,
 {
     loop {
-        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory)? {
+        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
             FetchInstructionResult::Instruction(instruction) => instruction,
-            FetchInstructionResult::ControlFlow(ControlFlow::Continue(())) => {
+            FetchInstructionResult::Continue => {
                 continue;
             }
-            FetchInstructionResult::ControlFlow(ControlFlow::Break(())) => {
+            FetchInstructionResult::Break => {
                 break;
+            }
+            FetchInstructionResult::Err(error) => {
+                return Err(error);
             }
         };
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -4,9 +4,10 @@ use crate::basic::{BasicInterpreterState, BasicRegisters};
 use crate::rv32::a::ReservationSet;
 use crate::zawrs::WrsHandler;
 use crate::{
-    Address, BasicInt, ExecutableInstruction, ExecutionError, FetchInstructionResult,
-    InstructionFetcher, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    Address, BasicInt, ExecutableInstruction, ExecutionError, ExecutionResult,
+    FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::vec;
@@ -159,6 +160,17 @@ where
         self.pc
     }
 
+    #[inline(always)]
+    fn set_pc_relative(
+        &mut self,
+        memory: &TestMemory,
+        instruction_size: u8,
+        offset: i32,
+    ) -> Result<ControlFlow<()>, ExecutionError<u32>> {
+        let old_pc = self.old_pc(instruction_size);
+        self.set_pc(memory, old_pc.wrapping_add_signed(offset))
+    }
+
     fn set_pc(
         &mut self,
         _memory: &TestMemory,
@@ -191,7 +203,9 @@ where
         };
 
         let Some(instruction) = maybe_instruction else {
-            return Err(ExecutionError::IllegalInstruction { address: self.pc });
+            return Err(ExecutionError::IllegalInstruction {
+                address: PackedAddress::new(self.pc),
+            });
         };
         self.pc += u32::from(instruction.size());
 
@@ -252,12 +266,14 @@ where
         program_counter: &mut TestInstructionFetcher<I>,
     ) -> Result<ControlFlow<()>, ExecutionError<u32>> {
         Err(ExecutionError::EcallUnsupported {
-            address: program_counter.old_pc(
-                Rv32Instruction::<Reg<u32>>::Ecall {
-                    rs1: Reg::Zero,
-                    rs2: Reg::Zero,
-                }
-                .size(),
+            address: crate::PackedAddress::new(
+                program_counter.old_pc(
+                    Rv32Instruction::<Reg<u32>>::Ecall {
+                        rs1: Reg::Zero,
+                        rs2: Reg::Zero,
+                    }
+                    .size(),
+                ),
             ),
         })
     }
@@ -353,12 +369,34 @@ where
             &mut state.memory,
             &mut state.instruction_fetcher,
             &mut state.system_instruction_handler,
-        )? {
-            ControlFlow::Continue((rd, rd_value)) => {
-                state.regs.write(rd, rd_value);
+        ) {
+            ExecutionResult::Continue { rd, value } => {
+                state.regs.write(rd, value);
             }
-            ControlFlow::Break(()) => {
+            ExecutionResult::Branch { offset } => {
+                let control_flow = state.instruction_fetcher.set_pc_relative(
+                    &state.memory,
+                    instruction.size(),
+                    offset,
+                )?;
+                if control_flow.is_break() {
+                    break;
+                }
+            }
+            ExecutionResult::Jump { target } => {
+                if state
+                    .instruction_fetcher
+                    .set_pc(&state.memory, target)?
+                    .is_break()
+                {
+                    break;
+                }
+            }
+            ExecutionResult::Break => {
                 break;
+            }
+            ExecutionResult::Err(error) => {
+                return Err(error);
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/tests.rs
@@ -973,7 +973,10 @@ fn test_out_of_bounds_read() {
 
     let result = execute(&mut state);
 
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsRead { .. })
+    ));
 }
 
 #[test]
@@ -990,7 +993,10 @@ fn test_out_of_bounds_write() {
 
     let result = execute(&mut state);
 
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsWrite { .. })
+    ));
 }
 
 // Register Zero Tests

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZabhaInstruction<Reg> where
@@ -47,7 +46,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::AmoswapB {
                 rd,
@@ -58,7 +57,10 @@ where
             } => {
                 let old = memory.read::<i8>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), rs2_value as u8)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoswapH {
                 rd,
@@ -69,7 +71,10 @@ where
             } => {
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), rs2_value as u16)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoaddB {
                 rd,
@@ -81,7 +86,10 @@ where
                 let old = memory.read::<i8>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned().wrapping_add(rs2_value as u8);
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoaddH {
                 rd,
@@ -93,7 +101,10 @@ where
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned().wrapping_add(rs2_value as u16);
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoxorB {
                 rd,
@@ -105,7 +116,10 @@ where
                 let old = memory.read::<i8>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() ^ (rs2_value as u8);
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoxorH {
                 rd,
@@ -117,7 +131,10 @@ where
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() ^ (rs2_value as u16);
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoandB {
                 rd,
@@ -129,7 +146,10 @@ where
                 let old = memory.read::<i8>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() & (rs2_value as u8);
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoandH {
                 rd,
@@ -141,7 +161,10 @@ where
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() & (rs2_value as u16);
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoorB {
                 rd,
@@ -153,7 +176,10 @@ where
                 let old = memory.read::<i8>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() | (rs2_value as u8);
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmoorH {
                 rd,
@@ -165,7 +191,10 @@ where
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() | (rs2_value as u16);
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmominB {
                 rd,
@@ -181,7 +210,10 @@ where
                     rs2_value as u8
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmominH {
                 rd,
@@ -197,7 +229,10 @@ where
                     rs2_value as u16
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmomaxB {
                 rd,
@@ -213,7 +248,10 @@ where
                     rs2_value as u8
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmomaxH {
                 rd,
@@ -229,7 +267,10 @@ where
                     rs2_value as u16
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmominuB {
                 rd,
@@ -245,7 +286,10 @@ where
                     rs2_value as u8
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmominuH {
                 rd,
@@ -261,7 +305,10 @@ where
                     rs2_value as u16
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmomaxuB {
                 rd,
@@ -277,7 +324,10 @@ where
                     rs2_value as u8
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmomaxuH {
                 rd,
@@ -293,7 +343,10 @@ where
                     rs2_value as u16
                 };
                 memory.write(u64::from(rs1_value), new)?;
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmocasB {
                 rd,
@@ -307,7 +360,10 @@ where
                 if old.cast_unsigned() == compare {
                     memory.write(u64::from(rs1_value), rs2_value as u8)?;
                 }
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
             Self::AmocasH {
                 rd,
@@ -321,7 +377,10 @@ where
                 if old.cast_unsigned() == compare {
                     memory.write(u64::from(rs1_value), rs2_value as u16)?;
                 }
-                Ok(ControlFlow::Continue((rd, i32::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i32::from(old).cast_unsigned(),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZacasInstruction<Reg> where
@@ -47,7 +46,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::AmocasW {
                 rd,
@@ -62,7 +61,7 @@ where
                 if old == compare {
                     memory.write(addr, rs2_value)?;
                 }
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmocasD {
                 rd,
@@ -97,7 +96,7 @@ where
                 if rd != Reg::ZERO {
                     regs.write(rd_hi, old_hi);
                 }
-                Ok(ControlFlow::Continue((rd, old_lo)))
+                ExecutionResult::Continue { rd, value: old_lo }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZalasrInstruction<Reg> where
@@ -47,22 +46,28 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::LbAq { rd, rs1: _, rl: _ } => {
                 let addr = u64::from(rs1_value);
                 let value = i32::from(memory.read::<i8>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::LhAq { rd, rs1: _, rl: _ } => {
                 let addr = u64::from(rs1_value);
                 let value = i32::from(memory.read::<i16>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::LwAq { rd, rs1: _, rl: _ } => {
                 let addr = u64::from(rs1_value);
                 let value = memory.read::<u32>(addr)?;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::SbRl {
                 rs1: _,
@@ -71,7 +76,7 @@ where
             } => {
                 let addr = u64::from(rs1_value);
                 memory.write(addr, rs2_value as u8)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::ShRl {
                 rs1: _,
@@ -80,7 +85,7 @@ where
             } => {
                 let addr = u64::from(rs1_value);
                 memory.write(addr, rs2_value as u16)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::SwRl {
                 rs1: _,
@@ -89,7 +94,7 @@ where
             } => {
                 let addr = u64::from(rs1_value);
                 memory.write(addr, rs2_value)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -6,13 +6,12 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZcbInstruction<Reg> where
@@ -48,8 +47,8 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }
 
@@ -91,22 +90,31 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::CLbu { rd, rs1: _, uimm } => {
                 let addr = u64::from(rs1_value.wrapping_add(u32::from(uimm)));
                 let value = memory.read::<u8>(addr)?;
-                Ok(ControlFlow::Continue((rd, u32::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from(value),
+                }
             }
             Self::CLh { rd, rs1: _, uimm } => {
                 let addr = u64::from(rs1_value.wrapping_add(u32::from(uimm)));
                 let value = i32::from(memory.read::<i16>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CLhu { rd, rs1: _, uimm } => {
                 let addr = u64::from(rs1_value.wrapping_add(u32::from(uimm)));
                 let value = memory.read::<u16>(addr)?;
-                Ok(ControlFlow::Continue((rd, u32::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from(value),
+                }
             }
             Self::CSb {
                 rs1: _,
@@ -115,7 +123,7 @@ where
             } => {
                 let addr = u64::from(rs1_value.wrapping_add(u32::from(uimm)));
                 memory.write(addr, rs2_value as u8)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CSh {
                 rs1: _,
@@ -124,31 +132,37 @@ where
             } => {
                 let addr = u64::from(rs1_value.wrapping_add(u32::from(uimm)));
                 memory.write(addr, rs2_value as u16)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CZextB { rd } => {
                 let value = regs.read(rd) & 0xff;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSextB { rd } => {
                 let value = i32::from(regs.read(rd) as i8);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CZextH { rd } => {
                 let value = regs.read(rd) & 0xffff;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSextH { rd } => {
                 let value = i32::from(regs.read(rd) as i16);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CNot { rd } => {
                 let value = !regs.read(rd);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CMul { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_mul(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb/tests.rs
@@ -1,5 +1,5 @@
 use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
 
 // C.LBU
@@ -46,7 +46,7 @@ fn test_clbu_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(crate::ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsRead { .. })
     ));
 }
 
@@ -96,7 +96,7 @@ fn test_clhu_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(crate::ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsRead { .. })
     ));
 }
 
@@ -143,7 +143,7 @@ fn test_clh_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(crate::ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsRead { .. })
     ));
 }
 
@@ -187,7 +187,7 @@ fn test_csb_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(crate::ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsWrite { .. })
     ));
 }
 
@@ -215,7 +215,7 @@ fn test_csh_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(crate::ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsWrite { .. })
     ));
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -1,17 +1,17 @@
 //! RV32 Zcmp extension
 
 pub mod rv32_zcmp_helpers;
+use crate::PackedAddress;
 #[cfg(test)]
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZcmpInstruction<Reg> where
@@ -47,8 +47,8 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }
 
@@ -88,16 +88,16 @@ where
         regs: &mut Regs,
         _ext_state: &mut ExtState,
         memory: &mut Memory,
-        program_counter: &mut PC,
+        _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::CmPush { urlist, stack_adj } => {
                 rv32_zcmp_helpers::do_push(regs, memory, urlist, stack_adj)
             }
             Self::CmPop { urlist, stack_adj } => {
                 rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CmPopretz { urlist, stack_adj } => {
                 let ra_val = rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
@@ -105,31 +105,33 @@ where
                 regs.write(Reg::A0, 0);
                 // Jump to ra with LSB cleared (RISC-V mode bit)
                 let target = ra_val & !1;
-                program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
+                ExecutionResult::Jump { target }
             }
             Self::CmPopret { urlist, stack_adj } => {
                 let ra_val = rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
                 // Jump to ra with LSB cleared (RISC-V mode bit)
                 let target = ra_val & !1;
-                program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
+                ExecutionResult::Jump { target }
             }
             Self::CmMva01s { rs1: _, rs2: _ } => {
                 // Read both sources before any write to avoid aliasing
                 let v1 = rs1_value;
                 let v2 = rs2_value;
                 regs.write(Reg::A0, v1);
-                Ok(ControlFlow::Continue((Reg::A1, v2)))
+                ExecutionResult::Continue {
+                    rd: Reg::A1,
+                    value: v2,
+                }
             }
             Self::CmMvsa01 { rs1, rs2 } => {
                 // Read both sources before any write to avoid aliasing
                 let a0_val = regs.read(Reg::A0);
                 let a1_val = regs.read(Reg::A1);
                 regs.write(rs1, a0_val);
-                Ok(ControlFlow::Continue((rs2, a1_val)))
+                ExecutionResult::Continue {
+                    rd: rs2,
+                    value: a1_val,
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -108,7 +108,6 @@ where
                 program_counter
                     .set_pc(memory, target)
                     .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from)
             }
             Self::CmPopret { urlist, stack_adj } => {
                 let ra_val = rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
@@ -117,7 +116,6 @@ where
                 program_counter
                     .set_pc(memory, target)
                     .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from)
             }
             Self::CmMva01s { rs1: _, rs2: _ } => {
                 // Read both sources before any write to avoid aliasing

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
@@ -1,20 +1,18 @@
 //! Opaque helpers for Zcmp extension
 
-use crate::{ExecutionError, RegisterFile, VirtualMemory};
+use crate::{ExecutionError, ExecutionResult, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 /// Execute CM.PUSH: store registers below sp, then decrement sp
 #[inline]
 #[doc(hidden)]
-#[expect(clippy::type_complexity, reason = "Internal helper")]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn do_push<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u8,
-) -> Result<ControlFlow<(), (Reg, u32)>, ExecutionError<Reg::Type, CustomError>>
+) -> ExecutionResult<Reg, CustomError>
 where
     Reg: ZcmpRegister<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -27,10 +25,10 @@ where
         memory.write(store_addr, regs.read(reg))?;
         store_addr = store_addr.wrapping_sub(size_of::<Reg::Type>() as u64);
     }
-    Ok(ControlFlow::Continue((
-        Reg::SP,
-        sp.wrapping_sub(u32::from(stack_adj)),
-    )))
+    ExecutionResult::Continue {
+        rd: Reg::SP,
+        value: sp.wrapping_sub(u32::from(stack_adj)),
+    }
 }
 
 /// Execute CM.POP and variants: restore registers and increment sp.

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/tests.rs
@@ -388,5 +388,8 @@ fn test_cm_push_oob_memory() {
     }]);
     state.regs.write(Reg::Sp, 2);
     let result = execute(&mut state);
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsWrite { .. })
+    ));
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZbkbInstruction<Reg> where
@@ -47,21 +46,21 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Pack { rd, rs1: _, rs2: _ } => {
                 // Pack low 16 bits of rs1 into rd[15:0],
                 // low 16 bits of rs2 into rd[31:16].
                 let lo = rs1_value & 0x0000_FFFFu32;
                 let hi = (rs2_value & 0x0000_FFFFu32) << 16;
-                Ok(ControlFlow::Continue((rd, lo | hi)))
+                ExecutionResult::Continue { rd, value: lo | hi }
             }
             Self::Packh { rd, rs1: _, rs2: _ } => {
                 // Pack low byte of rs1 into bits [7:0], low byte of rs2 into bits [15:8].
                 // Upper bits of rd are zeroed.
                 let lo = rs1_value & 0xFF;
                 let hi = (rs2_value & 0xFF) << 8;
-                Ok(ControlFlow::Continue((rd, lo | hi)))
+                ExecutionResult::Continue { rd, value: lo | hi }
             }
             Self::Brev8 { rd, rs1: _ } => {
                 // Reverse bits within each byte of rs1
@@ -70,7 +69,10 @@ where
                 for byte in &mut bytes {
                     *byte = byte.reverse_bits();
                 }
-                Ok(ControlFlow::Continue((rd, u32::from_le_bytes(bytes))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u32::from_le_bytes(bytes),
+                }
             }
             Self::Zip { rd, rs1: _ } => {
                 // Bit-interleave: scatter bits of rs1 so that
@@ -79,7 +81,10 @@ where
                 // for i in 0..16.
                 let src = rs1_value;
 
-                Ok(ControlFlow::Continue((rd, rv32_zbkb_helpers::zip(src))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv32_zbkb_helpers::zip(src),
+                }
             }
             Self::Unzip { rd, rs1: _ } => {
                 // Inverse of zip: gather bits of rs1 so that
@@ -88,7 +93,10 @@ where
                 // for i in 0..16.
                 let src = rs1_value;
 
-                Ok(ControlFlow::Continue((rd, rv32_zbkb_helpers::unzip(src))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv32_zbkb_helpers::unzip(src),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
@@ -3,11 +3,10 @@
 use crate::rv32::b::zbc::rv32_zbc_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZbkcInstruction<Reg> where
@@ -43,7 +42,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZbkxInstruction<Reg> where
@@ -47,16 +46,16 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
-            Self::Xperm4 { rd, rs1: _, rs2: _ } => Ok(ControlFlow::Continue((
+            Self::Xperm4 { rd, rs1: _, rs2: _ } => ExecutionResult::Continue {
                 rd,
-                rv32_zbkx_helpers::xperm4(rs1_value, rs2_value),
-            ))),
-            Self::Xperm8 { rd, rs1: _, rs2: _ } => Ok(ControlFlow::Continue((
+                value: rv32_zbkx_helpers::xperm4(rs1_value, rs2_value),
+            },
+            Self::Xperm8 { rd, rs1: _, rs2: _ } => ExecutionResult::Continue {
                 rd,
-                rv32_zbkx_helpers::xperm8(rs1_value, rs2_value),
-            ))),
+                value: rv32_zbkx_helpers::xperm8(rs1_value, rs2_value),
+            },
         }
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
@@ -12,11 +12,10 @@ use crate::rv32::zk::zkn::zkne::rv32_zkne_helpers;
 use crate::rv32::zk::zkn::zknh::rv32_zknh_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZknInstruction<Reg> where
@@ -52,7 +51,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZkndInstruction<Reg> where
@@ -47,7 +46,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Aes32Dsi {
                 rd,
@@ -57,10 +56,10 @@ where
             } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknd_helpers::aes32dsi(v1, v2, bs),
-                )))
+                    value: rv32_zknd_helpers::aes32dsi(v1, v2, bs),
+                }
             }
             Self::Aes32Dsmi {
                 rd,
@@ -70,10 +69,10 @@ where
             } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknd_helpers::aes32dsmi(v1, v2, bs),
-                )))
+                    value: rv32_zknd_helpers::aes32dsmi(v1, v2, bs),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZkneInstruction<Reg> where
@@ -47,7 +46,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Aes32Esi {
                 rd,
@@ -57,10 +56,10 @@ where
             } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zkne_helpers::aes32esi(v1, v2, bs),
-                )))
+                    value: rv32_zkne_helpers::aes32esi(v1, v2, bs),
+                }
             }
             Self::Aes32Esmi {
                 rd,
@@ -70,10 +69,10 @@ where
             } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zkne_helpers::aes32esmi(v1, v2, bs),
-                )))
+                    value: rv32_zkne_helpers::aes32esmi(v1, v2, bs),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZknhInstruction<Reg> where
@@ -47,36 +46,36 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // SHA-256 (single-register)
             Self::Sha256Sig0 { rd, rs1: _ } => {
                 let x = rs1_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha256sig0(x),
-                )))
+                    value: rv32_zknh_helpers::sha256sig0(x),
+                }
             }
             Self::Sha256Sig1 { rd, rs1: _ } => {
                 let x = rs1_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha256sig1(x),
-                )))
+                    value: rv32_zknh_helpers::sha256sig1(x),
+                }
             }
             Self::Sha256Sum0 { rd, rs1: _ } => {
                 let x = rs1_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha256sum0(x),
-                )))
+                    value: rv32_zknh_helpers::sha256sum0(x),
+                }
             }
             Self::Sha256Sum1 { rd, rs1: _ } => {
                 let x = rs1_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha256sum1(x),
-                )))
+                    value: rv32_zknh_helpers::sha256sum1(x),
+                }
             }
 
             // SHA-512 (two-register R-type)
@@ -96,50 +95,50 @@ where
             Self::Sha512Sig0h { rd, rs1: _, rs2: _ } => {
                 let rs1_val = rs1_value;
                 let rs2_val = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha512sig0h(rs1_val, rs2_val),
-                )))
+                    value: rv32_zknh_helpers::sha512sig0h(rs1_val, rs2_val),
+                }
             }
             Self::Sha512Sig0l { rd, rs1: _, rs2: _ } => {
                 let rs1_val = rs1_value;
                 let rs2_val = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha512sig0l(rs1_val, rs2_val),
-                )))
+                    value: rv32_zknh_helpers::sha512sig0l(rs1_val, rs2_val),
+                }
             }
             Self::Sha512Sig1h { rd, rs1: _, rs2: _ } => {
                 let rs1_val = rs1_value;
                 let rs2_val = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha512sig1h(rs1_val, rs2_val),
-                )))
+                    value: rv32_zknh_helpers::sha512sig1h(rs1_val, rs2_val),
+                }
             }
             Self::Sha512Sig1l { rd, rs1: _, rs2: _ } => {
                 let rs1_val = rs1_value;
                 let rs2_val = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha512sig1l(rs1_val, rs2_val),
-                )))
+                    value: rv32_zknh_helpers::sha512sig1l(rs1_val, rs2_val),
+                }
             }
             Self::Sha512Sum0r { rd, rs1: _, rs2: _ } => {
                 let rs1_val = rs1_value;
                 let rs2_val = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha512sum0r(rs1_val, rs2_val),
-                )))
+                    value: rv32_zknh_helpers::sha512sum0r(rs1_val, rs2_val),
+                }
             }
             Self::Sha512Sum1r { rd, rs1: _, rs2: _ } => {
                 let rs1_val = rs1_value;
                 let rs2_val = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv32_zknh_helpers::sha512sum1r(rs1_val, rs2_val),
-                )))
+                    value: rv32_zknh_helpers::sha512sum1r(rs1_val, rs2_val),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -245,13 +245,10 @@ where
                 let target = (rs1_value.wrapping_add(i64::from(imm).cast_unsigned())) & !1u64;
                 regs.write(rd, program_counter.get_pc());
 
-                match program_counter.set_pc(memory, target) {
-                    Ok(control_flow) => Ok(match control_flow {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::from(err)),
-                }
+                Ok(match program_counter.set_pc(memory, target)? {
+                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                    ControlFlow::Break(()) => ControlFlow::Break(()),
+                })
             }
 
             Self::Sb {
@@ -298,15 +295,14 @@ where
             } => {
                 if rs1_value == rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -318,15 +314,14 @@ where
             } => {
                 if rs1_value != rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -338,15 +333,14 @@ where
             } => {
                 if rs1_value.cast_signed() < rs2_value.cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -358,15 +352,14 @@ where
             } => {
                 if rs1_value.cast_signed() >= rs2_value.cast_signed() {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -378,15 +371,14 @@ where
             } => {
                 if rs1_value < rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -398,15 +390,14 @@ where
             } => {
                 if rs1_value >= rs2_value {
                     let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::from(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -429,15 +420,14 @@ where
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 regs.write(rd, pc);
 
-                match program_counter
-                    .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                {
-                    Ok(control_flow) => Ok(match control_flow {
+                Ok(
+                    match program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                    {
                         ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                         ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::from(err)),
-                }
+                    },
+                )
             }
 
             Self::Fence { pred, succ } => {

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -15,8 +15,8 @@ pub mod zce;
 pub mod zk;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
@@ -63,192 +63,234 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Add { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sub { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_sub(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sll { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x3f;
                 let value = rs1_value << shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Slt { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.cast_signed() < rs2_value.cast_signed();
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
             Self::Sltu { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value < rs2_value;
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
             Self::Xor { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value ^ rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Srl { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x3f;
                 let value = rs1_value >> shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sra { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x3f;
                 let value = rs1_value.cast_signed() >> shamt;
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Or { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value | rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::And { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value & rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
 
             Self::Addw { rd, rs1: _, rs2: _ } => {
                 let sum = (rs1_value as i32).wrapping_add(rs2_value as i32);
-                Ok(ControlFlow::Continue((rd, i64::from(sum).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(sum).cast_unsigned(),
+                }
             }
             Self::Subw { rd, rs1: _, rs2: _ } => {
                 let diff = (rs1_value as i32).wrapping_sub(rs2_value as i32);
-                Ok(ControlFlow::Continue((rd, i64::from(diff).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(diff).cast_unsigned(),
+                }
             }
             Self::Sllw { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x1f;
                 let shifted = (rs1_value as u32) << shamt;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(shifted.cast_signed()).cast_unsigned(),
-                )))
+                    value: i64::from(shifted.cast_signed()).cast_unsigned(),
+                }
             }
             Self::Srlw { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x1f;
                 let shifted = (rs1_value as u32) >> shamt;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(shifted.cast_signed()).cast_unsigned(),
-                )))
+                    value: i64::from(shifted.cast_signed()).cast_unsigned(),
+                }
             }
             Self::Sraw { rd, rs1: _, rs2: _ } => {
                 let shamt = rs2_value & 0x1f;
                 let shifted = (rs1_value as i32) >> shamt;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(shifted).cast_unsigned(),
-                )))
+                    value: i64::from(shifted).cast_unsigned(),
+                }
             }
 
             Self::Addi { rd, rs1: _, imm } => {
                 let value = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Slti { rd, rs1: _, imm } => {
                 let value = rs1_value.cast_signed() < i64::from(imm);
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
             Self::Sltiu { rd, rs1: _, imm } => {
                 let value = rs1_value < i64::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
             Self::Xori { rd, rs1: _, imm } => {
                 let value = rs1_value ^ i64::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Ori { rd, rs1: _, imm } => {
                 let value = rs1_value | i64::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Andi { rd, rs1: _, imm } => {
                 let value = rs1_value & i64::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Slli { rd, rs1: _, shamt } => {
                 let value = rs1_value << shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Srli { rd, rs1: _, shamt } => {
                 let value = rs1_value >> shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Srai { rd, rs1: _, shamt } => {
                 let value = rs1_value.cast_signed() >> shamt;
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
 
             Self::Addiw { rd, rs1: _, imm } => {
                 let sum = (rs1_value as i32).wrapping_add(i32::from(imm));
-                Ok(ControlFlow::Continue((rd, i64::from(sum).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(sum).cast_unsigned(),
+                }
             }
             Self::Slliw { rd, rs1: _, shamt } => {
                 let shifted = (rs1_value as u32) << shamt;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(shifted.cast_signed()).cast_unsigned(),
-                )))
+                    value: i64::from(shifted.cast_signed()).cast_unsigned(),
+                }
             }
             Self::Srliw { rd, rs1: _, shamt } => {
                 let shifted = (rs1_value as u32) >> shamt;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(shifted.cast_signed()).cast_unsigned(),
-                )))
+                    value: i64::from(shifted.cast_signed()).cast_unsigned(),
+                }
             }
             Self::Sraiw { rd, rs1: _, shamt } => {
                 let shifted = (rs1_value as i32) >> shamt;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(shifted).cast_unsigned(),
-                )))
+                    value: i64::from(shifted).cast_unsigned(),
+                }
             }
 
             Self::Lb { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 let value = i64::from(memory.read::<i8>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Lh { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 let value = i64::from(memory.read::<i16>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Lw { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 let value = i64::from(memory.read::<i32>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Ld { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 let value = memory.read::<u64>(addr)?;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Lbu { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 let value = memory.read::<u8>(addr)?;
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
             Self::Lhu { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 let value = memory.read::<u16>(addr)?;
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
             Self::Lwu { rd, rs1: _, imm } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 let value = memory.read::<u32>(addr)?;
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
 
             Self::Jalr { rd, rs1: _, imm } => {
                 let target = (rs1_value.wrapping_add(i64::from(imm).cast_unsigned())) & !1u64;
                 regs.write(rd, program_counter.get_pc());
 
-                Ok(match program_counter.set_pc(memory, target)? {
-                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                    ControlFlow::Break(()) => ControlFlow::Break(()),
-                })
+                ExecutionResult::Jump { target }
             }
 
             Self::Sb {
@@ -258,7 +300,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 memory.write(addr, rs2_value as u8)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Sh {
                 rs2: _,
@@ -267,7 +309,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 memory.write(addr, rs2_value as u16)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Sw {
                 rs2: _,
@@ -276,7 +318,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 memory.write(addr, rs2_value as u32)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Sd {
                 rs2: _,
@@ -285,7 +327,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 memory.write(addr, rs2_value)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             Self::Beq {
@@ -294,18 +336,12 @@ where
                 imm,
             } => {
                 if rs1_value == rs2_value {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Bne {
                 rs1: _,
@@ -313,18 +349,12 @@ where
                 imm,
             } => {
                 if rs1_value != rs2_value {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Blt {
                 rs1: _,
@@ -332,18 +362,12 @@ where
                 imm,
             } => {
                 if rs1_value.cast_signed() < rs2_value.cast_signed() {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Bge {
                 rs1: _,
@@ -351,18 +375,12 @@ where
                 imm,
             } => {
                 if rs1_value.cast_signed() >= rs2_value.cast_signed() {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Bltu {
                 rs1: _,
@@ -370,18 +388,12 @@ where
                 imm,
             } => {
                 if rs1_value < rs2_value {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::Bgeu {
                 rs1: _,
@@ -389,73 +401,61 @@ where
                 imm,
             } => {
                 if rs1_value >= rs2_value {
-                    let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
-            Self::Lui { rd, imm } => {
-                Ok(ControlFlow::Continue((rd, i64::from(imm).cast_unsigned())))
-            }
+            Self::Lui { rd, imm } => ExecutionResult::Continue {
+                rd,
+                value: i64::from(imm).cast_unsigned(),
+            },
 
             Self::Auipc { rd, imm } => {
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
-                )))
+                    value: old_pc.wrapping_add(i64::from(imm).cast_unsigned()),
+                }
             }
 
             Self::Jal { rd, imm } => {
                 let pc = program_counter.get_pc();
-                let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
                 regs.write(rd, pc);
 
-                Ok(
-                    match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                    {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    },
-                )
+                ExecutionResult::Branch {
+                    offset: i32::from(imm),
+                }
             }
 
             Self::Fence { pred, succ } => {
                 system_instruction_handler.handle_fence(pred, succ);
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::FenceTso => {
                 system_instruction_handler.handle_fence_tso();
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             Self::Ecall => {
-                match system_instruction_handler.handle_ecall(regs, memory, program_counter) {
-                    Ok(control_flow) => Ok(match control_flow {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(err),
+                match system_instruction_handler.handle_ecall(regs, memory, program_counter)? {
+                    ControlFlow::Continue(()) => ExecutionResult::CONTINUE_ZERO,
+                    ControlFlow::Break(()) => ExecutionResult::Break,
                 }
             }
             Self::Ebreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             Self::Unimp => {
                 let old_pc = program_counter.old_pc(size_of::<u32>() as u8);
-                Err(ExecutionError::IllegalInstruction { address: old_pc })
+                ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                    address: PackedAddress::new(old_pc),
+                })
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
@@ -6,11 +6,10 @@ pub mod zalrsc;
 use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64AInstruction<Reg> where
@@ -49,7 +48,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZaamoInstruction<Reg> where
@@ -47,7 +46,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Amoswap {
                 rd,
@@ -58,7 +57,10 @@ where
             } => {
                 let old = memory.read::<i32>(rs1_value)?;
                 memory.write(rs1_value, rs2_value as u32)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::Amoadd {
                 rd,
@@ -70,7 +72,10 @@ where
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = (old.cast_unsigned()).wrapping_add(rs2_value as u32);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::Amoxor {
                 rd,
@@ -82,7 +87,10 @@ where
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = old.cast_unsigned() ^ (rs2_value as u32);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::Amoand {
                 rd,
@@ -94,7 +102,10 @@ where
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = old.cast_unsigned() & (rs2_value as u32);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::Amoor {
                 rd,
@@ -106,7 +117,10 @@ where
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = old.cast_unsigned() | (rs2_value as u32);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::Amomin {
                 rd,
@@ -122,7 +136,10 @@ where
                     rs2_value as u32
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::Amomax {
                 rd,
@@ -138,7 +155,10 @@ where
                     rs2_value as u32
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::Amominu {
                 rd,
@@ -154,7 +174,10 @@ where
                     rs2_value as u32
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::Amomaxu {
                 rd,
@@ -170,7 +193,10 @@ where
                     rs2_value as u32
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
 
             Self::AmoswapD {
@@ -182,7 +208,7 @@ where
             } => {
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, rs2_value)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmoaddD {
                 rd,
@@ -193,7 +219,7 @@ where
             } => {
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, old.wrapping_add(rs2_value))?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmoxorD {
                 rd,
@@ -204,7 +230,7 @@ where
             } => {
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, old ^ rs2_value)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmoandD {
                 rd,
@@ -215,7 +241,7 @@ where
             } => {
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, old & rs2_value)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmoorD {
                 rd,
@@ -226,7 +252,7 @@ where
             } => {
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, old | rs2_value)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmominD {
                 rd,
@@ -242,7 +268,7 @@ where
                     rs2_value
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmomaxD {
                 rd,
@@ -258,7 +284,7 @@ where
                     rs2_value
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmominuD {
                 rd,
@@ -270,7 +296,7 @@ where
                 let old = memory.read::<u64>(rs1_value)?;
                 let new = if old < rs2_value { old } else { rs2_value };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmomaxuD {
                 rd,
@@ -282,7 +308,7 @@ where
                 let old = memory.read::<u64>(rs1_value)?;
                 let new = if old > rs2_value { old } else { rs2_value };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
@@ -6,11 +6,10 @@ mod tests;
 use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZalrscInstruction<Reg> where
@@ -49,7 +48,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Lr {
                 rd,
@@ -59,10 +58,10 @@ where
             } => {
                 let value = memory.read::<i32>(rs1_value)?;
                 ext_state.set_reservation(rs1_value);
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(value).cast_unsigned(),
-                )))
+                    value: i64::from(value).cast_unsigned(),
+                }
             }
             Self::Sc {
                 rd,
@@ -76,9 +75,9 @@ where
 
                 if success {
                     memory.write(rs1_value, rs2_value as u32)?;
-                    Ok(ControlFlow::Continue((rd, 0)))
+                    ExecutionResult::Continue { rd, value: 0 }
                 } else {
-                    Ok(ControlFlow::Continue((rd, 1)))
+                    ExecutionResult::Continue { rd, value: 1 }
                 }
             }
             Self::LrD {
@@ -89,7 +88,7 @@ where
             } => {
                 let value = memory.read::<u64>(rs1_value)?;
                 ext_state.set_reservation(rs1_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::ScD {
                 rd,
@@ -103,9 +102,9 @@ where
 
                 if success {
                     memory.write(rs1_value, rs2_value)?;
-                    Ok(ControlFlow::Continue((rd, 0)))
+                    ExecutionResult::Continue { rd, value: 0 }
                 } else {
-                    Ok(ControlFlow::Continue((rd, 1)))
+                    ExecutionResult::Continue { rd, value: 1 }
                 }
             }
         }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
@@ -8,11 +8,10 @@ pub mod zbs;
 use crate::rv64::b::zbb::rv64_zbb_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64BInstruction<Reg> where
@@ -48,7 +47,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZbaInstruction<Reg> where
@@ -46,44 +45,44 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::AddUw { rd, rs1: _, rs2: _ } => {
                 let rs1_val = u64::from(rs1_value as u32);
                 let value = rs1_val.wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sh1add { rd, rs1: _, rs2: _ } => {
                 let value = (rs1_value << 1).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sh1addUw { rd, rs1: _, rs2: _ } => {
                 let rs1_val = u64::from(rs1_value as u32);
                 let value = (rs1_val << 1).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sh2add { rd, rs1: _, rs2: _ } => {
                 let value = (rs1_value << 2).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sh2addUw { rd, rs1: _, rs2: _ } => {
                 let rs1_val = u64::from(rs1_value as u32);
                 let value = (rs1_val << 2).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sh3add { rd, rs1: _, rs2: _ } => {
                 let value = (rs1_value << 3).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sh3addUw { rd, rs1: _, rs2: _ } => {
                 let rs1_val = u64::from(rs1_value as u32);
                 let value = (rs1_val << 3).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::SlliUw { rd, rs1: _, shamt } => {
                 let rs1_val = u64::from(rs1_value as u32);
                 let value = rs1_val << (shamt & 0x3f);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZbbInstruction<Reg> where
@@ -47,94 +46,97 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Andn { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value & !rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Orn { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value | !rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Xnor { rd, rs1: _, rs2: _ } => {
                 let value = !(rs1_value ^ rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Clz { rd, rs1: _ } => {
                 let value = u64::from(rs1_value.leading_zeros());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Clzw { rd, rs1: _ } => {
                 let value = u64::from((rs1_value as u32).leading_zeros());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Ctz { rd, rs1: _ } => {
                 let value = u64::from(rs1_value.trailing_zeros());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Ctzw { rd, rs1: _ } => {
                 let value = u64::from((rs1_value as u32).trailing_zeros());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Cpop { rd, rs1: _ } => {
                 let value = u64::from(rs1_value.count_ones());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Cpopw { rd, rs1: _ } => {
                 let value = u64::from((rs1_value as u32).count_ones());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Max { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value.cast_signed();
                 let b = rs2_value.cast_signed();
                 let value = a.max(b).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Maxu { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.max(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Min { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value.cast_signed();
                 let b = rs2_value.cast_signed();
                 let value = a.min(b).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Minu { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.min(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sextb { rd, rs1: _ } => {
                 let value = i64::from(rs1_value as i8).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Sexth { rd, rs1: _ } => {
                 let value = i64::from(rs1_value as i16).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Zexth { rd, rs1: _ } => {
                 let value = u64::from(rs1_value as u16);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Rol { rd, rs1: _, rs2: _ } => {
                 let shamt = (rs2_value & 0x3f) as u32;
                 let value = rs1_value.rotate_left(shamt);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Rolw { rd, rs1: _, rs2: _ } => {
                 let shamt = (rs2_value & 0x1f) as u32;
                 let value = i64::from((rs1_value as u32).rotate_left(shamt).cast_signed());
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Ror { rd, rs1: _, rs2: _ } => {
                 let shamt = (rs2_value & 0x3f) as u32;
                 let value = rs1_value.rotate_right(shamt);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Rori { rd, rs1: _, shamt } => {
                 let value = rs1_value.rotate_right(u32::from(shamt & 0x3f));
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Roriw { rd, rs1: _, shamt } => {
                 let value = i64::from(
@@ -142,21 +144,30 @@ where
                         .rotate_right(u32::from(shamt & 0x1f))
                         .cast_signed(),
                 );
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Rorw { rd, rs1: _, rs2: _ } => {
                 let shamt = (rs2_value & 0x1f) as u32;
                 let value = i64::from((rs1_value as u32).rotate_right(shamt).cast_signed());
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Orcb { rd, rs1: _ } => {
                 let src = rs1_value;
 
-                Ok(ControlFlow::Continue((rd, rv64_zbb_helpers::orc_b(src))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv64_zbb_helpers::orc_b(src),
+                }
             }
             Self::Rev8 { rd, rs1: _ } => {
                 let value = rs1_value.swap_bytes();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZbcInstruction<Reg> where
@@ -47,25 +46,34 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Clmul { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value;
                 let b = rs2_value;
 
-                Ok(ControlFlow::Continue((rd, rv64_zbc_helpers::clmul(a, b))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv64_zbc_helpers::clmul(a, b),
+                }
             }
             Self::Clmulh { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value;
                 let b = rs2_value;
 
-                Ok(ControlFlow::Continue((rd, rv64_zbc_helpers::clmulh(a, b))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv64_zbc_helpers::clmulh(a, b),
+                }
             }
             Self::Clmulr { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value;
                 let b = rs2_value;
 
-                Ok(ControlFlow::Continue((rd, rv64_zbc_helpers::clmulr(a, b))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv64_zbc_helpers::clmulr(a, b),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZbsInstruction<Reg> where
@@ -46,48 +45,48 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Bset { rd, rs1: _, rs2: _ } => {
                 // Only the bottom 6 bits for RV64
                 let index = rs2_value & 0x3f;
                 let result = rs1_value | (1u64 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bseti { rd, rs1: _, shamt } => {
                 let index = shamt;
                 let result = rs1_value | (1u64 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bclr { rd, rs1: _, rs2: _ } => {
                 let index = rs2_value & 0x3f;
                 let result = rs1_value & !(1u64 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bclri { rd, rs1: _, shamt } => {
                 let index = shamt;
                 let result = rs1_value & !(1u64 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Binv { rd, rs1: _, rs2: _ } => {
                 let index = rs2_value & 0x3f;
                 let result = rs1_value ^ (1u64 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Binvi { rd, rs1: _, shamt } => {
                 let index = shamt;
                 let result = rs1_value ^ (1u64 << index);
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bext { rd, rs1: _, rs2: _ } => {
                 let index = rs2_value & 0x3f;
                 let result = (rs1_value >> index) & 1;
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
             Self::Bexti { rd, rs1: _, shamt } => {
                 let index = shamt;
                 let result = (rs1_value >> index) & 1;
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -152,28 +152,26 @@ where
             }
             Self::CJ { imm } => {
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                match program_counter
-                    .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                {
-                    Ok(control_flow) => Ok(match control_flow {
+                Ok(
+                    match program_counter
+                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                    {
                         ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                         ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::ProgramCounter(err)),
-                }
+                    },
+                )
             }
             Self::CBeqz { rs1: _, imm } => {
                 if rs1_value == 0 {
                     let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::ProgramCounter(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -181,15 +179,14 @@ where
             Self::CBnez { rs1: _, imm } => {
                 if rs1_value != 0 {
                     let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))
-                    {
-                        Ok(control_flow) => Ok(match control_flow {
+                    return Ok(
+                        match program_counter
+                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
+                        {
                             ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
                             ControlFlow::Break(()) => ControlFlow::Break(()),
-                        }),
-                        Err(err) => Err(ExecutionError::ProgramCounter(err)),
-                    };
+                        },
+                    );
                 }
 
                 Ok(ControlFlow::Continue(Default::default()))
@@ -212,13 +209,10 @@ where
             }
             Self::CJr { rs1: _ } => {
                 let target = rs1_value & !1;
-                match program_counter.set_pc(memory, target) {
-                    Ok(control_flow) => Ok(match control_flow {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::ProgramCounter(err)),
-                }
+                Ok(match program_counter.set_pc(memory, target)? {
+                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                    ControlFlow::Break(()) => ControlFlow::Break(()),
+                })
             }
             Self::CMv { rd, rs2: _ } => Ok(ControlFlow::Continue((rd, rs2_value))),
             Self::CEbreak => {
@@ -229,13 +223,10 @@ where
                 let target = rs1_value & !1;
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
-                match program_counter.set_pc(memory, target) {
-                    Ok(control_flow) => Ok(match control_flow {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    }),
-                    Err(err) => Err(ExecutionError::ProgramCounter(err)),
-                }
+                Ok(match program_counter.set_pc(memory, target)? {
+                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
+                    ControlFlow::Break(()) => ControlFlow::Break(()),
+                })
             }
             Self::CAdd { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_add(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -4,14 +4,13 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZcaInstruction<Reg> where
@@ -52,25 +51,28 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // Quadrant 00
             Self::CAddi4spn { rd, nzuimm } => {
                 let sp_val = regs.read(Reg::SP);
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    sp_val.wrapping_add(u64::from(nzuimm)),
-                )))
+                    value: sp_val.wrapping_add(u64::from(nzuimm)),
+                }
             }
             Self::CLw { rd, rs1: _, uimm } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 let value = i64::from(memory.read::<i32>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CLd { rd, rs1: _, uimm } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 let value = memory.read::<u64>(addr)?;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSw {
                 rs1: _,
@@ -79,7 +81,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value as u32)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CSd {
                 rs1: _,
@@ -88,163 +90,158 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             // Quadrant 01
             Self::CNop => {}
             Self::CAddi { rd, nzimm } => {
                 let value = regs.read(rd).wrapping_add(i64::from(nzimm).cast_unsigned());
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CAddiw { rd, imm } => {
                 let sum = (regs.read(rd) as i32).wrapping_add(i32::from(imm));
-                Ok(ControlFlow::Continue((rd, i64::from(sum).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(sum).cast_unsigned(),
+                }
             }
-            Self::CLi { rd, imm } => {
-                Ok(ControlFlow::Continue((rd, i64::from(imm).cast_unsigned())))
-            }
+            Self::CLi { rd, imm } => ExecutionResult::Continue {
+                rd,
+                value: i64::from(imm).cast_unsigned(),
+            },
             Self::CAddi16sp { nzimm } => {
                 let value = regs
                     .read(Reg::SP)
                     .wrapping_add(i64::from(nzimm).cast_unsigned());
-                Ok(ControlFlow::Continue((Reg::SP, value)))
+                ExecutionResult::Continue { rd: Reg::SP, value }
             }
-            Self::CLui { rd, nzimm } => Ok(ControlFlow::Continue((
+            Self::CLui { rd, nzimm } => ExecutionResult::Continue {
                 rd,
-                i64::from(nzimm).cast_unsigned(),
-            ))),
+                value: i64::from(nzimm).cast_unsigned(),
+            },
             Self::CSrli { rd, shamt } => {
                 let value = regs.read(rd) >> shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSrai { rd, shamt } => {
                 let value = regs.read(rd).cast_signed() >> shamt;
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CAndi { rd, imm } => {
                 let value = regs.read(rd) & i64::from(imm).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSub { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_sub(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CXor { rd, rs2: _ } => {
                 let value = regs.read(rd) ^ rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::COr { rd, rs2: _ } => {
                 let value = regs.read(rd) | rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CAnd { rd, rs2: _ } => {
                 let value = regs.read(rd) & rs2_value;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSubw { rd, rs2: _ } => {
                 let diff = (regs.read(rd) as i32).wrapping_sub(rs2_value as i32);
-                Ok(ControlFlow::Continue((rd, i64::from(diff).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(diff).cast_unsigned(),
+                }
             }
             Self::CAddw { rd, rs2: _ } => {
                 let sum = (regs.read(rd) as i32).wrapping_add(rs2_value as i32);
-                Ok(ControlFlow::Continue((rd, i64::from(sum).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(sum).cast_unsigned(),
+                }
             }
-            Self::CJ { imm } => {
-                let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                Ok(
-                    match program_counter
-                        .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                    {
-                        ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                        ControlFlow::Break(()) => ControlFlow::Break(()),
-                    },
-                )
-            }
+            Self::CJ { imm } => ExecutionResult::Branch {
+                offset: i32::from(imm),
+            },
             Self::CBeqz { rs1: _, imm } => {
                 if rs1_value == 0 {
-                    let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CBnez { rs1: _, imm } => {
                 if rs1_value != 0 {
-                    let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                    return Ok(
-                        match program_counter
-                            .set_pc(memory, old_pc.wrapping_add(i64::from(imm).cast_unsigned()))?
-                        {
-                            ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                            ControlFlow::Break(()) => ControlFlow::Break(()),
-                        },
-                    );
+                    return ExecutionResult::Branch {
+                        offset: i32::from(imm),
+                    };
                 }
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
 
             // Quadrant 10
             Self::CSlli { rd, shamt } => {
                 let value = regs.read(rd) << shamt;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CLwsp { rd, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
                 let value = i64::from(memory.read::<i32>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CLdsp { rd, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
                 let value = memory.read::<u64>(addr)?;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CJr { rs1: _ } => {
                 let target = rs1_value & !1;
-                Ok(match program_counter.set_pc(memory, target)? {
-                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                    ControlFlow::Break(()) => ControlFlow::Break(()),
-                })
+                ExecutionResult::Jump { target }
             }
-            Self::CMv { rd, rs2: _ } => Ok(ControlFlow::Continue((rd, rs2_value))),
+            Self::CMv { rd, rs2: _ } => ExecutionResult::Continue {
+                rd,
+                value: rs2_value,
+            },
             Self::CEbreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CJalr { rs1: _ } => {
                 let target = rs1_value & !1;
                 let return_addr = program_counter.get_pc();
                 regs.write(Reg::RA, return_addr);
-                Ok(match program_counter.set_pc(memory, target)? {
-                    ControlFlow::Continue(()) => ControlFlow::Continue(Default::default()),
-                    ControlFlow::Break(()) => ControlFlow::Break(()),
-                })
+                ExecutionResult::Jump { target }
             }
             Self::CAdd { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_add(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSwsp { rs2: _, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value as u32)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CSdsp { rs2: _, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CUnimp => {
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);
-                return Err(ExecutionError::IllegalInstruction { address: old_pc });
+                return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                    address: PackedAddress::new(old_pc),
+                });
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca/tests.rs
@@ -572,7 +572,10 @@ fn test_clw_out_of_bounds() {
     }]);
     state.regs.write(Reg::A0, 0);
     let result = execute(&mut state);
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsRead { .. })
+    ));
 }
 
 #[test]
@@ -584,7 +587,10 @@ fn test_csd_out_of_bounds() {
     }]);
     state.regs.write(Reg::A0, 0);
     let result = execute(&mut state);
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsWrite { .. })
+    ));
 }
 
 #[test]

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
@@ -6,11 +6,10 @@ pub mod zmmul;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64MInstruction<Reg> where
@@ -47,30 +46,39 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Mul { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_mul(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Mulh { rd, rs1: _, rs2: _ } => {
                 // Signed × signed: multiply and take upper 64 bits
                 let (_lo, prod) = rs1_value
                     .cast_signed()
                     .carrying_mul(rs2_value.cast_signed(), 0);
-                Ok(ControlFlow::Continue((rd, prod.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: prod.cast_unsigned(),
+                }
             }
             Self::Mulhsu { rd, rs1: _, rs2: _ } => {
                 // Signed × unsigned: widen to i128, take upper 64 bits
                 let prod = i128::from(rs1_value.cast_signed()) * i128::from(rs2_value);
                 let value = prod >> 64;
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned() as u64)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned() as u64,
+                }
             }
             Self::Mulhu { rd, rs1: _, rs2: _ } => {
                 // Unsigned × unsigned: widen to u128, take upper 64 bits
                 let prod = u128::from(rs1_value) * u128::from(rs2_value);
                 let value = prod >> 64;
-                Ok(ControlFlow::Continue((rd, value as u64)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value as u64,
+                }
             }
             Self::Div { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value.cast_signed();
@@ -82,13 +90,16 @@ where
                 } else {
                     dividend / divisor
                 };
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Divu { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value;
                 let divisor = rs2_value;
                 let value = dividend.checked_div(divisor).unwrap_or(u64::MAX);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Rem { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value.cast_signed();
@@ -104,7 +115,10 @@ where
                 } else {
                     dividend % divisor
                 };
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Remu { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value;
@@ -114,13 +128,16 @@ where
                 } else {
                     dividend % divisor
                 };
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
 
             // RV64 R-type W
             Self::Mulw { rd, rs1: _, rs2: _ } => {
                 let prod = (rs1_value as i32).wrapping_mul(rs2_value as i32);
-                Ok(ControlFlow::Continue((rd, i64::from(prod).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(prod).cast_unsigned(),
+                }
             }
             Self::Divw { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value as i32;
@@ -132,7 +149,10 @@ where
                 } else {
                     i64::from(dividend / divisor)
                 };
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::Divuw { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value as u32;
@@ -141,7 +161,7 @@ where
                     Some(value) => i64::from(value.cast_signed()).cast_unsigned(),
                     None => u64::MAX,
                 };
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Remw { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value as i32;
@@ -157,7 +177,7 @@ where
                 } else {
                     i64::from(dividend % divisor).cast_unsigned()
                 };
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Remuw { rd, rs1: _, rs2: _ } => {
                 let dividend = rs1_value as u32;
@@ -167,10 +187,10 @@ where
                 } else {
                     (dividend % divisor).cast_signed()
                 };
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(value).cast_unsigned(),
-                )))
+                    value: i64::from(value).cast_unsigned(),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
@@ -2,11 +2,10 @@
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZmmulInstruction<Reg> where
@@ -42,7 +41,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -9,9 +9,8 @@ use crate::zawrs::WrsHandler;
 use crate::zkr::{ZkrSeedPoll, ZkrSeedSource};
 use crate::{
     Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError,
-    FetchInstructionResult, InstructionFetcher, ProgramCounter, ProgramCounterError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::collections::BTreeMap;
@@ -169,7 +168,7 @@ where
         &mut self,
         _memory: &TestMemory,
         pc: u64,
-    ) -> Result<ControlFlow<()>, ProgramCounterError<u64>> {
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
         self.pc = pc;
 
         Ok(ControlFlow::Continue(()))

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -192,29 +192,26 @@ where
     I: Instruction<Reg = Reg<u64>>,
 {
     #[inline]
-    fn fetch_instruction(
-        &mut self,
-        _memory: &TestMemory,
-    ) -> Result<FetchInstructionResult<I>, ExecutionError<Address<I>>> {
+    fn fetch_instruction(&mut self, _memory: &TestMemory) -> FetchInstructionResult<I> {
         if self.pc == self.return_trap_address {
-            return Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(())));
+            return FetchInstructionResult::Break;
         }
 
         let Some(&maybe_instruction) = self
             .instructions
             .get((self.pc - self.base_address) as usize / size_of::<u16>())
         else {
-            return Ok(FetchInstructionResult::ControlFlow(ControlFlow::Break(())));
+            return FetchInstructionResult::Break;
         };
 
         let Some(instruction) = maybe_instruction else {
-            return Err(ExecutionError::IllegalInstruction {
+            return FetchInstructionResult::Err(ExecutionError::IllegalInstruction {
                 address: PackedAddress::new(self.pc),
             });
         };
         self.pc += u64::from(instruction.size());
 
-        Ok(FetchInstructionResult::Instruction(instruction))
+        FetchInstructionResult::Instruction(instruction)
     }
 }
 
@@ -539,13 +536,16 @@ where
         >,
 {
     loop {
-        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory)? {
+        let instruction = match state.instruction_fetcher.fetch_instruction(&state.memory) {
             FetchInstructionResult::Instruction(instruction) => instruction,
-            FetchInstructionResult::ControlFlow(ControlFlow::Continue(())) => {
+            FetchInstructionResult::Continue => {
                 continue;
             }
-            FetchInstructionResult::ControlFlow(ControlFlow::Break(())) => {
+            FetchInstructionResult::Break => {
                 break;
+            }
+            FetchInstructionResult::Err(error) => {
+                return Err(error);
             }
         };
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -8,9 +8,10 @@ use crate::v::vector_registers::{
 use crate::zawrs::WrsHandler;
 use crate::zkr::{ZkrSeedPoll, ZkrSeedSource};
 use crate::{
-    Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError,
-    FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError, ExecutionResult,
+    FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::collections::BTreeMap;
@@ -164,6 +165,17 @@ where
         self.pc
     }
 
+    #[inline(always)]
+    fn set_pc_relative(
+        &mut self,
+        memory: &TestMemory,
+        instruction_size: u8,
+        offset: i32,
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+        let old_pc = self.old_pc(instruction_size);
+        self.set_pc(memory, old_pc.wrapping_add_signed(i64::from(offset)))
+    }
+
     fn set_pc(
         &mut self,
         _memory: &TestMemory,
@@ -196,7 +208,9 @@ where
         };
 
         let Some(instruction) = maybe_instruction else {
-            return Err(ExecutionError::IllegalInstruction { address: self.pc });
+            return Err(ExecutionError::IllegalInstruction {
+                address: PackedAddress::new(self.pc),
+            });
         };
         self.pc += u64::from(instruction.size());
 
@@ -257,12 +271,14 @@ where
         program_counter: &mut TestInstructionFetcher<I>,
     ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
         Err(ExecutionError::EcallUnsupported {
-            address: program_counter.old_pc(
-                Rv64Instruction::<Reg<u64>>::Ecall {
-                    rs1: Reg::Zero,
-                    rs2: Reg::Zero,
-                }
-                .size(),
+            address: crate::PackedAddress::new(
+                program_counter.old_pc(
+                    Rv64Instruction::<Reg<u64>>::Ecall {
+                        rs1: Reg::Zero,
+                        rs2: Reg::Zero,
+                    }
+                    .size(),
+                ),
             ),
         })
     }
@@ -546,12 +562,34 @@ where
             &mut state.memory,
             &mut state.instruction_fetcher,
             &mut state.system_instruction_handler,
-        )? {
-            ControlFlow::Continue((rd, rd_value)) => {
-                state.regs.write(rd, rd_value);
+        ) {
+            ExecutionResult::Continue { rd, value } => {
+                state.regs.write(rd, value);
             }
-            ControlFlow::Break(()) => {
+            ExecutionResult::Branch { offset } => {
+                let control_flow = state.instruction_fetcher.set_pc_relative(
+                    &state.memory,
+                    instruction.size(),
+                    offset,
+                )?;
+                if control_flow.is_break() {
+                    break;
+                }
+            }
+            ExecutionResult::Jump { target } => {
+                if state
+                    .instruction_fetcher
+                    .set_pc(&state.memory, target)?
+                    .is_break()
+                {
+                    break;
+                }
+            }
+            ExecutionResult::Break => {
                 break;
+            }
+            ExecutionResult::Err(error) => {
+                return Err(error);
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/tests.rs
@@ -1166,7 +1166,10 @@ fn test_out_of_bounds_read() {
 
     let result = execute(&mut state);
 
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsRead { .. })
+    ));
 }
 
 #[test]
@@ -1183,7 +1186,10 @@ fn test_out_of_bounds_write() {
 
     let result = execute(&mut state);
 
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsWrite { .. })
+    ));
 }
 
 // Register Zero Tests

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZabhaInstruction<Reg> where
@@ -47,7 +46,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::AmoswapB {
                 rd,
@@ -58,7 +57,10 @@ where
             } => {
                 let old = memory.read::<i8>(rs1_value)?;
                 memory.write(rs1_value, rs2_value as u8)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoswapH {
                 rd,
@@ -69,7 +71,10 @@ where
             } => {
                 let old = memory.read::<i16>(rs1_value)?;
                 memory.write(rs1_value, rs2_value as u16)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoaddB {
                 rd,
@@ -81,7 +86,10 @@ where
                 let old = memory.read::<i8>(rs1_value)?;
                 let new = old.cast_unsigned().wrapping_add(rs2_value as u8);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoaddH {
                 rd,
@@ -93,7 +101,10 @@ where
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = old.cast_unsigned().wrapping_add(rs2_value as u16);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoxorB {
                 rd,
@@ -105,7 +116,10 @@ where
                 let old = memory.read::<i8>(rs1_value)?;
                 let new = old.cast_unsigned() ^ (rs2_value as u8);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoxorH {
                 rd,
@@ -117,7 +131,10 @@ where
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = old.cast_unsigned() ^ (rs2_value as u16);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoandB {
                 rd,
@@ -129,7 +146,10 @@ where
                 let old = memory.read::<i8>(rs1_value)?;
                 let new = old.cast_unsigned() & (rs2_value as u8);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoandH {
                 rd,
@@ -141,7 +161,10 @@ where
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = old.cast_unsigned() & (rs2_value as u16);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoorB {
                 rd,
@@ -153,7 +176,10 @@ where
                 let old = memory.read::<i8>(rs1_value)?;
                 let new = old.cast_unsigned() | (rs2_value as u8);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmoorH {
                 rd,
@@ -165,7 +191,10 @@ where
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = old.cast_unsigned() | (rs2_value as u16);
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmominB {
                 rd,
@@ -181,7 +210,10 @@ where
                     rs2_value as u8
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmominH {
                 rd,
@@ -197,7 +229,10 @@ where
                     rs2_value as u16
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmomaxB {
                 rd,
@@ -213,7 +248,10 @@ where
                     rs2_value as u8
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmomaxH {
                 rd,
@@ -229,7 +267,10 @@ where
                     rs2_value as u16
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmominuB {
                 rd,
@@ -245,7 +286,10 @@ where
                     rs2_value as u8
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmominuH {
                 rd,
@@ -261,7 +305,10 @@ where
                     rs2_value as u16
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmomaxuB {
                 rd,
@@ -277,7 +324,10 @@ where
                     rs2_value as u8
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmomaxuH {
                 rd,
@@ -293,7 +343,10 @@ where
                     rs2_value as u16
                 };
                 memory.write(rs1_value, new)?;
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmocasB {
                 rd,
@@ -307,7 +360,10 @@ where
                 if old.cast_unsigned() == compare {
                     memory.write(rs1_value, rs2_value as u8)?;
                 }
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmocasH {
                 rd,
@@ -321,7 +377,10 @@ where
                 if old.cast_unsigned() == compare {
                     memory.write(rs1_value, rs2_value as u16)?;
                 }
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZacasInstruction<Reg> where
@@ -47,7 +46,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::AmocasW {
                 rd,
@@ -63,7 +62,10 @@ where
                 if old.cast_unsigned() == compare {
                     memory.write(addr, rs2_value as u32)?;
                 }
-                Ok(ControlFlow::Continue((rd, i64::from(old).cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: i64::from(old).cast_unsigned(),
+                }
             }
             Self::AmocasD {
                 rd,
@@ -78,7 +80,7 @@ where
                 if old == compare {
                     memory.write(addr, rs2_value)?;
                 }
-                Ok(ControlFlow::Continue((rd, old)))
+                ExecutionResult::Continue { rd, value: old }
             }
             Self::AmocasQ {
                 rd,
@@ -113,7 +115,7 @@ where
                 if rd != Reg::ZERO {
                     regs.write(rd_hi, old_hi);
                 }
-                Ok(ControlFlow::Continue((rd, old_lo)))
+                ExecutionResult::Continue { rd, value: old_lo }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZalasrInstruction<Reg> where
@@ -47,23 +46,32 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::LbAq { rd, rs1: _, rl: _ } => {
                 let value = i64::from(memory.read::<i8>(rs1_value)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::LhAq { rd, rs1: _, rl: _ } => {
                 let value = i64::from(memory.read::<i16>(rs1_value)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::LwAq { rd, rs1: _, rl: _ } => {
                 let value = i64::from(memory.read::<i32>(rs1_value)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::LdAq { rd, rs1: _, rl: _ } => {
                 let value = memory.read::<u64>(rs1_value)?;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::SbRl {
                 rs1: _,
@@ -71,7 +79,7 @@ where
                 aq: _,
             } => {
                 memory.write(rs1_value, rs2_value as u8)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::ShRl {
                 rs1: _,
@@ -79,7 +87,7 @@ where
                 aq: _,
             } => {
                 memory.write(rs1_value, rs2_value as u16)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::SwRl {
                 rs1: _,
@@ -87,7 +95,7 @@ where
                 aq: _,
             } => {
                 memory.write(rs1_value, rs2_value as u32)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::SdRl {
                 rs1: _,
@@ -95,7 +103,7 @@ where
                 aq: _,
             } => {
                 memory.write(rs1_value, rs2_value)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -4,13 +4,12 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZcbInstruction<Reg> where
@@ -46,8 +45,8 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }
 
@@ -89,22 +88,31 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::CLbu { rd, rs1: _, uimm } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 let value = memory.read::<u8>(addr)?;
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
             Self::CLh { rd, rs1: _, uimm } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 let value = i64::from(memory.read::<i16>(addr)?);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CLhu { rd, rs1: _, uimm } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 let value = memory.read::<u16>(addr)?;
-                Ok(ControlFlow::Continue((rd, u64::from(value))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from(value),
+                }
             }
             Self::CSb {
                 rs1: _,
@@ -113,7 +121,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value as u8)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CSh {
                 rs1: _,
@@ -123,35 +131,41 @@ where
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value as u16)?;
 
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CZextB { rd } => {
                 let value = regs.read(rd) & 0xff;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSextB { rd } => {
                 let value = i64::from(regs.read(rd) as i8);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CZextH { rd } => {
                 let value = regs.read(rd) & 0xffff;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CSextH { rd } => {
                 let value = i64::from(regs.read(rd) as i16);
-                Ok(ControlFlow::Continue((rd, value.cast_unsigned())))
+                ExecutionResult::Continue {
+                    rd,
+                    value: value.cast_unsigned(),
+                }
             }
             Self::CZextW { rd } => {
                 let value = regs.read(rd) & 0xffff_ffff;
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CNot { rd } => {
                 let value = !regs.read(rd);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::CMul { rd, rs2: _ } => {
                 let value = regs.read(rd).wrapping_mul(rs2_value);
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb/tests.rs
@@ -46,7 +46,7 @@ fn test_clbu_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsRead { .. })
     ));
 }
 
@@ -93,7 +93,7 @@ fn test_clhu_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsRead { .. })
     ));
 }
 
@@ -140,7 +140,7 @@ fn test_clh_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsRead { .. })
     ));
 }
 
@@ -170,7 +170,7 @@ fn test_csb_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsWrite { .. })
     ));
 }
 
@@ -200,7 +200,7 @@ fn test_csh_oob() {
     state.regs.write(Reg::A0, 0);
     assert!(matches!(
         execute(&mut state),
-        Err(ExecutionError::MemoryAccess(_))
+        Err(ExecutionError::OutOfBoundsWrite { .. })
     ));
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -108,7 +108,6 @@ where
                 program_counter
                     .set_pc(memory, target)
                     .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from)
             }
             Self::CmPopret { urlist, stack_adj } => {
                 let ra_val = rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
@@ -117,7 +116,6 @@ where
                 program_counter
                     .set_pc(memory, target)
                     .map(|control_flow| control_flow.map_continue(|()| Default::default()))
-                    .map_err(ExecutionError::from)
             }
             Self::CmMva01s { rs1: _, rs2: _ } => {
                 // Read both sources before any write to avoid aliasing

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -1,17 +1,17 @@
 //! RV64 Zcmp extension
 
 pub mod rv64_zcmp_helpers;
+use crate::PackedAddress;
 #[cfg(test)]
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZcmpInstruction<Reg> where
@@ -47,8 +47,8 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }
 
@@ -88,16 +88,16 @@ where
         regs: &mut Regs,
         _ext_state: &mut ExtState,
         memory: &mut Memory,
-        program_counter: &mut PC,
+        _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::CmPush { urlist, stack_adj } => {
                 rv64_zcmp_helpers::do_push(regs, memory, urlist, stack_adj)
             }
             Self::CmPop { urlist, stack_adj } => {
                 rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::CmPopretz { urlist, stack_adj } => {
                 let ra_val = rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
@@ -105,31 +105,33 @@ where
                 regs.write(Reg::A0, 0);
                 // Jump to ra with LSB cleared (RISC-V mode bit)
                 let target = ra_val & !1;
-                program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
+                ExecutionResult::Jump { target }
             }
             Self::CmPopret { urlist, stack_adj } => {
                 let ra_val = rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
                 // Jump to ra with LSB cleared (RISC-V mode bit)
                 let target = ra_val & !1;
-                program_counter
-                    .set_pc(memory, target)
-                    .map(|control_flow| control_flow.map_continue(|()| Default::default()))
+                ExecutionResult::Jump { target }
             }
             Self::CmMva01s { rs1: _, rs2: _ } => {
                 // Read both sources before any write to avoid aliasing
                 let v1 = rs1_value;
                 let v2 = rs2_value;
                 regs.write(Reg::A0, v1);
-                Ok(ControlFlow::Continue((Reg::A1, v2)))
+                ExecutionResult::Continue {
+                    rd: Reg::A1,
+                    value: v2,
+                }
             }
             Self::CmMvsa01 { rs1, rs2 } => {
                 // Read both sources before any write to avoid aliasing
                 let a0_val = regs.read(Reg::A0);
                 let a1_val = regs.read(Reg::A1);
                 regs.write(rs1, a0_val);
-                Ok(ControlFlow::Continue((rs2, a1_val)))
+                ExecutionResult::Continue {
+                    rd: rs2,
+                    value: a1_val,
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
@@ -1,20 +1,18 @@
 //! Opaque helpers for Zcmp extension
 
-use crate::{ExecutionError, RegisterFile, VirtualMemory};
+use crate::{ExecutionError, ExecutionResult, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 /// Execute CM.PUSH: store registers below sp, then decrement sp
 #[inline]
 #[doc(hidden)]
-#[expect(clippy::type_complexity, reason = "Internal helper")]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn do_push<Reg, Regs, Memory, CustomError>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u8,
-) -> Result<ControlFlow<(), (Reg, u64)>, ExecutionError<Reg::Type, CustomError>>
+) -> ExecutionResult<Reg, CustomError>
 where
     Reg: ZcmpRegister<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -27,10 +25,10 @@ where
         memory.write(store_addr, regs.read(reg))?;
         store_addr = store_addr.wrapping_sub(size_of::<Reg::Type>() as u64);
     }
-    Ok(ControlFlow::Continue((
-        Reg::SP,
-        sp.wrapping_sub(u64::from(stack_adj)),
-    )))
+    ExecutionResult::Continue {
+        rd: Reg::SP,
+        value: sp.wrapping_sub(u64::from(stack_adj)),
+    }
 }
 
 /// Execute CM.POP and variants: restore registers and increment sp.

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/tests.rs
@@ -350,5 +350,8 @@ fn test_cm_push_oob_memory() {
     }]);
     state.regs.write(Reg::Sp, 4);
     let result = execute(&mut state);
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsWrite { .. })
+    ));
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZbkbInstruction<Reg> where
@@ -46,21 +45,21 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Pack { rd, rs1: _, rs2: _ } => {
                 // Pack lower 32 bits of rs1 into lower 32 bits of rd,
                 // lower 32 bits of rs2 into upper 32 bits of rd.
                 let lo = rs1_value & 0x0000_0000_FFFF_FFFFu64;
                 let hi = (rs2_value & 0x0000_0000_FFFF_FFFFu64) << 32;
-                Ok(ControlFlow::Continue((rd, lo | hi)))
+                ExecutionResult::Continue { rd, value: lo | hi }
             }
             Self::Packh { rd, rs1: _, rs2: _ } => {
                 // Pack low byte of rs1 into bits [7:0], low byte of rs2 into bits [15:8].
                 // Upper bits of rd are zeroed.
                 let lo = rs1_value & 0xFF;
                 let hi = (rs2_value & 0xFF) << 8;
-                Ok(ControlFlow::Continue((rd, lo | hi)))
+                ExecutionResult::Continue { rd, value: lo | hi }
             }
             Self::Packw { rd, rs1: _, rs2: _ } => {
                 // Pack low 16 bits of rs1 into bits [15:0] of the 32-bit result,
@@ -69,7 +68,7 @@ where
                 let hi = (rs2_value & 0xFFFF) << 16;
                 let word = (lo | hi) as u32;
                 let value = i64::from(word.cast_signed()).cast_unsigned();
-                Ok(ControlFlow::Continue((rd, value)))
+                ExecutionResult::Continue { rd, value }
             }
             Self::Brev8 { rd, rs1: _ } => {
                 // Reverse bits within each byte of rs1
@@ -78,7 +77,10 @@ where
                 for byte in &mut bytes {
                     *byte = byte.reverse_bits();
                 }
-                Ok(ControlFlow::Continue((rd, u64::from_le_bytes(bytes))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: u64::from_le_bytes(bytes),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
@@ -3,11 +3,10 @@
 use crate::rv64::b::zbc::rv64_zbc_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZbkcInstruction<Reg> where
@@ -43,7 +42,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZbkxInstruction<Reg> where
@@ -47,16 +46,16 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
-            Self::Xperm4 { rd, rs1: _, rs2: _ } => Ok(ControlFlow::Continue((
+            Self::Xperm4 { rd, rs1: _, rs2: _ } => ExecutionResult::Continue {
                 rd,
-                rv64_zbkx_helpers::xperm4(rs1_value, rs2_value),
-            ))),
-            Self::Xperm8 { rd, rs1: _, rs2: _ } => Ok(ControlFlow::Continue((
+                value: rv64_zbkx_helpers::xperm4(rs1_value, rs2_value),
+            },
+            Self::Xperm8 { rd, rs1: _, rs2: _ } => ExecutionResult::Continue {
                 rd,
-                rv64_zbkx_helpers::xperm8(rs1_value, rs2_value),
-            ))),
+                value: rv64_zbkx_helpers::xperm8(rs1_value, rs2_value),
+            },
         }
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
@@ -11,11 +11,10 @@ use crate::rv64::zk::zkn::zkne::rv64_zkne_helpers;
 use crate::rv64::zk::zkn::zknh::rv64_zknh_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZknInstruction<Reg> where
@@ -51,7 +50,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZkndInstruction<Reg> where
@@ -47,42 +46,45 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Aes64Ds { rd, rs1: _, rs2: _ } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zknd_helpers::aes64ds(v1, v2),
-                )))
+                    value: rv64_zknd_helpers::aes64ds(v1, v2),
+                }
             }
             Self::Aes64Dsm { rd, rs1: _, rs2: _ } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zknd_helpers::aes64dsm(v1, v2),
-                )))
+                    value: rv64_zknd_helpers::aes64dsm(v1, v2),
+                }
             }
             Self::Aes64Im { rd, rs1: _ } => {
                 let v1 = rs1_value;
-                Ok(ControlFlow::Continue((rd, rv64_zknd_helpers::aes64im(v1))))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rv64_zknd_helpers::aes64im(v1),
+                }
             }
             Self::Aes64Ks1i { rd, rs1: _, rnum } => {
                 let v1 = rs1_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zknd_helpers::aes64ks1i(v1, rnum),
-                )))
+                    value: rv64_zknd_helpers::aes64ks1i(v1, rnum),
+                }
             }
             Self::Aes64Ks2 { rd, rs1: _, rs2: _ } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zknd_helpers::aes64ks2(v1, v2),
-                )))
+                    value: rv64_zknd_helpers::aes64ks2(v1, v2),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
@@ -10,11 +10,10 @@ mod tests;
 use crate::rv64::zk::zkn::zknd::rv64_zknd_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZkneInstruction<Reg> where
@@ -51,23 +50,23 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Aes64Es { rd, rs1: _, rs2: _ } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zkne_helpers::aes64es(v1, v2),
-                )))
+                    value: rv64_zkne_helpers::aes64es(v1, v2),
+                }
             }
             Self::Aes64Esm { rd, rs1: _, rs2: _ } => {
                 let v1 = rs1_value;
                 let v2 = rs2_value;
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zkne_helpers::aes64esm(v1, v2),
-                )))
+                    value: rv64_zkne_helpers::aes64esm(v1, v2),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
@@ -6,11 +6,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZknhInstruction<Reg> where
@@ -47,79 +46,79 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Sha256Sig0 { rd, rs1: _ } => {
                 let x = rs1_value as u32;
 
                 let res32 = rv64_zknh_helpers::sha256sig0(x);
 
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(res32.cast_signed()).cast_unsigned(),
-                )))
+                    value: i64::from(res32.cast_signed()).cast_unsigned(),
+                }
             }
             Self::Sha256Sig1 { rd, rs1: _ } => {
                 let x = rs1_value as u32;
 
                 let res32 = rv64_zknh_helpers::sha256sig1(x);
 
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(res32.cast_signed()).cast_unsigned(),
-                )))
+                    value: i64::from(res32.cast_signed()).cast_unsigned(),
+                }
             }
             Self::Sha256Sum0 { rd, rs1: _ } => {
                 let x = rs1_value as u32;
 
                 let res32 = rv64_zknh_helpers::sha256sum0(x);
 
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(res32.cast_signed()).cast_unsigned(),
-                )))
+                    value: i64::from(res32.cast_signed()).cast_unsigned(),
+                }
             }
             Self::Sha256Sum1 { rd, rs1: _ } => {
                 let x = rs1_value as u32;
 
                 let res32 = rv64_zknh_helpers::sha256sum1(x);
 
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    i64::from(res32.cast_signed()).cast_unsigned(),
-                )))
+                    value: i64::from(res32.cast_signed()).cast_unsigned(),
+                }
             }
             Self::Sha512Sig0 { rd, rs1: _ } => {
                 let x = rs1_value;
 
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zknh_helpers::sha512sig0(x),
-                )))
+                    value: rv64_zknh_helpers::sha512sig0(x),
+                }
             }
             Self::Sha512Sig1 { rd, rs1: _ } => {
                 let x = rs1_value;
 
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zknh_helpers::sha512sig1(x),
-                )))
+                    value: rv64_zknh_helpers::sha512sig1(x),
+                }
             }
             Self::Sha512Sum0 { rd, rs1: _ } => {
                 let x = rs1_value;
 
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zknh_helpers::sha512sum0(x),
-                )))
+                    value: rv64_zknh_helpers::sha512sum0(x),
+                }
             }
             Self::Sha512Sum1 { rd, rs1: _ } => {
                 let x = rs1_value;
 
-                Ok(ControlFlow::Continue((
+                ExecutionResult::Continue {
                     rd,
-                    rv64_zknh_helpers::sha512sum1(x),
-                )))
+                    value: rv64_zknh_helpers::sha512sum1(x),
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/tests.rs
@@ -1,0 +1,26 @@
+use crate::basic::BasicMemory;
+use crate::*;
+
+/// `?` on a memory access inside a function returning [`ExecutionResult`], in const context,
+/// which is what instruction bodies need
+const fn load<Memory>(memory: &Memory, address: u64) -> ExecutionResult<Reg<u64>>
+where
+    Memory: [const] VirtualMemory,
+{
+    let value = memory.read::<u64>(address)?;
+    ExecutionResult::Continue { rd: Reg::A0, value }
+}
+
+#[test]
+fn question_mark_converts_memory_errors() {
+    let memory = BasicMemory::<0x1000, 128>::default();
+
+    assert!(matches!(
+        load(&memory, 0x1000),
+        ExecutionResult::Continue { rd: Reg::A0, .. }
+    ));
+    assert!(matches!(
+        load(&memory, 0xdead_0000),
+        ExecutionResult::Err(ExecutionError::OutOfBoundsRead { .. })
+    ));
+}

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
@@ -28,13 +28,12 @@ use crate::v::zvexx::widen_narrow::zvexx_widen_narrow_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionError, ExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxInstruction<Reg> where Reg: Register {}
@@ -67,7 +66,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
@@ -7,13 +7,12 @@ pub mod zvexx_arith_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxArithInstruction<Reg> where Reg: Register {}
@@ -51,20 +50,24 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vadd
             Self::VaddVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -85,8 +88,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -112,14 +117,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -135,8 +144,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -157,14 +168,18 @@ where
             Self::VaddVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -180,8 +195,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -204,14 +221,18 @@ where
             Self::VsubVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -232,8 +253,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -258,14 +281,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -281,8 +308,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -308,14 +337,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -331,8 +364,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -354,14 +389,18 @@ where
             Self::VrsubVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -377,8 +416,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -400,14 +441,18 @@ where
             Self::VandVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -428,8 +473,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -454,14 +501,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -477,8 +528,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -499,14 +552,18 @@ where
             Self::VandVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -522,8 +579,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -545,14 +604,18 @@ where
             Self::VorVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -573,8 +636,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -599,14 +664,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -622,8 +691,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -644,14 +715,18 @@ where
             Self::VorVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -667,8 +742,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -690,14 +767,18 @@ where
             Self::VxorVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -718,8 +799,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -744,14 +827,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -767,8 +854,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -789,14 +878,18 @@ where
             Self::VxorVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -812,8 +905,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -835,14 +930,18 @@ where
             Self::VsllVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -863,8 +962,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -890,14 +991,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -913,8 +1018,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -935,14 +1042,18 @@ where
             Self::VsllVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -958,8 +1069,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -982,14 +1095,18 @@ where
             Self::VsrlVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1010,8 +1127,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1041,14 +1160,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1064,8 +1187,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1090,14 +1215,18 @@ where
             Self::VsrlVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1113,8 +1242,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1136,14 +1267,18 @@ where
             Self::VsraVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1164,8 +1299,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1194,14 +1331,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1217,8 +1358,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1243,14 +1386,18 @@ where
             Self::VsraVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1266,8 +1413,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1292,14 +1441,18 @@ where
             Self::VminuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1320,8 +1473,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1349,14 +1504,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1372,8 +1531,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1397,14 +1558,18 @@ where
             Self::VminVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1425,8 +1590,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1459,14 +1626,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1482,8 +1653,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1513,14 +1686,18 @@ where
             Self::VmaxuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1541,8 +1718,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1570,14 +1749,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1593,8 +1776,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1618,14 +1803,18 @@ where
             Self::VmaxVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1646,8 +1835,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1680,14 +1871,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1703,8 +1898,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1734,14 +1931,18 @@ where
             Self::VmseqVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1794,14 +1995,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1837,14 +2042,18 @@ where
             Self::VmseqVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1881,14 +2090,18 @@ where
             Self::VmsneVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1939,14 +2152,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1982,14 +2199,18 @@ where
             Self::VmsneVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2026,14 +2247,18 @@ where
             Self::VmsltuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2084,14 +2309,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2128,14 +2357,18 @@ where
             Self::VmsltVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2186,14 +2419,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2230,14 +2467,18 @@ where
             Self::VmsleuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2288,14 +2529,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2331,14 +2576,18 @@ where
             Self::VmsleuVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2382,14 +2631,18 @@ where
             Self::VmsleVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2440,14 +2693,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2483,14 +2740,18 @@ where
             Self::VmsleVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2532,14 +2793,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2575,14 +2840,18 @@ where
             Self::VmsgtuVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2624,14 +2893,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2667,14 +2940,18 @@ where
             Self::VmsgtVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -2709,6 +2986,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/tests.rs
@@ -1,11 +1,10 @@
 use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 /// Encode a raw vtype value (vta=false, vma=false)
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
@@ -38,15 +37,23 @@ fn exec(
         rs2_value: state.regs.read(rs2),
     };
 
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
 
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
@@ -3,7 +3,7 @@
 use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, ProgramCounter};
+use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
 use core::num::NonZeroU8;
@@ -26,7 +26,7 @@ where
     if !vreg_idx.is_multiple_of(group_regs) || vreg_idx + group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())
@@ -66,7 +66,7 @@ where
         if vd_idx > src && vd_idx < src + group_regs {
             cold_path();
             return Err(ExecutionError::IllegalInstruction {
-                address: program_counter.old_pc(INSTRUCTION_SIZE),
+                address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
             });
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
@@ -7,13 +7,12 @@ pub mod zvexx_carry_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxCarryInstruction<Reg> where Reg: Register {}
@@ -51,20 +50,24 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vadc: add with carry-in from v0, data result
             Self::VadcVvm { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -86,8 +89,10 @@ where
                 // vd must not be v0: v0 holds carry-in
                 if vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -106,14 +111,18 @@ where
             Self::VadcVxm { vd, vs2, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -129,8 +138,10 @@ where
                 )?;
                 if vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -150,14 +161,18 @@ where
             Self::VadcVim { vd, vs2, imm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -173,8 +188,10 @@ where
                 )?;
                 if vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -195,14 +212,18 @@ where
             Self::VmadcVvm { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -244,14 +265,18 @@ where
             Self::VmadcVxm { vd, vs2, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -283,14 +308,18 @@ where
             Self::VmadcVim { vd, vs2, imm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -322,14 +351,18 @@ where
             Self::VmadcVv { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -371,14 +404,18 @@ where
             Self::VmadcVx { vd, vs2, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -410,14 +447,18 @@ where
             Self::VmadcVi { vd, vs2, imm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -450,14 +491,18 @@ where
             Self::VsbcVvm { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -478,8 +523,10 @@ where
                 )?;
                 if vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -498,14 +545,18 @@ where
             Self::VsbcVxm { vd, vs2, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -521,8 +572,10 @@ where
                 )?;
                 if vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -543,14 +596,18 @@ where
             Self::VmsbcVvm { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -592,14 +649,18 @@ where
             Self::VmsbcVxm { vd, vs2, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -631,14 +692,18 @@ where
             Self::VmsbcVv { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -680,14 +745,18 @@ where
             Self::VmsbcVx { vd, vs2, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -717,6 +786,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/tests.rs
@@ -1,11 +1,10 @@
 use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
@@ -35,15 +34,23 @@ fn exec(
         rs2_value: state.regs.read(rs2),
     };
 
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
 
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
@@ -7,12 +7,11 @@ pub mod zvexx_config_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxConfigInstruction<Reg> where Reg: Register {}
@@ -135,7 +134,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Vsetvli { rd, rs1, vtypei } => {
                 let rd_value = zvexx_config_helpers::apply_vsetvl(
@@ -147,13 +146,19 @@ where
                     Reg::Type::from(vtypei),
                 )?;
 
-                Ok(ControlFlow::Continue((rd, rd_value)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rd_value,
+                }
             }
             Self::Vsetivli { rd, uimm, vtypei } => {
                 let rd_value =
                     zvexx_config_helpers::apply_vsetivli(ext_state, program_counter, uimm, vtypei)?;
 
-                Ok(ControlFlow::Continue((rd, rd_value)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rd_value,
+                }
             }
             Self::Vsetvl { rd, rs1, rs2: _ } => {
                 let vtype_raw = rs2_value;
@@ -166,7 +171,10 @@ where
                     vtype_raw,
                 )?;
 
-                Ok(ControlFlow::Continue((rd, rd_value)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: rd_value,
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/zvexx_config_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/zvexx_config_helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, ProgramCounter};
+use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
 use core::marker::Destruct;
@@ -35,7 +35,7 @@ where
     if !ext_state.vector_instructions_allowed() {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
 
@@ -117,7 +117,7 @@ where
     if !ext_state.vector_instructions_allowed() {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
@@ -7,13 +7,12 @@ pub mod zvexx_fixed_point_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxFixedPointInstruction<Reg> where Reg: Register
@@ -52,20 +51,24 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vsaddu.vv / vsaddu.vx / vsaddu.vi - saturating unsigned add
             Self::VsadduVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -86,8 +89,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -114,14 +119,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -137,8 +146,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -161,14 +172,18 @@ where
             Self::VsadduVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -184,8 +199,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -211,14 +228,18 @@ where
             Self::VsaddVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -239,8 +260,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -267,14 +290,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -290,8 +317,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -314,14 +343,18 @@ where
             Self::VsaddVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -337,8 +370,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -363,14 +398,18 @@ where
             Self::VssubuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -391,8 +430,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -419,14 +460,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -442,8 +487,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -467,14 +514,18 @@ where
             Self::VssubVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -495,8 +546,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -523,14 +576,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -546,8 +603,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -571,14 +630,18 @@ where
             Self::VaadduVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -599,8 +662,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -627,14 +692,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -650,8 +719,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -675,14 +746,18 @@ where
             Self::VaaddVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -703,8 +778,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -731,14 +808,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -754,8 +835,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -779,14 +862,18 @@ where
             Self::VasubuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -807,8 +894,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -835,14 +924,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -858,8 +951,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -883,14 +978,18 @@ where
             Self::VasubVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -911,8 +1010,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -939,14 +1040,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -962,8 +1067,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -987,21 +1094,27 @@ where
             Self::VsmulVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Not supported for SEW=64 in Zve64x (would need 128-bit result)
                 if !Self::implements_extension::<V<_>>() && vtype.vsew() == Vsew::E64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1022,8 +1135,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1050,21 +1165,27 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Not supported for SEW=64 in Zve64x (would need 128-bit result)
                 if !Self::implements_extension::<V<_>>() && vtype.vsew() == Vsew::E64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1080,8 +1201,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1105,14 +1228,18 @@ where
             Self::VssrlVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1133,8 +1260,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1165,14 +1294,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1188,8 +1321,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1215,14 +1350,18 @@ where
             Self::VssrlVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1238,8 +1377,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1267,14 +1408,18 @@ where
             Self::VssraVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1295,8 +1440,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1325,14 +1472,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1348,8 +1499,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1374,14 +1527,18 @@ where
             Self::VssraVi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1397,8 +1554,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1424,14 +1583,18 @@ where
             Self::VnclipuWv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Destination SEW must be <= 32 so that 2*SEW fits in 64 bits
@@ -1461,8 +1624,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: sew <= 32 checked; alignment checked above
@@ -1488,14 +1653,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1517,8 +1686,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = rs1_value.as_u64();
@@ -1540,14 +1711,18 @@ where
             Self::VnclipuWi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1569,8 +1744,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: sew <= 32 checked; alignment checked above
@@ -1593,14 +1770,18 @@ where
             Self::VnclipWv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1627,8 +1808,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: sew <= 32 checked; alignment checked above
@@ -1654,14 +1837,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1683,8 +1870,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = rs1_value.as_u64();
@@ -1706,14 +1895,18 @@ where
             Self::VnclipWi { vd, vs2, imm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1735,8 +1928,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: sew <= 32 checked; alignment checked above
@@ -1756,6 +1951,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/tests.rs
@@ -2,11 +2,10 @@ use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::v::zvexx::arith::zvexx_arith_helpers::sign_extend;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3u8)
@@ -47,15 +46,23 @@ fn exec(
         rs2_value: state.regs.read(rs2),
     };
 
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
 
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
@@ -9,7 +9,7 @@ use crate::v::zvexx::arith::zvexx_arith_helpers::{
 };
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, ProgramCounter};
+use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
 
@@ -570,7 +570,7 @@ where
     if sew.bits_width() > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())
@@ -607,7 +607,7 @@ where
         Vsew::E64 => {
             cold_path();
             return Err(ExecutionError::IllegalInstruction {
-                address: program_counter.old_pc(INSTRUCTION_SIZE),
+                address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
             });
         }
     };
@@ -615,7 +615,7 @@ where
     let Some(wide_group) = vlmul.data_register_count(wide_eew, sew) else {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     };
     let wide_group = wide_group.get();
@@ -623,7 +623,7 @@ where
     if !vs2_idx.is_multiple_of(wide_group) || vs2_idx + wide_group > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -7,13 +7,12 @@ pub mod zvexx_load_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxLoadInstruction<Reg> where Reg: Register {}
@@ -51,7 +50,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // Whole-register load: loads `nreg` consecutive registers starting at `vd` directly
             // from memory. `vd` must be aligned to `nreg`. Ignores vtype, vl, vstart, masking.
@@ -64,14 +63,18 @@ where
                 let nreg = nreg.num_registers();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if vd.to_bits() % nreg != 0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let base = rs1_value.as_u64();
@@ -101,8 +104,10 @@ where
             Self::Vlm { vd, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let vl = ext_state.vl();
@@ -139,21 +144,27 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -169,8 +180,10 @@ where
                     )
                 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY:
@@ -204,21 +217,27 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -234,8 +253,10 @@ where
                     )
                 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: preconditions identical to `Vle`; see that arm for the full argument.
@@ -263,21 +284,27 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -293,8 +320,10 @@ where
                     )
                 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // rs2 holds a signed stride; reinterpret the register value as signed
@@ -332,14 +361,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let data_group_regs = vtype.vlmul().register_count();
@@ -347,7 +380,9 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -372,8 +407,10 @@ where
                     vtype.vlmul(),
                 ) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm
@@ -385,8 +422,10 @@ where
                     )
                 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY:
@@ -428,14 +467,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let data_group_regs = vtype.vlmul().register_count();
@@ -443,7 +486,9 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -467,8 +512,10 @@ where
                     vtype.vlmul(),
                 ) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm
@@ -480,8 +527,10 @@ where
                     )
                 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: preconditions identical to `Vluxei`; see that arm for the full
@@ -513,21 +562,27 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
                     program_counter,
@@ -569,21 +624,27 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
                     program_counter,
@@ -619,21 +680,27 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype
                     .vlmul()
                     .index_register_count(eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
                     program_counter,
@@ -677,14 +744,18 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let data_group_regs = vtype.vlmul().register_count();
@@ -692,7 +763,9 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 // `validate_segment_registers` is called before the per-field overlap loop so
                 // that `vd.to_bits() + f * data_group_regs < 32` is established for all `f < nf`,
@@ -724,8 +797,10 @@ where
                         index_group_regs,
                     ) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 }
@@ -771,14 +846,18 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let data_group_regs = vtype.vlmul().register_count();
@@ -786,7 +865,9 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
                     program_counter,
@@ -815,8 +896,10 @@ where
                         index_group_regs,
                     ) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 }
@@ -839,6 +922,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/tests.rs
@@ -255,7 +255,7 @@ fn vlr_out_of_bounds_memory_returns_error() {
         },
     )
     .unwrap_err();
-    assert!(matches!(err, ExecutionError::MemoryAccess(_)));
+    assert!(matches!(err, ExecutionError::OutOfBoundsRead { .. }));
 }
 
 // `Vlm` tests
@@ -670,7 +670,7 @@ fn vle_memory_fault_propagates() {
         },
     )
     .unwrap_err();
-    assert!(matches!(err, ExecutionError::MemoryAccess(_)));
+    assert!(matches!(err, ExecutionError::OutOfBoundsRead { .. }));
 }
 
 // `Vleff` tests
@@ -720,7 +720,7 @@ fn vleff_fault_at_i0_traps() {
         },
     )
     .unwrap_err();
-    assert!(matches!(err, ExecutionError::MemoryAccess(_)));
+    assert!(matches!(err, ExecutionError::OutOfBoundsRead { .. }));
     // vl must not be modified on a trapped fault
     assert_eq!(state.ext_state.vl(), Vl::new(4).unwrap());
 }
@@ -1601,7 +1601,7 @@ fn vlsseg_fault_at_f1_of_i0_marks_vs_dirty_and_sets_vstart() {
     )
     .unwrap_err();
 
-    assert!(matches!(err, ExecutionError::MemoryAccess(_)));
+    assert!(matches!(err, ExecutionError::OutOfBoundsRead { .. }));
     // f>0 at the fault point: field 0 of element 0 was written
     assert_eq!(
         state.ext_state.vs_dirty_count(),
@@ -1646,7 +1646,7 @@ fn vlsseg_fault_at_i1_f0_marks_vs_dirty_and_sets_vstart() {
     )
     .unwrap_err();
 
-    assert!(matches!(err, ExecutionError::MemoryAccess(_)));
+    assert!(matches!(err, ExecutionError::OutOfBoundsRead { .. }));
     assert_eq!(state.ext_state.vs_dirty_count(), 1);
     assert_eq!(state.ext_state.vstart(), Vstart::from(2));
 }
@@ -2078,7 +2078,7 @@ fn vle_fault_after_first_element_marks_vs_dirty() {
     )
     .unwrap_err();
 
-    assert!(matches!(err, ExecutionError::MemoryAccess(_)));
+    assert!(matches!(err, ExecutionError::OutOfBoundsRead { .. }));
     // Elements 0 and 1 were committed before the fault at element 2.
     assert_eq!(vreg_byte(&state, VReg::V1, 0), 0xAA, "element 0 committed");
     assert_eq!(vreg_byte(&state, VReg::V1, 1), 0xBB, "element 1 committed");
@@ -2111,7 +2111,7 @@ fn vle_fault_after_first_element_sets_vstart_to_faulting_index() {
     )
     .unwrap_err();
 
-    assert!(matches!(err, ExecutionError::MemoryAccess(_)));
+    assert!(matches!(err, ExecutionError::OutOfBoundsRead { .. }));
     assert_eq!(
         state.ext_state.vstart(),
         Vstart::from(2),
@@ -2138,7 +2138,7 @@ fn vle_fault_at_first_element_does_not_mark_vs_dirty() {
     )
     .unwrap_err();
 
-    assert!(matches!(err, ExecutionError::MemoryAccess(_)));
+    assert!(matches!(err, ExecutionError::OutOfBoundsRead { .. }));
     assert_eq!(
         state.ext_state.vs_dirty_count(),
         0,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/tests.rs
@@ -1,8 +1,8 @@
 use crate::rv64::test_utils::{TEST_BASE_ADDR, TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
 use core::array;
@@ -74,16 +74,18 @@ fn exec_one(
         rs2_value: state.regs.read(rs2),
     };
 
-    instr
-        .execute(
-            rs1rs2_values,
-            &mut state.regs,
-            &mut state.ext_state,
-            &mut state.memory,
-            &mut state.instruction_fetcher,
-            &mut state.system_instruction_handler,
-        )
-        .map(|_| ())
+    if let ExecutionResult::Err(error) = instr.execute(
+        rs1rs2_values,
+        &mut state.regs,
+        &mut state.ext_state,
+        &mut state.memory,
+        &mut state.instruction_fetcher,
+        &mut state.system_instruction_handler,
+    ) {
+        Err(error)
+    } else {
+        Ok(())
+    }
 }
 
 // `Vlr` tests

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::v::vector_registers::{VLENB_USIZE, VectorRegisterFile, VectorRegistersExt};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, ProgramCounter, VirtualMemory, VirtualMemoryError};
+use crate::{ExecutionError, PackedAddress, ProgramCounter, VirtualMemory, VirtualMemoryError};
 use ab_riscv_primitives::prelude::*;
 use core::cmp::Ordering;
 use core::hint::cold_path;
@@ -142,7 +142,7 @@ where
     if !vd.is_multiple_of(group_regs) || vd + group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())
@@ -173,7 +173,7 @@ where
     if vd_idx % group_regs != 0 || vd_idx + nf * group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     // When masked, no field group may contain v0 (index 0). Since groups are laid out
@@ -182,7 +182,7 @@ where
     if !vm && vd_idx == 0 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -377,7 +377,7 @@ where
                         // vstart records the faulting element for restartability.
                         ext_state.set_vstart(Vstart::from(i));
                     }
-                    return Err(ExecutionError::MemoryAccess(mem_err));
+                    return Err(ExecutionError::from(mem_err));
                 }
             }
         }
@@ -476,7 +476,7 @@ where
                         ext_state.mark_vs_dirty();
                         ext_state.set_vstart(Vstart::from(i));
                     }
-                    return Err(ExecutionError::MemoryAccess(mem_err));
+                    return Err(ExecutionError::from(mem_err));
                 }
             };
             // SAFETY: Guaranteed by function contract
@@ -580,7 +580,7 @@ where
                         ext_state.mark_vs_dirty();
                         ext_state.set_vstart(Vstart::from(i));
                     }
-                    return Err(ExecutionError::MemoryAccess(mem_err));
+                    return Err(ExecutionError::from(mem_err));
                 }
             };
             // SAFETY: Guaranteed by function contract

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -7,13 +7,12 @@ pub mod zvexx_mask_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxMaskInstruction<Reg> where Reg: Register {}
@@ -51,7 +50,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // Mask-register logical instructions (§16.1).
             // These compute the body elements [vstart, vl); prestart bits [0, vstart) are
@@ -62,14 +61,18 @@ where
             Self::Vmandn { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: all VReg values are valid indices < 32; `vl <= VLEN` and
@@ -84,14 +87,18 @@ where
             Self::Vmand { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: see `Vmandn`
@@ -104,14 +111,18 @@ where
             Self::Vmor { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: see `Vmandn`
@@ -124,14 +135,18 @@ where
             Self::Vmxor { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: see `Vmandn`
@@ -144,14 +159,18 @@ where
             Self::Vmorn { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: see `Vmandn`
@@ -164,14 +183,18 @@ where
             Self::Vmnand { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: see `Vmandn`
@@ -184,14 +207,18 @@ where
             Self::Vmnor { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: see `Vmandn`
@@ -204,14 +231,18 @@ where
             Self::Vmxnor { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: see `Vmandn`
@@ -225,75 +256,99 @@ where
             Self::Vcpop { rd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // vcpop/vfirst require a valid vtype to know vl, but do not use SEW.
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: `vl <= VLMAX <= VLEN`; `vstart <= vl` by spec invariant.
                 let rd_value = unsafe { zvexx_mask_helpers::execute_vcpop(ext_state, vs2, vm) };
 
-                return Ok(ControlFlow::Continue((rd, rd_value)));
+                return ExecutionResult::Continue {
+                    rd,
+                    value: rd_value,
+                };
             }
             // vfirst.m (§16.3): find lowest-numbered active set bit in vs2, write index to rd.
             Self::Vfirst { rd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: same as `Vcpop`
                 let rd_value = unsafe { zvexx_mask_helpers::execute_vfirst(ext_state, vs2, vm) };
 
-                return Ok(ControlFlow::Continue((rd, rd_value)));
+                return ExecutionResult::Continue {
+                    rd,
+                    value: rd_value,
+                };
             }
             // vmsbf.m (§16.4): set-before-first mask bit.
             // Constraints: vd != vs2 (overlap illegal), vm=false implies vd != v0.
             Self::Vmsbf { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // Spec §16.4: vmsbf/vmsif/vmsof with vstart != 0 raise an illegal instruction
                 // exception.
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // Per spec §16.4: vd must not overlap vs2
                 if vd == vs2 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let vl = ext_state.vl();
@@ -308,34 +363,44 @@ where
             Self::Vmsof { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // Spec §16.4: vmsbf/vmsif/vmsof with vstart != 0 raise an illegal instruction
                 // exception.
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if vd == vs2 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let vl = ext_state.vl();
@@ -349,34 +414,44 @@ where
             Self::Vmsif { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if ext_state.vtype().is_none() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // Spec §16.4: vmsbf/vmsif/vmsof with vstart != 0 raise an illegal instruction
                 // exception.
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if vd == vs2 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let vl = ext_state.vl();
@@ -394,29 +469,37 @@ where
             Self::Viota { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Spec §16.8: viota.m with vstart != 0 raises an illegal instruction exception.
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count().get();
                 let vd_idx = vd.to_bits();
                 if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // vd must not overlap vs2; vs2 is always a single mask register (group size 1).
@@ -424,14 +507,18 @@ where
                 let vs2_start = u32::from(vs2.to_bits());
                 if vd_start < vs2_start + 1 && vs2_start < vd_start + u32::from(group_regs) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -448,28 +535,36 @@ where
             Self::Vid { vd, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count().get();
                 let vd_idx = vd.to_bits();
                 if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -481,6 +576,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/tests.rs
@@ -1,11 +1,10 @@
 use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 // With TEST_VLEN=256, VLENB=32:
 //   E8/M1 -> VLMAX=32, 1 reg
@@ -40,15 +39,23 @@ fn exec(
         rs2_value: state.regs.read(rs2),
     };
 
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
 
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
@@ -7,13 +7,12 @@ pub mod zvexx_muldiv_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxMulDivInstruction<Reg> where Reg: Register {}
@@ -51,20 +50,24 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vmul.vv / vmul.vx - signed multiply, low half
             Self::VmulVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -85,8 +88,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -111,14 +116,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -134,8 +143,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -157,14 +168,18 @@ where
             Self::VmulhVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Zve64x excludes the high-half multiplies at SEW=64 (spec §18.2). The full "V"
@@ -172,8 +187,10 @@ where
                 // 2*SEW product is formed in i128/u128
                 if !Self::implements_extension::<V<_>>() && vtype.vsew() == Vsew::E64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -194,8 +211,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -220,14 +239,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Zve64x excludes the high-half multiplies at SEW=64 (spec §18.2). The full "V"
@@ -235,8 +258,10 @@ where
                 // 2*SEW product is formed in i128/u128
                 if !Self::implements_extension::<V<_>>() && vtype.vsew() == Vsew::E64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -252,8 +277,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -275,14 +302,18 @@ where
             Self::VmulhuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Zve64x excludes the high-half multiplies at SEW=64 (spec §18.2). The full "V"
@@ -290,8 +321,10 @@ where
                 // 2*SEW product is formed in i128/u128
                 if !Self::implements_extension::<V<_>>() && vtype.vsew() == Vsew::E64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -312,8 +345,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -338,14 +373,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Zve64x excludes the high-half multiplies at SEW=64 (spec §18.2). The full "V"
@@ -353,8 +392,10 @@ where
                 // 2*SEW product is formed in i128/u128
                 if !Self::implements_extension::<V<_>>() && vtype.vsew() == Vsew::E64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -370,8 +411,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -393,14 +436,18 @@ where
             Self::VmulhsuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Zve64x excludes the high-half multiplies at SEW=64 (spec §18.2). The full "V"
@@ -408,8 +455,10 @@ where
                 // 2*SEW product is formed in i128/u128
                 if !Self::implements_extension::<V<_>>() && vtype.vsew() == Vsew::E64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -430,8 +479,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -457,14 +508,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Zve64x excludes the high-half multiplies at SEW=64 (spec §18.2). The full "V"
@@ -472,8 +527,10 @@ where
                 // 2*SEW product is formed in i128/u128
                 if !Self::implements_extension::<V<_>>() && vtype.vsew() == Vsew::E64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -489,8 +546,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -514,14 +573,18 @@ where
             Self::VdivuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -542,8 +605,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -574,14 +639,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -597,8 +666,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -625,14 +696,18 @@ where
             Self::VdivVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -653,8 +728,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -679,14 +756,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -702,8 +783,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -725,14 +808,18 @@ where
             Self::VremuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -753,8 +840,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -789,14 +878,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -812,8 +905,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -844,14 +939,18 @@ where
             Self::VremVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -872,8 +971,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -898,14 +999,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -921,8 +1026,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -944,22 +1051,28 @@ where
             Self::VwmuluVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -968,7 +1081,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -987,8 +1102,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // vd and vs2/vs1 must not overlap
@@ -1031,22 +1148,28 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1054,7 +1177,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -1068,8 +1193,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -1101,22 +1228,28 @@ where
             Self::VwmulsuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1124,7 +1257,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -1143,8 +1278,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -1188,22 +1325,28 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1211,7 +1354,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -1225,8 +1370,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -1260,22 +1407,28 @@ where
             Self::VwmulVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1283,7 +1436,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -1302,8 +1457,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -1347,22 +1504,28 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1370,7 +1533,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -1384,8 +1549,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -1419,14 +1586,18 @@ where
             Self::VmaccVv { vd, vs1, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1447,8 +1618,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1474,14 +1647,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1497,8 +1674,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1520,14 +1699,18 @@ where
             Self::VnmsacVv { vd, vs1, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1548,8 +1731,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1575,14 +1760,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1598,8 +1787,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1621,14 +1812,18 @@ where
             Self::VmaddVv { vd, vs1, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1649,8 +1844,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1676,14 +1873,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1699,8 +1900,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1723,14 +1926,18 @@ where
             Self::VnmsubVv { vd, vs1, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1751,8 +1958,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1778,14 +1987,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -1801,8 +2014,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -1825,22 +2040,28 @@ where
             Self::VwmaccuVv { vd, vs1, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1848,7 +2069,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 // vd holds the 2*SEW accumulator
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
@@ -1868,8 +2091,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -1912,22 +2137,28 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1935,7 +2166,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -1949,8 +2182,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -1982,22 +2217,28 @@ where
             Self::VwmaccVv { vd, vs1, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2005,7 +2246,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -2024,8 +2267,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -2069,22 +2314,28 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2092,7 +2343,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -2106,8 +2359,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -2140,22 +2395,28 @@ where
             Self::VwmaccsuVv { vd, vs1, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2163,7 +2424,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -2182,8 +2445,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -2227,22 +2492,28 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2250,7 +2521,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -2264,8 +2537,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -2307,22 +2582,28 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Widening produces a 2*SEW result; an EEW above ELEN is reserved for every
                 // implementation, so this is not a Zve64x-specific restriction
                 if !zvexx_muldiv_helpers::widening_eew_supported(vtype.vsew(), ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2330,7 +2611,9 @@ where
                     vtype.vlmul(),
                 )
                 .ok_or(ExecutionError::IllegalInstruction {
-                    address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    address: PackedAddress::new(
+                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    ),
                 })?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -2344,8 +2627,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
@@ -2380,6 +2665,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
@@ -5,12 +5,11 @@ use crate::v::zvexx::muldiv::zvexx_muldiv_helpers::{
     mulh_ss, mulhsu_su, mulhu_uu, widening_dest_register_count,
 };
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
 use core::num::NonZeroU8;
-use core::ops::ControlFlow;
 
 // With TEST_VLEN=256, VLENB=32:
 //   E8/M1  -> VLMAX=32, 1 reg
@@ -54,15 +53,23 @@ fn exec(
         rs2_value: state.regs.read(rs2),
     };
 
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
 
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -8,7 +8,7 @@ use crate::v::zvexx::arith::zvexx_arith_helpers::{read_element_u64, write_elemen
 use crate::v::zvexx::fixed_point::zvexx_fixed_point_helpers::read_wide_element_u64;
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, ProgramCounter};
+use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
 use core::num::NonZeroU8;
@@ -116,7 +116,7 @@ where
 
     cold_path();
     Err(ExecutionError::IllegalInstruction {
-        address: program_counter.old_pc(INSTRUCTION_SIZE),
+        address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
     })
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -7,13 +7,12 @@ pub mod zvexx_perm_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxPermInstruction<Reg> where Reg: Register {}
@@ -51,7 +50,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vmv.x.s rd, vs2
             // Copies sign-extended element 0 of vs2 (at current SEW) to GPR rd.
@@ -61,14 +60,18 @@ where
             Self::VmvXS { rd, vs2 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -81,7 +84,10 @@ where
                 ext_state.mark_vs_dirty();
                 ext_state.reset_vstart();
 
-                return Ok(ControlFlow::Continue((rd, sign_extended)));
+                return ExecutionResult::Continue {
+                    rd,
+                    value: sign_extended,
+                };
             }
             // vmv.s.x vd, rs1
             // Copies scalar GPR rs1 (zero-extended / truncated to SEW) into element 0 of vd.
@@ -90,14 +96,18 @@ where
             Self::VmvSX { vd, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -132,14 +142,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -162,8 +176,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -178,14 +194,18 @@ where
             Self::VslideupVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -207,8 +227,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -229,14 +251,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -252,8 +278,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -271,14 +299,18 @@ where
             Self::VslidedownVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -294,8 +326,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -320,14 +354,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -349,8 +387,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -372,14 +412,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -395,8 +439,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -412,14 +458,18 @@ where
             Self::VrgatherVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -452,8 +502,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -474,14 +526,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -503,8 +559,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -522,14 +580,18 @@ where
             Self::VrgatherVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -551,8 +613,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -572,14 +636,18 @@ where
             Self::Vrgatherei16Vv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -601,7 +669,9 @@ where
                         vtype.vsew(),
                     )
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -625,8 +695,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let sew = vtype.vsew();
@@ -655,14 +727,18 @@ where
             Self::VmergeVvm { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -707,14 +783,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -749,14 +829,18 @@ where
             Self::VmergeVim { vd, vs2, simm5, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -793,21 +877,27 @@ where
             Self::VcompressVm { vd, vs2, vs1 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Spec §16.5: vstart must be zero.
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -847,8 +937,10 @@ where
             Self::Vmv1rV { vd, vs2 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: both vd.to_bits() and vs2.to_bits() are always in [0, 32) by VReg
@@ -869,14 +961,18 @@ where
             Self::Vmv2rV { vd, vs2 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vd.to_bits().is_multiple_of(2) || !vs2.to_bits().is_multiple_of(2) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment verified; 2 registers from aligned base always stay in [0, 32).
@@ -895,14 +991,18 @@ where
             Self::Vmv4rV { vd, vs2 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vd.to_bits().is_multiple_of(4) || !vs2.to_bits().is_multiple_of(4) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment verified; 4 registers from aligned base always stay in [0, 32).
@@ -921,14 +1021,18 @@ where
             Self::Vmv8rV { vd, vs2 } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vd.to_bits().is_multiple_of(8) || !vs2.to_bits().is_multiple_of(8) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment verified; 8 registers from aligned base always stay in [0, 32).
@@ -944,6 +1048,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/tests.rs
@@ -1,11 +1,10 @@
 use crate::rv64::test_utils::initialize_state;
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 // With TEST_VLEN=256, VLENB=32:
 //   E8/M1   -> VLMAX=32, 1 reg,  32 elems/reg
@@ -46,15 +45,23 @@ fn exec(
         rs2_value: state.regs.read(rs2),
     };
 
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
 
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
@@ -5,7 +5,7 @@ pub use crate::v::zvexx::arith::zvexx_arith_helpers::check_vreg_group_alignment;
 use crate::v::zvexx::arith::zvexx_arith_helpers::{read_element_u64, write_element_u64};
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, ProgramCounter};
+use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
 use core::num::NonZeroU8;
@@ -36,7 +36,7 @@ where
     if a_start < b_start + count && b_start < a_start + count {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())
@@ -70,7 +70,7 @@ where
     if a_start < b_start + b_count && b_start < a_start + a_count {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
@@ -8,13 +8,12 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::arith::zvexx_arith_helpers;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxReductionInstruction<Reg> where Reg: Register {}
@@ -52,26 +51,32 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::Vredsum { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 // Spec §14: reductions with vstart > 0 are reserved; raise illegal instruction
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -100,20 +105,26 @@ where
             Self::Vredand { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -141,20 +152,26 @@ where
             Self::Vredor { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -182,20 +199,26 @@ where
             Self::Vredxor { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -223,20 +246,26 @@ where
             Self::Vredminu { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -267,20 +296,26 @@ where
             Self::Vredmin { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -316,20 +351,26 @@ where
             Self::Vredmaxu { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -360,20 +401,26 @@ where
             Self::Vredmax { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -409,27 +456,35 @@ where
             Self::Vwredsumu { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // Widening: 2*SEW must fit in ELEN
                 if u32::from(vtype.vsew().bits_width()) * 2 > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -459,26 +514,34 @@ where
             Self::Vwredsum { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 if ext_state.vstart() != Vstart::ZERO {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if u32::from(vtype.vsew().bits_width()) * 2 > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -506,6 +569,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/tests.rs
@@ -1,11 +1,10 @@
 use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
@@ -35,15 +34,23 @@ fn exec(
         rs2_value: state.regs.read(rs2),
     };
 
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
 
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -92,7 +92,7 @@ where
                             unsafe { ext_state.read_vregs().get(reg).get_unchecked(in_reg..) };
                         if let Err(error) = memory.write_slice(base + byte_off, src) {
                             ext_state.set_vstart(Vstart::from(byte_off as u16));
-                            return Err(ExecutionError::MemoryAccess(error));
+                            return Err(ExecutionError::from(error));
                         }
                         byte_off += src.len() as u64;
                     }
@@ -124,7 +124,7 @@ where
                     };
                     memory
                         .write_slice(base + u64::from(u16::from(start_byte)), src)
-                        .map_err(ExecutionError::MemoryAccess)?;
+                        .map_err(ExecutionError::from)?;
                 }
                 ext_state.reset_vstart();
             }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -8,13 +8,12 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::load::zvexx_load_helpers;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxStoreInstruction<Reg> where Reg: Register {}
@@ -52,7 +51,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // Whole-register store: stores `nreg` consecutive registers starting at `vs3` directly
             // to memory as a flat byte array of `EVL = nreg * VLEN.bytes()` bytes. `vs3` must be
@@ -63,14 +62,18 @@ where
                 let nreg = nreg.num_registers();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if vs3.to_bits() % nreg != 0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let vlenb = u64::from(ExtState::VLEN.bytes());
@@ -92,7 +95,7 @@ where
                             unsafe { ext_state.read_vregs().get(reg).get_unchecked(in_reg..) };
                         if let Err(error) = memory.write_slice(base + byte_off, src) {
                             ext_state.set_vstart(Vstart::from(byte_off as u16));
-                            return Err(ExecutionError::from(error));
+                            return ExecutionResult::Err(ExecutionError::from(error));
                         }
                         byte_off += src.len() as u64;
                     }
@@ -105,8 +108,10 @@ where
             Self::Vsm { vs3, rs1: _ } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let vl = ext_state.vl();
@@ -141,19 +146,25 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().data_register_count(eew, vtype.vsew()).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
@@ -192,19 +203,25 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().data_register_count(eew, vtype.vsew()).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
@@ -238,14 +255,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let data_eew = vtype.vsew().as_eew();
@@ -254,7 +275,9 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -302,14 +325,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let data_eew = vtype.vsew().as_eew();
@@ -318,7 +345,9 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
                     program_counter,
@@ -357,19 +386,25 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().data_register_count(eew, vtype.vsew()).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
@@ -408,19 +443,25 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().data_register_count(eew, vtype.vsew()).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
@@ -457,14 +498,18 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let data_eew = vtype.vsew().as_eew();
@@ -473,7 +518,9 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
                     program_counter,
@@ -519,14 +566,18 @@ where
                 let nf = vm_nf.nf();
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let data_eew = vtype.vsew().as_eew();
@@ -535,7 +586,9 @@ where
                     .vlmul()
                     .index_register_count(index_eew, vtype.vsew())
                     .ok_or(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     })?;
                 zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
                     program_counter,
@@ -566,6 +619,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/tests.rs
@@ -1,8 +1,8 @@
 use crate::rv64::test_utils::{TEST_BASE_ADDR, TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
 use core::array;
@@ -61,16 +61,18 @@ fn exec_one(
         rs2_value: state.regs.read(rs2),
     };
 
-    instr
-        .execute(
-            rs1rs2_values,
-            &mut state.regs,
-            &mut state.ext_state,
-            &mut state.memory,
-            &mut state.instruction_fetcher,
-            &mut state.system_instruction_handler,
-        )
-        .map(|_| ())
+    if let ExecutionResult::Err(error) = instr.execute(
+        rs1rs2_values,
+        &mut state.regs,
+        &mut state.ext_state,
+        &mut state.memory,
+        &mut state.instruction_fetcher,
+        &mut state.system_instruction_handler,
+    ) {
+        Err(error)
+    } else {
+        Ok(())
+    }
 }
 
 // Vsr (whole-register store)

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/tests.rs
@@ -1526,7 +1526,10 @@ fn vse_out_of_bounds_write_returns_memory_access_error() {
         },
     );
 
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsWrite { .. })
+    ));
 }
 
 #[test]
@@ -1548,5 +1551,8 @@ fn vsse_out_of_bounds_write_returns_memory_access_error() {
         },
     );
 
-    assert!(matches!(result, Err(ExecutionError::MemoryAccess(_))));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::OutOfBoundsWrite { .. })
+    ));
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
@@ -5,7 +5,7 @@ use crate::v::zvexx::load::zvexx_load_helpers::{
     check_register_group_alignment, mask_bit, read_group_element, snapshot_mask,
 };
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, ProgramCounter, VirtualMemory, VirtualMemoryError};
+use crate::{ExecutionError, PackedAddress, ProgramCounter, VirtualMemory, VirtualMemoryError};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
 use core::num::NonZeroU8;
@@ -70,7 +70,7 @@ where
     if total > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
@@ -146,7 +146,7 @@ where
             if let Err(error) = write_mem_element(memory, addr, eew, data) {
                 cold_path();
                 ext_state.set_vstart(Vstart::from(i));
-                return Err(ExecutionError::MemoryAccess(error));
+                return Err(ExecutionError::from(error));
             }
         }
     }
@@ -214,7 +214,7 @@ where
             if let Err(error) = write_mem_element(memory, addr, eew, data) {
                 cold_path();
                 ext_state.set_vstart(Vstart::from(i));
-                return Err(ExecutionError::MemoryAccess(error));
+                return Err(ExecutionError::from(error));
             }
         }
     }
@@ -294,7 +294,7 @@ where
             if let Err(error) = write_mem_element(memory, addr, data_eew, data) {
                 cold_path();
                 ext_state.set_vstart(Vstart::from(i));
-                return Err(ExecutionError::MemoryAccess(error));
+                return Err(ExecutionError::from(error));
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -7,13 +7,12 @@ pub mod zvexx_widen_narrow_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
     Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxWidenNarrowInstruction<Reg> where
@@ -54,20 +53,24 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vwaddu.vv - 2*SEW = zext(SEW) + zext(SEW)
             Self::VwadduVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -79,20 +82,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
@@ -115,8 +124,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -141,14 +152,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -159,20 +174,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
@@ -190,8 +211,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // Scalar is zero-extended to 2*SEW; the low SEW bits are what matter
@@ -213,14 +236,18 @@ where
             Self::VwaddVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -231,20 +258,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
@@ -267,8 +300,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -293,14 +328,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -311,20 +350,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
@@ -342,8 +387,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // Scalar is sign-extended from XLEN to 64 bits
@@ -369,14 +416,18 @@ where
             Self::VwsubuVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -387,20 +438,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
@@ -423,8 +480,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -449,14 +508,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -467,20 +530,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
@@ -498,8 +567,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = rs1_value.as_u64();
@@ -520,14 +591,18 @@ where
             Self::VwsubVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -538,20 +613,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
@@ -574,8 +655,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -600,14 +683,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -618,20 +705,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
@@ -649,8 +742,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = zvexx_widen_narrow_helpers::sign_extend_bits(
@@ -675,14 +770,18 @@ where
             Self::VwadduWv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -693,20 +792,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 // vs2 is the wide source; vs1 is narrow
@@ -730,8 +835,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -756,14 +863,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -773,20 +884,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 // For .wx scalar variants vd may alias vs2 (same wide group); no narrow vs1
@@ -802,8 +919,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = rs1_value.as_u64();
@@ -824,14 +943,18 @@ where
             Self::VwaddWv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -842,20 +965,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
@@ -878,8 +1007,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -904,14 +1035,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -921,20 +1056,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
@@ -949,8 +1090,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = zvexx_widen_narrow_helpers::sign_extend_bits(
@@ -975,14 +1118,18 @@ where
             Self::VwsubuWv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -993,20 +1140,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
@@ -1029,8 +1182,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1055,14 +1210,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1072,20 +1231,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
@@ -1100,8 +1265,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = rs1_value.as_u64();
@@ -1122,14 +1289,18 @@ where
             Self::VwsubWv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1140,20 +1311,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
@@ -1176,8 +1353,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1202,14 +1381,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1219,20 +1402,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
@@ -1247,8 +1436,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = zvexx_widen_narrow_helpers::sign_extend_bits(
@@ -1273,14 +1464,18 @@ where
             Self::VnsrlWv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1292,20 +1487,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
@@ -1325,8 +1526,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1350,14 +1553,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1368,20 +1575,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
@@ -1396,8 +1609,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = rs1_value.as_u64();
@@ -1417,14 +1632,18 @@ where
             Self::VnsrlWi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1435,20 +1654,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
@@ -1463,8 +1688,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1483,14 +1710,18 @@ where
             Self::VnsraWv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1501,20 +1732,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
@@ -1534,8 +1771,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1559,14 +1798,18 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1577,20 +1820,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
@@ -1605,8 +1854,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let scalar = rs1_value.as_u64();
@@ -1626,14 +1877,18 @@ where
             Self::VnsraWi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
@@ -1644,20 +1899,26 @@ where
                     Vsew::E32 => Eew::E64,
                     Vsew::E64 => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::IllegalInstruction {
-                            address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                            address: PackedAddress::new(
+                                program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                            ),
                         });
                     }
                 };
                 if u32::from(wide_eew.bits_width()) > u32::from(ExtState::ELEN) {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let wide_group_regs = vtype.vlmul().data_register_count(wide_eew, sew).ok_or(
                     ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     },
                 )?;
                 zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
@@ -1672,8 +1933,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1692,22 +1955,28 @@ where
             Self::VzextVf2 { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 // SEW must be >= 2*8 = 16
                 if u32::from(sew.bits_width()) < 16 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1728,8 +1997,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1748,22 +2019,28 @@ where
             Self::VzextVf4 { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 // SEW must be >= 4*8 = 32
                 if u32::from(sew.bits_width()) < 32 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1783,8 +2060,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1803,22 +2082,28 @@ where
             Self::VzextVf8 { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 // SEW must be >= 8*8 = 64; only SEW=64 qualifies in Zve64x
                 if u32::from(sew.bits_width()) < 64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1838,8 +2123,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1858,21 +2145,27 @@ where
             Self::VsextVf2 { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 if u32::from(sew.bits_width()) < 16 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1892,8 +2185,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1912,21 +2207,27 @@ where
             Self::VsextVf4 { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 if u32::from(sew.bits_width()) < 32 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -1946,8 +2247,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -1966,21 +2269,27 @@ where
             Self::VsextVf8 { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 if u32::from(sew.bits_width()) < 64 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
@@ -2000,8 +2309,10 @@ where
                 )?;
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 // SAFETY: alignment/overlap/SEW checked above
@@ -2018,6 +2329,6 @@ where
             }
         }
 
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/tests.rs
@@ -1,11 +1,10 @@
 use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
@@ -35,15 +34,23 @@ fn exec(
         rs2_value: state.regs.read(rs2),
     };
 
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
 
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
@@ -3,7 +3,7 @@
 use crate::v::vector_registers::{VLENB_USIZE, VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{OpSrc, check_vreg_group_alignment};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
-use crate::{ExecutionError, ProgramCounter};
+use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::instructions::v::Vsew;
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
@@ -28,7 +28,7 @@ where
     if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())
@@ -62,7 +62,7 @@ where
     if !vs2_idx.is_multiple_of(src_group_regs) || vs2_idx + src_group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     // The wide destination (group_regs) may overlap the narrow source (src_group_regs) only in the
@@ -70,7 +70,7 @@ where
     if widen_src_overlap_illegal(vd.to_bits(), group_regs, vs2_idx, src_group_regs) {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())
@@ -109,13 +109,13 @@ where
     if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     if widen_src_overlap_illegal(vd_idx, wide_group_regs, vs_a.to_bits(), group_regs) {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     if let Some(vs_b) = vs_b_opt
@@ -123,7 +123,7 @@ where
     {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())
@@ -167,7 +167,7 @@ where
     if !vs_idx.is_multiple_of(wide_group_regs) || vs_idx + wide_group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())
@@ -195,7 +195,7 @@ where
     if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
-            address: program_counter.old_pc(INSTRUCTION_SIZE),
+            address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     }
     Ok(())

--- a/crates/execution/ab-riscv-interpreter/src/zawrs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zawrs.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 /// Custom handler for `Zawrs` extension's `wrs.nto`/`wrs.sto` instructions.
 ///
@@ -61,15 +60,15 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             Self::WrsNto => {
                 system_instruction_handler.handle_wrs_nto();
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
             Self::WrsSto => {
                 system_instruction_handler.handle_wrs_sto();
-                Ok(ControlFlow::Continue(Default::default()))
+                ExecutionResult::CONTINUE_ZERO
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/zicond.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicond.rs
@@ -5,11 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZicondInstruction<Reg> where Reg: Register {}
@@ -43,7 +42,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // Conditional zero, equal to zero.
             //
@@ -56,7 +55,7 @@ where
                 } else {
                     src
                 };
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
 
             // Conditional zero, nonzero.
@@ -70,7 +69,7 @@ where
                 } else {
                     Reg::Type::from(0u8)
                 };
-                Ok(ControlFlow::Continue((rd, result)))
+                ExecutionResult::Continue { rd, value: result }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -5,7 +5,7 @@ mod tests;
 pub mod zicsr_helpers;
 
 use crate::{
-    CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
     ExecutableInstructionResult, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
@@ -61,7 +61,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
+                    return Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -76,7 +76,7 @@ where
                         Ok(read_value) => read_value,
                         Err(err) => {
                             ::core::hint::cold_path();
-                            return Err(ExecutionError::CsrError(err));
+                            return Err(ExecutionError::from(err));
                         }
                     };
                     zicsr_helpers::process_csr_read::<Reg, ExtState, Self, CustomError>(
@@ -94,7 +94,7 @@ where
                     Ok(()) => Ok(ControlFlow::Continue((rd, read_output))),
                     Err(err) => {
                         ::core::hint::cold_path();
-                        Err(ExecutionError::CsrError(err))
+                        Err(ExecutionError::from(err))
                     }
                 }
             }
@@ -107,7 +107,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if rs1 != Reg::ZERO && csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
+                    return Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -115,7 +115,7 @@ where
                     Ok(read_value) => read_value,
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::CsrError(error));
+                        return Err(ExecutionError::from(error));
                     }
                 };
                 let read_output =
@@ -138,7 +138,7 @@ where
                     >(ext_state, csr_index, write_value)?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::CsrError(error));
+                        return Err(ExecutionError::from(error));
                     }
                 }
                 Ok(ControlFlow::Continue((rd, read_output)))
@@ -152,7 +152,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if rs1 != Reg::ZERO && csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
+                    return Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -160,7 +160,7 @@ where
                     Ok(read_value) => read_value,
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::CsrError(error));
+                        return Err(ExecutionError::from(error));
                     }
                 };
                 let read_output =
@@ -183,7 +183,7 @@ where
                     >(ext_state, csr_index, write_value)?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::CsrError(error));
+                        return Err(ExecutionError::from(error));
                     }
                 }
 
@@ -201,7 +201,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
+                    return Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -213,7 +213,7 @@ where
                         Ok(read_value) => read_value,
                         Err(error) => {
                             ::core::hint::cold_path();
-                            return Err(ExecutionError::CsrError(error));
+                            return Err(ExecutionError::from(error));
                         }
                     };
                     zicsr_helpers::process_csr_read::<Reg, ExtState, Self, CustomError>(
@@ -231,7 +231,7 @@ where
                     Ok(()) => Ok(ControlFlow::Continue((rd, read_output))),
                     Err(error) => {
                         ::core::hint::cold_path();
-                        Err(ExecutionError::CsrError(error))
+                        Err(ExecutionError::from(error))
                     }
                 }
             }
@@ -248,7 +248,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if zimm != 0 && csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
+                    return Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -256,7 +256,7 @@ where
                     Ok(read_value) => read_value,
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::CsrError(error));
+                        return Err(ExecutionError::from(error));
                     }
                 };
                 let read_output = zicsr_helpers::process_csr_read::<
@@ -278,7 +278,7 @@ where
                     >(ext_state, csr_index, write_value)?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::CsrError(error));
+                        return Err(ExecutionError::from(error));
                     }
                 }
 
@@ -297,7 +297,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if zimm != 0 && csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrError(CsrError::ReadOnly { csr_index }));
+                    return Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -305,7 +305,7 @@ where
                     Ok(read_value) => read_value,
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::CsrError(error));
+                        return Err(ExecutionError::from(error));
                     }
                 };
                 let read_output = zicsr_helpers::process_csr_read::<
@@ -327,7 +327,7 @@ where
                     >(ext_state, csr_index, write_value)?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::CsrError(error));
+                        return Err(ExecutionError::from(error));
                     }
                 }
 

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -6,12 +6,11 @@ pub mod zicsr_helpers;
 
 use crate::{
     Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionError, ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZicsrInstruction<Reg> where Reg: Register {}
@@ -47,7 +46,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // Atomic read/write CSR.
             //
@@ -61,7 +60,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrReadOnly { csr_index });
+                    return ExecutionResult::Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -76,7 +75,7 @@ where
                         Ok(read_value) => read_value,
                         Err(err) => {
                             ::core::hint::cold_path();
-                            return Err(ExecutionError::from(err));
+                            return ExecutionResult::Err(ExecutionError::from(err));
                         }
                     };
                     zicsr_helpers::process_csr_read::<Reg, ExtState, Self, CustomError>(
@@ -91,10 +90,13 @@ where
                     CustomError,
                 >(ext_state, csr_index, write_value)?;
                 match ext_state.write_csr(csr_index, write_output) {
-                    Ok(()) => Ok(ControlFlow::Continue((rd, read_output))),
+                    Ok(()) => ExecutionResult::Continue {
+                        rd,
+                        value: read_output,
+                    },
                     Err(err) => {
                         ::core::hint::cold_path();
-                        Err(ExecutionError::from(err))
+                        ExecutionResult::Err(ExecutionError::from(err))
                     }
                 }
             }
@@ -107,7 +109,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if rs1 != Reg::ZERO && csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrReadOnly { csr_index });
+                    return ExecutionResult::Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -115,7 +117,7 @@ where
                     Ok(read_value) => read_value,
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::from(error));
+                        return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 };
                 let read_output =
@@ -138,10 +140,13 @@ where
                     >(ext_state, csr_index, write_value)?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::from(error));
+                        return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 }
-                Ok(ControlFlow::Continue((rd, read_output)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: read_output,
+                }
             }
 
             // Atomic read and clear bits in CSR.
@@ -152,7 +157,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if rs1 != Reg::ZERO && csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrReadOnly { csr_index });
+                    return ExecutionResult::Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -160,7 +165,7 @@ where
                     Ok(read_value) => read_value,
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::from(error));
+                        return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 };
                 let read_output =
@@ -183,11 +188,14 @@ where
                     >(ext_state, csr_index, write_value)?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::from(error));
+                        return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 }
 
-                Ok(ControlFlow::Continue((rd, read_output)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: read_output,
+                }
             }
 
             // Atomic read/write CSR immediate.
@@ -201,7 +209,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrReadOnly { csr_index });
+                    return ExecutionResult::Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -213,7 +221,7 @@ where
                         Ok(read_value) => read_value,
                         Err(error) => {
                             ::core::hint::cold_path();
-                            return Err(ExecutionError::from(error));
+                            return ExecutionResult::Err(ExecutionError::from(error));
                         }
                     };
                     zicsr_helpers::process_csr_read::<Reg, ExtState, Self, CustomError>(
@@ -228,10 +236,13 @@ where
                     CustomError,
                 >(ext_state, csr_index, zimm.into())?;
                 match ext_state.write_csr(csr_index, write_output) {
-                    Ok(()) => Ok(ControlFlow::Continue((rd, read_output))),
+                    Ok(()) => ExecutionResult::Continue {
+                        rd,
+                        value: read_output,
+                    },
                     Err(error) => {
                         ::core::hint::cold_path();
-                        Err(ExecutionError::from(error))
+                        ExecutionResult::Err(ExecutionError::from(error))
                     }
                 }
             }
@@ -248,7 +259,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if zimm != 0 && csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrReadOnly { csr_index });
+                    return ExecutionResult::Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -256,7 +267,7 @@ where
                     Ok(read_value) => read_value,
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::from(error));
+                        return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 };
                 let read_output = zicsr_helpers::process_csr_read::<
@@ -278,11 +289,14 @@ where
                     >(ext_state, csr_index, write_value)?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::from(error));
+                        return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 }
 
-                Ok(ControlFlow::Continue((rd, read_output)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: read_output,
+                }
             }
 
             // Atomic read and clear bits in CSR immediate.
@@ -297,7 +311,7 @@ where
                 let csr_is_read_only = (csr_index >> 10) == 0b11;
                 if zimm != 0 && csr_is_read_only {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::CsrReadOnly { csr_index });
+                    return ExecutionResult::Err(ExecutionError::CsrReadOnly { csr_index });
                 }
                 zicsr_helpers::check_csr_privilege_level(ext_state, csr_index)?;
 
@@ -305,7 +319,7 @@ where
                     Ok(read_value) => read_value,
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::from(error));
+                        return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 };
                 let read_output = zicsr_helpers::process_csr_read::<
@@ -327,11 +341,14 @@ where
                     >(ext_state, csr_index, write_value)?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
-                        return Err(ExecutionError::from(error));
+                        return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 }
 
-                Ok(ControlFlow::Continue((rd, read_output)))
+                ExecutionResult::Continue {
+                    rd,
+                    value: read_output,
+                }
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
@@ -1568,9 +1568,9 @@ fn test_reserved_privilege_csr() {
 
     assert_matches!(
         execute(&mut state),
-        Err(ExecutionError::CsrError(CsrError::IllegalRead {
+        Err(ExecutionError::CsrIllegalRead {
             csr_index: RESERVED_PRIV_CSR
-        }))
+        })
     );
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
@@ -2,12 +2,11 @@ use crate::rv64::test_utils::{ExtState, execute, initialize_state};
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, CustomErrorPlaceholder, ExecutableInstruction, ExecutableInstructionCsr,
-    ExecutableInstructionOperands, ExecutableInstructionResult, ExecutionError, RegisterFile,
+    ExecutableInstructionOperands, ExecutionError, ExecutionResult, RegisterFile,
     Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;
-use core::ops::ControlFlow;
 use core::{assert_matches, fmt};
 
 /// Lets [`TestZicsr`] forward to the closures configured via
@@ -137,8 +136,8 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/zkr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zkr.rs
@@ -7,12 +7,11 @@ pub mod zkr_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionError, ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 /// Result of polling the entropy source behind the `Zkr` extension's `seed` CSR, corresponding to
 /// one of the specification's `OPST` states
@@ -126,7 +125,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
-        Ok(ControlFlow::Continue(Default::default()))
+    ) -> ExecutionResult<Self::Reg, CustomError> {
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zkr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zkr/tests.rs
@@ -273,9 +273,9 @@ fn csrrs_pure_read_of_seed_is_rejected_end_to_end() {
     let error = execute(&mut state).unwrap_err();
     assert_matches!(
         error,
-        ExecutionError::CsrError(CsrError::IllegalRead {
+        ExecutionError::CsrIllegalRead {
             csr_index: SEED_CSR_INDEX
-        })
+        }
     );
 }
 
@@ -316,9 +316,9 @@ fn csrrc_pure_read_of_seed_is_rejected_end_to_end() {
     let error = execute(&mut state).unwrap_err();
     assert_matches!(
         error,
-        ExecutionError::CsrError(CsrError::IllegalRead {
+        ExecutionError::CsrIllegalRead {
             csr_index: SEED_CSR_INDEX
-        })
+        }
     );
 }
 
@@ -337,9 +337,9 @@ fn csrrsi_pure_read_of_seed_is_rejected_end_to_end() {
     let error = execute(&mut state).unwrap_err();
     assert_matches!(
         error,
-        ExecutionError::CsrError(CsrError::IllegalRead {
+        ExecutionError::CsrIllegalRead {
             csr_index: SEED_CSR_INDEX
-        })
+        }
     );
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -22,13 +22,12 @@ use crate::zicsr::zicsr_helpers;
 use crate::zvbb::zvkb::zvkb_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionError, ExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZvbbInstruction<Reg> where Reg: Register {}
@@ -66,26 +65,32 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vbrev: reverse all bits within each SEW-wide element
             Self::VbrevV { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -109,20 +114,26 @@ where
             Self::VclzV { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -146,20 +157,26 @@ where
             Self::VctzV { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -183,20 +200,26 @@ where
             Self::VcpopV { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -221,27 +244,35 @@ where
             Self::VwsllVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 let Some(double_sew) = sew.double_width() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -249,8 +280,10 @@ where
                     vtype.vlmul().data_register_count(double_sew.as_eew(), sew)
                 else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
@@ -289,27 +322,35 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 let Some(double_sew) = sew.double_width() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -317,8 +358,10 @@ where
                     vtype.vlmul().data_register_count(double_sew.as_eew(), sew)
                 else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
@@ -349,27 +392,35 @@ where
             Self::VwsllVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let sew = vtype.vsew();
                 let Some(double_sew) = sew.double_width() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -377,8 +428,10 @@ where
                     vtype.vlmul().data_register_count(double_sew.as_eew(), sew)
                 else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
@@ -405,6 +458,6 @@ where
                 }
             }
         }
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/tests.rs
@@ -1,12 +1,11 @@
 use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
 use core::assert_matches;
-use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
@@ -31,15 +30,23 @@ fn exec(
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),
     };
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
     Ok(())
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -20,13 +20,12 @@ use crate::v::zvexx::zvexx_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionError, ExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZvkbInstruction<Reg> where Reg: Register {}
@@ -64,26 +63,32 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vandn: vd[i] = ~vs1[i] & vs2[i]  (or ~rs1 & vs2[i])
             Self::VandnVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -123,20 +128,26 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -168,20 +179,26 @@ where
             Self::Vbrev8V { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -205,20 +222,26 @@ where
             Self::Vrev8V { vd, vs2, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -242,20 +265,26 @@ where
             Self::VrolVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -295,20 +324,26 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -340,20 +375,26 @@ where
             Self::VrorVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -393,20 +434,26 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -438,20 +485,26 @@ where
             Self::VrorVi { vd, vs2, uimm, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -479,6 +532,6 @@ where
                 }
             }
         }
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/tests.rs
@@ -1,12 +1,11 @@
 use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
 use core::assert_matches;
-use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
@@ -31,15 +30,23 @@ fn exec(
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),
     };
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
     Ok(())
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc.rs
@@ -20,13 +20,12 @@ use crate::v::zvexx::zvexx_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutableInstructionResult, ExecutionError, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionError, ExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
 use core::marker::Destruct;
-use core::ops::ControlFlow;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZvbcInstruction<Reg> where Reg: Register {}
@@ -64,26 +63,32 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutableInstructionResult<(), Self, CustomError> {
+    ) -> ExecutionResult<Self::Reg, CustomError> {
         match self {
             // vclmul: vd[i] = lower SEW bits of clmul(vs2[i], vs1[i])
             Self::VclmulVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -123,20 +128,26 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -168,20 +179,26 @@ where
             Self::VclmulhVv { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -221,20 +238,26 @@ where
             } => {
                 if !ext_state.vector_instructions_allowed() {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 if !vm && vd == VReg::V0 {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 }
                 let Some(vtype) = ext_state.vtype() else {
                     ::core::hint::cold_path();
-                    return Err(ExecutionError::IllegalInstruction {
-                        address: program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                    return ExecutionResult::Err(ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
@@ -263,6 +286,6 @@ where
                 }
             }
         }
-        Ok(ControlFlow::Continue(Default::default()))
+        ExecutionResult::CONTINUE_ZERO
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbc/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc/tests.rs
@@ -1,12 +1,11 @@
 use crate::rv64::test_utils::{TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{
-    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
 use core::assert_matches;
-use core::ops::ControlFlow;
 
 fn encode_vtype(vsew: Vsew, vlmul: Vlmul) -> u64 {
     u64::from(vlmul.to_bits()) | (u64::from(vsew.to_bits()) << 3)
@@ -31,15 +30,23 @@ fn exec(
         rs1_value: state.regs.read(rs1),
         rs2_value: state.regs.read(rs2),
     };
-    if let ControlFlow::Continue((rd, rd_value)) = instr.execute(
+    match instr.execute(
         rs1rs2_values,
         &mut state.regs,
         &mut state.ext_state,
         &mut state.memory,
         &mut state.instruction_fetcher,
         &mut state.system_instruction_handler,
-    )? {
-        state.regs.write(rd, rd_value);
+    ) {
+        ExecutionResult::Continue { rd, value } => {
+            state.regs.write(rd, value);
+        }
+        ExecutionResult::Err(error) => {
+            return Err(error);
+        }
+        result => {
+            panic!("Unexpected result: {result:?}");
+        }
     }
     Ok(())
 }

--- a/crates/execution/ab-riscv-macros-impl/src/lib.rs
+++ b/crates/execution/ab-riscv-macros-impl/src/lib.rs
@@ -172,7 +172,7 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// * matching in the following style: `match self { Self::Variant { .. } }`
 ///   * note that `Self` must be used instead of the explicit type name, such that it works when
 ///     inherited
-/// * `Ok(ControlFlow::Continue(Default::default()))` expression.
+/// * `ExecutionResult::CONTINUE_ZERO` expression.
 ///
 /// Also requires `process_instruction_macros()` in `build.rs` to function, see `#[instruction]`
 /// macro documentation.

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
@@ -7,7 +7,7 @@ use syn::{
 };
 
 fn is_exact_ok(expr: &Expr) -> bool {
-    let expected = quote! { Ok(ControlFlow::Continue(Default::default())) };
+    let expected = quote! {ExecutionResult::CONTINUE_ZERO};
     let actual = expr.to_token_stream();
     actual.to_string() == expected.to_string()
 }
@@ -102,7 +102,7 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
             block,
         }) = arm.body.as_mut()
         {
-            let continue_expr = parse_quote! { Ok(ControlFlow::Continue(Default::default())) };
+            let continue_expr = parse_quote! { ExecutionResult::CONTINUE_ZERO };
             if let Some(last_statement) = block.stmts.last_mut() {
                 // Has at least one statement
                 if let Stmt::Expr(expr, maybe_semicolon) = last_statement {
@@ -118,8 +118,7 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
                                 // Replace `return T` with `T`
                                 inner_expr.as_ref().clone()
                             } else {
-                                // Replace `return` with
-                                // `Ok(ControlFlow::Continue(Default::default()))`
+                                // Replace `return` with `ExecutionResult::CONTINUE_ZERO`
                                 continue_expr
                             }
                         }
@@ -128,16 +127,15 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
                                 // Ensure that the last statement ends with `;` even if it returns a
                                 // unit value already
                                 maybe_semicolon.replace(Semi::default());
-                                // Insert `Ok(ControlFlow::Continue(Default::default()))` at the end
-                                // of the block
+                                // Insert `ExecutionResult::CONTINUE_ZERO` at
+                                // the end of the block
                                 block.stmts.push(Stmt::Expr(continue_expr, None));
                             }
                         }
                     }
                 }
             } else {
-                // No statements, insert `Ok(ControlFlow::Continue(Default::default()))` at the end
-                // of the block
+                // No statements, insert `ExecutionResult::CONTINUE_ZERO` at the end of the block
                 block.stmts.push(Stmt::Expr(continue_expr, None));
             }
         }
@@ -189,16 +187,14 @@ pub(super) fn extract_variant_arms(
 
         let Stmt::Expr(ok_expr, None) = second_stmt else {
             return Err(anyhow::anyhow!(
-                "Second statement must be exactly `Ok(ControlFlow::Continue(Default::default()))`: \
-                {}",
+                "Second statement must be exactly `ExecutionResult::CONTINUE_ZERO`: {}",
                 second_stmt.to_token_stream()
             ));
         };
 
         if !is_exact_ok(ok_expr) {
             return Err(anyhow::anyhow!(
-                "Second statement must be exactly `Ok(ControlFlow::Continue(Default::default()))`: \
-                {}",
+                "Second statement must be exactly `ExecutionResult::CONTINUE_ZERO`: {}",
                 second_stmt.to_token_stream()
             ));
         }
@@ -218,7 +214,7 @@ pub(super) fn extract_variant_arms(
         } else {
             Err(anyhow::anyhow!(
                 "Single tail expression must be either `match` on `self` or \
-                `Ok(ControlFlow::Continue(Default::default()))`: {}",
+                `ExecutionResult::CONTINUE_ZERO`: {}",
                 expr.to_token_stream()
             ))
         }

--- a/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
@@ -16,33 +16,33 @@ use core::{fmt, ptr};
 /// `u32` for RV32 and `u64` for RV64.
 pub const trait RegType
 where
-    Self: [const] Default
-        + [const] Destruct
-        + [const] From<bool>
-        + [const] From<u8>
-        + [const] From<u16>
-        + [const] From<u32>
-        + [const] Eq
-        + [const] Ord
-        + [const] Add<Output = Self>
-        + [const] AddAssign
-        + [const] Sub<Output = Self>
-        + [const] SubAssign
-        + [const] BitAnd<Output = Self>
-        + [const] BitAndAssign
-        + [const] BitOr<Output = Self>
-        + [const] BitOrAssign
-        + [const] BitXor<Output = Self>
-        + [const] BitXorAssign
-        + [const] Not<Output = Self>
-        + [const] Shl<u8, Output = Self>
-        + [const] Shl<u16, Output = Self>
-        + [const] Shl<u32, Output = Self>
-        + [const] Shl<i32, Output = Self>
-        + [const] Shr<u8, Output = Self>
-        + [const] Shr<u16, Output = Self>
-        + [const] Shr<u32, Output = Self>
-        + [const] Shr<i32, Output = Self>
+    Self: const Default
+        + const Destruct
+        + const From<bool>
+        + const From<u8>
+        + const From<u16>
+        + const From<u32>
+        + const Eq
+        + const Ord
+        + const Add<Output = Self>
+        + const AddAssign
+        + const Sub<Output = Self>
+        + const SubAssign
+        + const BitAnd<Output = Self>
+        + const BitAndAssign
+        + const BitOr<Output = Self>
+        + const BitOrAssign
+        + const BitXor<Output = Self>
+        + const BitXorAssign
+        + const Not<Output = Self>
+        + const Shl<u8, Output = Self>
+        + const Shl<u16, Output = Self>
+        + const Shl<u32, Output = Self>
+        + const Shl<i32, Output = Self>
+        + const Shr<u8, Output = Self>
+        + const Shr<u16, Output = Self>
+        + const Shr<u32, Output = Self>
+        + const Shr<i32, Output = Self>
         + fmt::Display
         + fmt::LowerHex
         + fmt::UpperHex
@@ -61,6 +61,9 @@ where
 
     /// Convert to `i64` (sign-extended)
     fn as_i64(&self) -> i64;
+
+    /// Wrapping addition of a signed byte offset, as used for PC-relative control flow
+    fn wrapping_add_signed(&self, offset: i32) -> Self;
 }
 
 const impl RegType for u32 {
@@ -74,6 +77,11 @@ const impl RegType for u32 {
     #[inline(always)]
     fn as_i64(&self) -> i64 {
         i64::from(self.cast_signed())
+    }
+
+    #[inline(always)]
+    fn wrapping_add_signed(&self, offset: i32) -> Self {
+        u32::wrapping_add_signed(*self, offset)
     }
 }
 
@@ -89,15 +97,20 @@ const impl RegType for u64 {
     fn as_i64(&self) -> i64 {
         self.cast_signed()
     }
+
+    #[inline(always)]
+    fn wrapping_add_signed(&self, offset: i32) -> Self {
+        u64::wrapping_add_signed(*self, i64::from(offset))
+    }
 }
 
 /// GPR (General Purpose Register)
 pub const trait Register:
     fmt::Display
     + fmt::Debug
-    + [const] Default
-    + [const] Eq
-    + [const] Destruct
+    + const Default
+    + const Eq
+    + const Destruct
     + Copy
     + Send
     + Sync
@@ -120,7 +133,7 @@ pub const trait Register:
     /// Register type.
     ///
     /// `u32` for RV32 and `u64` for RV64.
-    type Type: [const] RegType;
+    type Type: const RegType;
 
     /// Create a register from its bit representation
     fn from_bits(bits: u8) -> Option<Self>;


### PR DESCRIPTION
This is a large-scale change, but it essentially make result types flatter and smaller as well as removes control flow operations from instruction handlers.

These changes result in significantly better performance for CoreMark benchmark compared to `main`. They will be instrumental in implementing alternative (much faster) instruction dispatch method, which is the primary motivation here.