### PR TITLE
Extract execution functions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -672,7 +672,7 @@ jobs:
       - name: Set up RUSTFLAGS
         shell: bash
         run: |
-          echo "RUSTFLAGS=${RUSTFLAGS} -Cllvm-args=--inline-threshold=15000 -C embed-bitcode -C lto -Z dylib-lto ${{ matrix.target == '' && '-C target-cpu=native' || '' }}" >> $GITHUB_ENV
+          echo "RUSTFLAGS=${RUSTFLAGS} -Cllvm-args=--inline-threshold=10000 -C embed-bitcode -C lto -Z dylib-lto ${{ matrix.target == '' && '-C target-cpu=native' || '' }}" >> $GITHUB_ENV
 
       - name: Ensure no panics in annotated code
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "ab-riscv-macros-common",
  "ab-riscv-macros-impl",
  "anyhow",
+ "heck 0.5.0",
  "prettyplease",
  "quote",
  "syn 3.0.3",

--- a/crates/execution/ab-riscv-interpreter/Cargo.toml
+++ b/crates/execution/ab-riscv-interpreter/Cargo.toml
@@ -34,9 +34,6 @@ ab-riscv-macros = { workspace = true, features = ["build"] }
 [features]
 alloc = []
 # TODO: no-panic coverage is limited very slightly:
-#  * Some `::execute()` methods do not have `no_panic_const::no_panic` macro applied due to unreasonable inlining limits
-#    required, but all helpers and other APIs used are guaranteed to not panic, and the rest of the code is trivially
-#    panic-free as well (this can be worked around by extracting each execution branch into a non-panicking closure)
 #  * `BasicInterpreterState::execute` method does not have `no_panic_const::no_panic` macro applied due to being used
 #    with lots of extensions, many of which are too large, but is also trivially panic-free and only calls panic-free
 #    methods

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc/rv32_zbc_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc/rv32_zbc_helpers.rs
@@ -11,7 +11,8 @@
                 target_feature = "aes"
             ),
             all(target_arch = "x86_64", target_feature = "pclmulqdq")
-        )
+        ),
+        not(feature = "no-panic")
     ),
     expect(
         clippy::items_after_statements,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
@@ -38,7 +38,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
@@ -38,7 +38,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
@@ -39,7 +39,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -69,7 +69,7 @@ where
                         ),
                     });
                 }
-                if vd.to_bits() % nreg != 0 {
+                if !vd.to_bits().is_multiple_of(nreg) {
                     ::core::hint::cold_path();
                     return ExecutionResult::Err(ExecutionError::IllegalInstruction {
                         address: PackedAddress::new(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -38,7 +38,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -38,7 +38,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
@@ -38,7 +38,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -38,7 +38,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
@@ -39,7 +39,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -68,7 +68,7 @@ where
                         ),
                     });
                 }
-                if vs3.to_bits() % nreg != 0 {
+                if !vs3.to_bits().is_multiple_of(nreg) {
                     ::core::hint::cold_path();
                     return ExecutionResult::Err(ExecutionError::IllegalInstruction {
                         address: PackedAddress::new(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -39,7 +39,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -41,7 +41,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -34,7 +34,7 @@ where
     CustomError: [const] Destruct,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/zkr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zkr.rs
@@ -113,7 +113,7 @@ where
     ExtState: [const] ZkrSeedSource,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -53,7 +53,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -51,7 +51,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-interpreter/src/zvbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc.rs
@@ -51,7 +51,7 @@ where
     PC: ProgramCounter<Reg::Type, Memory, CustomError>,
 {
     #[inline(always)]
-    // TODO: #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn execute(
         self,
         Rs1Rs2OperandValues {

--- a/crates/execution/ab-riscv-macros-impl/src/lib.rs
+++ b/crates/execution/ab-riscv-macros-impl/src/lib.rs
@@ -174,6 +174,21 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     inherited
 /// * `ExecutionResult::CONTINUE_ZERO` expression.
 ///
+/// The composed `execute()` body is not kept as one large `match`. Instead, each `match` arm
+/// (both own and inherited) is turned into its own `#[inline(always)]` free function, generated
+/// right next to `execute()`, and `execute()` itself is reduced to a lean `match` that dispatches
+/// to those functions (with the impl's generic parameters specified explicitly via turbofish,
+/// since a free function has no `Self` for them to be inferred from). This is purely an
+/// implementation detail; those functions are not meant to be used or referred to directly.
+///
+/// If `execute()` carries `#[cfg_attr(feature = "no-panic", no_panic_const::no_panic(..))]`, it
+/// is stripped from `execute()` itself (which becomes a plain dispatcher, so the attribute would
+/// no longer serve its purpose there) and placed on every one of those generated functions
+/// instead, so each variant's execution logic is checked for panics individually. Since this
+/// depends on `execute()` in the implementation currently being processed specifically carrying
+/// this attribute, an implementation that inherits from a lower-level one that has it, but does
+/// not itself repeat it, will not get it applied to its own generated functions either.
+///
 /// Also requires `process_instruction_macros()` in `build.rs` to function, see `#[instruction]`
 /// macro documentation.
 ///

--- a/crates/execution/ab-riscv-macros/Cargo.toml
+++ b/crates/execution/ab-riscv-macros/Cargo.toml
@@ -21,6 +21,7 @@ all-features = true
 ab-riscv-macros-impl = { workspace = true, optional = true }
 ab-riscv-macros-common = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
+heck = { workspace = true, optional = true }
 prettyplease = { workspace = true, optional = true }
 quote = { workspace = true, optional = true }
 syn = { workspace = true, optional = true, features = ["extra-traits", "full", "visit", "visit-mut"] }
@@ -34,6 +35,7 @@ default = [
 build = [
     "dep:ab-riscv-macros-common",
     "dep:anyhow",
+    "dep:heck",
     "dep:prettyplease",
     "dep:quote",
     "dep:syn",

--- a/crates/execution/ab-riscv-macros/src/build.rs
+++ b/crates/execution/ab-riscv-macros/src/build.rs
@@ -13,8 +13,9 @@ use crate::build::enum_impl::{
     process_pending_enum_impls,
 };
 use crate::build::execution_impl::{
-    collect_enum_csr_impls_from_dependencies, collect_enum_execution_impls_from_dependencies,
-    process_execution_impl, process_pending_enum_execution_impls,
+    collect_enum_csr_impls_from_dependencies,
+    collect_original_enum_execution_impls_from_dependencies, process_execution_impl,
+    process_pending_enum_execution_impls,
 };
 use crate::build::state::State;
 use ab_riscv_macros_common::code_utils::pre_process_rust_code;
@@ -65,9 +66,9 @@ pub fn process_instruction_macros() -> anyhow::Result<()> {
         let (item_impl, source) = maybe_enum_csr_impl?;
         state.insert_known_enum_csr_impl(item_impl, source)?;
     }
-    for maybe_enum_execution_impl in collect_enum_execution_impls_from_dependencies() {
+    for maybe_enum_execution_impl in collect_original_enum_execution_impls_from_dependencies() {
         let (item_impl, source) = maybe_enum_execution_impl?;
-        state.insert_known_enum_execution_impl(item_impl, source)?;
+        state.insert_known_original_enum_execution_impl(item_impl, source)?;
     }
 
     for maybe_rust_file in rust_files_in(Path::new(&manifest_dir).join("src")) {

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -1,9 +1,11 @@
 mod extract_matches;
 mod forbidden_checker;
+mod generate_variant_fns;
 
 use crate::build::enum_impl::enum_name_from_impl;
 use crate::build::execution_impl::extract_matches::extract_variant_arms;
 use crate::build::execution_impl::forbidden_checker::block_contains_forbidden_syntax;
+use crate::build::execution_impl::generate_variant_fns::generate_variant_fns;
 use crate::build::shared::collect_all_dependencies;
 use crate::build::state::{
     PendingEnumCsrImpl, PendingEnumExecutionImpl, PendingEnumOperandsImpl, State,
@@ -11,16 +13,18 @@ use crate::build::state::{
 use ab_riscv_macros_common::code_utils::{post_process_rust_code, pre_process_rust_code};
 use anyhow::Context;
 use prettyplease::unparse;
-use quote::ToTokens;
+use quote::{ToTokens, quote};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::rc::Rc;
 use std::{env, fs, iter};
 use syn::{
-    Ident, ImplItem, ImplItemFn, ItemImpl, WherePredicate, parse_file, parse_quote, parse_str,
+    Ident, ImplItem, ImplItemFn, ItemFn, ItemImpl, Token, WherePredicate, parse_file, parse_quote,
+    parse_str,
 };
 
-const ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_EXECUTION_IMPL_PATH";
+const ORIGINAL_ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX: &str =
+    "__INSTRUCTION_ENUM_ORIGINAL_EXECUTION_IMPL_PATH";
 const ENUM_CSR_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_CSR_IMPL_PATH";
 
 pub(super) fn collect_enum_csr_impls_from_dependencies()
@@ -53,26 +57,26 @@ pub(super) fn collect_enum_csr_impls_from_dependencies()
     })
 }
 
-pub(super) fn collect_enum_execution_impls_from_dependencies()
+pub(super) fn collect_original_enum_execution_impls_from_dependencies()
 -> impl Iterator<Item = anyhow::Result<(ItemImpl, Rc<Path>)>> {
     // Collect exported instruction enums from dependencies
     env::vars().filter_map(|(key, value)| {
-        if !key.ends_with(ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX) {
+        if !key.ends_with(ORIGINAL_ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX) {
             return None;
         }
 
         let result = try {
             let mut item_enum_contents = fs::read_to_string(&value).with_context(|| {
                 format!(
-                    "Failed to read Rust file `{value}` that is expected to contain instruction \
-                    enum execution implementation"
+                    "Failed to read Rust file `{value}` that is expected to contain original \
+                    instruction enum execution implementation"
                 )
             })?;
             pre_process_rust_code(&mut item_enum_contents);
             let item_impl = parse_str::<ItemImpl>(&item_enum_contents).with_context(|| {
                 format!(
-                    "Failed to parse Rust file `{value}` that is expected to contain instruction \
-                    enum execution implementation"
+                    "Failed to parse Rust file `{value}` that is expected to contain original \
+                    instruction enum execution implementation"
                 )
             })?;
 
@@ -215,34 +219,59 @@ fn output_processed_enum_csr_impl(
 
 fn output_processed_enum_execution_impl(
     enum_name: &Ident,
+    original_item_impl: ItemImpl,
     item_impl: ItemImpl,
+    variant_fns: Vec<ItemFn>,
     out_dir: &Path,
     state: &mut State,
 ) -> anyhow::Result<()> {
-    let enum_file_path = out_dir.join(format!("{enum_name}_execution_impl.rs"));
-    let code = item_impl.to_token_stream().to_string();
-    // Format
-    let mut code = unparse(&parse_file(&code).expect("Generated code is valid; qed"));
-    // Normalize source
-    let item_impl = parse_str(&code).expect("Generated code is valid; qed");
-    post_process_rust_code(&mut code);
+    {
+        let enum_file_path = out_dir.join(format!("{enum_name}_execution_impl.rs"));
+        let code = quote! { #( #variant_fns )* #item_impl }.to_string();
+        // Format
+        let mut code = unparse(&parse_file(&code).expect("Generated code is valid; qed"));
+        post_process_rust_code(&mut code);
 
-    // Avoid extra file truncation/override if it didn't change
-    if fs::read_to_string(&enum_file_path).ok().as_ref() != Some(&code) {
-        fs::write(&enum_file_path, code).with_context(|| {
-            format!(
-                "Failed to write generated Rust file with instruction execution implementation for \
-                `{enum_name}`",
-            )
-        })?;
+        // Avoid extra file truncation/override if it didn't change
+        if fs::read_to_string(&enum_file_path).ok().as_ref() != Some(&code) {
+            fs::write(&enum_file_path, code).with_context(|| {
+                format!(
+                    "Failed to write generated Rust file with instruction execution \
+                    implementation for `{enum_name}`",
+                )
+            })?;
+        }
     }
-    println!(
-        "cargo::metadata={}{ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX}={}",
-        enum_name,
-        enum_file_path.display()
-    );
+    {
+        let original_enum_file_path =
+            out_dir.join(format!("{enum_name}_original_execution_impl.rs"));
+        let code = original_item_impl.to_token_stream().to_string();
+        // Format
+        let mut code = unparse(&parse_file(&code).expect("Original code is valid; qed"));
+        // Normalize source
+        let original_item_impl = parse_str(&code).expect("Original code is valid; qed");
+        post_process_rust_code(&mut code);
 
-    state.insert_known_enum_execution_impl(item_impl, Rc::from(enum_file_path))
+        // Avoid extra file truncation/override if it didn't change
+        if fs::read_to_string(&original_enum_file_path).ok().as_ref() != Some(&code) {
+            fs::write(&original_enum_file_path, code).with_context(|| {
+                format!(
+                    "Failed to write Rust file with original instruction execution \
+                    implementation for `{enum_name}`",
+                )
+            })?;
+        }
+        println!(
+            "cargo::metadata={}{ORIGINAL_ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX}={}",
+            enum_name,
+            original_enum_file_path.display()
+        );
+
+        state.insert_known_original_enum_execution_impl(
+            original_item_impl,
+            Rc::from(original_enum_file_path),
+        )
+    }
 }
 
 pub(super) fn process_execution_impl(
@@ -587,11 +616,12 @@ pub(super) fn process_enum_csr_impl(
 }
 
 pub(super) fn process_enum_execution_impl(
-    mut item_impl: ItemImpl,
+    original_item_impl: ItemImpl,
     out_dir: &Path,
     state: &mut State,
 ) -> anyhow::Result<()> {
-    let enum_name = enum_name_from_impl(&item_impl);
+    let enum_name = enum_name_from_impl(&original_item_impl);
+    let mut item_impl = original_item_impl.clone();
 
     let Some(execute_fn) = extract_execute_fn_from_impl_mut(&mut item_impl.items) else {
         return Err(anyhow::anyhow!(
@@ -600,11 +630,17 @@ pub(super) fn process_enum_execution_impl(
             item_impl.self_ty.to_token_stream()
         ));
     };
-    let execute_block = &mut execute_fn.block;
+
+    // Support for `no_panic` macro, which is moved from the method to each extracted instruction
+    // execution function
+    let no_panic_attr_index = execute_fn.attrs.iter().position(|attr| {
+        attr.path().is_ident("cfg_attr") && attr.to_token_stream().to_string().contains("no_panic")
+    });
+    let no_panic_attr = no_panic_attr_index.map(|index| execute_fn.attrs.remove(index));
 
     let Some(enum_definition) = state.get_known_enum_definition(&enum_name) else {
         eprintln!("{enum_name} execution is waiting on its definition");
-        state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+        state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { original_item_impl });
         return Ok(());
     };
 
@@ -615,7 +651,7 @@ pub(super) fn process_enum_execution_impl(
         Ok(all_dependencies) => all_dependencies,
         Err(dependency_enum_name) => {
             eprintln!("{enum_name} execution is waiting on {dependency_enum_name} definition");
-            state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+            state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { original_item_impl });
             return Ok(());
         }
     };
@@ -625,13 +661,13 @@ pub(super) fn process_enum_execution_impl(
 
     for (dependency_enum_name, _dependency_enum_definition) in all_dependencies {
         let Some(dependency_enum_execution_impl) =
-            state.get_known_enum_execution_impl(&dependency_enum_name)
+            state.get_known_original_enum_execution_impl(&dependency_enum_name)
         else {
             eprintln!(
                 "{enum_name} execution is waiting on {dependency_enum_name} execution \
                 implementation"
             );
-            state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { item_impl });
+            state.add_pending_enum_execution_impl(PendingEnumExecutionImpl { original_item_impl });
             return Ok(());
         };
 
@@ -704,7 +740,7 @@ pub(super) fn process_enum_execution_impl(
 
     let all_execute_blocks = all_execute_blocks
         .into_iter()
-        .chain(iter::once(&*execute_block));
+        .chain(iter::once(&execute_fn.block));
 
     let mut all_instructions = HashMap::new();
     for block in all_execute_blocks {
@@ -714,7 +750,7 @@ pub(super) fn process_enum_execution_impl(
         }
     }
 
-    let all_instructions = enum_definition
+    let mut match_arms = enum_definition
         .instructions
         .iter()
         .map(|variant| {
@@ -727,27 +763,33 @@ pub(super) fn process_enum_execution_impl(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    *execute_block = parse_quote! {{
+    let is_const = item_impl.attrs.last() == Some(&parse_quote! { #[cst] });
+
+    let variant_fns = generate_variant_fns(
+        &enum_name,
+        &item_impl.self_ty,
+        &item_impl.generics,
+        is_const.then(<Token![const]>::default),
+        no_panic_attr.as_ref(),
+        &execute_fn.sig,
+        &enum_definition.instructions,
+        &mut match_arms,
+    )?;
+
+    execute_fn.block = parse_quote! {{
         match self {
-            #( #all_instructions )*
+            #( #match_arms )*
         }
     }};
 
-    // Comments will be stripped, this will suppress some of the lints that are caused by it
-    item_impl.attrs.insert(
-        0,
-        parse_quote! { #[expect(clippy::allow_attributes, reason = "Attribute below")] },
-    );
-    item_impl.attrs.insert(
-        1,
-        parse_quote! { #[allow(
-            clippy::undocumented_unsafe_blocks,
-            reason = "Comments will be stripped, this will suppress some of the lints that are \
-            caused by it"
-        )] },
-    );
-
-    output_processed_enum_execution_impl(&enum_name, item_impl, out_dir, state)
+    output_processed_enum_execution_impl(
+        &enum_name,
+        original_item_impl,
+        item_impl,
+        variant_fns,
+        out_dir,
+        state,
+    )
 }
 
 /// Process remaining enums that were waiting for dependencies
@@ -823,14 +865,14 @@ pub(super) fn process_pending_enum_execution_impls(
                     `ExecutableInstruction`, circular dependency detected, pending_enums: {:?}",
                     pending_enums
                         .iter()
-                        .map(|pending_enum| enum_name_from_impl(&pending_enum.item_impl))
+                        .map(|pending_enum| enum_name_from_impl(&pending_enum.original_item_impl))
                         .collect::<Vec<_>>()
                 ));
             }
             last_pending_enums_count = pending_enums.len();
 
-            for PendingEnumExecutionImpl { item_impl } in pending_enums {
-                process_enum_execution_impl(item_impl, out_dir, state)?;
+            for PendingEnumExecutionImpl { original_item_impl } in pending_enums {
+                process_enum_execution_impl(original_item_impl, out_dir, state)?;
             }
         }
     }

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_variant_fns.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_variant_fns.rs
@@ -1,0 +1,362 @@
+use anyhow::Context;
+use heck::ToSnakeCase;
+use quote::{ToTokens, format_ident};
+use std::mem;
+use std::rc::Rc;
+use syn::visit_mut::{self, VisitMut};
+use syn::{
+    Arm, Attribute, Expr, ExprPath, Fields, FnArg, GenericArgument, Generics, Ident, ItemFn,
+    Member, Pat, PatIdent, PatType, Path, PathArguments, QSelf, Signature, Token, Type, TypePath,
+    Variant, parse_quote,
+};
+
+/// A single named+typed parameter, used both for variant-specific fields and for arguments
+/// shared by all generated functions (derived from `execute()`'s own signature)
+struct Param<'a> {
+    /// Local identifier used both as the parameter name and as the name of the value passed at
+    /// the call site
+    ident: &'a Ident,
+    ty: Type,
+}
+
+/// This rewrites every `Self` into a fully qualified concrete instruction enum type instead.
+///
+/// `execute()`'s own body is written against `Self`, but the functions generated here are
+/// standalone functions without `Self`, which needs correction.
+struct SelfRewriter<'a> {
+    self_ty: &'a Type,
+}
+
+impl SelfRewriter<'_> {
+    /// If `path` starts with `Self::`, returns the `<self_ty as Instruction>` qualifier and the
+    /// remaining path (`Instruction` followed by whatever came after `Self::`)
+    fn qualify_self_item(&self, path: &Path) -> Option<(QSelf, Path)> {
+        let first = path.segments.first()?;
+        if first.ident != "Self" || !first.arguments.is_none() || path.segments.len() < 2 {
+            return None;
+        }
+
+        let self_ty = &self.self_ty;
+        let rest = path.segments.iter().skip(1);
+        let TypePath {
+            attrs: _,
+            qself,
+            path,
+        } = parse_quote! {
+            <#self_ty as Instruction>::#(#rest)::*
+        };
+
+        Some((qself.expect("Statically known to be present; qed"), path))
+    }
+}
+
+impl VisitMut for SelfRewriter<'_> {
+    fn visit_type_mut(&mut self, i: &mut Type) {
+        if let Type::Path(TypePath {
+            qself: None,
+            path,
+            attrs: _,
+        }) = i
+        {
+            if path.segments.len() == 1 && path.segments[0].ident == "Self" {
+                *i = self.self_ty.clone();
+            } else if let Some((qself, path)) = self.qualify_self_item(path) {
+                *i = Type::Path(TypePath {
+                    attrs: Vec::new(),
+                    qself: Some(qself),
+                    path,
+                });
+            }
+        }
+        visit_mut::visit_type_mut(self, i);
+    }
+
+    fn visit_expr_mut(&mut self, i: &mut Expr) {
+        if let Expr::Path(ExprPath {
+            qself: None,
+            path,
+            attrs,
+        }) = i
+            && let Some((qself, path)) = self.qualify_self_item(path)
+        {
+            *i = Expr::Path(ExprPath {
+                attrs: mem::take(attrs),
+                qself: Some(qself),
+                path,
+            });
+        }
+        visit_mut::visit_expr_mut(self, i);
+    }
+}
+
+/// Extracts the single generic type argument out of a type like `Foo<Bar>`, returning `Bar`.
+///
+/// This is used to recover field types of destructured arguments of `execute()` (such as
+/// `Rs1Rs2OperandValues<T>`) without having access to the original struct definition.
+fn extract_single_generic_type(ty: &Type) -> anyhow::Result<&Type> {
+    let Type::Path(type_path) = ty else {
+        return Err(anyhow::anyhow!(
+            "Expected a generic path type for a destructured `execute()` argument, found: {}",
+            ty.to_token_stream()
+        ));
+    };
+    let last_segment = type_path
+        .path
+        .segments
+        .last()
+        .expect("Path is never empty; qed");
+    let PathArguments::AngleBracketed(generic_args) = &last_segment.arguments else {
+        return Err(anyhow::anyhow!(
+            "Expected a single generic argument in destructured `execute()` argument type `{}`",
+            ty.to_token_stream()
+        ));
+    };
+    let mut args = generic_args.args.iter();
+    let (Some(GenericArgument::Type(inner_ty)), None) = (args.next(), args.next()) else {
+        return Err(anyhow::anyhow!(
+            "Expected exactly one generic type argument in destructured `execute()` argument \
+            type `{}`",
+            ty.to_token_stream()
+        ));
+    };
+
+    Ok(inner_ty)
+}
+
+/// Extracts parameters shared by all generated per-variant functions from `execute()`'s own
+/// signature (excluding `self`).
+///
+/// Arguments (or destructured fields of a struct argument) whose identifier starts with `_` are
+/// considered unused and skipped.
+fn extract_shared_params(sig: &Signature) -> anyhow::Result<Vec<Param<'_>>> {
+    let mut shared_params = Vec::new();
+
+    for input in &sig.inputs {
+        let FnArg::Typed(PatType {
+            pat,
+            ty,
+            attrs: _,
+            colon_token: _,
+        }) = input
+        else {
+            // `self` receiver is ignored (matched on by `match` and unused after that)
+            continue;
+        };
+
+        match pat.as_ref() {
+            Pat::Ident(PatIdent {
+                ident,
+                attrs: _,
+                by_ref: _,
+                mutability: _,
+                subpat: _,
+            }) => {
+                if !ident.to_string().starts_with('_') {
+                    shared_params.push(Param {
+                        ident,
+                        ty: ty.as_ref().clone(),
+                    });
+                }
+            }
+            Pat::Struct(pat_struct) => {
+                let field_ty = extract_single_generic_type(ty)?;
+                for field in &pat_struct.fields {
+                    let Pat::Ident(PatIdent {
+                        ident,
+                        attrs: _,
+                        by_ref: _,
+                        mutability: _,
+                        subpat: _,
+                    }) = field.pat.as_ref()
+                    else {
+                        // `_` or another unsupported nested pattern, treated as unused
+                        continue;
+                    };
+                    if !ident.to_string().starts_with('_') {
+                        shared_params.push(Param {
+                            ident,
+                            ty: field_ty.clone(),
+                        });
+                    }
+                }
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Unsupported `execute()` argument pattern `{}`",
+                    pat.to_token_stream()
+                ));
+            }
+        }
+    }
+
+    Ok(shared_params)
+}
+
+/// Extracts variant-specific parameters (fields bound by the match arm's pattern that are not `_`)
+/// together with their types looked up from the enum variant's definition
+fn extract_variant_params<'a>(
+    arm_pat: &'a Pat,
+    variant: &'a Variant,
+) -> anyhow::Result<Vec<Param<'a>>> {
+    let Pat::Struct(pat_struct) = arm_pat else {
+        return Err(anyhow::anyhow!(
+            "Expected a struct pattern for instruction variant `{}`, found: {}",
+            variant.ident,
+            arm_pat.to_token_stream()
+        ));
+    };
+    let Fields::Named(fields_named) = &variant.fields else {
+        return Err(anyhow::anyhow!(
+            "Instruction variant `{}` must have named fields",
+            variant.ident
+        ));
+    };
+
+    let mut params = Vec::new();
+    for field_pat in &pat_struct.fields {
+        let Pat::Ident(PatIdent {
+            ident: local_ident,
+            attrs: _,
+            by_ref: _,
+            mutability: _,
+            subpat: _,
+        }) = field_pat.pat.as_ref()
+        else {
+            // `_` or another unsupported nested pattern, treated as unused
+            continue;
+        };
+
+        let Member::Named(field_name) = &field_pat.member else {
+            return Err(anyhow::anyhow!(
+                "Instruction variant `{}` fields must be named",
+                variant.ident
+            ));
+        };
+
+        let field = fields_named
+            .named
+            .iter()
+            .find(|field| field.ident.as_ref() == Some(field_name))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Field `{field_name}` not found in instruction variant `{}`",
+                    variant.ident
+                )
+            })?;
+
+        params.push(Param {
+            ident: local_ident,
+            ty: field.ty.clone(),
+        });
+    }
+
+    Ok(params)
+}
+
+/// Splits a composed `execute()` method into a `#[inline(always)]` function generated for each
+/// enum variant, replacing its match arm bodies with calls to those functions.
+///
+/// `execute()`'s generic parameters are kept in full on every generated function, and call sites
+/// always specify them explicitly. This is much simpler than tracking their usage. Same with
+/// arguments.
+///
+/// `variants` and `arms` must have the same length and be in the same order (typically
+/// `enum_definition.instructions` and the correspondingly ordered arms extracted from `execute()`).
+#[expect(clippy::allow_attributes, reason = "Attribute below")]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Each parameter is a distinct piece of already-parsed `execute()` context; bundling \
+    them would not make this any clearer"
+)]
+pub(super) fn generate_variant_fns(
+    enum_name: &Ident,
+    self_ty: &Type,
+    generics: &Generics,
+    constness: Option<Token![const]>,
+    no_panic_attr: Option<&Attribute>,
+    execute_sig: &Signature,
+    variants: &[Rc<Variant>],
+    match_arms: &mut [Arm],
+) -> anyhow::Result<Vec<ItemFn>> {
+    let mut self_rewriter = SelfRewriter { self_ty };
+
+    let mut shared_params = extract_shared_params(execute_sig)?;
+    let mut output = execute_sig.output.clone();
+    for param in &mut shared_params {
+        self_rewriter.visit_type_mut(&mut param.ty);
+    }
+    self_rewriter.visit_return_type_mut(&mut output);
+
+    let mut generated_fns = Vec::with_capacity(variants.len());
+    let generic_params = &generics.params;
+    let where_clause = &generics.where_clause;
+
+    for (variant, arm) in variants.iter().zip(match_arms) {
+        let mut variant_params = extract_variant_params(&arm.pat, variant)
+            .with_context(|| format!("Instruction variant `{}`", variant.ident))?;
+        for param in &mut variant_params {
+            self_rewriter.visit_type_mut(&mut param.ty);
+        }
+
+        let fn_name = format_ident!(
+            "execute_{}_{}",
+            enum_name.to_string().to_snake_case(),
+            variant.ident.to_string().to_snake_case(),
+        );
+
+        let call_args = variant_params
+            .iter()
+            .chain(&shared_params)
+            .map(|param| &param.ident);
+        let mut original_arm_body = mem::replace(
+            arm.body.as_mut(),
+            parse_quote! { #fn_name::<#generic_params>(#( #call_args ),*) },
+        );
+        arm.comma = Some(<Token![,]>::default());
+
+        self_rewriter.visit_expr_mut(&mut original_arm_body);
+
+        let call_args = variant_params
+            .iter()
+            .chain(&shared_params)
+            .map(|param| &param.ident);
+        let args = variant_params
+            .iter()
+            .chain(&shared_params)
+            .map(|Param { ident, ty }| {
+                parse_quote! { #ident: #ty }
+            })
+            .collect::<Vec<FnArg>>();
+
+        generated_fns.push(parse_quote! {
+            #[expect(clippy::allow_attributes, reason = "Attributes below")]
+            #[allow(
+                clippy::extra_unused_type_parameters,
+                reason = "Much easier in generated code than properly tracking used generics"
+            )]
+            #[allow(clippy::too_many_arguments, reason = "Generated and force-inlined")]
+            // Comments will be stripped, this will suppress some of the lints that are caused by it
+            #[allow(
+                clippy::undocumented_unsafe_blocks,
+                reason = "Comments will be stripped, this will suppress some of the lints \
+                that are caused by it"
+            )]
+            #no_panic_attr
+            #[inline(always)]
+            #constness fn #fn_name<#generic_params>(#( #args ),*) #output
+                #where_clause
+            {
+                // This prevents warnings about unused arguments in a way that avoids suppression of
+                // lints for the implementation itself
+                #[expect(clippy::let_underscore_untyped, reason = "Generated code")]
+                {
+                    #( let _ = #call_args; )*
+                }
+                #[allow(unused_braces, reason = "Generated code")]
+                #original_arm_body
+            }
+        });
+    }
+
+    Ok(generated_fns)
+}

--- a/crates/execution/ab-riscv-macros/src/build/state.rs
+++ b/crates/execution/ab-riscv-macros/src/build/state.rs
@@ -54,14 +54,14 @@ pub(super) struct PendingEnumCsrImpl {
 }
 
 #[derive(Debug)]
-pub(super) struct KnownEnumExecutionImpl {
+pub(super) struct KnownOriginalEnumExecutionImpl {
     pub(super) item_impl: ItemImpl,
     pub(super) source: Rc<Path>,
 }
 
 #[derive(Debug)]
 pub(super) struct PendingEnumExecutionImpl {
-    pub(super) item_impl: ItemImpl,
+    pub(super) original_item_impl: ItemImpl,
 }
 
 pub(super) struct State {
@@ -73,7 +73,7 @@ pub(super) struct State {
     pending_enum_operands_impls: Vec<PendingEnumOperandsImpl>,
     known_enum_csr_impls: HashMap<Ident, KnownEnumCsrImpl>,
     pending_enum_csr_impls: Vec<PendingEnumCsrImpl>,
-    known_enum_execution_impls: HashMap<Ident, KnownEnumExecutionImpl>,
+    known_original_enum_execution_impls: HashMap<Ident, KnownOriginalEnumExecutionImpl>,
     pending_enum_execution_impls: Vec<PendingEnumExecutionImpl>,
 }
 
@@ -88,7 +88,7 @@ impl State {
             pending_enum_operands_impls: Vec::new(),
             known_enum_csr_impls: HashMap::new(),
             pending_enum_csr_impls: Vec::new(),
-            known_enum_execution_impls: HashMap::new(),
+            known_original_enum_execution_impls: HashMap::new(),
             pending_enum_execution_impls: Vec::new(),
         }
     }
@@ -111,11 +111,11 @@ impl State {
         self.known_enum_csr_impls.get(enum_name)
     }
 
-    pub(super) fn get_known_enum_execution_impl(
+    pub(super) fn get_known_original_enum_execution_impl(
         &self,
         enum_name: &Ident,
-    ) -> Option<&KnownEnumExecutionImpl> {
-        self.known_enum_execution_impls.get(enum_name)
+    ) -> Option<&KnownOriginalEnumExecutionImpl> {
+        self.known_original_enum_execution_impls.get(enum_name)
     }
 
     pub(super) fn insert_known_enum_definition(
@@ -224,7 +224,7 @@ impl State {
         Ok(())
     }
 
-    pub(super) fn insert_known_enum_execution_impl(
+    pub(super) fn insert_known_original_enum_execution_impl(
         &mut self,
         item_impl: ItemImpl,
         source: Rc<Path>,
@@ -236,9 +236,9 @@ impl State {
             key: enum_name,
             value,
             ..
-        }) = self.known_enum_execution_impls.try_insert(
+        }) = self.known_original_enum_execution_impls.try_insert(
             enum_name,
-            KnownEnumExecutionImpl {
+            KnownOriginalEnumExecutionImpl {
                 item_impl,
                 source: Rc::clone(&source),
             },


### PR DESCRIPTION
Each `ExecutableInstruction::execute()` function is essentially a large `match`. This PR extract each arm into a separate `#[inline(always)]` function, and original arm is replaced with a call to this function.

Now `no-panic` macro is applied to these new individual functions, which helps compiler with the complexity (was able to reduce inlining threshold) and allows to apply it to all instructions now (some were skipped before despite being, technically, panic-free).

The whole `fn execute()` is now just a `match` + calls to panic-free functions, so the attribute is stripped from it while retaining panic-free guarantees.