### PR TITLE
Update Rust toolchain to the latest nightly

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,0 @@
-# This wildcard allows to merge whatever user might have configured in their home folder
-[target.'cfg(all())']
-# TODO: `-Znext-solver=globally` is a requirement for `generic_const_args`, `-Zmin-recursion-limit=256` is in turn
-#  needed for some crates due to `-Znext-solver=globally`
-rustflags = ["-Znext-solver=globally", "-Zmin-recursion-limit=256"]
-rustdocflags = ["-Znext-solver=globally", "-Zmin-recursion-limit=256"]
-# TODO: Specify `miriflags` is/when it is supported: https://github.com/rust-lang/cargo/issues/17079

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,9 +35,7 @@ jobs:
           cargo -Zgitoxide -Zgit doc --locked --all --no-deps --lib --all-features
           cp -r target/doc gh-pages/rust-docs
         env:
-          # TODO: `-Znext-solver=globally` is a requirement for `generic_const_args`, `-Zmin-recursion-limit=256` is in
-          #  turn needed for some crates due to `-Znext-solver=globally`
-          RUSTDOCFLAGS: -Znext-solver=globally -Zmin-recursion-limit=256 -D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links -Z unstable-options --enable-index-page
+          RUSTDOCFLAGS: -D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links -Z unstable-options --enable-index-page
 
       - name: Install Hugo
         uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # 3.2.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,13 +17,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_BUILD_WARNINGS: deny
   # Build smaller artifacts to avoid running out of space in CI and make it a bit faster.
-  # TODO: `-Znext-solver=globally` is a requirement for `generic_const_args`, `-Zmin-recursion-limit=256` is in turn
-  #  needed for some crates due to `-Znext-solver=globally`
-  RUSTFLAGS: -Znext-solver=globally -Zmin-recursion-limit=256 -C strip=symbols
+  RUSTFLAGS: -C strip=symbols
   # Needed for things like file system access
-  # TODO: `-Znext-solver=globally` is a requirement for `generic_const_args`, `-Zmin-recursion-limit=256` is in turn
-  #  needed for some crates due to `-Znext-solver=globally`
-  MIRIFLAGS: -Znext-solver=globally -Zmin-recursion-limit=256 -Zmiri-disable-isolation
+  MIRIFLAGS: -Zmiri-disable-isolation
   RUST_BACKTRACE: full
   # TODO: Short-term workaround for https://github.com/rust-lang/miri/issues/5234
   __CARGO_TEMPORARY_BUILD_DIR_NEW_LAYOUT_OPT_OUT: 1
@@ -94,11 +90,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
-      # TODO: `-Ztarget-applies-to-host` and the rest of arguments here are for `-Znext-solver=globally`
       command: >-
         cargo -Zgitoxide -Zgit clippy
         ${{ matrix.target != '' && format('-Zjson-target-spec --target {0}', matrix.target) || '' }}
-        -Ztarget-applies-to-host -Zhost-config --config 'host.rustflags=["-Znext-solver=globally"]'
     # Gives the slow cargo test jobs a head start, forcing others to start after this relatively quick job instead
     needs: act4
 
@@ -326,11 +320,9 @@ jobs:
     env:
       # NOTE: Running tests under Miri with nextest is SLOWER than without it:
       #  https://github.com/nextest-rs/nextest/issues/27#issuecomment-4187292411
-      # TODO: `-Ztarget-applies-to-host` and the rest of arguments here are for `-Znext-solver=globally`
       command: >-
         ${{ matrix.miri == true && 'miri test --bins --lib --tests' || 'nextest run --no-tests pass' }}
         ${{ matrix.target != '' && format('-Zjson-target-spec --target {0}', matrix.target) || '' }}
-        -Ztarget-applies-to-host -Zhost-config --config 'host.rustflags=["-Znext-solver=globally"]'
 
     steps: &test-steps
       - name: Install cargo-nextest
@@ -628,11 +620,9 @@ jobs:
     env:
       # NOTE: Running tests under Miri with nextest is SLOWER than without it:
       #  https://github.com/nextest-rs/nextest/issues/27#issuecomment-4187292411
-      # TODO: `-Ztarget-applies-to-host` and the rest of arguments here are for `-Znext-solver=globally`
       command: >-
         ${{ matrix.miri == true && 'miri test --bins --lib --tests' || 'nextest run --no-tests pass' }}
         ${{ matrix.target != '' && format('-Zjson-target-spec --target {0}', matrix.target) || '' }}
-        -Ztarget-applies-to-host -Zhost-config --config 'host.rustflags=["-Znext-solver=globally"]'
 
     steps: *test-steps
 
@@ -668,11 +658,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
-      # TODO: `-Ztarget-applies-to-host` and the rest of arguments here are for `-Znext-solver=globally`
       command: >-
         cargo -Zgitoxide -Zgit build
         ${{ matrix.target != '' && format('-Zjson-target-spec --target {0}', matrix.target) || '' }}
-        -Ztarget-applies-to-host -Zhost-config --config 'host.rustflags=["-Znext-solver=globally"]'
 
     steps:
       - *rust-gpu-cache

--- a/crates/contracts/core/ab-contracts-tooling/src/build.rs
+++ b/crates/contracts/core/ab-contracts-tooling/src/build.rs
@@ -42,12 +42,10 @@ pub fn build_cdylib(options: BuildOptions<'_>) -> anyhow::Result<PathBuf> {
         // Hack for enabling RISC-V Zknh backend in `sha2` crate since it is a nightly-only feature,
         // and they really don't like using normal features for it.
         // `-Zthreads=4` takes advantage of the parallel frontend
-        // `-Znext-solver=globally` is needed for `generic_const_args` in various crates.
         .env(
             "RUSTFLAGS",
             r#"--cfg sha2_backend="riscv-zknh" --cfg sha2_backend_riscv_zknh="compact"
-            -Zthreads=4
-            -Znext-solver=globally"#,
+            -Zthreads=4"#,
         )
         .args([
             "rustc",
@@ -59,14 +57,6 @@ pub fn build_cdylib(options: BuildOptions<'_>) -> anyhow::Result<PathBuf> {
             target_specification_path
                 .to_str()
                 .context("Path to target specification file is not valid UTF-8")?,
-        ])
-        // `-Znext-solver=globally` is needed for `generic_const_args` in various crates, it is not
-        // propagated to the target's build script by default, hence such hacks
-        .args([
-            "-Ztarget-applies-to-host",
-            "-Zhost-config",
-            "--config",
-            r#"host.rustflags=["-Znext-solver=globally"]"#,
         ]);
 
     if env::var("MIRI_SYSROOT").is_ok() {

--- a/crates/farmer/ab-farmer/src/bin/ab-farmer/main.rs
+++ b/crates/farmer/ab-farmer/src/bin/ab-farmer/main.rs
@@ -1,4 +1,6 @@
 #![feature(type_changing_struct_update)]
+// TODO: Remove once https://github.com/gfx-rs/wgpu/pull/9953 is released
+#![recursion_limit = "256"]
 
 mod commands;
 

--- a/crates/farmer/ab-farmer/src/lib.rs
+++ b/crates/farmer/ab-farmer/src/lib.rs
@@ -14,6 +14,8 @@
     )
 )]
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
+// TODO: Remove once https://github.com/gfx-rs/wgpu/pull/9953 is released
+#![recursion_limit = "256"]
 
 //! `ab-farmer` is both a library and an app for everything related to farming.
 //!

--- a/crates/farmer/ab-proof-of-space-gpu/build.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/build.rs
@@ -36,7 +36,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // SAFETY: Single-threaded
     unsafe {
         env::set_var("RUST_MIN_STACK", "16777216");
-        // TODO: `-Znext-solver=globally` is a requirement for `generic_const_args`
+        // TODO: `-Znext-solver=globally` is a requirement for `generic_const_args` on the toolchain
+        //  rust-gpu uses
         env::set_var("RUSTGPU_RUSTFLAGS", "-Znext-solver=globally");
     }
 

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -15,6 +15,8 @@
     all(test, not(target_arch = "spirv")),
     feature(const_convert, const_trait_impl, maybe_uninit_fill)
 )]
+// TODO: Remove once https://github.com/gfx-rs/wgpu/pull/9953 is released
+#![recursion_limit = "256"]
 
 #[cfg(not(target_arch = "spirv"))]
 mod host;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-08-18"
+channel = "nightly-2026-08-23"
 components = ["miri", "rust-src"]
 targets = []
 profile = "default"


### PR DESCRIPTION
This is the first nightly where next solver is the default, so a lot (but not all) hacks can be removed. Still waiting on https://github.com/gfx-rs/wgpu/pull/9953 to be released to remove a couple more TODOs related to recursion limits.