### PR TITLE
Remove `VectorRegistersBase`

### DIFF
--- a/crates/execution/ab-riscv-act4-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/interpreter.rs
@@ -134,20 +134,16 @@ where
     }
 }
 
-impl<Reg, const ELEN: Elen, const VLEN: Vlen> VectorRegistersBase for TestExtState<Reg, ELEN, VLEN>
-where
-    Reg: Register,
-{
-    const ELEN: Elen = ELEN;
-    const VLEN: Vlen = VLEN;
-}
-
-// TODO: The compiler does not normalize `<Self as VectorRegistersBase>::VLEN` (as used in the
-//  signatures of the methods below) to `VLEN` while `Self` is generic, so this impl has to be
-//  instantiated for concrete parameters instead of being generic like the rest of them
+// TODO: The compiler does not normalize `<Self as VectorRegisters>::VLEN` (as used in the
+//  signatures of the methods below) to the `VLEN` const generic while `Self` is generic, so this
+//  impl has to be instantiated for concrete parameters instead of being generic like the rest of
+//  them
 macro_rules! impl_vector_registers {
     ($reg:ty, $elen:expr, $vlen:expr) => {
         impl VectorRegisters for TestExtState<$reg, { $elen }, { $vlen }> {
+            const ELEN: Elen = $elen;
+            const VLEN: Vlen = $vlen;
+
             fn read_vregs(&self) -> &VectorRegisterFile<{ Self::VLEN }> {
                 &self.vregs
             }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -2,9 +2,7 @@ extern crate alloc;
 
 use crate::basic::{BasicInterpreterState, BasicRegisters};
 use crate::rv32::a::ReservationSet;
-use crate::v::vector_registers::{
-    VectorRegisterFile, VectorRegisters, VectorRegistersBase, VectorRegistersExt,
-};
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegisters, VectorRegistersExt};
 use crate::zawrs::WrsHandler;
 use crate::zkr::{ZkrSeedPoll, ZkrSeedSource};
 use crate::{
@@ -389,15 +387,13 @@ impl Csrs<Reg<u64>> for ExtState {
     }
 }
 
-const impl VectorRegistersBase for ExtState {
-    const ELEN: Elen = Elen::L64;
-    const VLEN: Vlen = Vlen::L256;
-}
-
 const impl VectorRegisters for ExtState
 where
     Self: Csrs<Reg<u64>>,
 {
+    const ELEN: Elen = Elen::L64;
+    const VLEN: Vlen = Vlen::L256;
+
     fn read_vregs(&self) -> &VectorRegisterFile<{ Self::VLEN }> {
         &self.vector.vregs
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
@@ -38,18 +38,6 @@ impl<const VLEN: Vlen> VectorRegisterFile<VLEN> {
     }
 }
 
-/// Base for [`VectorRegisters`].
-///
-/// This is primarily a workaround for type system cycles.
-pub const trait VectorRegistersBase {
-    /// Maximum vector element width `ELEN` in bits
-    const ELEN: Elen;
-    /// Vector register width `VLEN` in bits
-    const VLEN: Vlen;
-}
-
-// TODO: Figure out a way to make `VectorRegisters + VectorRegistersExt` trait bounds work without
-//  type system cycles
 /// Vector register state.
 ///
 /// This trait contains only methods that implementations genuinely need to provide. Derived
@@ -62,13 +50,12 @@ pub const trait VectorRegistersBase {
 /// update semantics: `vtype` must maintain a cached decoded form and handle the XLEN-dependent vill
 /// bit, and `vl` is read-only via CSR instructions but writable by `vsetvl{i}` and fault-only-first
 /// loads.
-///
-/// `ELEN` is the maximum element width in bits.
-pub const trait VectorRegisters<CustomError = CustomErrorPlaceholder>
-where
-    Self: [const] VectorRegistersBase,
-    [(); SUPPORTED_ELEN_VLEN::<{ Self::ELEN }, { Self::VLEN }>]:,
-{
+pub const trait VectorRegisters<CustomError = CustomErrorPlaceholder> {
+    /// Maximum vector element width `ELEN` in bits
+    const ELEN: Elen;
+    /// Vector register width `VLEN` in bits
+    const VLEN: Vlen;
+
     /// Read the vector register file
     fn read_vregs(&self) -> &VectorRegisterFile<{ Self::VLEN }>;
 
@@ -101,7 +88,10 @@ where
     /// Compute `VLMAX` for a given vtype
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
-    fn vlmax_for_vtype(&self, vtype: Vtype<{ Self::ELEN }, { Self::VLEN }>) -> Vl {
+    fn vlmax_for_vtype(&self, vtype: Vtype<{ Self::ELEN }, { Self::VLEN }>) -> Vl
+    where
+        [(); SUPPORTED_ELEN_VLEN::<{ Self::ELEN }, { Self::VLEN }>]:,
+    {
         vtype.vlmul().vlmax::<{ Self::VLEN }>(vtype.vsew())
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/tests.rs
@@ -1,5 +1,5 @@
 use crate::rv64::test_utils::{ExtState, execute, initialize_state};
-use crate::v::vector_registers::{VectorRegistersBase, VectorRegistersExt};
+use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::{Csrs, ExecutableInstructionCsr, RegisterFile};
 use ab_riscv_primitives::prelude::*;
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{VLENB_USIZE, VectorRegistersBase};
+use crate::prelude::VLENB_USIZE;
 use crate::rv64::test_utils::{ExtState, TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
 use crate::v::zvexx::muldiv::zvexx_muldiv_helpers::{
@@ -20,7 +20,7 @@ use core::num::NonZeroU8;
 //   E16/M2 -> VLMAX=32, 2 regs
 //   E32/M2 -> VLMAX=16, 2 regs (vd for widening E16 uses 2 regs)
 //   E8/M4  -> VLMAX=128, 4 regs (vd for widening E32 uses 4 regs - but VLMAX=8 at E32/M1)
-const TEST_VLENB: usize = VLENB_USIZE::<{ <ExtState as VectorRegistersBase>::VLEN }>;
+const TEST_VLENB: usize = VLENB_USIZE::<{ <ExtState as VectorRegisters>::VLEN }>;
 const {
     assert!(TEST_VLENB == 32);
 }


### PR DESCRIPTION
The type system cycles were possible to break by moving `where` to the only method that requires it