### PR TITLE
Add `ExecutionResult::ContinueNoWrite` instead of writing to zero register

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -273,7 +273,7 @@ where
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }
 

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max/instruction.rs
@@ -98,6 +98,6 @@ where
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max/instruction.rs
@@ -94,6 +94,6 @@ where
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/instruction.rs
@@ -152,6 +152,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -447,6 +447,15 @@ fn run_rv32i_max_test(
                     break;
                 }
             }
+            ExecutionResult::ContinueNoWrite => {
+                if state
+                    .memory
+                    .tohost_value::<RegisterType<AbundanceRv32IMaxInstruction>>(elf.tohost_addr)?
+                    .is_some()
+                {
+                    break;
+                }
+            }
             ExecutionResult::Branch { offset } => {
                 match state.instruction_fetcher.set_pc_relative(
                     &state.memory,
@@ -644,6 +653,15 @@ fn run_rv64i_max_test(
         ) {
             ExecutionResult::Continue { rd, value } => {
                 state.regs.write(rd, value);
+                if state
+                    .memory
+                    .tohost_value::<RegisterType<AbundanceRv64IMaxInstruction>>(elf.tohost_addr)?
+                    .is_some()
+                {
+                    break;
+                }
+            }
+            ExecutionResult::ContinueNoWrite => {
                 if state
                     .memory
                     .tohost_value::<RegisterType<AbundanceRv64IMaxInstruction>>(elf.tohost_addr)?

--- a/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
@@ -79,6 +79,6 @@ where
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -157,6 +157,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -191,6 +191,9 @@ impl<Regs, ExtState, Memory, IF, InstructionHandler>
                                 self.regs.write(rd, value);
                                 continue;
                             }
+                            ExecutionResult::ContinueNoWrite => {
+                                continue;
+                            }
                             ExecutionResult::Branch { offset } => instruction_fetcher
                                 .set_pc_relative(&self.memory, instruction.size(), offset),
                             ExecutionResult::Jump { target } => {

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -535,15 +535,15 @@ pub enum ExecutionResult<Reg, CustomError = CustomErrorPlaceholder>
 where
     Reg: Register,
 {
-    /// Write the register and continue with the instruction that follows this one.
-    ///
-    /// `rd` being the zero register writes nothing, see [`Self::CONTINUE_ZERO`].
+    /// Write the register and continue with the instruction that follows this one
     Continue {
         /// Register to write
         rd: Reg,
         /// Value to write into it
         value: Reg::Type,
     },
+    /// Continue with the instruction that follows this one without writing to `rd` register
+    ContinueNoWrite,
     /// Continue `offset` bytes away from the address of *this* instruction.
     ///
     /// Keeping it relative rather than resolving it against the program counter here means a
@@ -568,20 +568,6 @@ const {
     // Ensure result type retains its size
     assert!(size_of::<ExecutionResult<Reg<u64>>>() <= 16);
     assert!(size_of::<ExecutionResult<Reg<u32>>>() <= 16);
-}
-
-impl<Reg, CustomError> ExecutionResult<Reg, CustomError>
-where
-    Reg: Register,
-{
-    /// Continue with the instruction that follows this one without writing a register.
-    ///
-    /// The zero register discards whatever is written to it, so this is what an instruction whose
-    /// only effect is elsewhere returns.
-    pub const CONTINUE_ZERO: Self = Self::Continue {
-        rd: Reg::ZERO,
-        value: Reg::Type::from(0u8),
-    };
 }
 
 const impl<Reg, CustomError> From<ExecutionError<Reg::Type, CustomError>>
@@ -962,9 +948,8 @@ pub const trait ExecutableInstruction<
     ///
     /// On success `ExecutionResult::Continue { rd: rd, value: rd_value }` is returned, which will
     /// be written into the register file. In most cases this is the only register that needs to
-    /// be written. If no value needs to be written,
-    /// `ExecutionResult::CONTINUE_ZERO` should be returned, which corresponds
-    /// to `Ok(ControlFlow::Continue(Reg::ZERO, 0))` and is no-op.
+    /// be written. If no value needs to be written, `ExecutionResult::ContinueNoWrite` should be
+    /// returned, which skips the register file write entirely.
     fn execute(
         self,
         rs1rs2_values: Rs1Rs2OperandValues<<Self::Reg as Register>::Type>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -216,7 +216,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 memory.write(u64::from(addr), rs2_value as u8)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Sh {
                 rs2: _,
@@ -225,7 +225,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 memory.write(u64::from(addr), rs2_value as u16)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Sw {
                 rs2: _,
@@ -234,7 +234,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i32::from(imm).cast_unsigned());
                 memory.write(u64::from(addr), rs2_value)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             Self::Beq {
@@ -248,7 +248,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Bne {
                 rs1: _,
@@ -261,7 +261,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Blt {
                 rs1: _,
@@ -274,7 +274,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Bge {
                 rs1: _,
@@ -287,7 +287,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Bltu {
                 rs1: _,
@@ -300,7 +300,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Bgeu {
                 rs1: _,
@@ -313,7 +313,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             Self::Lui { rd, imm } => ExecutionResult::Continue {
@@ -340,22 +340,22 @@ where
 
             Self::Fence { pred, succ } => {
                 system_instruction_handler.handle_fence(pred, succ);
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::FenceTso => {
                 system_instruction_handler.handle_fence_tso();
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             Self::Ecall => {
                 match system_instruction_handler.handle_ecall(regs, memory, program_counter)? {
-                    ControlFlow::Continue(()) => ExecutionResult::CONTINUE_ZERO,
+                    ControlFlow::Continue(()) => ExecutionResult::ContinueNoWrite,
                     ControlFlow::Break(()) => ExecutionResult::Break,
                 }
             }
             Self::Ebreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             Self::Unimp => {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
@@ -67,6 +67,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
@@ -48,6 +48,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -73,11 +73,11 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(u32::from(uimm));
                 memory.write(u64::from(addr), rs2_value)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             // Quadrant 01
-            Self::CNop => ExecutionResult::CONTINUE_ZERO,
+            Self::CNop => ExecutionResult::ContinueNoWrite,
             Self::CAddi { rd, nzimm } => {
                 let value = regs.read(rd).wrapping_add(i32::from(nzimm).cast_unsigned());
                 ExecutionResult::Continue { rd, value }
@@ -144,7 +144,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CBnez { rs1: _, imm } => {
                 if rs1_value != 0 {
@@ -153,7 +153,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             // Quadrant 10
@@ -176,7 +176,7 @@ where
             },
             Self::CEbreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CJalr { rs1: _ } => {
                 let target = rs1_value & !1;
@@ -191,7 +191,7 @@ where
             Self::CSwsp { rs2: _, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u32::from(uimm));
                 memory.write(u64::from(addr), rs2_value)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CUnimp => {
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
@@ -42,6 +42,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -373,6 +373,7 @@ where
             ExecutionResult::Continue { rd, value } => {
                 state.regs.write(rd, value);
             }
+            ExecutionResult::ContinueNoWrite => {}
             ExecutionResult::Branch { offset } => {
                 let control_flow = state.instruction_fetcher.set_pc_relative(
                     &state.memory,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
@@ -76,7 +76,7 @@ where
             } => {
                 let addr = u64::from(rs1_value);
                 memory.write(addr, rs2_value as u8)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::ShRl {
                 rs1: _,
@@ -85,7 +85,7 @@ where
             } => {
                 let addr = u64::from(rs1_value);
                 memory.write(addr, rs2_value as u16)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::SwRl {
                 rs1: _,
@@ -94,7 +94,7 @@ where
             } => {
                 let addr = u64::from(rs1_value);
                 memory.write(addr, rs2_value)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -48,7 +48,7 @@ where
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }
 
@@ -123,7 +123,7 @@ where
             } => {
                 let addr = u64::from(rs1_value.wrapping_add(u32::from(uimm)));
                 memory.write(addr, rs2_value as u8)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CSh {
                 rs1: _,
@@ -132,7 +132,7 @@ where
             } => {
                 let addr = u64::from(rs1_value.wrapping_add(u32::from(uimm)));
                 memory.write(addr, rs2_value as u16)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CZextB { rd } => {
                 let value = regs.read(rd) & 0xff;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -48,7 +48,7 @@ where
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }
 
@@ -97,7 +97,7 @@ where
             }
             Self::CmPop { urlist, stack_adj } => {
                 rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CmPopretz { urlist, stack_adj } => {
                 let ra_val = rv32_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
@@ -43,6 +43,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
@@ -52,6 +52,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -300,7 +300,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 memory.write(addr, rs2_value as u8)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Sh {
                 rs2: _,
@@ -309,7 +309,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 memory.write(addr, rs2_value as u16)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Sw {
                 rs2: _,
@@ -318,7 +318,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 memory.write(addr, rs2_value as u32)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Sd {
                 rs2: _,
@@ -327,7 +327,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(i64::from(imm).cast_unsigned());
                 memory.write(addr, rs2_value)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             Self::Beq {
@@ -341,7 +341,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Bne {
                 rs1: _,
@@ -354,7 +354,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Blt {
                 rs1: _,
@@ -367,7 +367,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Bge {
                 rs1: _,
@@ -380,7 +380,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Bltu {
                 rs1: _,
@@ -393,7 +393,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::Bgeu {
                 rs1: _,
@@ -406,7 +406,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             Self::Lui { rd, imm } => ExecutionResult::Continue {
@@ -433,22 +433,22 @@ where
 
             Self::Fence { pred, succ } => {
                 system_instruction_handler.handle_fence(pred, succ);
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::FenceTso => {
                 system_instruction_handler.handle_fence_tso();
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             Self::Ecall => {
                 match system_instruction_handler.handle_ecall(regs, memory, program_counter)? {
-                    ControlFlow::Continue(()) => ExecutionResult::CONTINUE_ZERO,
+                    ControlFlow::Continue(()) => ExecutionResult::ContinueNoWrite,
                     ControlFlow::Break(()) => ExecutionResult::Break,
                 }
             }
             Self::Ebreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             Self::Unimp => {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
@@ -49,6 +49,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
@@ -48,6 +48,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -81,7 +81,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value as u32)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CSd {
                 rs1: _,
@@ -90,7 +90,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             // Quadrant 01
@@ -175,7 +175,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CBnez { rs1: _, imm } => {
                 if rs1_value != 0 {
@@ -184,7 +184,7 @@ where
                     };
                 }
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
 
             // Quadrant 10
@@ -215,7 +215,7 @@ where
             },
             Self::CEbreak => {
                 system_instruction_handler.handle_ebreak(regs, memory, program_counter.get_pc());
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CJalr { rs1: _ } => {
                 let target = rs1_value & !1;
@@ -230,12 +230,12 @@ where
             Self::CSwsp { rs2: _, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value as u32)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CSdsp { rs2: _, uimm } => {
                 let addr = regs.read(Reg::SP).wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CUnimp => {
                 let old_pc = program_counter.old_pc(size_of::<u16>() as u8);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
@@ -42,6 +42,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -566,6 +566,7 @@ where
             ExecutionResult::Continue { rd, value } => {
                 state.regs.write(rd, value);
             }
+            ExecutionResult::ContinueNoWrite => {}
             ExecutionResult::Branch { offset } => {
                 let control_flow = state.instruction_fetcher.set_pc_relative(
                     &state.memory,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
@@ -79,7 +79,7 @@ where
                 aq: _,
             } => {
                 memory.write(rs1_value, rs2_value as u8)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::ShRl {
                 rs1: _,
@@ -87,7 +87,7 @@ where
                 aq: _,
             } => {
                 memory.write(rs1_value, rs2_value as u16)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::SwRl {
                 rs1: _,
@@ -95,7 +95,7 @@ where
                 aq: _,
             } => {
                 memory.write(rs1_value, rs2_value as u32)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::SdRl {
                 rs1: _,
@@ -103,7 +103,7 @@ where
                 aq: _,
             } => {
                 memory.write(rs1_value, rs2_value)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -46,7 +46,7 @@ where
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }
 
@@ -121,7 +121,7 @@ where
             } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value as u8)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CSh {
                 rs1: _,
@@ -131,7 +131,7 @@ where
                 let addr = rs1_value.wrapping_add(u64::from(uimm));
                 memory.write(addr, rs2_value as u16)?;
 
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CZextB { rd } => {
                 let value = regs.read(rd) & 0xff;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -48,7 +48,7 @@ where
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }
 
@@ -97,7 +97,7 @@ where
             }
             Self::CmPop { urlist, stack_adj } => {
                 rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::CmPopretz { urlist, stack_adj } => {
                 let ra_val = rv64_zcmp_helpers::do_pop(regs, memory, urlist, stack_adj)?;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
@@ -43,6 +43,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
@@ -51,6 +51,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
@@ -67,6 +67,6 @@ where
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
@@ -2986,6 +2986,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/tests.rs
@@ -48,6 +48,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
@@ -786,6 +786,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/tests.rs
@@ -45,6 +45,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
@@ -1951,6 +1951,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/tests.rs
@@ -57,6 +57,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -922,6 +922,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -576,6 +576,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/tests.rs
@@ -50,6 +50,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
@@ -2665,6 +2665,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
@@ -64,6 +64,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -1048,6 +1048,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/tests.rs
@@ -56,6 +56,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
@@ -569,6 +569,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/tests.rs
@@ -45,6 +45,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -619,6 +619,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -2329,6 +2329,6 @@ where
             }
         }
 
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/tests.rs
@@ -45,6 +45,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/zawrs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zawrs.rs
@@ -64,11 +64,11 @@ where
         match self {
             Self::WrsNto => {
                 system_instruction_handler.handle_wrs_nto();
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
             Self::WrsSto => {
                 system_instruction_handler.handle_wrs_sto();
-                ExecutionResult::CONTINUE_ZERO
+                ExecutionResult::ContinueNoWrite
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
@@ -137,7 +137,7 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/zkr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zkr.rs
@@ -126,6 +126,6 @@ where
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError> {
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -458,6 +458,6 @@ where
                 }
             }
         }
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/tests.rs
@@ -41,6 +41,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -532,6 +532,6 @@ where
                 }
             }
         }
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/tests.rs
@@ -41,6 +41,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-interpreter/src/zvbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc.rs
@@ -286,6 +286,6 @@ where
                 }
             }
         }
-        ExecutionResult::CONTINUE_ZERO
+        ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zvbc/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc/tests.rs
@@ -41,6 +41,7 @@ fn exec(
         ExecutionResult::Continue { rd, value } => {
             state.regs.write(rd, value);
         }
+        ExecutionResult::ContinueNoWrite => {}
         ExecutionResult::Err(error) => {
             return Err(error);
         }

--- a/crates/execution/ab-riscv-macros-impl/src/lib.rs
+++ b/crates/execution/ab-riscv-macros-impl/src/lib.rs
@@ -172,7 +172,7 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// * matching in the following style: `match self { Self::Variant { .. } }`
 ///   * note that `Self` must be used instead of the explicit type name, such that it works when
 ///     inherited
-/// * `ExecutionResult::CONTINUE_ZERO` expression.
+/// * `ExecutionResult::ContinueNoWrite` expression.
 ///
 /// The composed `execute()` body is not kept as one large `match`. Instead, each `match` arm
 /// (both own and inherited) is turned into its own `#[inline(always)]` free function, generated

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/extract_matches.rs
@@ -7,7 +7,7 @@ use syn::{
 };
 
 fn is_exact_ok(expr: &Expr) -> bool {
-    let expected = quote! {ExecutionResult::CONTINUE_ZERO};
+    let expected = quote! {ExecutionResult::ContinueNoWrite};
     let actual = expr.to_token_stream();
     actual.to_string() == expected.to_string()
 }
@@ -102,7 +102,7 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
             block,
         }) = arm.body.as_mut()
         {
-            let continue_expr = parse_quote! { ExecutionResult::CONTINUE_ZERO };
+            let continue_expr = parse_quote! { ExecutionResult::ContinueNoWrite };
             if let Some(last_statement) = block.stmts.last_mut() {
                 // Has at least one statement
                 if let Stmt::Expr(expr, maybe_semicolon) = last_statement {
@@ -118,7 +118,7 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
                                 // Replace `return T` with `T`
                                 inner_expr.as_ref().clone()
                             } else {
-                                // Replace `return` with `ExecutionResult::CONTINUE_ZERO`
+                                // Replace `return` with `ExecutionResult::ContinueNoWrite`
                                 continue_expr
                             }
                         }
@@ -127,7 +127,7 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
                                 // Ensure that the last statement ends with `;` even if it returns a
                                 // unit value already
                                 maybe_semicolon.replace(Semi::default());
-                                // Insert `ExecutionResult::CONTINUE_ZERO` at
+                                // Insert `ExecutionResult::ContinueNoWrite` at
                                 // the end of the block
                                 block.stmts.push(Stmt::Expr(continue_expr, None));
                             }
@@ -135,7 +135,7 @@ fn get_variant_ident_and_block(arm: &Arm, add_ok: bool) -> anyhow::Result<(Ident
                     }
                 }
             } else {
-                // No statements, insert `ExecutionResult::CONTINUE_ZERO` at the end of the block
+                // No statements, insert `ExecutionResult::ContinueNoWrite` at the end of the block
                 block.stmts.push(Stmt::Expr(continue_expr, None));
             }
         }
@@ -187,14 +187,14 @@ pub(super) fn extract_variant_arms(
 
         let Stmt::Expr(ok_expr, None) = second_stmt else {
             return Err(anyhow::anyhow!(
-                "Second statement must be exactly `ExecutionResult::CONTINUE_ZERO`: {}",
+                "Second statement must be exactly `ExecutionResult::ContinueNoWrite`: {}",
                 second_stmt.to_token_stream()
             ));
         };
 
         if !is_exact_ok(ok_expr) {
             return Err(anyhow::anyhow!(
-                "Second statement must be exactly `ExecutionResult::CONTINUE_ZERO`: {}",
+                "Second statement must be exactly `ExecutionResult::ContinueNoWrite`: {}",
                 second_stmt.to_token_stream()
             ));
         }
@@ -214,7 +214,7 @@ pub(super) fn extract_variant_arms(
         } else {
             Err(anyhow::anyhow!(
                 "Single tail expression must be either `match` on `self` or \
-                `ExecutionResult::CONTINUE_ZERO`: {}",
+                `ExecutionResult::ContinueNoWrite`: {}",
                 expr.to_token_stream()
             ))
         }


### PR DESCRIPTION
This will be useful for threaded dispatch to clearly distinguish cases where nothing needs to be written