### PR TITLE
Implement threaded tail call-based execution in RISC-V interpreter

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/lib.rs
+++ b/crates/contracts/core/ab-contract-file/src/lib.rs
@@ -27,6 +27,7 @@
 //! `ab-contracts-tooling` crate exists that can build and convert contracts to this format both
 //! programmatically and using CLI interface.
 
+#![expect(incomplete_features, reason = "explicit_tail_calls")]
 #![feature(
     const_block_items,
     const_cmp,
@@ -37,6 +38,7 @@
     const_try,
     const_try_residual,
     derive_const,
+    explicit_tail_calls,
     maybe_uninit_fill,
     signed_bigint_helpers,
     trusted_len,

--- a/crates/execution/ab-riscv-act4-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/interpreter.rs
@@ -137,7 +137,7 @@ where
 // TODO: The compiler does not normalize `<Self as VectorRegisters>::VLEN` (as used in the
 //  signatures of the methods below) to the `VLEN` const generic while `Self` is generic, so this
 //  impl has to be instantiated for concrete parameters instead of being generic like the rest of
-//  them
+//  them: https://github.com/rust-lang/rust/issues/161264
 macro_rules! impl_vector_registers {
     ($reg:ty, $elen:expr, $vlen:expr) => {
         impl VectorRegisters for TestExtState<$reg, { $elen }, { $vlen }> {

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -1,10 +1,11 @@
-#![expect(incomplete_features, reason = "generic_const_*")]
+#![expect(incomplete_features, reason = "generic_const_*, explicit_tail_calls")]
 #![feature(
     adt_const_params,
     const_cmp,
     const_trait_impl,
     const_try,
     const_try_residual,
+    explicit_tail_calls,
     generic_const_args,
     generic_const_items,
     inherent_associated_types,

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -1,8 +1,10 @@
+#![expect(incomplete_features, reason = "explicit_tail_calls")]
 #![feature(
     const_cmp,
     const_trait_impl,
     const_try,
     const_try_residual,
+    explicit_tail_calls,
     signed_bigint_helpers,
     try_blocks
 )]

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -7,8 +7,8 @@ use crate::zawrs::WrsHandler;
 use crate::{
     Address, BasicInt, CustomErrorPlaceholder, ExecutableInstruction, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 #[cfg(feature = "alloc")]
@@ -223,6 +223,55 @@ impl<Regs, ExtState, Memory, IF, InstructionHandler>
                 }
 
                 (Ok(()), instruction_fetcher)
+            },
+        )
+    }
+
+    /// Execute the program with a given basic interpreter state using tail-call-threaded dispatch.
+    ///
+    /// This is [`Self::execute()`] with the central `match` replaced by one handler function per
+    /// instruction variant, chained with guaranteed tail calls. It executes exactly the same
+    /// instruction implementations and produces the same results, trading a larger amount of
+    /// generated code for higher throughput, so which one to call is a property of the workload
+    /// rather than of the program being interpreted.
+    pub fn execute_threaded<I>(&mut self) -> Result<(), ExecutionError<Address<I>>>
+    where
+        Regs: RegisterFile<<I as Instruction>::Reg>,
+        I: for<'a> ThreadedExecutableInstruction<
+                Regs,
+                &'a mut ExtState,
+                Memory,
+                IF,
+                &'a mut InstructionHandler,
+            >,
+        Memory: VirtualMemory,
+        IF: InstructionFetcher<I, Memory>,
+    {
+        // This interpreter state owns both, so what is passed on by value is a borrow of each. A
+        // caller whose extension state and system instruction handler are zero-sized can call
+        // `I::execute_threaded()` with them directly instead and save two argument registers across
+        // the whole chain.
+        let ext_state = &mut self.ext_state;
+        let system_instruction_handler = &mut self.system_instruction_handler;
+        let regs = &mut self.regs;
+        let memory = &mut self.memory;
+
+        replace_with_or_abort_and_return(
+            &mut self.instruction_fetcher,
+            #[inline(always)]
+            |instruction_fetcher| {
+                let ThreadedExecutionResult {
+                    instruction_fetcher,
+                    outcome,
+                } = I::execute_threaded(
+                    instruction_fetcher,
+                    regs,
+                    ext_state,
+                    memory,
+                    system_instruction_handler,
+                );
+
+                (outcome, instruction_fetcher)
             },
         )
     }

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -86,7 +86,7 @@
 //!   of, although it would be cheaper to support the fuller feature set only required by V
 //!   extension
 
-#![expect(incomplete_features, reason = "generic_const_*")]
+#![expect(incomplete_features, reason = "generic_const_*, explicit_tail_calls")]
 #![feature(
     adt_const_params,
     const_block_items,
@@ -101,6 +101,7 @@
     const_result_trait_fn,
     const_trait_impl,
     const_try,
+    explicit_tail_calls,
     generic_const_args,
     generic_const_items,
     inherent_associated_types,
@@ -771,6 +772,29 @@ where
     fn write_csr(&mut self, csr_index: u16, value: Reg::Type) -> Result<(), CsrError<CustomError>>;
 }
 
+// Convenience for threaded execution
+const impl<Reg, CustomError, T> Csrs<Reg, CustomError> for &mut T
+where
+    Reg: [const] Register,
+    CustomError: [const] Destruct,
+    T: [const] Csrs<Reg, CustomError>,
+{
+    #[inline(always)]
+    fn privilege_level(&self) -> PrivilegeLevel {
+        T::privilege_level(self)
+    }
+
+    #[inline(always)]
+    fn read_csr(&self, csr_index: u16) -> Result<Reg::Type, CsrError<CustomError>> {
+        T::read_csr(self, csr_index)
+    }
+
+    #[inline(always)]
+    fn write_csr(&mut self, csr_index: u16, value: Reg::Type) -> Result<(), CsrError<CustomError>> {
+        T::write_csr(self, csr_index, value)
+    }
+}
+
 /// Custom handler for system instructions `ecall` and `ebreak`
 pub const trait SystemInstructionHandler<
     Reg,
@@ -816,6 +840,39 @@ pub const trait SystemInstructionHandler<
         let _: &mut Memory = memory;
         let _: Reg::Type = pc;
         // NOP by default
+    }
+}
+
+// Convenience for threaded execution
+const impl<Reg, Regs, Memory, PC, CustomError, T>
+    SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError> for &mut T
+where
+    Reg: [const] Register,
+    T: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+{
+    #[inline(always)]
+    fn handle_fence(&mut self, pred: u8, succ: u8) {
+        T::handle_fence(self, pred, succ);
+    }
+
+    #[inline(always)]
+    fn handle_fence_tso(&mut self) {
+        T::handle_fence_tso(self);
+    }
+
+    #[inline(always)]
+    fn handle_ecall(
+        &mut self,
+        regs: &mut Regs,
+        memory: &mut Memory,
+        program_counter: &mut PC,
+    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
+        T::handle_ecall(self, regs, memory, program_counter)
+    }
+
+    #[inline(always)]
+    fn handle_ebreak(&mut self, regs: &mut Regs, memory: &mut Memory, pc: Reg::Type) {
+        T::handle_ebreak(self, regs, memory, pc);
     }
 }
 
@@ -959,4 +1016,99 @@ pub const trait ExecutableInstruction<
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
     ) -> ExecutionResult<Self::Reg, CustomError>;
+}
+
+/// Outcome of [`ThreadedExecutableInstruction::execute_threaded()`].
+///
+/// Unlike [`ExecutionResult`], this is produced exactly once, by the handler that stops the chain
+/// and is not on the per-instruction path.
+///
+/// The instruction fetcher travels through the chain by value and comes back here to remain
+/// available, exactly as it would be after [`ExecutableInstruction::execute()`].
+#[derive(Debug)]
+pub struct ThreadedExecutionResult<IF, I, CustomError = CustomErrorPlaceholder>
+where
+    I: Instruction,
+{
+    /// Instruction fetcher as of the moment execution stopped
+    pub instruction_fetcher: IF,
+    /// Why execution stopped
+    pub outcome: Result<(), ExecutionError<Address<I>, CustomError>>,
+}
+
+impl<IF, I, CustomError> ThreadedExecutionResult<IF, I, CustomError>
+where
+    I: Instruction,
+{
+    /// Execution stopped gracefully
+    #[inline(always)]
+    pub const fn stopped(instruction_fetcher: IF) -> Self {
+        Self {
+            instruction_fetcher,
+            outcome: Ok(()),
+        }
+    }
+
+    /// Execution failed
+    #[inline(always)]
+    pub const fn failed(
+        instruction_fetcher: IF,
+        error: ExecutionError<Address<I>, CustomError>,
+    ) -> Self {
+        cold_path();
+        Self {
+            instruction_fetcher,
+            outcome: Err(error),
+        }
+    }
+}
+
+/// Tail-call-threaded counterpart of [`ExecutableInstruction`].
+///
+/// [`ExecutableInstruction::execute()`] describes what a single instruction does and leaves both
+/// fetching and control flow to a driver loop. This trait instead runs the whole program: it is
+/// generated as one handler function per instruction variant, each of which executes its own
+/// instruction and then tail-calls (`become`) the handler of the next one, so there is no loop and
+/// no return until execution stops. Each handler touches only the operands its own instruction
+/// names, which is what the shared loop cannot do.
+///
+/// Instruction implementations are unaffected: the handlers are assembled from the very same
+/// `match` arms that [`ExecutableInstruction::execute()`] are assembled from, so both paths execute
+/// identical logic and a caller picks between them purely on the trade between code size
+/// (`execute`) and throughput (`execute_threaded`).
+///
+/// This trait is deliberately not `const`, unlike [`ExecutableInstruction`]: dispatch goes through
+/// a table of function pointers, and calls through a function pointer are not allowed in
+/// `const fn`.
+pub trait ThreadedExecutableInstruction<
+    Regs,
+    ExtState,
+    Memory,
+    PC,
+    InstructionHandler,
+    CustomError = CustomErrorPlaceholder,
+> where
+    Self: ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
+    PC: InstructionFetcher<Self, Memory, CustomError>,
+{
+    /// Execute instructions starting at the instruction fetcher's current position and continue
+    /// until execution stops or fails.
+    ///
+    /// The instruction fetcher is taken by value rather than behind a reference so that it stays in
+    /// registers across the whole handler chain and is returned in [`ThreadedExecutionResult`].
+    ///
+    /// `ext_state` and `system_instruction_handler` are taken by value for the same reason and one
+    /// more: an owned value can be a zero-sized type, which occupies no argument register at all,
+    /// whereas a `&mut` occupies one whether there is anything behind it or not. Most
+    /// configurations have no extension state and a stateless system instruction handler, so both
+    /// vanish, allowing more registers for other arguments. A configuration that does have a state
+    /// passes a `&mut` to it (which is an owned value too and for which there are blanket
+    /// implementations for convenience).
+    fn execute_threaded(
+        instruction_fetcher: PC,
+        regs: &mut Regs,
+        ext_state: ExtState,
+        memory: &mut Memory,
+        system_instruction_handler: InstructionHandler,
+    ) -> ThreadedExecutionResult<PC, Self, CustomError>;
 }

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -39,5 +39,6 @@ pub use crate::{
     BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
     ExecutableInstructionOperands, ExecutionError, ExecutionResult, FetchInstructionResult,
     InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory, VirtualMemoryError,
+    Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory, VirtualMemoryError,
 };

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -16,8 +16,9 @@ pub mod zk;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
@@ -4,8 +4,9 @@ pub mod zaamo;
 pub mod zalrsc;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -27,6 +28,28 @@ where
 
     /// Clear any currently held reservation
     fn clear_reservation(&mut self);
+}
+
+// Convenience for threaded execution
+const impl<Reg, T> ReservationSet<Reg> for &mut T
+where
+    Reg: [const] Register,
+    T: [const] ReservationSet<Reg>,
+{
+    #[inline(always)]
+    fn reservation(&self) -> Option<Reg::Type> {
+        T::reservation(self)
+    }
+
+    #[inline(always)]
+    fn set_reservation(&mut self, address: Reg::Type) {
+        T::set_reservation(self, address);
+    }
+
+    #[inline(always)]
+    fn clear_reservation(&mut self) {
+        T::clear_reservation(self);
+    }
 }
 
 #[instruction_execution]

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::rv32::a::ReservationSet;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
@@ -7,8 +7,9 @@ pub mod zbs;
 
 use crate::rv32::b::zbb::rv32_zbb_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
@@ -5,8 +5,9 @@ pub mod rv32_zbb_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
@@ -5,8 +5,9 @@ pub mod rv32_zbc_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
@@ -5,8 +5,9 @@ mod tests;
 pub mod zmmul;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
@@ -1,8 +1,9 @@
 //! RV32 Zmmul extension (multiplication subset of M extension)
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -7,8 +7,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -7,8 +7,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
@@ -5,8 +5,9 @@ pub mod rv32_zbkb_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
@@ -2,8 +2,9 @@
 
 use crate::rv32::b::zbc::rv32_zbc_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
@@ -5,8 +5,9 @@ pub mod rv32_zbkx_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
@@ -11,8 +11,9 @@ use crate::rv32::zk::zkn::zknd::rv32_zknd_helpers;
 use crate::rv32::zk::zkn::zkne::rv32_zkne_helpers;
 use crate::rv32::zk::zkn::zknh::rv32_zknh_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
@@ -5,8 +5,9 @@ pub mod rv32_zknd_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
@@ -5,8 +5,9 @@ pub mod rv32_zkne_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
@@ -5,8 +5,9 @@ pub mod rv32_zknh_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -8,6 +8,8 @@ pub mod m;
 pub(crate) mod test_utils;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod threaded_tests;
 pub mod zabha;
 pub mod zacas;
 pub mod zalasr;
@@ -16,8 +18,9 @@ pub mod zk;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
@@ -5,8 +5,9 @@ pub mod zalrsc;
 
 use crate::rv32::a::ReservationSet;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::rv32::a::ReservationSet;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
@@ -7,8 +7,9 @@ pub mod zbs;
 
 use crate::rv64::b::zbb::rv64_zbb_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
@@ -5,8 +5,9 @@ pub mod rv64_zbb_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
@@ -5,8 +5,9 @@ pub mod rv64_zbc_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
@@ -5,8 +5,9 @@ mod tests;
 pub mod zmmul;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
@@ -1,8 +1,9 @@
 //! RV64 Zmmul extension (multiplication subset of M extension)
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -8,8 +8,8 @@ use crate::zkr::{ZkrSeedPoll, ZkrSeedSource};
 use crate::{
     Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError, ExecutionResult,
     FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
-    VirtualMemoryError,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
+    VirtualMemory, VirtualMemoryError, impl_vector_registers_for_mut_ref,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::collections::BTreeMap;
@@ -413,6 +413,8 @@ where
 
 impl VectorRegistersExt<Reg<u64>> for ExtState {}
 
+impl_vector_registers_for_mut_ref!(ExtState, Reg<u64>);
+
 impl ExtState {
     pub(crate) fn set_privilege_level(&mut self, privilege_level: PrivilegeLevel) {
         self.csr.privilege_level = privilege_level;
@@ -592,4 +594,21 @@ where
     }
 
     Ok(())
+}
+
+/// Same as [`execute()`], but driven by tail-call-threaded dispatch instead of an explicit loop
+pub(crate) fn execute_threaded<I>(
+    state: &mut TestInterpreterState<I>,
+) -> Result<(), ExecutionError<Address<I>>>
+where
+    I: Instruction<Reg = Reg<u64>>
+        + for<'a> ThreadedExecutableInstruction<
+            BasicRegisters<Reg<u64>>,
+            &'a mut ExtState,
+            TestMemory,
+            TestInstructionFetcher<I>,
+            &'a mut TestInstructionHandler,
+        >,
+{
+    state.execute_threaded::<I>()
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/threaded_tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/threaded_tests.rs
@@ -1,0 +1,317 @@
+//! Tail-call-threaded dispatch is generated from the same instruction implementations the
+//! `match`-based [`ExecutableInstruction::execute()`] is generated from, so it is worth testing
+//! both paths agree, all the way through register writes, branches, jumps and failures.
+
+extern crate alloc;
+
+use crate::basic::BasicRegisters;
+use crate::rv64::test_utils::{
+    ExtState, TEST_BASE_ADDR, TestInstructionFetcher, TestInstructionHandler, TestMemory, execute,
+    execute_threaded, initialize_state,
+};
+use crate::{
+    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile,
+    ThreadedExecutableInstruction, VirtualMemory,
+};
+use ab_riscv_primitives::prelude::*;
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// Runs `instructions` twice, once through each dispatch path, and asserts that the two agree on
+/// the error (if any), on every general purpose register and on the final program counter
+fn assert_paths_agree<I, Instructions>(
+    instructions: Instructions,
+    setup: fn(&mut BasicRegisters<Reg<u64>>),
+) where
+    I: Instruction<Reg = Reg<u64>>
+        + ExecutableInstruction<
+            BasicRegisters<Reg<u64>>,
+            ExtState,
+            TestMemory,
+            TestInstructionFetcher<I>,
+            TestInstructionHandler,
+        > + for<'a> ThreadedExecutableInstruction<
+            BasicRegisters<Reg<u64>>,
+            &'a mut ExtState,
+            TestMemory,
+            TestInstructionFetcher<I>,
+            &'a mut TestInstructionHandler,
+        >,
+    Instructions: IntoIterator<Item = I> + Clone,
+{
+    let mut looped_state = initialize_state(instructions.clone());
+    setup(&mut looped_state.regs);
+    let looped_result = execute(&mut looped_state);
+
+    let mut threaded_state = initialize_state(instructions);
+    setup(&mut threaded_state.regs);
+    let threaded_result = execute_threaded(&mut threaded_state);
+
+    assert_eq!(
+        alloc::format!("{looped_result:?}"),
+        alloc::format!("{threaded_result:?}"),
+        "Dispatch paths disagree on the outcome"
+    );
+
+    for bits in 0..32 {
+        let reg = Reg::<u64>::from_bits(bits).unwrap();
+        assert_eq!(
+            looped_state.regs.read(reg),
+            threaded_state.regs.read(reg),
+            "Dispatch paths disagree on register {bits}"
+        );
+    }
+
+    assert_eq!(
+        ProgramCounter::<u64, TestMemory>::get_pc(&looped_state.instruction_fetcher),
+        ProgramCounter::<u64, TestMemory>::get_pc(&threaded_state.instruction_fetcher),
+        "Dispatch paths disagree on the program counter"
+    );
+}
+
+#[test]
+fn threaded_matches_looped_arithmetic() {
+    assert_paths_agree(
+        vec![
+            Rv64Instruction::Add {
+                rd: Reg::A2,
+                rs1: Reg::A0,
+                rs2: Reg::A1,
+            },
+            Rv64Instruction::Sub {
+                rd: Reg::A3,
+                rs1: Reg::A0,
+                rs2: Reg::A1,
+            },
+            // Writes to the zero register have to be discarded on both paths
+            Rv64Instruction::Add {
+                rd: Reg::Zero,
+                rs1: Reg::A0,
+                rs2: Reg::A1,
+            },
+            // Neither source register is used, so the handler for this one reads neither
+            Rv64Instruction::Lui {
+                rd: Reg::A4,
+                imm: I24WithZeroedBits::from_i32(0x1000),
+                rs1: Reg::Zero,
+                rs2: Reg::Zero,
+            },
+        ],
+        |regs| {
+            regs.write(Reg::A0, 10);
+            regs.write(Reg::A1, 20);
+        },
+    );
+}
+
+#[test]
+fn threaded_matches_looped_memory() {
+    assert_paths_agree(
+        vec![
+            Rv64Instruction::Sd {
+                rs1: Reg::A0,
+                rs2: Reg::A1,
+                imm: 0,
+            },
+            Rv64Instruction::Ld {
+                rd: Reg::A2,
+                rs1: Reg::A0,
+                imm: 0,
+                rs2: Reg::Zero,
+            },
+        ],
+        |regs| {
+            regs.write(Reg::A0, TEST_BASE_ADDR);
+            regs.write(Reg::A1, 0x0123_4567_89ab_cdef);
+        },
+    );
+}
+
+#[test]
+fn threaded_matches_looped_taken_branch() {
+    assert_paths_agree(
+        vec![
+            // Skips over the `Addi` below when the branch is taken
+            Rv64Instruction::Beq {
+                rs1: Reg::A0,
+                rs2: Reg::A1,
+                imm: I24::from_i32(8),
+            },
+            Rv64Instruction::Addi {
+                rd: Reg::A2,
+                rs1: Reg::Zero,
+                imm: 1,
+                rs2: Reg::Zero,
+            },
+            Rv64Instruction::Addi {
+                rd: Reg::A3,
+                rs1: Reg::Zero,
+                imm: 2,
+                rs2: Reg::Zero,
+            },
+        ],
+        |regs| {
+            regs.write(Reg::A0, 7);
+            regs.write(Reg::A1, 7);
+        },
+    );
+}
+
+#[test]
+fn threaded_matches_looped_untaken_branch() {
+    assert_paths_agree(
+        vec![
+            Rv64Instruction::Beq {
+                rs1: Reg::A0,
+                rs2: Reg::A1,
+                imm: I24::from_i32(8),
+            },
+            Rv64Instruction::Addi {
+                rd: Reg::A2,
+                rs1: Reg::Zero,
+                imm: 1,
+                rs2: Reg::Zero,
+            },
+            Rv64Instruction::Addi {
+                rd: Reg::A3,
+                rs1: Reg::Zero,
+                imm: 2,
+                rs2: Reg::Zero,
+            },
+        ],
+        |regs| {
+            regs.write(Reg::A0, 7);
+            regs.write(Reg::A1, 8);
+        },
+    );
+}
+
+#[test]
+fn threaded_matches_looped_jump() {
+    assert_paths_agree(
+        vec![
+            Rv64Instruction::Jal {
+                rd: Reg::Ra,
+                imm: I24::from_i32(8),
+                rs1: Reg::Zero,
+                rs2: Reg::Zero,
+            },
+            Rv64Instruction::Addi {
+                rd: Reg::A2,
+                rs1: Reg::Zero,
+                imm: 1,
+                rs2: Reg::Zero,
+            },
+            Rv64Instruction::Addi {
+                rd: Reg::A3,
+                rs1: Reg::Zero,
+                imm: 2,
+                rs2: Reg::Zero,
+            },
+        ],
+        |_regs| {},
+    );
+}
+
+#[test]
+fn threaded_matches_looped_failure() {
+    // Both paths have to stop at the same instruction with the same error and leave the registers
+    // written by the instructions before it
+    assert_paths_agree(
+        vec![
+            Rv64Instruction::Addi {
+                rd: Reg::A2,
+                rs1: Reg::Zero,
+                imm: 42,
+                rs2: Reg::Zero,
+            },
+            Rv64Instruction::Ld {
+                rd: Reg::A3,
+                rs1: Reg::A0,
+                imm: 0,
+                rs2: Reg::Zero,
+            },
+            Rv64Instruction::Addi {
+                rd: Reg::A4,
+                rs1: Reg::Zero,
+                imm: 1,
+                rs2: Reg::Zero,
+            },
+        ],
+        |regs| {
+            regs.write(Reg::A0, 0xdead_0000);
+        },
+    );
+}
+
+#[test]
+fn threaded_reports_the_error_it_stopped_on() {
+    let mut state = initialize_state(vec![Rv64Instruction::Ld {
+        rd: Reg::A3,
+        rs1: Reg::A0,
+        imm: 0,
+        rs2: Reg::Zero,
+    }]);
+    state.regs.write(Reg::A0, 0xdead_0000);
+
+    assert!(matches!(
+        execute_threaded(&mut state),
+        Err(ExecutionError::OutOfBoundsRead { .. })
+    ));
+}
+
+#[test]
+fn threaded_runs_a_loop_to_completion() {
+    // Counts down from 1000, which is more iterations than any stack could hold if the handler
+    // chain were not made of real tail calls
+    let instructions = vec![
+        Rv64Instruction::Addi {
+            rd: Reg::A0,
+            rs1: Reg::A0,
+            imm: -1,
+            rs2: Reg::Zero,
+        },
+        Rv64Instruction::Bne {
+            rs1: Reg::A0,
+            rs2: Reg::Zero,
+            imm: I24::from_i32(-4),
+        },
+    ];
+
+    let mut state = initialize_state(instructions);
+    state.regs.write(Reg::A0, 1000);
+
+    execute_threaded(&mut state).unwrap();
+
+    assert_eq!(state.regs.read(Reg::A0), 0);
+}
+
+#[test]
+fn threaded_leaves_memory_in_the_same_state() {
+    let instructions: Vec<_> = (0..8)
+        .map(|index| Rv64Instruction::Sd {
+            rs1: Reg::A0,
+            rs2: Reg::A1,
+            imm: index * 8,
+        })
+        .collect();
+
+    let mut looped_state = initialize_state(instructions.clone());
+    looped_state.regs.write(Reg::A0, TEST_BASE_ADDR);
+    looped_state.regs.write(Reg::A1, 0xabcd);
+    execute(&mut looped_state).unwrap();
+
+    let mut threaded_state = initialize_state(instructions);
+    threaded_state.regs.write(Reg::A0, TEST_BASE_ADDR);
+    threaded_state.regs.write(Reg::A1, 0xabcd);
+    execute_threaded(&mut threaded_state).unwrap();
+
+    for index in 0..8 {
+        let address = TEST_BASE_ADDR + index * 8;
+        assert_eq!(
+            looped_state.memory.read::<u64>(address).unwrap(),
+            threaded_state.memory.read::<u64>(address).unwrap(),
+            "Dispatch paths disagree on memory at {address:#x}"
+        );
+    }
+}

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -7,8 +7,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    SystemInstructionHandler, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
@@ -2,8 +2,9 @@
 
 use crate::rv64::b::zbc::rv64_zbc_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
@@ -5,8 +5,9 @@ pub mod rv64_zbkx_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
@@ -10,8 +10,9 @@ use crate::rv64::zk::zkn::zknd::rv64_zknd_helpers;
 use crate::rv64::zk::zkn::zkne::rv64_zkne_helpers;
 use crate::rv64::zk::zkn::zknh::rv64_zknh_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
@@ -5,8 +5,9 @@ pub mod rv64_zknd_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
@@ -9,8 +9,9 @@ mod tests;
 
 use crate::rv64::zk::zkn::zknd::rv64_zknd_helpers;
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
@@ -5,8 +5,9 @@ pub mod rv64_zknh_helpers;
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
@@ -278,3 +278,39 @@ where
         debug_assert!(result.is_ok(), "Implementation must initialize `vtype` CSR");
     }
 }
+
+// Convenience for threaded execution
+// TODO: Forward generically instead, once the compiler normalizes
+//  `<&mut T as VectorRegisters>::VLEN` to `T::VLEN`:
+//  https://github.com/rust-lang/rust/issues/161264
+#[macro_export]
+macro_rules! impl_vector_registers_for_mut_ref {
+    ($ext_state:ty, $reg:ty) => {
+        impl VectorRegisters for &mut $ext_state {
+            const ELEN: Elen = <$ext_state as VectorRegisters>::ELEN;
+            const VLEN: Vlen = <$ext_state as VectorRegisters>::VLEN;
+
+            #[inline(always)]
+            fn read_vregs(&self) -> &VectorRegisterFile<{ Self::VLEN }> {
+                <$ext_state as VectorRegisters>::read_vregs(self)
+            }
+
+            #[inline(always)]
+            fn write_vregs(&mut self) -> &mut VectorRegisterFile<{ Self::VLEN }> {
+                <$ext_state as VectorRegisters>::write_vregs(self)
+            }
+
+            #[inline(always)]
+            fn vector_instructions_allowed(&self) -> bool {
+                <$ext_state as VectorRegisters>::vector_instructions_allowed(self)
+            }
+
+            #[inline(always)]
+            fn mark_vs_dirty(&mut self) {
+                <$ext_state as VectorRegisters>::mark_vs_dirty(self);
+            }
+        }
+
+        impl VectorRegistersExt<$reg> for &mut $ext_state {}
+    };
+}

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
@@ -28,8 +28,9 @@ use crate::v::zvexx::widen_narrow::zvexx_widen_narrow_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
@@ -8,8 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
@@ -8,8 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
@@ -7,7 +7,9 @@ pub mod zvexx_config_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
@@ -8,8 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -8,8 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -8,8 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
@@ -8,8 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -8,8 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
@@ -9,8 +9,9 @@ use crate::v::zvexx::arith::zvexx_arith_helpers;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -9,8 +9,9 @@ use crate::v::zvexx::load::zvexx_load_helpers;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -8,8 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zawrs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zawrs.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -25,6 +26,22 @@ pub const trait WrsHandler {
     #[inline(always)]
     fn handle_wrs_sto(&mut self) {
         // NOP by default
+    }
+}
+
+// Convenience for threaded execution
+const impl<T> WrsHandler for &mut T
+where
+    T: [const] WrsHandler,
+{
+    #[inline(always)]
+    fn handle_wrs_nto(&mut self) {
+        T::handle_wrs_nto(self);
+    }
+
+    #[inline(always)]
+    fn handle_wrs_sto(&mut self) {
+        T::handle_wrs_sto(self);
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/zicond.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicond.rs
@@ -4,8 +4,9 @@
 mod tests;
 
 use crate::{
-    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -6,7 +6,8 @@ pub mod zicsr_helpers;
 
 use crate::{
     Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
@@ -2,8 +2,9 @@ use crate::rv64::test_utils::{ExtState, execute, initialize_state};
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, CustomErrorPlaceholder, ExecutableInstruction, ExecutableInstructionCsr,
-    ExecutableInstructionOperands, ExecutionError, ExecutionResult, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutableInstructionOperands, ExecutionError, ExecutionResult, FetchInstructionResult,
+    InstructionFetcher, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zkr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zkr.rs
@@ -7,7 +7,8 @@ pub mod zkr_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -42,6 +43,17 @@ pub enum ZkrSeedPoll {
 pub const trait ZkrSeedSource {
     /// Poll the entropy source once, advancing its internal state as necessary
     fn poll_seed(&mut self) -> ZkrSeedPoll;
+}
+
+// Convenience for threaded execution
+const impl<T> ZkrSeedSource for &mut T
+where
+    T: [const] ZkrSeedSource,
+{
+    #[inline(always)]
+    fn poll_seed(&mut self) -> ZkrSeedPoll {
+        T::poll_seed(self)
+    }
 }
 
 #[instruction_execution]

--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -22,8 +22,9 @@ use crate::zicsr::zicsr_helpers;
 use crate::zvbb::zvkb::zvkb_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -20,8 +20,9 @@ use crate::v::zvexx::zvexx_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zvbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc.rs
@@ -20,8 +20,9 @@ use crate::v::zvexx::zvexx_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, VirtualMemory,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-macros-impl/src/lib.rs
+++ b/crates/execution/ab-riscv-macros-impl/src/lib.rs
@@ -181,13 +181,19 @@ pub fn instruction(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// since a free function has no `Self` for them to be inferred from). This is purely an
 /// implementation detail; those functions are not meant to be used or referred to directly.
 ///
+/// Alongside `execute()`, an implementation of `ThreadedExecutableInstruction` is generated for the
+/// same enum, out of the very same arms. It is done in a somewhat opaque way here with the hopes
+/// that it would become possible to move the `ThreadedExecutableInstruction::execute_threaded()`
+/// method into `ExecutableInstruction` trait at some point. Right now it is not possible to mix
+/// const and non-const methods in the same trait.
+///
 /// If `execute()` carries `#[cfg_attr(feature = "no-panic", no_panic_const::no_panic(..))]`, it
 /// is stripped from `execute()` itself (which becomes a plain dispatcher, so the attribute would
 /// no longer serve its purpose there) and placed on every one of those generated functions
 /// instead, so each variant's execution logic is checked for panics individually. Since this
 /// depends on `execute()` in the implementation currently being processed specifically carrying
 /// this attribute, an implementation that inherits from a lower-level one that has it, but does
-/// not itself repeat it, will not get it applied to its own generated functions either.
+/// not itself repeat it will not get it applied to its own generated functions either.
 ///
 /// Also requires `process_instruction_macros()` in `build.rs` to function, see `#[instruction]`
 /// macro documentation.

--- a/crates/execution/ab-riscv-macros/Cargo.toml
+++ b/crates/execution/ab-riscv-macros/Cargo.toml
@@ -36,9 +36,9 @@ build = [
     "dep:ab-riscv-macros-common",
     "dep:anyhow",
     "dep:heck",
-    "dep:prettyplease",
     "dep:quote",
     "dep:syn",
+    "prettyplease/verbatim",
 ]
 # Enable proc macro re-export
 proc-macro = [

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -1,12 +1,14 @@
 mod extract_matches;
 mod forbidden_checker;
+mod generate_threaded_fns;
 mod generate_variant_fns;
 
 use crate::build::enum_impl::enum_name_from_impl;
 use crate::build::execution_impl::extract_matches::extract_variant_arms;
 use crate::build::execution_impl::forbidden_checker::block_contains_forbidden_syntax;
+use crate::build::execution_impl::generate_threaded_fns::generate_threaded_fns;
 use crate::build::execution_impl::generate_variant_fns::generate_variant_fns;
-use crate::build::shared::collect_all_dependencies;
+use crate::build::shared::{collect_all_dependencies, strip_const_where_predicates};
 use crate::build::state::{
     PendingEnumCsrImpl, PendingEnumExecutionImpl, PendingEnumOperandsImpl, State,
 };
@@ -19,8 +21,8 @@ use std::path::Path;
 use std::rc::Rc;
 use std::{env, fs, iter};
 use syn::{
-    Ident, ImplItem, ImplItemFn, ItemFn, ItemImpl, Token, WherePredicate, parse_file, parse_quote,
-    parse_str,
+    FnArg, Ident, ImplItem, ImplItemFn, Item, ItemFn, ItemImpl, Member, Pat, PatType, Token,
+    parse_file, parse_quote, parse_str,
 };
 
 const ORIGINAL_ENUM_EXECUTION_IMPL_ENV_VAR_SUFFIX: &str =
@@ -222,12 +224,13 @@ fn output_processed_enum_execution_impl(
     original_item_impl: ItemImpl,
     item_impl: ItemImpl,
     variant_fns: Vec<ItemFn>,
+    threaded_items: Vec<Item>,
     out_dir: &Path,
     state: &mut State,
 ) -> anyhow::Result<()> {
     {
         let enum_file_path = out_dir.join(format!("{enum_name}_execution_impl.rs"));
-        let code = quote! { #( #variant_fns )* #item_impl }.to_string();
+        let code = quote! { #( #variant_fns )* #item_impl #( #threaded_items )* }.to_string();
         // Format
         let mut code = unparse(&parse_file(&code).expect("Generated code is valid; qed"));
         post_process_rust_code(&mut code);
@@ -466,6 +469,8 @@ pub(super) fn process_enum_csr_impl(
         }
     }
 
+    let is_const = item_impl.attrs.last() == Some(&parse_quote! { #[cst] });
+
     {
         let where_clause = item_impl
             .generics
@@ -484,37 +489,9 @@ pub(super) fn process_enum_csr_impl(
             where_clause.predicates.push(predicate);
         }
 
-        // TODO: This is a massive hack for implementations that strips `[const]` for non-const
-        //  instructions that inherit const instructions. `Destruct` is a special case here that is
-        //  avoided altogether for non-const implementations to improve downstream user experience.
-        if item_impl.attrs.last() != Some(&parse_quote! { #[cst] }) {
-            where_clause.predicates = where_clause
-                .predicates
-                .clone()
-                .into_iter()
-                .filter_map(|mut predicate| match &mut predicate {
-                    WherePredicate::Type(predicate_type) => {
-                        // TODO: Remove `Destruct` hack once stabilized:
-                        //  https://github.com/rust-lang/rust/issues/133214
-                        if predicate_type.bounds.to_token_stream().to_string()
-                            == "BRCONST + Destruct"
-                        {
-                            return None;
-                        }
-
-                        // TODO: `BRCONST` is a hack that allows `syn` to parse unstable Rust syntax
-                        //  around const traits and such. It will change to a proper modifier once
-                        //  stabilized
-                        if predicate_type.bounds.first() == Some(&parse_quote! { BRCONST }) {
-                            predicate_type.bounds =
-                                predicate_type.bounds.clone().into_iter().skip(1).collect();
-                        }
-
-                        Some(predicate)
-                    }
-                    _ => Some(predicate),
-                })
-                .collect();
+        // Non-const implementations that inherit arms from const ones must not keep `[const]`
+        if !is_const {
+            where_clause.predicates = strip_const_where_predicates(where_clause.predicates.clone());
         }
     }
 
@@ -631,6 +608,44 @@ pub(super) fn process_enum_execution_impl(
         ));
     };
 
+    // Every argument is normalized to not start with `_` in the name, so the later code can rely on
+    // canonical names
+    for input in &mut execute_fn.sig.inputs {
+        let FnArg::Typed(PatType {
+            pat,
+            attrs: _,
+            colon_token: _,
+            ty: _,
+        }) = input
+        else {
+            continue;
+        };
+
+        match pat.as_mut() {
+            Pat::Ident(pat_ident) => {
+                let ident = pat_ident.ident.to_string();
+                let Some(name) = ident.strip_prefix('_') else {
+                    continue;
+                };
+
+                pat_ident.ident = Ident::new(name, pat_ident.ident.span());
+            }
+            Pat::Struct(pat_struct) => {
+                for field in &mut pat_struct.fields {
+                    let Member::Named(member) = &field.member else {
+                        continue;
+                    };
+
+                    *field.pat = parse_quote! { #member };
+                    // The binding and the field are now spelled the same, so the field name is
+                    // redundant
+                    field.colon_token = None;
+                }
+            }
+            _ => {}
+        }
+    }
+
     // Support for `no_panic` macro, which is moved from the method to each extracted instruction
     // execution function
     let no_panic_attr_index = execute_fn.attrs.iter().position(|attr| {
@@ -685,6 +700,8 @@ pub(super) fn process_enum_execution_impl(
         }
     }
 
+    let is_const = item_impl.attrs.last() == Some(&parse_quote! { #[cst] });
+
     if let Some(where_clause) = &mut item_impl.generics.where_clause {
         let mut already_inserted = where_clause
             .predicates
@@ -699,37 +716,9 @@ pub(super) fn process_enum_execution_impl(
             where_clause.predicates.push(predicate);
         }
 
-        // TODO: This is a massive hack for implementations that strips `[const]` for non-const
-        //  instructions that inherit const instructions. `Destruct` is a special case here that is
-        //  avoided altogether for non-const implementations to improve downstream user experience.
-        if item_impl.attrs.last() != Some(&parse_quote! { #[cst] }) {
-            where_clause.predicates = where_clause
-                .predicates
-                .clone()
-                .into_iter()
-                .filter_map(|mut predicate| match &mut predicate {
-                    WherePredicate::Type(predicate_type) => {
-                        // TODO: Remove `Destruct` hack once stabilized:
-                        //  https://github.com/rust-lang/rust/issues/133214
-                        if predicate_type.bounds.to_token_stream().to_string()
-                            == "BRCONST + Destruct"
-                        {
-                            return None;
-                        }
-
-                        // TODO: `BRCONST` is a hack that allows `syn` to parse unstable Rust syntax
-                        //  around const traits and such. It will change to a proper modifier once
-                        //  stabilized
-                        if predicate_type.bounds.first() == Some(&parse_quote! { BRCONST }) {
-                            predicate_type.bounds =
-                                predicate_type.bounds.clone().into_iter().skip(1).collect();
-                        }
-
-                        Some(predicate)
-                    }
-                    _ => Some(predicate),
-                })
-                .collect();
+        // Non-const implementations that inherit arms from const ones must not keep `[const]`
+        if !is_const {
+            where_clause.predicates = strip_const_where_predicates(where_clause.predicates.clone());
         }
     } else {
         return Err(anyhow::anyhow!(
@@ -763,8 +752,6 @@ pub(super) fn process_enum_execution_impl(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let is_const = item_impl.attrs.last() == Some(&parse_quote! { #[cst] });
-
     let variant_fns = generate_variant_fns(
         &enum_name,
         &item_impl.self_ty,
@@ -774,6 +761,16 @@ pub(super) fn process_enum_execution_impl(
         &execute_fn.sig,
         &enum_definition.instructions,
         &mut match_arms,
+    )?;
+
+    // The tail-call-threaded implementation is generated from the very same arms, alongside the
+    // `match`-based `execute()` rather than instead of it
+    let threaded_items = generate_threaded_fns(
+        &enum_name,
+        &item_impl.self_ty,
+        &item_impl.generics,
+        &enum_definition.instructions,
+        &match_arms,
     )?;
 
     execute_fn.block = parse_quote! {{
@@ -787,6 +784,7 @@ pub(super) fn process_enum_execution_impl(
         original_item_impl,
         item_impl,
         variant_fns,
+        threaded_items,
         out_dir,
         state,
     )

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
@@ -1,0 +1,373 @@
+use crate::build::execution_impl::generate_variant_fns::variant_fn_name;
+use crate::build::shared::strip_const_where_predicates;
+use anyhow::Context;
+use heck::ToSnakeCase;
+use quote::{ToTokens, format_ident, quote};
+use std::env;
+use std::rc::Rc;
+use syn::{Abi, Arm, Generics, Ident, Item, Pat, Token, Type, Variant, WhereClause, parse_quote};
+
+/// Calling convention used for functions involved in threaded execution.
+///
+/// Windows x86-64 passes only four arguments in registers, where the System V convention every
+/// other x86-64 target uses passes six, and it is critical for performance that a threaded
+/// interpreter has six registers available for arguments. `sysv64` ABI is supported on Windows too
+/// and solves this particular issue.
+fn handler_abi() -> anyhow::Result<Option<Abi>> {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").context(
+        "Failed to retrieve `CARGO_CFG_TARGET_ARCH` environment variable, make sure to call \
+        `process_instruction_macros` from `build.rs`",
+    )?;
+    let target_os = env::var("CARGO_CFG_TARGET_OS").context(
+        "Failed to retrieve `CARGO_CFG_TARGET_OS` environment variable, make sure to call \
+        `process_instruction_macros` from `build.rs`",
+    )?;
+
+    Ok((target_arch == "x86_64" && target_os == "windows")
+        .then(|| parse_quote! { extern "sysv64" }))
+}
+
+/// Where clause for the generated threaded items.
+///
+/// Threaded execution is never `const` (dispatch goes through a table of function pointers, which
+/// `const fn` does not allow), so `[const]` bounds are relaxed to ordinary ones, exactly like they
+/// are for a non-`const` execution implementation, and the fetching half of the program counter is
+/// required on top of what `execute()` needs.
+fn threaded_where_clause(generics: &Generics, self_ty: &Type) -> anyhow::Result<WhereClause> {
+    let Some(where_clause) = &generics.where_clause else {
+        return Err(anyhow::anyhow!("Missing where clause"));
+    };
+
+    let mut predicates = strip_const_where_predicates(where_clause.predicates.clone());
+
+    predicates.push(parse_quote! {
+        PC: InstructionFetcher<#self_ty, Memory, CustomError>
+    });
+    // Applying an `ExecutionResult` is the executor's job rather than the instruction's, so the
+    // handlers need the register file even for an extension whose own instructions never touch it
+    predicates.push(parse_quote! {
+        Regs: RegisterFile<Reg>
+    });
+
+    Ok(WhereClause {
+        where_token: <Token![where]>::default(),
+        predicates,
+    })
+}
+
+/// Generates tail-call-threaded execution alongside the `match`-based `execute()`.
+///
+/// One handler function per instruction variant is generated. A handler destructures its own
+/// instruction (so it reads only the operands that instruction names), calls the per-variant
+/// execution function that
+/// [`generate_variant_fns`](super::generate_variant_fns::generate_variant_fns) already produced,
+/// applies the `ExecutionResult` it returns, and tail-calls the next handler, so the chain never
+/// returns until execution stops.
+pub(super) fn generate_threaded_fns(
+    enum_name: &Ident,
+    self_ty: &Type,
+    generics: &Generics,
+    variants: &[Rc<Variant>],
+    match_arms: &[Arm],
+) -> anyhow::Result<Vec<Item>> {
+    let generic_params = &generics.params;
+    let where_clause = threaded_where_clause(generics, self_ty)?;
+    let abi = handler_abi()?;
+    let dispatch_fn_name = format_ident!("dispatch_{}", enum_name.to_string().to_snake_case());
+    let dispatch_result_name = format_ident!("{enum_name}ThreadedDispatchResult");
+    let result_ty: Type = parse_quote! {
+        ThreadedExecutionResult<PC, #self_ty, CustomError>
+    };
+
+    let mut generated_items = Vec::with_capacity(variants.len() + 3);
+    let mut dispatch_arms = Vec::with_capacity(variants.len());
+
+    // `FetchInstructionResult` with the handler that executes the fetched instruction attached, and
+    // without the `Continue` variant, which dispatch resolves while fetching rather than passing
+    // on. It never escapes the dispatch step it is created in, so it never materializes.
+    generated_items.push(parse_quote! {
+        enum #dispatch_result_name<I, Handler, CustomError>
+        where
+            I: Instruction,
+        {
+            Next { instruction: I, handler: Handler },
+            Break,
+            Err(ExecutionError<<I::Reg as Register>::Type, CustomError>),
+        }
+    });
+
+    for (variant, arm) in variants.iter().zip(match_arms) {
+        let variant_ident = &variant.ident;
+        let Pat::Struct(pat_struct) = &arm.pat else {
+            return Err(anyhow::anyhow!(
+                "Expected a struct pattern for instruction variant `{variant_ident}`, found `{}`",
+                arm.pat.to_token_stream()
+            ));
+        };
+        let pat_fields = &pat_struct.fields;
+
+        let variant_fn_name = variant_fn_name(enum_name, variant_ident);
+        let handler_fn_name = format_ident!("{variant_fn_name}_threaded");
+
+        let variant_call_args = pat_fields
+            .iter()
+            .filter_map(|field| match field.pat.as_ref() {
+                Pat::Ident(pat_ident) => Some(&pat_ident.ident),
+                _ => None,
+            });
+
+        generated_items.push(parse_quote! {
+            #[cfg_attr(
+                all(target_arch = "x86_64", target_os = "windows"),
+                expect(
+                    improper_ctypes_definitions,
+                    reason = "Handlers only ever call each other, within this crate"
+                )
+            )]
+            #abi fn #handler_fn_name<#generic_params>(
+                instruction: #self_ty,
+                mut instruction_fetcher: PC,
+                regs: &mut Regs,
+                mut ext_state: ExtState,
+                memory: &mut Memory,
+                mut system_instruction_handler: InstructionHandler,
+            ) -> #result_ty
+                #where_clause
+            {
+                let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
+                let rs1_value = regs.read(rs1);
+                let rs2_value = regs.read(rs2);
+
+                #[expect(
+                    clippy::undocumented_unsafe_blocks,
+                    reason = "Comments will be stripped, this will suppress some of the lints that \
+                    are caused by it"
+                )]
+                let #enum_name::#variant_ident { #pat_fields } = instruction else {
+                    // SAFETY: A handler is only ever reached through the dispatch arm for its own
+                    // variant
+                    unsafe {
+                        ::core::hint::unreachable_unchecked();
+                    }
+                };
+
+                let execution_result = #variant_fn_name::<#generic_params>(
+                    #( #variant_call_args, )*
+                    rs1_value,
+                    rs2_value,
+                    regs,
+                    &mut ext_state,
+                    memory,
+                    &mut instruction_fetcher,
+                    &mut system_instruction_handler,
+                );
+
+                let control_flow = match execution_result {
+                    ExecutionResult::Continue { rd, value } => {
+                        regs.write(rd, value);
+                        Ok(::core::ops::ControlFlow::Continue(()))
+                    }
+                    ExecutionResult::ContinueNoWrite => {
+                        Ok(::core::ops::ControlFlow::Continue(()))
+                    }
+                    ExecutionResult::Branch { offset } => {
+                        instruction_fetcher.set_pc_relative(
+                            memory,
+                            Instruction::size(&instruction),
+                            offset,
+                        )
+                    }
+                    ExecutionResult::Jump { target } => {
+                        instruction_fetcher.set_pc(memory, target)
+                    }
+                    ExecutionResult::Break => {
+                        ::core::hint::cold_path();
+                        return ThreadedExecutionResult::stopped(
+                            instruction_fetcher,
+                        );
+                    }
+                    ExecutionResult::Err(error) => {
+                        ::core::hint::cold_path();
+                        return ThreadedExecutionResult::failed(
+                            instruction_fetcher,
+                            error,
+                        );
+                    }
+                };
+
+                match control_flow {
+                    Ok(::core::ops::ControlFlow::Continue(())) => {}
+                    Ok(::core::ops::ControlFlow::Break(())) => {
+                        ::core::hint::cold_path();
+                        return ThreadedExecutionResult::stopped(
+                            instruction_fetcher,
+                        );
+                    }
+                    Err(error) => {
+                        ::core::hint::cold_path();
+                        return ThreadedExecutionResult::failed(
+                            instruction_fetcher,
+                            error,
+                        );
+                    }
+                }
+
+                let (instruction, handler) = match #dispatch_fn_name::<#generic_params>(
+                    &mut instruction_fetcher,
+                    memory,
+                ) {
+                    #dispatch_result_name::Next {
+                        instruction,
+                        handler,
+                    } => (instruction, handler),
+                    #dispatch_result_name::Break => {
+                        ::core::hint::cold_path();
+                        return ThreadedExecutionResult::stopped(
+                            instruction_fetcher,
+                        );
+                    }
+                    #dispatch_result_name::Err(error) => {
+                        ::core::hint::cold_path();
+                        return ThreadedExecutionResult::failed(
+                            instruction_fetcher,
+                            error,
+                        );
+                    }
+                };
+
+                become handler(
+                    instruction,
+                    instruction_fetcher,
+                    regs,
+                    ext_state,
+                    memory,
+                    system_instruction_handler,
+                )
+            }
+        });
+
+        dispatch_arms.push(quote! {
+            #enum_name::#variant_ident { .. } => #handler_fn_name::<#generic_params>,
+        });
+    }
+
+    generated_items.push(parse_quote! {
+        #[expect(
+            clippy::type_complexity,
+            reason = "`become` requires an exact signature match and a type alias cannot capture \
+            the enclosing generics, so the handler type is spelled out here"
+        )]
+        #[cfg_attr(
+            all(target_arch = "x86_64", target_os = "windows"),
+            expect(
+                improper_ctypes_definitions,
+                reason = "Handlers only ever call each other, within this crate"
+            )
+        )]
+        #[inline(always)]
+        fn #dispatch_fn_name<#generic_params>(
+            instruction_fetcher: &mut PC,
+            memory: &Memory,
+        ) -> #dispatch_result_name<
+            #self_ty,
+            #abi fn(
+                #self_ty,
+                PC,
+                &mut Regs,
+                ExtState,
+                &mut Memory,
+                InstructionHandler,
+            ) -> #result_ty,
+            CustomError,
+        >
+            #where_clause
+        {
+            let instruction = loop {
+                match instruction_fetcher.fetch_instruction(memory) {
+                    FetchInstructionResult::Instruction(instruction) => {
+                        break instruction;
+                    }
+                    FetchInstructionResult::Continue => {
+                        ::core::hint::cold_path();
+                    }
+                    FetchInstructionResult::Break => {
+                        ::core::hint::cold_path();
+                        return #dispatch_result_name::Break;
+                    }
+                    FetchInstructionResult::Err(error) => {
+                        ::core::hint::cold_path();
+                        return #dispatch_result_name::Err(error);
+                    }
+                }
+            };
+
+            #[expect(
+                clippy::rest_pattern_accessible_field,
+                reason = "Dispatch selects a handler by variant and never looks at any field"
+            )]
+            let handler = match instruction {
+                #( #dispatch_arms )*
+            };
+
+            #dispatch_result_name::Next { instruction, handler }
+        }
+    });
+
+    generated_items.push(parse_quote! {
+        impl<#generic_params> ThreadedExecutableInstruction<
+            Regs,
+            ExtState,
+            Memory,
+            PC,
+            InstructionHandler,
+            CustomError,
+        > for #self_ty
+            #where_clause
+        {
+            #[inline(always)]
+            fn execute_threaded(
+                mut instruction_fetcher: PC,
+                regs: &mut Regs,
+                ext_state: ExtState,
+                memory: &mut Memory,
+                system_instruction_handler: InstructionHandler,
+            ) -> #result_ty {
+                // This is the one ordinary call in the whole chain: everything from here on is
+                // reached with `become` and nothing returns until execution stops
+                let (instruction, handler) = match #dispatch_fn_name::<#generic_params>(
+                    &mut instruction_fetcher,
+                    memory,
+                ) {
+                    #dispatch_result_name::Next {
+                        instruction,
+                        handler,
+                    } => (instruction, handler),
+                    #dispatch_result_name::Break => {
+                        ::core::hint::cold_path();
+                        return ThreadedExecutionResult::stopped(
+                            instruction_fetcher,
+                        );
+                    }
+                    #dispatch_result_name::Err(error) => {
+                        ::core::hint::cold_path();
+                        return ThreadedExecutionResult::failed(
+                            instruction_fetcher,
+                            error,
+                        );
+                    }
+                };
+
+                handler(
+                    instruction,
+                    instruction_fetcher,
+                    regs,
+                    ext_state,
+                    memory,
+                    system_instruction_handler,
+                )
+            }
+        }
+    });
+
+    Ok(generated_items)
+}

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_variant_fns.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_variant_fns.rs
@@ -19,6 +19,17 @@ struct Param<'a> {
     ty: Type,
 }
 
+/// Name of the function generated for a single instruction variant's execution logic.
+///
+/// Shared with the threaded emitter, which calls those functions rather than generating its own.
+pub(super) fn variant_fn_name(enum_name: &Ident, variant: &Ident) -> Ident {
+    format_ident!(
+        "execute_{}_{}",
+        enum_name.to_string().to_snake_case(),
+        variant.to_string().to_snake_case(),
+    )
+}
+
 /// This rewrites every `Self` into a fully qualified concrete instruction enum type instead.
 ///
 /// `execute()`'s own body is written against `Self`, but the functions generated here are
@@ -124,10 +135,7 @@ fn extract_single_generic_type(ty: &Type) -> anyhow::Result<&Type> {
 }
 
 /// Extracts parameters shared by all generated per-variant functions from `execute()`'s own
-/// signature (excluding `self`).
-///
-/// Arguments (or destructured fields of a struct argument) whose identifier starts with `_` are
-/// considered unused and skipped.
+/// signature (excluding `self`)
 fn extract_shared_params(sig: &Signature) -> anyhow::Result<Vec<Param<'_>>> {
     let mut shared_params = Vec::new();
 
@@ -151,12 +159,10 @@ fn extract_shared_params(sig: &Signature) -> anyhow::Result<Vec<Param<'_>>> {
                 mutability: _,
                 subpat: _,
             }) => {
-                if !ident.to_string().starts_with('_') {
-                    shared_params.push(Param {
-                        ident,
-                        ty: ty.as_ref().clone(),
-                    });
-                }
+                shared_params.push(Param {
+                    ident,
+                    ty: ty.as_ref().clone(),
+                });
             }
             Pat::Struct(pat_struct) => {
                 let field_ty = extract_single_generic_type(ty)?;
@@ -169,15 +175,16 @@ fn extract_shared_params(sig: &Signature) -> anyhow::Result<Vec<Param<'_>>> {
                         subpat: _,
                     }) = field.pat.as_ref()
                     else {
-                        // `_` or another unsupported nested pattern, treated as unused
-                        continue;
+                        return Err(anyhow::anyhow!(
+                            "Destructured `execute()` argument field `{}` must be bound to an \
+                            identifier",
+                            field.to_token_stream()
+                        ));
                     };
-                    if !ident.to_string().starts_with('_') {
-                        shared_params.push(Param {
-                            ident,
-                            ty: field_ty.clone(),
-                        });
-                    }
+                    shared_params.push(Param {
+                        ident,
+                        ty: field_ty.clone(),
+                    });
                 }
             }
             _ => {
@@ -298,11 +305,7 @@ pub(super) fn generate_variant_fns(
             self_rewriter.visit_type_mut(&mut param.ty);
         }
 
-        let fn_name = format_ident!(
-            "execute_{}_{}",
-            enum_name.to_string().to_snake_case(),
-            variant.ident.to_string().to_snake_case(),
-        );
+        let fn_name = variant_fn_name(enum_name, &variant.ident);
 
         let call_args = variant_params
             .iter()

--- a/crates/execution/ab-riscv-macros/src/build/shared.rs
+++ b/crates/execution/ab-riscv-macros/src/build/shared.rs
@@ -1,6 +1,8 @@
 use crate::build::state::{KnownEnumDefinition, State};
+use quote::ToTokens;
 use std::collections::{HashSet, VecDeque};
-use syn::Ident;
+use syn::punctuated::Punctuated;
+use syn::{Ident, Token, WherePredicate, parse_quote};
 
 pub(super) fn collect_all_dependencies<InitialDependencies>(
     state: &State,
@@ -34,4 +36,40 @@ where
     }
 
     Ok(all_dependencies)
+}
+
+/// Strips `[const]` from `where` predicates, dropping `[const] Destruct` ones altogether.
+///
+/// Used both for a non-`const` implementation that inherits arms from `const` ones and for the
+/// threaded implementation, which is never `const`.
+pub(super) fn strip_const_where_predicates<Predicates>(
+    predicates: Predicates,
+) -> Punctuated<WherePredicate, Token![,]>
+where
+    Predicates: IntoIterator<Item = WherePredicate>,
+{
+    predicates
+        .into_iter()
+        .filter_map(|mut predicate| match &mut predicate {
+            WherePredicate::Type(predicate_type) => {
+                // TODO: Remove `Destruct` hack once stabilized, removing it from non-const
+                //  implementations improves downstream user experience:
+                //  https://github.com/rust-lang/rust/issues/133214
+                if predicate_type.bounds.to_token_stream().to_string() == "BRCONST + Destruct" {
+                    return None;
+                }
+
+                // TODO: `BRCONST` is a hack that allows `syn` to parse unstable Rust syntax
+                //  around const traits and such. It will change to a proper modifier once
+                //  stabilized
+                if predicate_type.bounds.first() == Some(&parse_quote! { BRCONST }) {
+                    predicate_type.bounds =
+                        predicate_type.bounds.clone().into_iter().skip(1).collect();
+                }
+
+                Some(predicate)
+            }
+            _ => Some(predicate),
+        })
+        .collect()
 }


### PR DESCRIPTION
This implements code generation for a higher-performance threaded instruction dispatch interpreter that uses guaranteed tail calls.

The nice thing is that this whole thing is generated completely from the original `match` execution that was there all along and it wasn't even that much code after preliminary refactoring.

This code is not used yet for the actual execution, that'll land separately with corresponding benchmarking numbers.