### PR TITLE
RISC-V use threaded dispatch + optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,7 @@ version = "0.0.4"
 dependencies = [
  "ab-riscv-macros",
  "ab-riscv-primitives",
+ "cpufeatures 0.3.0",
  "no-panic-const",
  "replace_with",
  "thiserror 2.0.20",

--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -248,14 +248,11 @@ where
 const impl<Reg> ExecutableInstructionOperands for ContractInstruction<Reg> {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ContractInstruction<Reg>
-{
-}
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ContractInstruction<Reg> {}
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ContractInstruction<Reg>
 where
     Reg: Register,
@@ -272,7 +269,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -3,16 +3,20 @@ use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
 
-/// Registers used by contracts
+/// Registers used by contracts.
+///
+/// `ZEROSTORE` generic determines whether to zero `x0` register on write instead of checking
+/// register index on read. `match` loop usually performs better with branching, while threaded
+/// execution benefits from zeroing.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct ContractRegisters {
+pub struct ContractRegisters<const ZEROSTORE: bool> {
     regs: [u64; 32],
 }
 
-const impl RegisterFile<ContractRegister> for ContractRegisters {
+const impl<const ZEROSTORE: bool> RegisterFile<ContractRegister> for ContractRegisters<ZEROSTORE> {
     #[inline(always)]
     fn read(&self, reg: ContractRegister) -> u64 {
-        if reg == ContractRegister::Zero {
+        if reg == ContractRegister::Zero && !ZEROSTORE {
             // Always zero
             return 0;
         }
@@ -25,6 +29,11 @@ const impl RegisterFile<ContractRegister> for ContractRegisters {
     fn write(&mut self, reg: ContractRegister, value: u64) {
         // SAFETY: register offset is always within bounds
         *unsafe { self.regs.get_unchecked_mut(usize::from(reg as u8)) } = value;
+
+        if ZEROSTORE {
+            // SAFETY: The register file always has at least one slot
+            *unsafe { self.regs.get_unchecked_mut(0) } = 0;
+        }
     }
 }
 

--- a/crates/contracts/core/ab-contract-file/src/lib.rs
+++ b/crates/contracts/core/ab-contract-file/src/lib.rs
@@ -39,6 +39,7 @@
     const_try_residual,
     derive_const,
     explicit_tail_calls,
+    fn_align,
     maybe_uninit_fill,
     signed_bigint_helpers,
     trusted_len,

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max.rs
@@ -74,14 +74,14 @@ impl<Reg> ExecutableInstructionOperands for AbundanceRv32IMaxInstructionPrototyp
     clippy::useless_conversion,
     reason = "https://github.com/rust-lang/rust-clippy/issues/17083"
 )]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+impl<Reg, ExtState> ExecutableInstructionCsr<ExtState>
     for AbundanceRv32IMaxInstructionPrototype<Reg>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for AbundanceRv32IMaxInstructionPrototype<Reg>
 where
     Reg: Register,
@@ -97,7 +97,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max.rs
@@ -70,14 +70,14 @@ where
 impl<Reg> ExecutableInstructionOperands for AbundanceRv64IMaxInstructionPrototype<Reg> {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
+impl<Reg, ExtState> ExecutableInstructionCsr<ExtState>
     for AbundanceRv64IMaxInstructionPrototype<Reg>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for AbundanceRv64IMaxInstructionPrototype<Reg>
 where
     Reg: Register,
@@ -93,7 +93,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/instruction.rs
@@ -54,8 +54,7 @@ where
 impl<Reg> ExecutableInstructionOperands for MachineModePlaceholder<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for MachineModePlaceholder<Reg>
+impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for MachineModePlaceholder<Reg>
 where
     Reg: Register,
 {
@@ -65,7 +64,7 @@ where
         _will_write: bool,
         raw_value: Reg::Type,
         output_value: &mut Reg::Type,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         if matches!(
             MCsr::from_index(csr_index),
             Some(
@@ -95,7 +94,7 @@ where
         csr_index: u16,
         write_value: Reg::Type,
         output_value: &mut Reg::Type,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         match MCsr::from_index(csr_index) {
             Some(
                 MCsr::Mstatus
@@ -134,8 +133,8 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for MachineModePlaceholder<Reg>
 where
     Reg: Register,
@@ -151,7 +150,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -6,6 +6,7 @@
     const_try,
     const_try_residual,
     explicit_tail_calls,
+    fn_align,
     generic_const_args,
     generic_const_items,
     inherent_associated_types,

--- a/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
+++ b/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
@@ -4,7 +4,7 @@ use ab_contract_file::instruction::{ContractInstruction, ContractRegisters};
 use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_riscv_benchmarks::Benchmarks;
 use ab_riscv_benchmarks::host_utils::{
-    Blake3HashChunkInternalArgs, EagerTestInstructionFetcher, Ed25519VerifyInternalArgs,
+    Blake3HashChunkInternalArgs, EagerTestInstructions, Ed25519VerifyInternalArgs,
     LazyInstructionFetcher, RISCV_CONTRACT_BYTES, TestMemory,
 };
 use ab_riscv_interpreter::basic::{BasicInterpreterState, IllegalEcallSystemInstructionHandler};
@@ -78,17 +78,16 @@ fn criterion_benchmark(c: &mut Criterion) {
         // internally (+ memory allocation)
         group.bench_function("decode-instructions", |b| {
             b.iter(|| {
-                // SAFETY: Program counter is set later to the correct address
-                let instruction_fetcher = unsafe {
-                    EagerTestInstructionFetcher::new(
+                // SAFETY: All instructions are valid and contract ends with a jump
+                let instructions = unsafe {
+                    EagerTestInstructions::decode(
                         code,
                         TRAP_ADDRESS,
                         MEMORY_BASE_ADDRESS
                             + u64::from(contract_file.header().read_only_section_memory_size),
-                        benchmarks_blake3_hash_chunk_addr,
                     )
                 };
-                black_box(instruction_fetcher);
+                black_box(instructions);
             });
         });
     }
@@ -128,20 +127,21 @@ fn criterion_benchmark(c: &mut Criterion) {
         system_instruction_handler: IllegalEcallSystemInstructionHandler,
     };
 
+    // SAFETY: All instructions are valid and contract ends with a jump
+    let instructions = unsafe {
+        EagerTestInstructions::decode(
+            contract_file.get_code(),
+            TRAP_ADDRESS,
+            MEMORY_BASE_ADDRESS + u64::from(contract_file.header().read_only_section_memory_size),
+        )
+    };
+
     let mut eager_state = BasicInterpreterState {
         regs: ContractRegisters::<false>::default(),
         ext_state: (),
         memory,
         // SAFETY: Program counter is set later to the correct address
-        instruction_fetcher: unsafe {
-            EagerTestInstructionFetcher::new(
-                contract_file.get_code(),
-                TRAP_ADDRESS,
-                MEMORY_BASE_ADDRESS
-                    + u64::from(contract_file.header().read_only_section_memory_size),
-                benchmarks_blake3_hash_chunk_addr,
-            )
-        },
+        instruction_fetcher: unsafe { instructions.fetcher(benchmarks_blake3_hash_chunk_addr) },
         system_instruction_handler: IllegalEcallSystemInstructionHandler,
     };
 
@@ -150,15 +150,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         ext_state: (),
         memory,
         // SAFETY: Program counter is set later to the correct address
-        instruction_fetcher: unsafe {
-            EagerTestInstructionFetcher::new(
-                contract_file.get_code(),
-                TRAP_ADDRESS,
-                MEMORY_BASE_ADDRESS
-                    + u64::from(contract_file.header().read_only_section_memory_size),
-                benchmarks_blake3_hash_chunk_addr,
-            )
-        },
+        instruction_fetcher: unsafe { instructions.fetcher(benchmarks_blake3_hash_chunk_addr) },
         system_instruction_handler: IllegalEcallSystemInstructionHandler,
     };
 
@@ -254,7 +246,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
                 let state = black_box(&mut eager_state_zerostore);
                 ContractInstruction::execute_threaded(
-                    state.instruction_fetcher.clone(),
+                    state.instruction_fetcher,
                     &mut state.regs,
                     (),
                     &mut state.memory,
@@ -365,7 +357,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
                 let state = black_box(&mut eager_state_zerostore);
                 ContractInstruction::execute_threaded(
-                    state.instruction_fetcher.clone(),
+                    state.instruction_fetcher,
                     &mut state.regs,
                     (),
                     &mut state.memory,

--- a/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
+++ b/crates/execution/ab-riscv-benchmarks/benches/riscv.rs
@@ -1,6 +1,6 @@
 use ab_blake3::CHUNK_LEN;
 use ab_contract_file::ContractFile;
-use ab_contract_file::instruction::ContractRegisters;
+use ab_contract_file::instruction::{ContractInstruction, ContractRegisters};
 use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_riscv_benchmarks::Benchmarks;
 use ab_riscv_benchmarks::host_utils::{
@@ -117,7 +117,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let stack_pointer = (internal_args_addr - 16).next_multiple_of(16);
 
     let mut lazy_state = BasicInterpreterState {
-        regs: ContractRegisters::default(),
+        regs: ContractRegisters::<false>::default(),
         ext_state: (),
         memory,
         // SAFETY: Program counter is set later to the correct address, all instructions are valid
@@ -129,7 +129,24 @@ fn criterion_benchmark(c: &mut Criterion) {
     };
 
     let mut eager_state = BasicInterpreterState {
-        regs: ContractRegisters::default(),
+        regs: ContractRegisters::<false>::default(),
+        ext_state: (),
+        memory,
+        // SAFETY: Program counter is set later to the correct address
+        instruction_fetcher: unsafe {
+            EagerTestInstructionFetcher::new(
+                contract_file.get_code(),
+                TRAP_ADDRESS,
+                MEMORY_BASE_ADDRESS
+                    + u64::from(contract_file.header().read_only_section_memory_size),
+                benchmarks_blake3_hash_chunk_addr,
+            )
+        },
+        system_instruction_handler: IllegalEcallSystemInstructionHandler,
+    };
+
+    let mut eager_state_zerostore = BasicInterpreterState {
+        regs: ContractRegisters::<true>::default(),
         ext_state: (),
         memory,
         // SAFETY: Program counter is set later to the correct address
@@ -177,9 +194,14 @@ fn criterion_benchmark(c: &mut Criterion) {
                 .get_mut_bytes(internal_args_addr, size_of::<Blake3HashChunkInternalArgs>())
                 .unwrap()
                 .copy_from_slice(internal_args_bytes);
+            eager_state_zerostore
+                .memory
+                .get_mut_bytes(internal_args_addr, size_of::<Blake3HashChunkInternalArgs>())
+                .unwrap()
+                .copy_from_slice(internal_args_bytes);
         }
 
-        group.bench_function("interpreter/lazy", |b| {
+        group.bench_function("interpreter/loop/lazy", |b| {
             b.iter(|| {
                 lazy_state
                     .instruction_fetcher
@@ -195,7 +217,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             });
         });
 
-        group.bench_function("interpreter/eager", |b| {
+        group.bench_function("interpreter/loop/eager", |b| {
             b.iter(|| {
                 eager_state
                     .instruction_fetcher
@@ -208,6 +230,38 @@ fn criterion_benchmark(c: &mut Criterion) {
                 eager_state.regs.write(Register::SP, stack_pointer);
 
                 black_box(black_box(&mut eager_state).execute()).unwrap();
+            });
+        });
+
+        group.bench_function("interpreter/threaded/eager", |b| {
+            b.iter(|| {
+                eager_state_zerostore
+                    .instruction_fetcher
+                    .set_pc(
+                        &eager_state_zerostore.memory,
+                        benchmarks_blake3_hash_chunk_addr,
+                    )
+                    .unwrap()
+                    .continue_value()
+                    .unwrap();
+                eager_state_zerostore
+                    .regs
+                    .write(Register::A0, internal_args_addr);
+                // Stack is between internal arguments and contract memory
+                eager_state_zerostore
+                    .regs
+                    .write(Register::SP, stack_pointer);
+
+                let state = black_box(&mut eager_state_zerostore);
+                ContractInstruction::execute_threaded(
+                    state.instruction_fetcher.clone(),
+                    &mut state.regs,
+                    (),
+                    &mut state.memory,
+                    IllegalEcallSystemInstructionHandler,
+                )
+                .outcome
+                .unwrap();
             });
         });
     }
@@ -251,9 +305,14 @@ fn criterion_benchmark(c: &mut Criterion) {
                 .get_mut_bytes(internal_args_addr, size_of::<Ed25519VerifyInternalArgs>())
                 .unwrap()
                 .copy_from_slice(internal_args_bytes);
+            eager_state_zerostore
+                .memory
+                .get_mut_bytes(internal_args_addr, size_of::<Ed25519VerifyInternalArgs>())
+                .unwrap()
+                .copy_from_slice(internal_args_bytes);
         }
 
-        group.bench_function("interpreter/lazy", |b| {
+        group.bench_function("interpreter/loop/lazy", |b| {
             b.iter(|| {
                 lazy_state
                     .instruction_fetcher
@@ -269,7 +328,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             });
         });
 
-        group.bench_function("interpreter/eager", |b| {
+        group.bench_function("interpreter/loop/eager", |b| {
             b.iter(|| {
                 eager_state
                     .instruction_fetcher
@@ -282,6 +341,38 @@ fn criterion_benchmark(c: &mut Criterion) {
                 eager_state.regs.write(Register::SP, stack_pointer);
 
                 black_box(black_box(&mut eager_state).execute()).unwrap();
+            });
+        });
+
+        group.bench_function("interpreter/threaded/eager", |b| {
+            b.iter(|| {
+                eager_state_zerostore
+                    .instruction_fetcher
+                    .set_pc(
+                        &eager_state_zerostore.memory,
+                        benchmarks_ed25519_verify_addr,
+                    )
+                    .unwrap()
+                    .continue_value()
+                    .unwrap();
+                eager_state_zerostore
+                    .regs
+                    .write(Register::A0, internal_args_addr);
+                // Stack is between internal arguments and contract memory
+                eager_state_zerostore
+                    .regs
+                    .write(Register::SP, stack_pointer);
+
+                let state = black_box(&mut eager_state_zerostore);
+                ContractInstruction::execute_threaded(
+                    state.instruction_fetcher.clone(),
+                    &mut state.regs,
+                    (),
+                    &mut state.memory,
+                    IllegalEcallSystemInstructionHandler,
+                )
+                .outcome
+                .unwrap();
             });
         });
     }

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -307,14 +307,28 @@ where
     }
 
     #[inline(always)]
-    fn set_pc_relative(
+    unsafe fn try_set_pc_relative(&mut self, instruction_size: u8, offset: i32) -> bool {
+        let old_pc = <Self as ProgramCounter<_, Memory>>::old_pc(self, instruction_size);
+        let pc = old_pc.wrapping_add_signed(i64::from(offset));
+        // Stored either way: on the way out it is what `failed_branch()` reports on, and until then
+        // nothing else is allowed to look at it
+        self.pc = pc;
+
+        pc != self.return_trap_address
+            && pc.is_multiple_of(u64::from(
+                ContractInstruction::<ContractRegister>::alignment(),
+            ))
+    }
+
+    #[cold]
+    #[inline(never)]
+    unsafe fn failed_branch(
         &mut self,
         memory: &Memory,
-        instruction_size: u8,
-        offset: i32,
     ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
-        let old_pc = <Self as ProgramCounter<_, Memory>>::old_pc(self, instruction_size);
-        self.set_pc(memory, old_pc.wrapping_add_signed(i64::from(offset)))
+        // The program counter holds the refused target, and `set_pc()` is what says what is wrong
+        // with it
+        self.set_pc(memory, self.pc)
     }
 
     #[inline]
@@ -718,18 +732,13 @@ where
     /// Moves within the decoded stream instead of resolving an address and converting it back,
     /// which is what going through [`Self::set_pc()`] would do.
     ///
-    /// One comparison and one test are all this needs to hand every case it does not handle itself
-    /// over to [`Self::set_pc()`]: a target past the end of the decoded stream, a backwards branch
-    /// that ran off its start, and an unaligned target. The return trap sits outside the decoded
-    /// stream, so a branch to it fails the bounds check here and is stopped by [`Self::set_pc()`]
-    /// like any other jump to it.
+    /// One comparison and one test are all this needs to recognize every target it cannot resolve:
+    /// one past the end of the decoded stream, a backwards branch that ran off its start, and an
+    /// unaligned one. The return trap sits outside the decoded stream, so a branch to it fails the
+    /// bounds check here too and is answered by [`Self::failed_branch()`] like any other target
+    /// this refuses.
     #[inline(always)]
-    fn set_pc_relative(
-        &mut self,
-        memory: &Memory,
-        instruction_size: u8,
-        offset: i32,
-    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+    unsafe fn try_set_pc_relative(&mut self, instruction_size: u8, offset: i32) -> bool {
         // Byte offset from the instruction being executed to the branch target. The program counter
         // is advanced during instruction fetching, so that instruction starts `instruction_size`
         // bytes back.
@@ -745,6 +754,11 @@ where
             .next_instruction
             .as_ptr()
             .wrapping_byte_offset(byte_delta);
+        // Stored either way: on the way out it is the target `failed_branch()` reports on, and
+        // until then nothing else is allowed to look at it
+        // SAFETY: A wrapped pointer is never null, and nothing here dereferences it
+        self.next_instruction = unsafe { NonNull::new_unchecked(new_next_instruction) };
+
         let decoded_instruction_byte_offset = new_next_instruction
             .addr()
             .wrapping_sub(self.instructions().as_ptr().addr());
@@ -752,23 +766,37 @@ where
         // A target that does not land on a decoded instruction sits between two guest
         // instructions, which makes it an unaligned instruction rather than something to round to
         // the start of one. That rule lives in `set_pc()`, so rather than restating it here, where
-        // it could drift, such a target simply fails to qualify for the fast path, as does one past
-        // the end of the decoded stream, which a backwards branch that ran off its start wraps
-        // around into.
-        if decoded_instruction_byte_offset
-            >= self.instructions_len() * size_of::<ContractInstruction>()
-            || !decoded_instruction_byte_offset.is_multiple_of(size_of::<ContractInstruction>())
-        {
-            cold_path();
-            let pc = <Self as ProgramCounter<_, Memory>>::get_pc(self);
-            return self.set_pc(memory, pc.wrapping_add_signed(offset as i64));
-        }
+        // it could drift, such a target simply fails to qualify, as does one past the end of the
+        // decoded stream, which a backwards branch that ran off its start wraps around into.
+        decoded_instruction_byte_offset < self.instructions_len() * size_of::<ContractInstruction>()
+            && decoded_instruction_byte_offset.is_multiple_of(size_of::<ContractInstruction>())
+    }
 
-        // SAFETY: Just checked that `new_next_instruction` lands exactly on a decoded instruction
-        // within the bounds of the (non-empty) decoded stream
-        self.next_instruction = unsafe { NonNull::new_unchecked(new_next_instruction) };
+    /// Turns the refused target back into an address and hands it to [`Self::set_pc()`], which is
+    /// where the rules about what is and is not an instruction address live.
+    #[cold]
+    #[inline(never)]
+    unsafe fn failed_branch(
+        &mut self,
+        memory: &Memory,
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+        // Signed, because a backwards branch that ran off the start of the decoded stream is
+        // exactly one of the targets that gets here
+        let decoded_instruction_byte_offset = self
+            .next_instruction
+            .as_ptr()
+            .addr()
+            .wrapping_sub(self.instructions().as_ptr().addr())
+            .cast_signed();
+        // Every `size_of::<u16>()` of guest code owns one decoded instruction, and the position is
+        // always that many bytes from the start of the stream, so this is exact
+        let address = self.base_addr().wrapping_add_signed(
+            (decoded_instruction_byte_offset
+                / (size_of::<ContractInstruction>() / size_of::<u16>()).cast_signed())
+                as i64,
+        );
 
-        Ok(ControlFlow::Continue(()))
+        self.set_pc(memory, address)
     }
 
     #[inline]

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -309,7 +309,7 @@ where
         instruction_size: u8,
         offset: i32,
     ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
-        let old_pc = <Self as ProgramCounter<_, Memory, _>>::old_pc(self, instruction_size);
+        let old_pc = <Self as ProgramCounter<_, Memory>>::old_pc(self, instruction_size);
         self.set_pc(memory, old_pc.wrapping_add_signed(i64::from(offset)))
     }
 

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -9,9 +9,9 @@ use ab_riscv_primitives::prelude::*;
 use alloc::alloc::{alloc, dealloc, handle_alloc_error};
 use alloc::vec::Vec;
 use core::alloc::Layout;
-use core::cell::Cell;
 use core::fmt;
 use core::hint::cold_path;
+use core::marker::PhantomData;
 use core::mem::offset_of;
 use core::ops::ControlFlow;
 use core::ptr::NonNull;
@@ -414,19 +414,12 @@ impl LazyInstructionFetcher {
 /// instruction stream.
 ///
 /// This lives in a single heap allocation whose tail holds the decoded instructions themselves,
-/// starting [`EagerTestInstructionFetcher::INSTRUCTIONS_OFFSET`] bytes from the beginning of it.
+/// starting [`EagerTestInstructions::INSTRUCTIONS_OFFSET`] bytes from the beginning of it.
 /// That is what keeps the fetcher itself down to two pointers, so it fits into two argument
 /// registers when threaded through tail-called instruction handlers by value.
 #[derive(Debug)]
 #[repr(C)]
 struct EagerTestInstructionFetcherState {
-    /// Number of fetchers sharing this state.
-    ///
-    /// Threaded execution moves the fetcher into the handler chain and only hands the program
-    /// counter back, so a caller that runs the same program more than once hands over a clone
-    /// each time. Cloning the decoded instructions with it would be the dominant cost of a short
-    /// benchmark run, hence the reference count: a clone is an increment and two pointer copies.
-    strong_count: Cell<usize>,
     /// Number of decoded instructions stored right after this header
     instructions_len: usize,
     /// Guest address that corresponds to the first decoded instruction
@@ -435,9 +428,243 @@ struct EagerTestInstructionFetcherState {
     return_trap_address: u64,
 }
 
-/// Eager instruction handler eagerly decodes all instructions upfront
+/// Instructions decoded upfront, which [`EagerTestInstructionFetcher`] walks.
+///
+/// Ownership of the allocation lives here rather than in the fetcher because the fetcher is moved
+/// through tail-called instruction handlers by value. A destructor on it would make every handler
+/// that can fail (every load, store, branch and jump) responsible for dropping it on the way out,
+/// which costs a stack frame, callee-saved register spills and a reload in the hot path of each of
+/// them, even though the failing path is never taken.
+pub struct EagerTestInstructions {
+    /// State header, together with the decoded instructions themselves, in a single heap
+    /// allocation.
+    ///
+    /// This is a raw pointer rather than a `Box` on purpose: fetchers point into the same
+    /// allocation, and going through a `Box` would assert unique access to that allocation on
+    /// every use, invalidating pointers that must survive across all of them.
+    state: NonNull<EagerTestInstructionFetcherState>,
+}
+
+impl fmt::Debug for EagerTestInstructions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EagerTestInstructions")
+            .field("instructions_len", &self.instructions_len())
+            .field("base_addr", &self.base_addr())
+            .field("return_trap_address", &self.return_trap_address())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for EagerTestInstructions {
+    fn drop(&mut self) {
+        let layout = Self::allocation_layout(self.instructions_len());
+
+        // SAFETY: Allocated with the global allocator using exactly this layout, and this is the
+        // only owner of the allocation
+        unsafe {
+            dealloc(self.state.as_ptr().cast::<u8>(), layout);
+        }
+    }
+}
+
+impl EagerTestInstructions {
+    /// Byte offset of the decoded instructions from the start of the allocation that
+    /// [`Self::state`] points at
+    const INSTRUCTIONS_OFFSET: usize = size_of::<EagerTestInstructionFetcherState>()
+        .next_multiple_of(align_of::<ContractInstruction>());
+
+    /// Layout of the allocation holding [`EagerTestInstructionFetcherState`] followed by
+    /// `instructions_len` decoded instructions
+    fn allocation_layout(instructions_len: usize) -> Layout {
+        let (layout, instructions_offset) = Layout::new::<EagerTestInstructionFetcherState>()
+            .extend(
+                Layout::array::<ContractInstruction>(instructions_len)
+                    .expect("Decoded instructions fit into memory, they were just allocated; qed"),
+            )
+            .expect("Decoded instructions fit into memory, they were just allocated; qed");
+
+        debug_assert_eq!(instructions_offset, Self::INSTRUCTIONS_OFFSET);
+
+        layout.pad_to_align()
+    }
+
+    fn instantiate(
+        instructions: &[ContractInstruction],
+        base_addr: u64,
+        return_trap_address: u64,
+    ) -> Self {
+        let instructions_len = instructions.len();
+        let layout = Self::allocation_layout(instructions_len);
+        // SAFETY: The state itself is always there, so the layout has non-zero size
+        let state = unsafe { alloc(layout) }.cast::<EagerTestInstructionFetcherState>();
+        let Some(state) = NonNull::new(state) else {
+            handle_alloc_error(layout);
+        };
+
+        // SAFETY: Freshly allocated for exactly this type, correctly aligned
+        unsafe {
+            state.write(EagerTestInstructionFetcherState {
+                instructions_len,
+                base_addr,
+                return_trap_address,
+            });
+        }
+
+        let instance = Self { state };
+
+        // SAFETY: The allocation was made for exactly this many instructions and is distinct from
+        // the ones being copied in
+        unsafe {
+            instance.instructions().copy_from_nonoverlapping(
+                NonNull::from(instructions).cast::<ContractInstruction>(),
+                instructions_len,
+            );
+        }
+
+        instance
+    }
+
+    /// Pointer to the first decoded instruction
+    #[inline(always)]
+    fn instructions(&self) -> NonNull<ContractInstruction> {
+        // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
+        // state
+        unsafe { self.state.byte_add(Self::INSTRUCTIONS_OFFSET) }.cast::<ContractInstruction>()
+    }
+
+    /// Number of decoded instructions
+    #[inline(always)]
+    fn instructions_len(&self) -> usize {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).instructions_len }
+    }
+
+    /// Guest address that corresponds to the first decoded instruction
+    #[inline(always)]
+    fn base_addr(&self) -> u64 {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).base_addr }
+    }
+
+    /// Guest address at which execution stops gracefully
+    #[inline(always)]
+    fn return_trap_address(&self) -> u64 {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).return_trap_address }
+    }
+
+    /// Create a fetcher positioned at the instruction that guest address `pc` corresponds to
+    ///
+    /// # Safety
+    /// `pc` must be a valid and aligned guest address of one of the decoded instructions.
+    #[inline(always)]
+    pub unsafe fn fetcher(&self, pc: u64) -> EagerTestInstructionFetcher<'_> {
+        let instruction_offset = (pc - self.base_addr()) as usize / size_of::<u16>();
+
+        EagerTestInstructionFetcher {
+            // SAFETY: Guaranteed by function contract, meaning `instruction_offset` is within
+            // bounds of the decoded stream
+            next_instruction: unsafe { self.instructions().add(instruction_offset) },
+            state: self.state,
+            instructions: PhantomData,
+        }
+    }
+
+    /// Decode `instructions` and create a new instance holding the result.
+    ///
+    /// `base_addr` is the guest address of the first instruction, and `return_trap_address` is the
+    /// address at which the interpreter will stop execution (gracefully).
+    ///
+    /// # Safety
+    /// The instructions processed must be valid and end with a jump instruction, and
+    /// `return_trap_address` must not fall inside them. Instruction fetching does not compare
+    /// against the return trap, so an address inside the instructions would stop execution when
+    /// jumped to but not when reached by falling through.
+    #[inline(always)]
+    pub unsafe fn decode(instructions: &[u8], return_trap_address: u64, base_addr: u64) -> Self {
+        let mut decoded_instructions: Vec<ContractInstruction> =
+            Vec::with_capacity(instructions.len() / size_of::<u16>());
+
+        let mut offset = 0;
+        while let Some(instruction_bytes) = instructions.get(offset..offset + size_of::<u32>()) {
+            let decoded_instruction = u32::from_le_bytes([
+                instruction_bytes[0],
+                instruction_bytes[1],
+                instruction_bytes[2],
+                instruction_bytes[3],
+            ]);
+            // Use `Unimp` as a fallback, though contract is expected to only contain legal
+            // instructions
+            let decoded_instruction = Instruction::try_decode(decoded_instruction).unwrap_or(
+                ContractInstruction::Unimp {
+                    rs1: Register::ZERO,
+                    rs2: Register::ZERO,
+                },
+            );
+            decoded_instructions.push(decoded_instruction);
+            match decoded_instruction.size() {
+                2 => {
+                    offset += 2;
+                }
+                4 => {
+                    // The second half of a 32-bit instruction is a valid offset and may or may not
+                    // decode to a valid instruction on its own. Try to decode it but ignore
+                    // decoding failures.
+
+                    offset += 2;
+
+                    // Could be both 16-bit and 32-bit instruction, need to handle end of the
+                    // instruction stream
+                    let instruction_word = if let Some(instruction_bytes) =
+                        instructions.get(offset..offset + size_of::<u32>())
+                    {
+                        u32::from_le_bytes([
+                            instruction_bytes[0],
+                            instruction_bytes[1],
+                            instruction_bytes[2],
+                            instruction_bytes[3],
+                        ])
+                    } else {
+                        u32::from_le_bytes([instruction_bytes[2], instruction_bytes[3], 0, 0])
+                    };
+
+                    decoded_instructions.push(Instruction::try_decode(instruction_word).unwrap_or(
+                        ContractInstruction::Unimp {
+                            rs1: Register::ZERO,
+                            rs2: Register::ZERO,
+                        },
+                    ));
+                    offset += 2;
+                }
+                instruction_size => {
+                    unreachable!("Invalid instruction size {instruction_size}, expected 2 or 4");
+                }
+            }
+        }
+
+        let remainder_bytes = instructions.get(offset..).unwrap_or(&[]);
+
+        if remainder_bytes.len() == size_of::<u16>() {
+            let instruction_word =
+                u32::from_le_bytes([remainder_bytes[0], remainder_bytes[1], 0, 0]);
+            decoded_instructions.push(Instruction::try_decode(instruction_word).unwrap_or(
+                ContractInstruction::Unimp {
+                    rs1: Register::ZERO,
+                    rs2: Register::ZERO,
+                },
+            ));
+        }
+
+        Self::instantiate(&decoded_instructions, base_addr, return_trap_address)
+    }
+}
+
+/// Eager instruction fetcher walks instructions that [`EagerTestInstructions`] decoded upfront.
+///
+/// This is a plain `Copy` cursor without a destructor, see [`EagerTestInstructions`] for why.
+#[derive(Copy, Clone)]
 #[repr(C)]
-pub struct EagerTestInstructionFetcher {
+pub struct EagerTestInstructionFetcher<'a> {
     /// The instruction to be returned by the next [`InstructionFetcher::fetch_instruction()`]
     /// call.
     ///
@@ -445,22 +672,22 @@ pub struct EagerTestInstructionFetcher {
     /// retain this in a native register instead of recomputing it from an offset on every
     /// fetch.
     next_instruction: NonNull<ContractInstruction>,
-    /// Everything else the fetcher needs, together with the decoded instructions themselves, in a
-    /// single heap allocation.
-    ///
-    /// This is a raw pointer rather than a `Box` on purpose: `next_instruction` points into the
-    /// same allocation, and going through a `Box` would assert unique access to that allocation on
-    /// every use, invalidating a pointer that must survive across all of them.
+    /// Everything else the fetcher needs, borrowed from [`EagerTestInstructions`]
     state: NonNull<EagerTestInstructionFetcherState>,
+    /// Fetcher borrows the decoded instructions it walks
+    instructions: PhantomData<&'a EagerTestInstructions>,
 }
 
 const {
     // When fetcher is used with threaded dispatch, it must fit into two argument registers to be
     // passed used registers through tail calls
-    assert!(size_of::<EagerTestInstructionFetcher>() == 16);
+    assert!(size_of::<EagerTestInstructionFetcher<'_>>() == 16);
+    // Drop glue on the fetcher would force a stack frame into every fallible handler, see
+    // `EagerTestInstructions` for details
+    assert!(!core::mem::needs_drop::<EagerTestInstructionFetcher<'_>>());
 }
 
-impl fmt::Debug for EagerTestInstructionFetcher {
+impl fmt::Debug for EagerTestInstructionFetcher<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EagerTestInstructionFetcher")
             .field("next_instruction", &self.next_instruction)
@@ -471,44 +698,7 @@ impl fmt::Debug for EagerTestInstructionFetcher {
     }
 }
 
-impl Drop for EagerTestInstructionFetcher {
-    fn drop(&mut self) {
-        let strong_count = self.strong_count();
-        let remaining = strong_count.get() - 1;
-        strong_count.set(remaining);
-
-        if remaining > 0 {
-            return;
-        }
-
-        let layout = Self::allocation_layout(self.instructions_len());
-
-        // SAFETY: Allocated with the global allocator using exactly this layout, and this was the
-        // last fetcher sharing it
-        unsafe {
-            dealloc(self.state.as_ptr().cast::<u8>(), layout);
-        }
-    }
-}
-
-impl Clone for EagerTestInstructionFetcher {
-    fn clone(&self) -> Self {
-        let strong_count = self.strong_count();
-        strong_count.set(
-            strong_count
-                .get()
-                .checked_add(1)
-                .expect("Number of clones can't overflow `usize`; qed"),
-        );
-
-        Self {
-            next_instruction: self.next_instruction,
-            state: self.state,
-        }
-    }
-}
-
-impl<Memory> ProgramCounter<u64, Memory> for EagerTestInstructionFetcher
+impl<Memory> ProgramCounter<u64, Memory> for EagerTestInstructionFetcher<'_>
 where
     Memory: VirtualMemory,
 {
@@ -622,7 +812,7 @@ where
     }
 }
 
-impl<Memory> InstructionFetcher<ContractInstruction, Memory> for EagerTestInstructionFetcher
+impl<Memory> InstructionFetcher<ContractInstruction, Memory> for EagerTestInstructionFetcher<'_>
 where
     Memory: VirtualMemory,
 {
@@ -679,204 +869,40 @@ where
     }
 }
 
-impl EagerTestInstructionFetcher {
-    /// Byte offset of the decoded instructions from the start of the allocation that
-    /// [`Self::state`] points at
-    const INSTRUCTIONS_OFFSET: usize = size_of::<EagerTestInstructionFetcherState>()
-        .next_multiple_of(align_of::<ContractInstruction>());
-
-    /// Layout of the allocation holding [`EagerTestInstructionFetcherState`] followed by
-    /// `instructions_len` decoded instructions
-    fn allocation_layout(instructions_len: usize) -> Layout {
-        let (layout, instructions_offset) = Layout::new::<EagerTestInstructionFetcherState>()
-            .extend(
-                Layout::array::<ContractInstruction>(instructions_len)
-                    .expect("Decoded instructions fit into memory, they were just allocated; qed"),
-            )
-            .expect("Decoded instructions fit into memory, they were just allocated; qed");
-
-        debug_assert_eq!(instructions_offset, Self::INSTRUCTIONS_OFFSET);
-
-        layout.pad_to_align()
-    }
-
-    fn instantiate(
-        instructions: &[ContractInstruction],
-        base_addr: u64,
-        return_trap_address: u64,
-    ) -> Self {
-        let instructions_len = instructions.len();
-        let layout = Self::allocation_layout(instructions_len);
-        // SAFETY: The state itself is always there, so the layout has non-zero size
-        let state = unsafe { alloc(layout) }.cast::<EagerTestInstructionFetcherState>();
-        let Some(state) = NonNull::new(state) else {
-            handle_alloc_error(layout);
-        };
-
-        // SAFETY: Freshly allocated for exactly this type, correctly aligned
-        unsafe {
-            state.write(EagerTestInstructionFetcherState {
-                strong_count: Cell::new(1),
-                instructions_len,
-                base_addr,
-                return_trap_address,
-            });
-        }
-
-        let instance = Self {
-            // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
-            // state, and the position starts at the first of them
-            next_instruction: unsafe { state.byte_add(Self::INSTRUCTIONS_OFFSET) }
-                .cast::<ContractInstruction>(),
-            state,
-        };
-
-        // SAFETY: The allocation was made for exactly this many instructions and is distinct from
-        // the ones being copied in
-        unsafe {
-            instance.instructions().copy_from_nonoverlapping(
-                NonNull::from(instructions).cast::<ContractInstruction>(),
-                instructions_len,
-            );
-        }
-
-        instance
-    }
-
+impl EagerTestInstructionFetcher<'_> {
     /// Pointer to the first decoded instruction
     #[inline(always)]
     fn instructions(&self) -> NonNull<ContractInstruction> {
         // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
         // state
-        unsafe { self.state.byte_add(Self::INSTRUCTIONS_OFFSET) }.cast::<ContractInstruction>()
-    }
-
-    /// Number of fetchers sharing the state
-    #[inline(always)]
-    fn strong_count(&self) -> &Cell<usize> {
-        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
-        unsafe { &(*self.state.as_ptr()).strong_count }
+        unsafe {
+            self.state
+                .byte_add(EagerTestInstructions::INSTRUCTIONS_OFFSET)
+        }
+        .cast::<ContractInstruction>()
     }
 
     /// Number of decoded instructions
     #[inline(always)]
     fn instructions_len(&self) -> usize {
-        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        // SAFETY: State is initialized by `EagerTestInstructions` and borrowed for as long as
+        // `self` is alive
         unsafe { (*self.state.as_ptr()).instructions_len }
     }
 
     /// Guest address that corresponds to the first decoded instruction
     #[inline(always)]
     fn base_addr(&self) -> u64 {
-        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        // SAFETY: State is initialized by `EagerTestInstructions` and borrowed for as long as
+        // `self` is alive
         unsafe { (*self.state.as_ptr()).base_addr }
     }
 
     /// Guest address at which execution stops gracefully
     #[inline(always)]
     fn return_trap_address(&self) -> u64 {
-        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        // SAFETY: State is initialized by `EagerTestInstructions` and borrowed for as long as
+        // `self` is alive
         unsafe { (*self.state.as_ptr()).return_trap_address }
-    }
-
-    /// Decode `instructions` and create a new instance holding the result, with the position at
-    /// the instruction `pc` points at.
-    ///
-    /// `base_addr` is the guest address of the first instruction, and `return_trap_address` is the
-    /// address at which the interpreter will stop execution (gracefully).
-    ///
-    /// # Safety
-    /// The program counter must be valid and aligned, the instructions processed must end with a
-    /// jump instruction, and `return_trap_address` must not fall inside them. Instruction fetching
-    /// does not compare against the return trap, so an address inside the instructions would stop
-    /// execution when jumped to but not when reached by falling through.
-    #[inline(always)]
-    pub unsafe fn new(
-        instructions: &[u8],
-        return_trap_address: u64,
-        base_addr: u64,
-        pc: u64,
-    ) -> Self {
-        let mut decoded_instructions: Vec<ContractInstruction> =
-            Vec::with_capacity(instructions.len() / size_of::<u16>());
-
-        let mut offset = 0;
-        while let Some(instruction_bytes) = instructions.get(offset..offset + size_of::<u32>()) {
-            let decoded_instruction = u32::from_le_bytes([
-                instruction_bytes[0],
-                instruction_bytes[1],
-                instruction_bytes[2],
-                instruction_bytes[3],
-            ]);
-            // Use `Unimp` as a fallback, though contract is expected to only contain legal
-            // instructions
-            let decoded_instruction = Instruction::try_decode(decoded_instruction).unwrap_or(
-                ContractInstruction::Unimp {
-                    rs1: Register::ZERO,
-                    rs2: Register::ZERO,
-                },
-            );
-            decoded_instructions.push(decoded_instruction);
-            match decoded_instruction.size() {
-                2 => {
-                    offset += 2;
-                }
-                4 => {
-                    // The second half of a 32-bit instruction is a valid offset and may or may not
-                    // decode to a valid instruction on its own. Try to decode it but ignore
-                    // decoding failures.
-
-                    offset += 2;
-
-                    // Could be both 16-bit and 32-bit instruction, need to handle end of the
-                    // instruction stream
-                    let instruction_word = if let Some(instruction_bytes) =
-                        instructions.get(offset..offset + size_of::<u32>())
-                    {
-                        u32::from_le_bytes([
-                            instruction_bytes[0],
-                            instruction_bytes[1],
-                            instruction_bytes[2],
-                            instruction_bytes[3],
-                        ])
-                    } else {
-                        u32::from_le_bytes([instruction_bytes[2], instruction_bytes[3], 0, 0])
-                    };
-
-                    decoded_instructions.push(Instruction::try_decode(instruction_word).unwrap_or(
-                        ContractInstruction::Unimp {
-                            rs1: Register::ZERO,
-                            rs2: Register::ZERO,
-                        },
-                    ));
-                    offset += 2;
-                }
-                instruction_size => {
-                    unreachable!("Invalid instruction size {instruction_size}, expected 2 or 4");
-                }
-            }
-        }
-
-        let remainder_bytes = instructions.get(offset..).unwrap_or(&[]);
-
-        if remainder_bytes.len() == size_of::<u16>() {
-            let instruction_word =
-                u32::from_le_bytes([remainder_bytes[0], remainder_bytes[1], 0, 0]);
-            decoded_instructions.push(Instruction::try_decode(instruction_word).unwrap_or(
-                ContractInstruction::Unimp {
-                    rs1: Register::ZERO,
-                    rs2: Register::ZERO,
-                },
-            ));
-        }
-
-        let mut instance = Self::instantiate(&decoded_instructions, base_addr, return_trap_address);
-
-        let instruction_offset = (pc - base_addr) as usize / size_of::<u16>();
-        // SAFETY: Constructor's contract guarantees `pc` is valid, meaning `instruction_offset` is
-        // within bounds of the decoded stream
-        instance.next_instruction = unsafe { instance.instructions().add(instruction_offset) };
-
-        instance
     }
 }

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -6,11 +6,15 @@ use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_io_type::bool::Bool;
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
-use alloc::boxed::Box;
+use alloc::alloc::{alloc, dealloc, handle_alloc_error};
 use alloc::vec::Vec;
+use core::alloc::Layout;
+use core::cell::Cell;
+use core::fmt;
 use core::hint::cold_path;
 use core::mem::offset_of;
 use core::ops::ControlFlow;
+use core::ptr::NonNull;
 
 /// Contract file bytes
 pub const RISCV_CONTRACT_BYTES: &[u8] = cfg_select! {
@@ -384,16 +388,102 @@ impl LazyInstructionFetcher {
     }
 }
 
-/// Eager instruction handler eagerly decodes all instructions upfront
-#[derive(Debug, Clone)]
-#[repr(C, align(16))]
-pub struct EagerTestInstructionFetcher {
-    decoded_instruction_byte_offset: usize,
-    // A simple raw pointer separate field helps LLVM with SROA and aliasing analysis, so it can
-    // retain this pointer in the native register
-    instructions: Box<[ContractInstruction]>,
+/// Everything [`EagerTestInstructionFetcher`] needs besides its position within the decoded
+/// instruction stream.
+///
+/// This lives in a single heap allocation whose tail holds the decoded instructions themselves,
+/// starting [`EagerTestInstructionFetcher::INSTRUCTIONS_OFFSET`] bytes from the beginning of it.
+/// That is what keeps the fetcher itself down to two pointers, so it fits into two argument
+/// registers when threaded through tail-called instruction handlers by value.
+#[derive(Debug)]
+#[repr(C)]
+struct EagerTestInstructionFetcherState {
+    /// Number of fetchers sharing this state.
+    ///
+    /// Threaded execution moves the fetcher into the handler chain and only hands the program
+    /// counter back, so a caller that runs the same program more than once hands over a clone
+    /// each time. Cloning the decoded instructions with it would be the dominant cost of a short
+    /// benchmark run, hence the reference count: a clone is an increment and two pointer copies.
+    strong_count: Cell<usize>,
+    /// Number of decoded instructions stored right after this header
+    instructions_len: usize,
+    /// Guest address that corresponds to the first decoded instruction
     base_addr: u64,
+    /// Guest address at which execution stops gracefully
     return_trap_address: u64,
+}
+
+/// Eager instruction handler eagerly decodes all instructions upfront
+#[repr(C)]
+pub struct EagerTestInstructionFetcher {
+    /// The instruction to be returned by the next [`InstructionFetcher::fetch_instruction()`]
+    /// call.
+    ///
+    /// A pointer rather than an offset helps LLVM with SROA and aliasing analysis, so it can
+    /// retain this in a native register instead of recomputing it from an offset on every
+    /// fetch.
+    next_instruction: NonNull<ContractInstruction>,
+    /// Everything else the fetcher needs, together with the decoded instructions themselves, in a
+    /// single heap allocation.
+    ///
+    /// This is a raw pointer rather than a `Box` on purpose: `next_instruction` points into the
+    /// same allocation, and going through a `Box` would assert unique access to that allocation on
+    /// every use, invalidating a pointer that must survive across all of them.
+    state: NonNull<EagerTestInstructionFetcherState>,
+}
+
+const {
+    // When fetcher is used with threaded dispatch, it must fit into two argument registers to be
+    // passed used registers through tail calls
+    assert!(size_of::<EagerTestInstructionFetcher>() == 16);
+}
+
+impl fmt::Debug for EagerTestInstructionFetcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EagerTestInstructionFetcher")
+            .field("next_instruction", &self.next_instruction)
+            .field("instructions_len", &self.instructions_len())
+            .field("base_addr", &self.base_addr())
+            .field("return_trap_address", &self.return_trap_address())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for EagerTestInstructionFetcher {
+    fn drop(&mut self) {
+        let strong_count = self.strong_count();
+        let remaining = strong_count.get() - 1;
+        strong_count.set(remaining);
+
+        if remaining > 0 {
+            return;
+        }
+
+        let layout = Self::allocation_layout(self.instructions_len());
+
+        // SAFETY: Allocated with the global allocator using exactly this layout, and this was the
+        // last fetcher sharing it
+        unsafe {
+            dealloc(self.state.as_ptr().cast::<u8>(), layout);
+        }
+    }
+}
+
+impl Clone for EagerTestInstructionFetcher {
+    fn clone(&self) -> Self {
+        let strong_count = self.strong_count();
+        strong_count.set(
+            strong_count
+                .get()
+                .checked_add(1)
+                .expect("Number of clones can't overflow `usize`; qed"),
+        );
+
+        Self {
+            next_instruction: self.next_instruction,
+            state: self.state,
+        }
+    }
 }
 
 impl<Memory> ProgramCounter<u64, Memory> for EagerTestInstructionFetcher
@@ -402,8 +492,14 @@ where
 {
     #[inline(always)]
     fn get_pc(&self) -> u64 {
-        self.base_addr
-            + self.decoded_instruction_byte_offset as u64 * size_of::<u16>() as u64
+        let decoded_instruction_byte_offset = self
+            .next_instruction
+            .as_ptr()
+            .addr()
+            .wrapping_sub(self.instructions().as_ptr().addr());
+
+        self.base_addr()
+            + decoded_instruction_byte_offset as u64 * size_of::<u16>() as u64
                 / size_of::<ContractInstruction>() as u64
     }
 
@@ -425,13 +521,21 @@ where
         // Byte offset from the instruction being executed to the branch target. The program counter
         // is advanced during instruction fetching, so that instruction starts `instruction_size`
         // bytes back.
-        let offset = offset as isize - isize::from(instruction_size);
+        let offset = (offset as isize).wrapping_sub(isize::from(instruction_size));
         // Every `size_of::<u16>()` of guest code owns one decoded instruction, so the target is
         // reached by moving within the decoded stream
-        let decoded_instruction_byte_offset =
-            self.decoded_instruction_byte_offset.wrapping_add_signed(
-                offset * (size_of::<ContractInstruction>() / size_of::<u16>()).cast_signed(),
-            );
+        let byte_delta =
+            offset * (size_of::<ContractInstruction>() / size_of::<u16>()).cast_signed();
+        // This may land outside the decoded stream (including before its start), which is fine:
+        // `wrapping_byte_offset()` only computes an address, it never dereferences the pointer, and
+        // the bounds check below rejects such a target before it is ever used
+        let new_next_instruction = self
+            .next_instruction
+            .as_ptr()
+            .wrapping_byte_offset(byte_delta);
+        let decoded_instruction_byte_offset = new_next_instruction
+            .addr()
+            .wrapping_sub(self.instructions().as_ptr().addr());
 
         // A target that does not land on a decoded instruction sits between two guest
         // instructions, which makes it an unaligned instruction rather than something to round to
@@ -440,7 +544,7 @@ where
         // the end of the decoded stream, which a backwards branch that ran off its start wraps
         // around into.
         if decoded_instruction_byte_offset
-            >= self.instructions.len() * size_of::<ContractInstruction>()
+            >= self.instructions_len() * size_of::<ContractInstruction>()
             || !decoded_instruction_byte_offset.is_multiple_of(size_of::<ContractInstruction>())
         {
             cold_path();
@@ -448,7 +552,9 @@ where
             return self.set_pc(memory, pc.wrapping_add_signed(offset as i64));
         }
 
-        self.decoded_instruction_byte_offset = decoded_instruction_byte_offset;
+        // SAFETY: Just checked that `new_next_instruction` lands exactly on a decoded instruction
+        // within the bounds of the (non-empty) decoded stream
+        self.next_instruction = unsafe { NonNull::new_unchecked(new_next_instruction) };
 
         Ok(ControlFlow::Continue(()))
     }
@@ -461,7 +567,7 @@ where
     ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
         let address = pc;
 
-        if address == self.return_trap_address {
+        if address == self.return_trap_address() {
             cold_path();
             return Ok(ControlFlow::Break(()));
         }
@@ -473,7 +579,7 @@ where
             });
         }
 
-        let Some(offset) = address.checked_sub(self.base_addr) else {
+        let Some(offset) = address.checked_sub(self.base_addr()) else {
             cold_path();
             return Err(ExecutionError::OutOfBoundsRead {
                 address: PackedAddress::new(address),
@@ -482,13 +588,13 @@ where
         let offset = offset as usize;
         let instruction_offset = offset / size_of::<u16>();
 
-        if instruction_offset >= self.instructions.len() {
+        if instruction_offset >= self.instructions_len() {
             cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address }.into());
         }
 
-        self.decoded_instruction_byte_offset =
-            instruction_offset * size_of::<ContractInstruction>();
+        // SAFETY: `instruction_offset` was just checked to be within bounds of the decoded stream
+        self.next_instruction = unsafe { self.instructions().add(instruction_offset) };
 
         Ok(ControlFlow::Continue(()))
     }
@@ -506,29 +612,122 @@ where
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
         // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
-        let instruction = unsafe {
-            // Reading through byte offset rather than index to avoid extra computation (converting
-            // an index to a byte offset) on each fetch
-            self.instructions
-                .as_ptr()
-                .byte_add(self.decoded_instruction_byte_offset)
-                .read()
-        };
-        self.decoded_instruction_byte_offset +=
+        let instruction = unsafe { self.next_instruction.read() };
+        let byte_advance =
             usize::from(instruction.size()) / size_of::<u16>() * size_of::<ContractInstruction>();
+        // SAFETY: Same as above: advancing by one instruction from a valid position can't go out of
+        // bounds
+        self.next_instruction = unsafe { self.next_instruction.byte_add(byte_advance) };
 
         FetchInstructionResult::Instruction(instruction)
     }
 }
 
 impl EagerTestInstructionFetcher {
-    /// Create a new instance with the specified instructions and base address.
+    /// Byte offset of the decoded instructions from the start of the allocation that
+    /// [`Self::state`] points at
+    const INSTRUCTIONS_OFFSET: usize = size_of::<EagerTestInstructionFetcherState>()
+        .next_multiple_of(align_of::<ContractInstruction>());
+
+    /// Layout of the allocation holding [`EagerTestInstructionFetcherState`] followed by
+    /// `instructions_len` decoded instructions
+    fn allocation_layout(instructions_len: usize) -> Layout {
+        let (layout, instructions_offset) = Layout::new::<EagerTestInstructionFetcherState>()
+            .extend(
+                Layout::array::<ContractInstruction>(instructions_len)
+                    .expect("Decoded instructions fit into memory, they were just allocated; qed"),
+            )
+            .expect("Decoded instructions fit into memory, they were just allocated; qed");
+
+        debug_assert_eq!(instructions_offset, Self::INSTRUCTIONS_OFFSET);
+
+        layout.pad_to_align()
+    }
+
+    fn instantiate(
+        instructions: &[ContractInstruction],
+        base_addr: u64,
+        return_trap_address: u64,
+    ) -> Self {
+        let instructions_len = instructions.len();
+        let layout = Self::allocation_layout(instructions_len);
+        // SAFETY: The state itself is always there, so the layout has non-zero size
+        let state = unsafe { alloc(layout) }.cast::<EagerTestInstructionFetcherState>();
+        let Some(state) = NonNull::new(state) else {
+            handle_alloc_error(layout);
+        };
+
+        // SAFETY: Freshly allocated for exactly this type, correctly aligned
+        unsafe {
+            state.write(EagerTestInstructionFetcherState {
+                strong_count: Cell::new(1),
+                instructions_len,
+                base_addr,
+                return_trap_address,
+            });
+        }
+
+        let instance = Self {
+            // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
+            // state, and the position starts at the first of them
+            next_instruction: unsafe { state.byte_add(Self::INSTRUCTIONS_OFFSET) }
+                .cast::<ContractInstruction>(),
+            state,
+        };
+
+        // SAFETY: The allocation was made for exactly this many instructions and is distinct from
+        // the ones being copied in
+        unsafe {
+            instance.instructions().copy_from_nonoverlapping(
+                NonNull::from(instructions).cast::<ContractInstruction>(),
+                instructions_len,
+            );
+        }
+
+        instance
+    }
+
+    /// Pointer to the first decoded instruction
+    #[inline(always)]
+    fn instructions(&self) -> NonNull<ContractInstruction> {
+        // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
+        // state
+        unsafe { self.state.byte_add(Self::INSTRUCTIONS_OFFSET) }.cast::<ContractInstruction>()
+    }
+
+    /// Number of fetchers sharing the state
+    #[inline(always)]
+    fn strong_count(&self) -> &Cell<usize> {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { &(*self.state.as_ptr()).strong_count }
+    }
+
+    /// Number of decoded instructions
+    #[inline(always)]
+    fn instructions_len(&self) -> usize {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).instructions_len }
+    }
+
+    /// Guest address that corresponds to the first decoded instruction
+    #[inline(always)]
+    fn base_addr(&self) -> u64 {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).base_addr }
+    }
+
+    /// Guest address at which execution stops gracefully
+    #[inline(always)]
+    fn return_trap_address(&self) -> u64 {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).return_trap_address }
+    }
+
+    /// Decode `instructions` and create a new instance holding the result, with the position at
+    /// the instruction `pc` points at.
     ///
-    /// Instructions are decoded during instantiation of the instruction fetcher, and the base
-    /// address corresponds to the first instruction.
-    ///
-    /// `return_trap_address` is the address at which the interpreter will stop execution
-    /// (gracefully).
+    /// `base_addr` is the guest address of the first instruction, and `return_trap_address` is the
+    /// address at which the interpreter will stop execution (gracefully).
     ///
     /// # Safety
     /// The program counter must be valid and aligned, the instructions processed must end with a
@@ -542,7 +741,8 @@ impl EagerTestInstructionFetcher {
         base_addr: u64,
         pc: u64,
     ) -> Self {
-        let mut decoded_instructions = Vec::with_capacity(instructions.len() / size_of::<u16>());
+        let mut decoded_instructions: Vec<ContractInstruction> =
+            Vec::with_capacity(instructions.len() / size_of::<u16>());
 
         let mut offset = 0;
         while let Some(instruction_bytes) = instructions.get(offset..offset + size_of::<u32>()) {
@@ -614,13 +814,13 @@ impl EagerTestInstructionFetcher {
             ));
         }
 
-        let instructions = decoded_instructions.into_boxed_slice();
-        Self {
-            decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
-                * size_of::<ContractInstruction>(),
-            instructions,
-            base_addr,
-            return_trap_address,
-        }
+        let mut instance = Self::instantiate(&decoded_instructions, base_addr, return_trap_address);
+
+        let instruction_offset = (pc - base_addr) as usize / size_of::<u16>();
+        // SAFETY: Constructor's contract guarantees `pc` is valid, meaning `instruction_offset` is
+        // within bounds of the decoded stream
+        instance.next_instruction = unsafe { instance.instructions().add(instruction_offset) };
+
+        instance
     }
 }

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -352,21 +352,43 @@ where
     Memory: VirtualMemory,
 {
     #[inline]
-    fn fetch_instruction(
-        &mut self,
-        memory: &Memory,
-    ) -> FetchInstructionResult<ContractInstruction> {
+    fn peek_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<ContractInstruction> {
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
-        // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
-        // one instruction can't result in out-of-bounds access.
+        // through `Self::set_pc()` method does the necessary bounds check, so the program counter
+        // always sits on an instruction.
         let instruction = unsafe { memory.read_unchecked(self.pc) };
         // SAFETY: All instructions are valid, according to the constructor contract
         let instruction =
             unsafe { ContractInstruction::try_decode(instruction).unwrap_unchecked() };
 
-        self.pc += u64::from(instruction.size());
-
         FetchInstructionResult::Instruction(instruction)
+    }
+
+    #[inline]
+    unsafe fn advance(&mut self, instruction_size: u8) {
+        self.pc = self.pc.wrapping_add(u64::from(instruction_size));
+    }
+
+    #[inline]
+    fn fetch_instruction(
+        &mut self,
+        memory: &Memory,
+    ) -> FetchInstructionResult<ContractInstruction> {
+        let result =
+            InstructionFetcher::<ContractInstruction, Memory>::peek_instruction(self, memory);
+
+        if let FetchInstructionResult::Instruction(instruction) = result {
+            // SAFETY: The instruction was just peeked successfully, and this is the only place that
+            // moves past it
+            unsafe {
+                InstructionFetcher::<ContractInstruction, Memory>::advance(
+                    self,
+                    instruction.size(),
+                );
+            }
+        }
+
+        result
     }
 }
 
@@ -605,21 +627,55 @@ where
     Memory: VirtualMemory,
 {
     #[inline(always)]
-    fn fetch_instruction(
+    fn peek_instruction(
         &mut self,
         _memory: &Memory,
     ) -> FetchInstructionResult<ContractInstruction> {
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
-        // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
-        // one instruction can't result in out-of-bounds access.
+        // through `Self::set_pc()` method does the necessary bounds check, so the position always
+        // points at a decoded instruction.
         let instruction = unsafe { self.next_instruction.read() };
-        let byte_advance =
-            usize::from(instruction.size()) / size_of::<u16>() * size_of::<ContractInstruction>();
-        // SAFETY: Same as above: advancing by one instruction from a valid position can't go out of
-        // bounds
-        self.next_instruction = unsafe { self.next_instruction.byte_add(byte_advance) };
 
         FetchInstructionResult::Instruction(instruction)
+    }
+
+    #[inline(always)]
+    unsafe fn advance(&mut self, instruction_size: u8) {
+        let byte_advance =
+            usize::from(instruction_size) / size_of::<u16>() * size_of::<ContractInstruction>();
+        // Wrapping because nothing here dereferences the pointer: the contract of this method is
+        // what makes the resulting position a decoded instruction, and the bounds check that
+        // matters lives in `set_pc()`
+        // SAFETY: A wrapped pointer is never null, and nothing here dereferences it
+        self.next_instruction = unsafe {
+            NonNull::new_unchecked(
+                self.next_instruction
+                    .as_ptr()
+                    .wrapping_byte_add(byte_advance),
+            )
+        };
+    }
+
+    #[inline(always)]
+    fn fetch_instruction(
+        &mut self,
+        memory: &Memory,
+    ) -> FetchInstructionResult<ContractInstruction> {
+        let result =
+            InstructionFetcher::<ContractInstruction, Memory>::peek_instruction(self, memory);
+
+        if let FetchInstructionResult::Instruction(instruction) = result {
+            // SAFETY: The instruction was just peeked successfully, and this is the only place that
+            // moves past it
+            unsafe {
+                InstructionFetcher::<ContractInstruction, Memory>::advance(
+                    self,
+                    instruction.size(),
+                );
+            }
+        }
+
+        result
     }
 }
 

--- a/crates/execution/ab-riscv-benchmarks/src/lib.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(target_env = "abundance", no_std)]
+#![cfg_attr(not(target_env = "abundance"), feature(const_block_items))]
 
 #[cfg(not(target_env = "abundance"))]
 pub mod host_utils;

--- a/crates/execution/ab-riscv-benchmarks/tests/basic.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/basic.rs
@@ -1,6 +1,6 @@
 use ab_blake3::OUT_LEN;
 use ab_contract_file::ContractFile;
-use ab_contract_file::instruction::ContractRegisters;
+use ab_contract_file::instruction::{ContractInstruction, ContractRegisters};
 use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_riscv_benchmarks::Benchmarks;
 use ab_riscv_benchmarks::host_utils::{
@@ -22,6 +22,7 @@ const MEMORY_SIZE: usize = 128 * 1024;
 enum RunType {
     Lazy,
     Eager,
+    EagerThreaded,
 }
 
 fn call_method<IA, CIA>(method_name: &str, create_internal_args: CIA, run_type: RunType) -> IA
@@ -55,7 +56,10 @@ where
         );
     }
 
-    let mut regs = ContractRegisters::default();
+    let mut regs = ContractRegisters::<false>::default();
+    // The threaded path uses the register file that keeps reads unconditional
+    let mut threaded_regs = ContractRegisters::<true>::default();
+
     // Internal arguments are the end of the memory region
     let internal_args_addr = MEMORY_BASE_ADDRESS + MEMORY_SIZE as u64 - size_of::<IA>() as u64;
     // Stack pointer must be 16-byte aligned, according to the psABI
@@ -77,6 +81,9 @@ where
     regs.write(Register::A0, internal_args_addr);
     // Stack is between internal arguments and contract memory
     regs.write(Register::SP, stack_pointer);
+    threaded_regs.write(Register::A0, internal_args_addr);
+    // Stack is between internal arguments and contract memory
+    threaded_regs.write(Register::SP, stack_pointer);
 
     let pc = MEMORY_BASE_ADDRESS + u64::from(*methods.get(method_name.as_bytes()).unwrap());
     let memory = match run_type {
@@ -117,6 +124,30 @@ where
             state.execute().unwrap();
 
             state.memory
+        }
+        RunType::EagerThreaded => {
+            // SAFETY: Program counter is trusted
+            let instruction_fetcher = unsafe {
+                EagerTestInstructionFetcher::new(
+                    contract_file.get_code(),
+                    TRAP_ADDRESS,
+                    MEMORY_BASE_ADDRESS
+                        + u64::from(contract_file.header().read_only_section_memory_size),
+                    pc,
+                )
+            };
+
+            ContractInstruction::execute_threaded(
+                instruction_fetcher,
+                &mut threaded_regs,
+                (),
+                &mut memory,
+                IllegalEcallSystemInstructionHandler,
+            )
+            .outcome
+            .unwrap();
+
+            memory
         }
     };
 
@@ -248,6 +279,78 @@ fn ed25519_verify_invalid_eager() {
             Ed25519VerifyInternalArgs::new(internal_args_addr, public_key, signature, other_message)
         },
         RunType::Eager,
+    );
+
+    assert!(!internal_args.result.get());
+}
+
+#[cfg_attr(
+    all(target_arch = "x86_64", not(target_feature = "avx")),
+    ignore = "AVX is not the default feature on x86-64"
+)]
+#[test]
+fn blake3_hash_chunk_eager_threaded() {
+    let data_to_hash = [1; _];
+    let expected_hash = Benchmarks::blake3_hash_chunk(&data_to_hash);
+
+    let internal_args = call_method(
+        "benchmarks_blake3_hash_chunk",
+        |internal_args_addr| Blake3HashChunkInternalArgs::new(internal_args_addr, data_to_hash),
+        RunType::EagerThreaded,
+    );
+    let actual_hash = internal_args.result();
+
+    assert_eq!(expected_hash, actual_hash);
+}
+
+// TODO: Unlock if it becomes fast enough to run in CI
+#[cfg_attr(miri, ignore)]
+#[cfg_attr(
+    all(target_arch = "x86_64", not(target_feature = "avx")),
+    ignore = "AVX is not the default feature on x86-64"
+)]
+#[test]
+fn ed25519_verify_valid_eager_threaded() {
+    let signing_key = SigningKey::from([1; _]);
+    let public_key = Ed25519PublicKey::from(signing_key.verifying_key());
+    let message = [2; OUT_LEN];
+    let signature = Ed25519Signature::from(signing_key.sign(&message));
+
+    assert!(Benchmarks::ed25519_verify(&public_key, &signature, &message).get());
+
+    let internal_args = call_method(
+        "benchmarks_ed25519_verify",
+        |internal_args_addr| {
+            Ed25519VerifyInternalArgs::new(internal_args_addr, public_key, signature, message)
+        },
+        RunType::EagerThreaded,
+    );
+
+    assert!(internal_args.result.get());
+}
+
+// TODO: Unlock if it becomes fast enough to run in CI
+#[cfg_attr(miri, ignore)]
+#[cfg_attr(
+    all(target_arch = "x86_64", not(target_feature = "avx")),
+    ignore = "AVX is not the default feature on x86-64"
+)]
+#[test]
+fn ed25519_verify_invalid_eager_threaded() {
+    let signing_key = SigningKey::from([1; _]);
+    let public_key = Ed25519PublicKey::from(signing_key.verifying_key());
+    let message = [2; OUT_LEN];
+    let other_message = [3; OUT_LEN];
+    let signature = Ed25519Signature::from(signing_key.sign(&message));
+
+    assert!(!Benchmarks::ed25519_verify(&public_key, &signature, &other_message).get());
+
+    let internal_args = call_method(
+        "benchmarks_ed25519_verify",
+        |internal_args_addr| {
+            Ed25519VerifyInternalArgs::new(internal_args_addr, public_key, signature, other_message)
+        },
+        RunType::EagerThreaded,
     );
 
     assert!(!internal_args.result.get());

--- a/crates/execution/ab-riscv-benchmarks/tests/basic.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/basic.rs
@@ -4,7 +4,7 @@ use ab_contract_file::instruction::{ContractInstruction, ContractRegisters};
 use ab_core_primitives::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use ab_riscv_benchmarks::Benchmarks;
 use ab_riscv_benchmarks::host_utils::{
-    Blake3HashChunkInternalArgs, EagerTestInstructionFetcher, Ed25519VerifyInternalArgs,
+    Blake3HashChunkInternalArgs, EagerTestInstructions, Ed25519VerifyInternalArgs,
     LazyInstructionFetcher, RISCV_CONTRACT_BYTES, TestMemory,
 };
 use ab_riscv_interpreter::basic::{BasicInterpreterState, IllegalEcallSystemInstructionHandler};
@@ -103,16 +103,17 @@ where
             state.memory
         }
         RunType::Eager => {
-            // SAFETY: Program counter is trusted
-            let instruction_fetcher = unsafe {
-                EagerTestInstructionFetcher::new(
+            // SAFETY: Contract code is trusted
+            let instructions = unsafe {
+                EagerTestInstructions::decode(
                     contract_file.get_code(),
                     TRAP_ADDRESS,
                     MEMORY_BASE_ADDRESS
                         + u64::from(contract_file.header().read_only_section_memory_size),
-                    pc,
                 )
             };
+            // SAFETY: Program counter is trusted
+            let instruction_fetcher = unsafe { instructions.fetcher(pc) };
 
             let mut state = BasicInterpreterState {
                 regs,
@@ -126,16 +127,17 @@ where
             state.memory
         }
         RunType::EagerThreaded => {
-            // SAFETY: Program counter is trusted
-            let instruction_fetcher = unsafe {
-                EagerTestInstructionFetcher::new(
+            // SAFETY: Contract code is trusted
+            let instructions = unsafe {
+                EagerTestInstructions::decode(
                     contract_file.get_code(),
                     TRAP_ADDRESS,
                     MEMORY_BASE_ADDRESS
                         + u64::from(contract_file.header().read_only_section_memory_size),
-                    pc,
                 )
             };
+            // SAFETY: Program counter is trusted
+            let instruction_fetcher = unsafe { instructions.fetcher(pc) };
 
             ContractInstruction::execute_threaded(
                 instruction_fetcher,

--- a/crates/execution/ab-riscv-benchmarks/tests/instruction_fetcher.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/instruction_fetcher.rs
@@ -6,7 +6,9 @@
 //! handled: the return trap, branches past the end of the stream, branches off its start and
 //! unaligned targets.
 
-use ab_riscv_benchmarks::host_utils::{EagerTestInstructionFetcher, TestMemory};
+use ab_riscv_benchmarks::host_utils::{
+    EagerTestInstructionFetcher, EagerTestInstructions, TestMemory,
+};
 use ab_riscv_interpreter::prelude::*;
 use core::ops::ControlFlow;
 
@@ -34,19 +36,23 @@ fn code() -> Vec<u8> {
 /// Address one past the last instruction
 const END_ADDR: u64 = BASE_ADDR + 5 * 4;
 
+/// Decode [`code()`], which [`new_fetcher()`] then walks
+fn new_instructions(return_trap_address: u64) -> EagerTestInstructions {
+    // SAFETY: The instruction stream ends with a jump
+    unsafe { EagerTestInstructions::decode(&code(), return_trap_address, BASE_ADDR) }
+}
+
 /// Build a fetcher whose program counter sits just after the instruction at `BASE_ADDR + 4`, which
 /// is the state relative branches are resolved from: the program counter is advanced during
 /// instruction fetching, so `set_pc_relative(_, 4, offset)` branches from `BASE_ADDR + 4`
-fn new_fetcher(return_trap_address: u64) -> EagerTestInstructionFetcher {
-    // SAFETY: Program counter is valid and aligned, the instruction stream ends with a jump
-    unsafe {
-        EagerTestInstructionFetcher::new(&code(), return_trap_address, BASE_ADDR, BASE_ADDR + 8)
-    }
+fn new_fetcher(instructions: &EagerTestInstructions) -> EagerTestInstructionFetcher<'_> {
+    // SAFETY: Program counter is valid and aligned
+    unsafe { instructions.fetcher(BASE_ADDR + 8) }
 }
 
 /// Branch by `offset` from the instruction at `BASE_ADDR + 4`
 fn branch(
-    fetcher: &mut EagerTestInstructionFetcher,
+    fetcher: &mut EagerTestInstructionFetcher<'_>,
     offset: i32,
 ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
     let memory = Memory::default();
@@ -55,7 +61,8 @@ fn branch(
 
 #[test]
 fn forward_and_backward_branches_move_within_the_stream() {
-    let mut fetcher = new_fetcher(0);
+    let instructions = new_instructions(0);
+    let mut fetcher = new_fetcher(&instructions);
 
     assert!(
         matches!(branch(&mut fetcher, 8), Ok(ControlFlow::Continue(()))),
@@ -76,7 +83,8 @@ fn forward_and_backward_branches_move_within_the_stream() {
 
 #[test]
 fn branch_to_the_last_instruction_stays_in_bounds() {
-    let mut fetcher = new_fetcher(0);
+    let instructions = new_instructions(0);
+    let mut fetcher = new_fetcher(&instructions);
 
     assert!(
         matches!(branch(&mut fetcher, 12), Ok(ControlFlow::Continue(()))),
@@ -91,7 +99,8 @@ fn branch_to_the_last_instruction_stays_in_bounds() {
 #[test]
 fn branch_to_a_trap_below_the_stream_stops_execution() {
     // The usual arrangement: the trap sentinel sits outside the guest's code
-    let mut fetcher = new_fetcher(0);
+    let instructions = new_instructions(0);
+    let mut fetcher = new_fetcher(&instructions);
 
     // From `BASE_ADDR + 4` down to address 0
     let offset = -i32::try_from(BASE_ADDR + 4).unwrap();
@@ -103,7 +112,8 @@ fn branch_to_a_trap_below_the_stream_stops_execution() {
 
 #[test]
 fn branch_to_a_trap_above_the_stream_stops_execution() {
-    let mut fetcher = new_fetcher(END_ADDR + 4);
+    let instructions = new_instructions(END_ADDR + 4);
+    let mut fetcher = new_fetcher(&instructions);
 
     let offset = i32::try_from(END_ADDR + 4 - (BASE_ADDR + 4)).unwrap();
     assert!(
@@ -114,7 +124,8 @@ fn branch_to_a_trap_above_the_stream_stops_execution() {
 
 #[test]
 fn branch_past_the_end_of_the_stream_is_out_of_bounds() {
-    let mut fetcher = new_fetcher(0);
+    let instructions = new_instructions(0);
+    let mut fetcher = new_fetcher(&instructions);
 
     let error = branch(&mut fetcher, 1024).unwrap_err();
     assert!(
@@ -125,7 +136,8 @@ fn branch_past_the_end_of_the_stream_is_out_of_bounds() {
 
 #[test]
 fn branch_off_the_start_of_the_stream_is_out_of_bounds() {
-    let mut fetcher = new_fetcher(0);
+    let instructions = new_instructions(0);
+    let mut fetcher = new_fetcher(&instructions);
 
     // Lands below `BASE_ADDR`, which underflows the stream rather than wrapping into it
     let error = branch(&mut fetcher, -1024).unwrap_err();
@@ -140,7 +152,8 @@ fn branch_to_an_unaligned_target_is_rejected() {
     // Branch immediates encode a halfword count, so the decoder cannot produce an odd offset and
     // this is not reachable through instruction execution. It is still the rule `set_pc()` applies,
     // and the fast path must not quietly round such a target to a slot boundary instead.
-    let mut fetcher = new_fetcher(0);
+    let instructions = new_instructions(0);
+    let mut fetcher = new_fetcher(&instructions);
 
     let error = branch(&mut fetcher, 3).unwrap_err();
     assert!(
@@ -151,7 +164,8 @@ fn branch_to_an_unaligned_target_is_rejected() {
 
 #[test]
 fn branch_that_wraps_around_the_address_space_is_out_of_bounds() {
-    let mut fetcher = new_fetcher(0);
+    let instructions = new_instructions(0);
+    let mut fetcher = new_fetcher(&instructions);
 
     // Far enough back that the guest address itself wraps around zero
     let error = branch(&mut fetcher, i32::MIN).unwrap_err();

--- a/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
@@ -54,14 +54,11 @@ where
 impl<Reg> ExecutableInstructionOperands for CoremarkInstruction<Reg> {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for CoremarkInstruction<Reg>
-{
-}
+impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for CoremarkInstruction<Reg> {}
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for CoremarkInstruction<Reg>
 where
     Reg: Register,
@@ -78,7 +75,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -2,11 +2,11 @@ use crate::instruction::CoremarkInstruction;
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use core::fmt;
+use core::marker::PhantomData;
 use core::ops::ControlFlow;
 use std::alloc::{Layout, alloc, dealloc, handle_alloc_error};
 use std::hint::cold_path;
 use std::ptr::NonNull;
-use std::slice;
 
 /// Flat guest memory
 #[derive(Debug, Copy, Clone)]
@@ -139,7 +139,7 @@ impl<const BASE_ADDR: u64, const SIZE: usize> Default for GuestMemory<BASE_ADDR,
 /// instruction stream.
 ///
 /// This lives in a single heap allocation whose tail holds the decoded instructions themselves,
-/// starting [`EagerInstructionFetcher::INSTRUCTIONS_OFFSET`] bytes from the beginning of it. That
+/// starting [`EagerInstructions::INSTRUCTIONS_OFFSET`] bytes from the beginning of it. That
 /// is what keeps the fetcher itself down to two pointers, so it fits into two argument registers
 /// when threaded through tail-called instruction handlers by value.
 #[derive(Debug)]
@@ -153,35 +153,26 @@ struct EagerInstructionFetcherState {
     return_trap_address: u64,
 }
 
-/// Eager instruction handler eagerly decodes all instructions upfront
-#[repr(C)]
-pub(crate) struct EagerInstructionFetcher {
-    /// The instruction to be returned by the next [`InstructionFetcher::fetch_instruction()`]
-    /// call.
+/// Instructions decoded upfront, which [`EagerInstructionFetcher`] walks.
+///
+/// Ownership of the allocation lives here rather than in the fetcher because the fetcher is moved
+/// through tail-called instruction handlers by value. A destructor on it would make every handler
+/// that can fail (every load, store, branch and jump) responsible for dropping it on the way out,
+/// which costs a stack frame, callee-saved register spills and a reload in the hot path of each of
+/// them, even though the failing path is never taken.
+pub(crate) struct EagerInstructions {
+    /// State header, together with the decoded instructions themselves, in a single heap
+    /// allocation.
     ///
-    /// A pointer rather than an offset helps LLVM with SROA and aliasing analysis, so it can
-    /// retain this in a native register instead of recomputing it from an offset on every
-    /// fetch.
-    next_instruction: NonNull<CoremarkInstruction>,
-    /// Everything else the fetcher needs, together with the decoded instructions themselves, in a
-    /// single heap allocation.
-    ///
-    /// This is a raw pointer rather than a `Box` on purpose: `next_instruction` points into the
-    /// same allocation, and going through a `Box` would assert unique access to that allocation on
-    /// every use, invalidating a pointer that must survive across all of them.
+    /// This is a raw pointer rather than a `Box` on purpose: fetchers point into the same
+    /// allocation, and going through a `Box` would assert unique access to that allocation on
+    /// every use, invalidating pointers that must survive across all of them.
     state: NonNull<EagerInstructionFetcherState>,
 }
 
-const {
-    // When fetcher is used with threaded dispatch, it must fit into two argument registers to be
-    // passed used registers through tail calls
-    assert!(size_of::<EagerInstructionFetcher>() == 16);
-}
-
-impl fmt::Debug for EagerInstructionFetcher {
+impl fmt::Debug for EagerInstructions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EagerInstructionFetcher")
-            .field("next_instruction", &self.next_instruction)
+        f.debug_struct("EagerInstructions")
             .field("instructions_len", &self.instructions_len())
             .field("base_addr", &self.base_addr())
             .field("return_trap_address", &self.return_trap_address())
@@ -189,7 +180,7 @@ impl fmt::Debug for EagerInstructionFetcher {
     }
 }
 
-impl Drop for EagerInstructionFetcher {
+impl Drop for EagerInstructions {
     fn drop(&mut self) {
         let layout = Self::allocation_layout(self.instructions_len());
 
@@ -201,31 +192,241 @@ impl Drop for EagerInstructionFetcher {
     }
 }
 
-impl Clone for EagerInstructionFetcher {
-    fn clone(&self) -> Self {
-        // Preserve the position within the decoded stream, which is an offset rather than an
-        // address in the freshly allocated copy
-        // SAFETY: Both pointers are derived from the same allocation
-        let next_instruction_byte_offset =
-            unsafe { self.next_instruction.byte_offset_from(self.instructions()) };
-        // SAFETY: The constructor stored exactly this many initialized instructions there
-        let instructions =
-            unsafe { slice::from_raw_parts(self.instructions().as_ptr(), self.instructions_len()) };
+impl EagerInstructions {
+    /// Byte offset of the decoded instructions from the start of the allocation that
+    /// [`Self::state`] points at
+    const INSTRUCTIONS_OFFSET: usize = size_of::<EagerInstructionFetcherState>()
+        .next_multiple_of(align_of::<CoremarkInstruction>());
 
-        let mut clone =
-            Self::instantiate(instructions, self.base_addr(), self.return_trap_address());
-        // SAFETY: The offset was taken from an identically sized allocation
-        clone.next_instruction = unsafe {
-            clone
-                .instructions()
-                .byte_offset(next_instruction_byte_offset)
+    /// Layout of the allocation holding [`EagerInstructionFetcherState`] followed by
+    /// `instructions_len` decoded instructions
+    fn allocation_layout(instructions_len: usize) -> Layout {
+        let (layout, instructions_offset) = Layout::new::<EagerInstructionFetcherState>()
+            .extend(
+                Layout::array::<CoremarkInstruction>(instructions_len)
+                    .expect("Decoded instructions fit into memory, they were just allocated; qed"),
+            )
+            .expect("Decoded instructions fit into memory, they were just allocated; qed");
+
+        debug_assert_eq!(instructions_offset, Self::INSTRUCTIONS_OFFSET);
+
+        layout.pad_to_align()
+    }
+
+    fn instantiate(
+        instructions: &[CoremarkInstruction],
+        base_addr: u64,
+        return_trap_address: u64,
+    ) -> Self {
+        let instructions_len = instructions.len();
+        let layout = Self::allocation_layout(instructions_len);
+        // SAFETY: The state itself is always there, so the layout has non-zero size
+        let state = unsafe { alloc(layout) }.cast::<EagerInstructionFetcherState>();
+        let Some(state) = NonNull::new(state) else {
+            handle_alloc_error(layout);
         };
 
-        clone
+        // SAFETY: Freshly allocated for exactly this type, correctly aligned
+        unsafe {
+            state.write(EagerInstructionFetcherState {
+                instructions_len,
+                base_addr,
+                return_trap_address,
+            });
+        }
+
+        let instance = Self { state };
+
+        // SAFETY: The allocation was made for exactly this many instructions and is distinct from
+        // the ones being copied in
+        unsafe {
+            instance.instructions().copy_from_nonoverlapping(
+                NonNull::from(instructions).cast::<CoremarkInstruction>(),
+                instructions_len,
+            );
+        }
+
+        instance
+    }
+
+    /// Pointer to the first decoded instruction
+    #[inline(always)]
+    fn instructions(&self) -> NonNull<CoremarkInstruction> {
+        // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
+        // state
+        unsafe { self.state.byte_add(Self::INSTRUCTIONS_OFFSET) }.cast::<CoremarkInstruction>()
+    }
+
+    /// Number of decoded instructions
+    #[inline(always)]
+    fn instructions_len(&self) -> usize {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).instructions_len }
+    }
+
+    /// Guest address that corresponds to the first decoded instruction
+    #[inline(always)]
+    fn base_addr(&self) -> u64 {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).base_addr }
+    }
+
+    /// Guest address at which execution stops gracefully
+    #[inline(always)]
+    fn return_trap_address(&self) -> u64 {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).return_trap_address }
+    }
+
+    /// Create a fetcher positioned at the instruction that guest address `pc` corresponds to
+    ///
+    /// # Safety
+    /// `pc` must be a valid and aligned guest address of one of the decoded instructions.
+    #[inline(always)]
+    pub(super) unsafe fn fetcher(&self, pc: u64) -> EagerInstructionFetcher<'_> {
+        let instruction_offset = (pc - self.base_addr()) as usize / size_of::<u16>();
+
+        EagerInstructionFetcher {
+            // SAFETY: Guaranteed by function contract, meaning `instruction_offset` is within
+            // bounds of the decoded stream
+            next_instruction: unsafe { self.instructions().add(instruction_offset) },
+            state: self.state,
+            instructions: PhantomData,
+        }
+    }
+
+    /// Decode `instructions` and create a new instance holding the result.
+    ///
+    /// `base_addr` is the guest address of the first instruction, and `return_trap_address` is the
+    /// address at which the interpreter will stop execution (gracefully).
+    ///
+    /// # Safety
+    /// The instructions processed must end with a jump instruction, and `return_trap_address` must
+    /// not fall inside them. Instruction fetching does not compare against the return trap, so an
+    /// address inside the instructions would stop execution when jumped to but not when reached by
+    /// falling through.
+    #[inline(always)]
+    pub(super) unsafe fn decode(
+        instructions: &[u8],
+        return_trap_address: u64,
+        base_addr: u64,
+    ) -> Self {
+        let mut decoded_instructions: Vec<CoremarkInstruction> =
+            Vec::with_capacity(instructions.len() / size_of::<u16>());
+
+        let mut offset = 0;
+        while let Some(instruction_bytes) = instructions.get(offset..offset + size_of::<u32>()) {
+            let decoded_instruction = u32::from_le_bytes([
+                instruction_bytes[0],
+                instruction_bytes[1],
+                instruction_bytes[2],
+                instruction_bytes[3],
+            ]);
+            // Use `Unimp` as a fallback, though contract is expected to only contain legal
+            // instructions
+            let decoded_instruction = Instruction::try_decode(decoded_instruction).unwrap_or(
+                CoremarkInstruction::Unimp {
+                    rs1: Register::ZERO,
+                    rs2: Register::ZERO,
+                },
+            );
+            decoded_instructions.push(decoded_instruction);
+            match decoded_instruction.size() {
+                2 => {
+                    offset += 2;
+                }
+                4 => {
+                    // The second half of a 32-bit instruction is a valid offset and may or may not
+                    // decode to a valid instruction on its own. Try to decode it but ignore
+                    // decoding failures.
+
+                    offset += 2;
+
+                    // Could be both 16-bit and 32-bit instruction, need to handle end of the
+                    // instruction stream
+                    let instruction_word = if let Some(instruction_bytes) =
+                        instructions.get(offset..offset + size_of::<u32>())
+                    {
+                        u32::from_le_bytes([
+                            instruction_bytes[0],
+                            instruction_bytes[1],
+                            instruction_bytes[2],
+                            instruction_bytes[3],
+                        ])
+                    } else {
+                        u32::from_le_bytes([instruction_bytes[2], instruction_bytes[3], 0, 0])
+                    };
+
+                    decoded_instructions.push(Instruction::try_decode(instruction_word).unwrap_or(
+                        CoremarkInstruction::Unimp {
+                            rs1: Register::ZERO,
+                            rs2: Register::ZERO,
+                        },
+                    ));
+                    offset += 2;
+                }
+                instruction_size => {
+                    unreachable!("Invalid instruction size {instruction_size}, expected 2 or 4");
+                }
+            }
+        }
+
+        let remainder_bytes = instructions.get(offset..).unwrap_or(&[]);
+
+        if remainder_bytes.len() == size_of::<u16>() {
+            let instruction_word =
+                u32::from_le_bytes([remainder_bytes[0], remainder_bytes[1], 0, 0]);
+            decoded_instructions.push(Instruction::try_decode(instruction_word).unwrap_or(
+                CoremarkInstruction::Unimp {
+                    rs1: Register::ZERO,
+                    rs2: Register::ZERO,
+                },
+            ));
+        }
+        Self::instantiate(&decoded_instructions, base_addr, return_trap_address)
     }
 }
 
-impl<Memory> ProgramCounter<u64, Memory> for EagerInstructionFetcher
+/// Eager instruction fetcher walks instructions that [`EagerInstructions`] decoded upfront.
+///
+/// This is a plain `Copy` cursor without a destructor, see [`EagerInstructions`] for why.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub(crate) struct EagerInstructionFetcher<'a> {
+    /// The instruction to be returned by the next [`InstructionFetcher::fetch_instruction()`]
+    /// call.
+    ///
+    /// A pointer rather than an offset helps LLVM with SROA and aliasing analysis, so it can
+    /// retain this in a native register instead of recomputing it from an offset on every
+    /// fetch.
+    next_instruction: NonNull<CoremarkInstruction>,
+    /// Everything else the fetcher needs, borrowed from [`EagerInstructions`]
+    state: NonNull<EagerInstructionFetcherState>,
+    /// Fetcher borrows the decoded instructions it walks
+    instructions: PhantomData<&'a EagerInstructions>,
+}
+
+const {
+    // When fetcher is used with threaded dispatch, it must fit into two argument registers to be
+    // passed used registers through tail calls
+    assert!(size_of::<EagerInstructionFetcher<'_>>() == 16);
+    // Drop glue on the fetcher would force a stack frame into every fallible handler, see
+    // `EagerInstructions` for details
+    assert!(!core::mem::needs_drop::<EagerInstructionFetcher<'_>>());
+}
+
+impl fmt::Debug for EagerInstructionFetcher<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EagerInstructionFetcher")
+            .field("next_instruction", &self.next_instruction)
+            .field("instructions_len", &self.instructions_len())
+            .field("base_addr", &self.base_addr())
+            .field("return_trap_address", &self.return_trap_address())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<Memory> ProgramCounter<u64, Memory> for EagerInstructionFetcher<'_>
 where
     Memory: VirtualMemory,
 {
@@ -339,7 +540,7 @@ where
     }
 }
 
-impl<Memory> InstructionFetcher<CoremarkInstruction, Memory> for EagerInstructionFetcher
+impl<Memory> InstructionFetcher<CoremarkInstruction, Memory> for EagerInstructionFetcher<'_>
 where
     Memory: VirtualMemory,
 {
@@ -396,195 +597,37 @@ where
     }
 }
 
-impl EagerInstructionFetcher {
-    /// Byte offset of the decoded instructions from the start of the allocation that
-    /// [`Self::state`] points at
-    const INSTRUCTIONS_OFFSET: usize = size_of::<EagerInstructionFetcherState>()
-        .next_multiple_of(align_of::<CoremarkInstruction>());
-
-    /// Layout of the allocation holding [`EagerInstructionFetcherState`] followed by
-    /// `instructions_len` decoded instructions
-    fn allocation_layout(instructions_len: usize) -> Layout {
-        let (layout, instructions_offset) = Layout::new::<EagerInstructionFetcherState>()
-            .extend(
-                Layout::array::<CoremarkInstruction>(instructions_len)
-                    .expect("Decoded instructions fit into memory, they were just allocated; qed"),
-            )
-            .expect("Decoded instructions fit into memory, they were just allocated; qed");
-
-        debug_assert_eq!(instructions_offset, Self::INSTRUCTIONS_OFFSET);
-
-        layout.pad_to_align()
-    }
-
-    fn instantiate(
-        instructions: &[CoremarkInstruction],
-        base_addr: u64,
-        return_trap_address: u64,
-    ) -> Self {
-        let instructions_len = instructions.len();
-        let layout = Self::allocation_layout(instructions_len);
-        // SAFETY: The state itself is always there, so the layout has non-zero size
-        let state = unsafe { alloc(layout) }.cast::<EagerInstructionFetcherState>();
-        let Some(state) = NonNull::new(state) else {
-            handle_alloc_error(layout);
-        };
-
-        // SAFETY: Freshly allocated for exactly this type, correctly aligned
-        unsafe {
-            state.write(EagerInstructionFetcherState {
-                instructions_len,
-                base_addr,
-                return_trap_address,
-            });
-        }
-
-        let instance = Self {
-            // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
-            // state, and the position starts at the first of them
-            next_instruction: unsafe { state.byte_add(Self::INSTRUCTIONS_OFFSET) }
-                .cast::<CoremarkInstruction>(),
-            state,
-        };
-
-        // SAFETY: The allocation was made for exactly this many instructions and is distinct from
-        // the ones being copied in
-        unsafe {
-            instance.instructions().copy_from_nonoverlapping(
-                NonNull::from(instructions).cast::<CoremarkInstruction>(),
-                instructions_len,
-            );
-        }
-
-        instance
-    }
-
+impl EagerInstructionFetcher<'_> {
     /// Pointer to the first decoded instruction
     #[inline(always)]
     fn instructions(&self) -> NonNull<CoremarkInstruction> {
         // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
         // state
-        unsafe { self.state.byte_add(Self::INSTRUCTIONS_OFFSET) }.cast::<CoremarkInstruction>()
+        unsafe { self.state.byte_add(EagerInstructions::INSTRUCTIONS_OFFSET) }
+            .cast::<CoremarkInstruction>()
     }
 
     /// Number of decoded instructions
     #[inline(always)]
     fn instructions_len(&self) -> usize {
-        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        // SAFETY: State is initialized by `EagerInstructions` and borrowed for as long as `self`
+        // is alive
         unsafe { (*self.state.as_ptr()).instructions_len }
     }
 
     /// Guest address that corresponds to the first decoded instruction
     #[inline(always)]
     fn base_addr(&self) -> u64 {
-        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        // SAFETY: State is initialized by `EagerInstructions` and borrowed for as long as `self`
+        // is alive
         unsafe { (*self.state.as_ptr()).base_addr }
     }
 
     /// Guest address at which execution stops gracefully
     #[inline(always)]
     fn return_trap_address(&self) -> u64 {
-        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        // SAFETY: State is initialized by `EagerInstructions` and borrowed for as long as `self`
+        // is alive
         unsafe { (*self.state.as_ptr()).return_trap_address }
-    }
-
-    /// Decode `instructions` and create a new instance holding the result, with the position at
-    /// the instruction `pc` points at.
-    ///
-    /// `base_addr` is the guest address of the first instruction, and `return_trap_address` is the
-    /// address at which the interpreter will stop execution (gracefully).
-    ///
-    /// # Safety
-    /// The program counter must be valid and aligned, the instructions processed must end with a
-    /// jump instruction, and `return_trap_address` must not fall inside them. Instruction fetching
-    /// does not compare against the return trap, so an address inside the instructions would stop
-    /// execution when jumped to but not when reached by falling through.
-    #[inline(always)]
-    pub(super) unsafe fn new(
-        instructions: &[u8],
-        return_trap_address: u64,
-        base_addr: u64,
-        pc: u64,
-    ) -> Self {
-        let mut decoded_instructions: Vec<CoremarkInstruction> =
-            Vec::with_capacity(instructions.len() / size_of::<u16>());
-
-        let mut offset = 0;
-        while let Some(instruction_bytes) = instructions.get(offset..offset + size_of::<u32>()) {
-            let decoded_instruction = u32::from_le_bytes([
-                instruction_bytes[0],
-                instruction_bytes[1],
-                instruction_bytes[2],
-                instruction_bytes[3],
-            ]);
-            // Use `Unimp` as a fallback, though contract is expected to only contain legal
-            // instructions
-            let decoded_instruction = Instruction::try_decode(decoded_instruction).unwrap_or(
-                CoremarkInstruction::Unimp {
-                    rs1: Register::ZERO,
-                    rs2: Register::ZERO,
-                },
-            );
-            decoded_instructions.push(decoded_instruction);
-            match decoded_instruction.size() {
-                2 => {
-                    offset += 2;
-                }
-                4 => {
-                    // The second half of a 32-bit instruction is a valid offset and may or may not
-                    // decode to a valid instruction on its own. Try to decode it but ignore
-                    // decoding failures.
-
-                    offset += 2;
-
-                    // Could be both 16-bit and 32-bit instruction, need to handle end of the
-                    // instruction stream
-                    let instruction_word = if let Some(instruction_bytes) =
-                        instructions.get(offset..offset + size_of::<u32>())
-                    {
-                        u32::from_le_bytes([
-                            instruction_bytes[0],
-                            instruction_bytes[1],
-                            instruction_bytes[2],
-                            instruction_bytes[3],
-                        ])
-                    } else {
-                        u32::from_le_bytes([instruction_bytes[2], instruction_bytes[3], 0, 0])
-                    };
-
-                    decoded_instructions.push(Instruction::try_decode(instruction_word).unwrap_or(
-                        CoremarkInstruction::Unimp {
-                            rs1: Register::ZERO,
-                            rs2: Register::ZERO,
-                        },
-                    ));
-                    offset += 2;
-                }
-                instruction_size => {
-                    unreachable!("Invalid instruction size {instruction_size}, expected 2 or 4");
-                }
-            }
-        }
-
-        let remainder_bytes = instructions.get(offset..).unwrap_or(&[]);
-
-        if remainder_bytes.len() == size_of::<u16>() {
-            let instruction_word =
-                u32::from_le_bytes([remainder_bytes[0], remainder_bytes[1], 0, 0]);
-            decoded_instructions.push(Instruction::try_decode(instruction_word).unwrap_or(
-                CoremarkInstruction::Unimp {
-                    rs1: Register::ZERO,
-                    rs2: Register::ZERO,
-                },
-            ));
-        }
-        let mut instance = Self::instantiate(&decoded_instructions, base_addr, return_trap_address);
-
-        let instruction_offset = (pc - base_addr) as usize / size_of::<u16>();
-        // SAFETY: Constructor's contract guarantees `pc` is valid, meaning `instruction_offset` is
-        // within bounds of the decoded stream
-        instance.next_instruction = unsafe { instance.instructions().add(instruction_offset) };
-
-        instance
     }
 }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -344,21 +344,55 @@ where
     Memory: VirtualMemory,
 {
     #[inline(always)]
-    fn fetch_instruction(
+    fn peek_instruction(
         &mut self,
         _memory: &Memory,
     ) -> FetchInstructionResult<CoremarkInstruction> {
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
-        // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
-        // one instruction can't result in out-of-bounds access.
+        // through `Self::set_pc()` method does the necessary bounds check, so the position always
+        // points at a decoded instruction.
         let instruction = unsafe { self.next_instruction.read() };
-        let byte_advance =
-            usize::from(instruction.size()) / size_of::<u16>() * size_of::<CoremarkInstruction>();
-        // SAFETY: Same as above: advancing by one instruction from a valid position can't go out of
-        // bounds
-        self.next_instruction = unsafe { self.next_instruction.byte_add(byte_advance) };
 
         FetchInstructionResult::Instruction(instruction)
+    }
+
+    #[inline(always)]
+    unsafe fn advance(&mut self, instruction_size: u8) {
+        let byte_advance =
+            usize::from(instruction_size) / size_of::<u16>() * size_of::<CoremarkInstruction>();
+        // Wrapping because nothing here dereferences the pointer: the contract of this method is
+        // what makes the resulting position a decoded instruction, and the bounds check that
+        // matters lives in `set_pc()`
+        // SAFETY: A wrapped pointer is never null, and nothing here dereferences it
+        self.next_instruction = unsafe {
+            NonNull::new_unchecked(
+                self.next_instruction
+                    .as_ptr()
+                    .wrapping_byte_add(byte_advance),
+            )
+        };
+    }
+
+    #[inline(always)]
+    fn fetch_instruction(
+        &mut self,
+        memory: &Memory,
+    ) -> FetchInstructionResult<CoremarkInstruction> {
+        let result =
+            InstructionFetcher::<CoremarkInstruction, Memory>::peek_instruction(self, memory);
+
+        if let FetchInstructionResult::Instruction(instruction) = result {
+            // SAFETY: The instruction was just peeked successfully, and this is the only place that
+            // moves past it
+            unsafe {
+                InstructionFetcher::<CoremarkInstruction, Memory>::advance(
+                    self,
+                    instruction.size(),
+                );
+            }
+        }
+
+        result
     }
 }
 

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -1,8 +1,12 @@
 use crate::instruction::CoremarkInstruction;
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
+use core::fmt;
 use core::ops::ControlFlow;
+use std::alloc::{Layout, alloc, dealloc, handle_alloc_error};
 use std::hint::cold_path;
+use std::ptr::NonNull;
+use std::slice;
 
 /// Flat guest memory
 #[derive(Debug, Copy, Clone)]
@@ -131,16 +135,94 @@ impl<const BASE_ADDR: u64, const SIZE: usize> Default for GuestMemory<BASE_ADDR,
     }
 }
 
-/// Eager instruction handler eagerly decodes all instructions upfront
-#[derive(Debug, Clone)]
-#[repr(C, align(16))]
-pub(crate) struct EagerInstructionFetcher {
-    decoded_instruction_byte_offset: usize,
-    // A simple raw pointer separate field helps LLVM with SROA and aliasing analysis, so it can
-    // retain this pointer in the native register
-    instructions: Box<[CoremarkInstruction]>,
+/// Everything [`EagerInstructionFetcher`] needs besides its position within the decoded
+/// instruction stream.
+///
+/// This lives in a single heap allocation whose tail holds the decoded instructions themselves,
+/// starting [`EagerInstructionFetcher::INSTRUCTIONS_OFFSET`] bytes from the beginning of it. That
+/// is what keeps the fetcher itself down to two pointers, so it fits into two argument registers
+/// when threaded through tail-called instruction handlers by value.
+#[derive(Debug)]
+#[repr(C)]
+struct EagerInstructionFetcherState {
+    /// Number of decoded instructions stored right after this header
+    instructions_len: usize,
+    /// Guest address that corresponds to the first decoded instruction
     base_addr: u64,
+    /// Guest address at which execution stops gracefully
     return_trap_address: u64,
+}
+
+/// Eager instruction handler eagerly decodes all instructions upfront
+#[repr(C)]
+pub(crate) struct EagerInstructionFetcher {
+    /// The instruction to be returned by the next [`InstructionFetcher::fetch_instruction()`]
+    /// call.
+    ///
+    /// A pointer rather than an offset helps LLVM with SROA and aliasing analysis, so it can
+    /// retain this in a native register instead of recomputing it from an offset on every
+    /// fetch.
+    next_instruction: NonNull<CoremarkInstruction>,
+    /// Everything else the fetcher needs, together with the decoded instructions themselves, in a
+    /// single heap allocation.
+    ///
+    /// This is a raw pointer rather than a `Box` on purpose: `next_instruction` points into the
+    /// same allocation, and going through a `Box` would assert unique access to that allocation on
+    /// every use, invalidating a pointer that must survive across all of them.
+    state: NonNull<EagerInstructionFetcherState>,
+}
+
+const {
+    // When fetcher is used with threaded dispatch, it must fit into two argument registers to be
+    // passed used registers through tail calls
+    assert!(size_of::<EagerInstructionFetcher>() == 16);
+}
+
+impl fmt::Debug for EagerInstructionFetcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EagerInstructionFetcher")
+            .field("next_instruction", &self.next_instruction)
+            .field("instructions_len", &self.instructions_len())
+            .field("base_addr", &self.base_addr())
+            .field("return_trap_address", &self.return_trap_address())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for EagerInstructionFetcher {
+    fn drop(&mut self) {
+        let layout = Self::allocation_layout(self.instructions_len());
+
+        // SAFETY: Allocated with the global allocator using exactly this layout, and this is the
+        // only owner of the allocation
+        unsafe {
+            dealloc(self.state.as_ptr().cast::<u8>(), layout);
+        }
+    }
+}
+
+impl Clone for EagerInstructionFetcher {
+    fn clone(&self) -> Self {
+        // Preserve the position within the decoded stream, which is an offset rather than an
+        // address in the freshly allocated copy
+        // SAFETY: Both pointers are derived from the same allocation
+        let next_instruction_byte_offset =
+            unsafe { self.next_instruction.byte_offset_from(self.instructions()) };
+        // SAFETY: The constructor stored exactly this many initialized instructions there
+        let instructions =
+            unsafe { slice::from_raw_parts(self.instructions().as_ptr(), self.instructions_len()) };
+
+        let mut clone =
+            Self::instantiate(instructions, self.base_addr(), self.return_trap_address());
+        // SAFETY: The offset was taken from an identically sized allocation
+        clone.next_instruction = unsafe {
+            clone
+                .instructions()
+                .byte_offset(next_instruction_byte_offset)
+        };
+
+        clone
+    }
 }
 
 impl<Memory> ProgramCounter<u64, Memory> for EagerInstructionFetcher
@@ -149,8 +231,14 @@ where
 {
     #[inline(always)]
     fn get_pc(&self) -> u64 {
-        self.base_addr
-            + self.decoded_instruction_byte_offset as u64 * size_of::<u16>() as u64
+        let decoded_instruction_byte_offset = self
+            .next_instruction
+            .as_ptr()
+            .addr()
+            .wrapping_sub(self.instructions().as_ptr().addr());
+
+        self.base_addr()
+            + decoded_instruction_byte_offset as u64 * size_of::<u16>() as u64
                 / size_of::<CoremarkInstruction>() as u64
     }
 
@@ -172,13 +260,21 @@ where
         // Byte offset from the instruction being executed to the branch target. The program counter
         // is advanced during instruction fetching, so that instruction starts `instruction_size`
         // bytes back.
-        let offset = offset as isize - isize::from(instruction_size);
+        let offset = (offset as isize).wrapping_sub(isize::from(instruction_size));
         // Every `size_of::<u16>()` of guest code owns one decoded instruction, so the target is
         // reached by moving within the decoded stream
-        let decoded_instruction_byte_offset =
-            self.decoded_instruction_byte_offset.wrapping_add_signed(
-                offset * (size_of::<CoremarkInstruction>() / size_of::<u16>()).cast_signed(),
-            );
+        let byte_delta =
+            offset * (size_of::<CoremarkInstruction>() / size_of::<u16>()).cast_signed();
+        // This may land outside the decoded stream (including before its start), which is fine:
+        // `wrapping_byte_offset()` only computes an address, it never dereferences the pointer, and
+        // the bounds check below rejects such a target before it is ever used
+        let new_next_instruction = self
+            .next_instruction
+            .as_ptr()
+            .wrapping_byte_offset(byte_delta);
+        let decoded_instruction_byte_offset = new_next_instruction
+            .addr()
+            .wrapping_sub(self.instructions().as_ptr().addr());
 
         // A target that does not land on a decoded instruction sits between two guest
         // instructions, which makes it an unaligned instruction rather than something to round to
@@ -187,7 +283,7 @@ where
         // the end of the decoded stream, which a backwards branch that ran off its start wraps
         // around into.
         if decoded_instruction_byte_offset
-            >= self.instructions.len() * size_of::<CoremarkInstruction>()
+            >= self.instructions_len() * size_of::<CoremarkInstruction>()
             || !decoded_instruction_byte_offset.is_multiple_of(size_of::<CoremarkInstruction>())
         {
             cold_path();
@@ -195,7 +291,9 @@ where
             return self.set_pc(memory, pc.wrapping_add_signed(offset as i64));
         }
 
-        self.decoded_instruction_byte_offset = decoded_instruction_byte_offset;
+        // SAFETY: Just checked that `new_next_instruction` lands exactly on a decoded instruction
+        // within the bounds of the (non-empty) decoded stream
+        self.next_instruction = unsafe { NonNull::new_unchecked(new_next_instruction) };
 
         Ok(ControlFlow::Continue(()))
     }
@@ -208,7 +306,7 @@ where
     ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
         let address = pc;
 
-        if address == self.return_trap_address {
+        if address == self.return_trap_address() {
             cold_path();
             return Ok(ControlFlow::Break(()));
         }
@@ -220,7 +318,7 @@ where
             });
         }
 
-        let Some(offset) = address.checked_sub(self.base_addr) else {
+        let Some(offset) = address.checked_sub(self.base_addr()) else {
             cold_path();
             return Err(ExecutionError::OutOfBoundsRead {
                 address: PackedAddress::new(address),
@@ -229,13 +327,13 @@ where
         let offset = offset as usize;
         let instruction_offset = offset / size_of::<u16>();
 
-        if instruction_offset >= self.instructions.len() {
+        if instruction_offset >= self.instructions_len() {
             cold_path();
             return Err(VirtualMemoryError::OutOfBoundsRead { address }.into());
         }
 
-        self.decoded_instruction_byte_offset =
-            instruction_offset * size_of::<CoremarkInstruction>();
+        // SAFETY: `instruction_offset` was just checked to be within bounds of the decoded stream
+        self.next_instruction = unsafe { self.instructions().add(instruction_offset) };
 
         Ok(ControlFlow::Continue(()))
     }
@@ -253,26 +351,114 @@ where
         // SAFETY: Constructor guarantees that the last instruction is a jump, which means going
         // through `Self::set_pc()` method does the necessary bounds check and advancing forward by
         // one instruction can't result in out-of-bounds access.
-        let instruction = unsafe {
-            // Reading through byte offset rather than index to avoid extra computation (converting
-            // an index to a byte offset) on each fetch
-            self.instructions
-                .as_ptr()
-                .byte_add(self.decoded_instruction_byte_offset)
-                .read()
-        };
-        self.decoded_instruction_byte_offset +=
+        let instruction = unsafe { self.next_instruction.read() };
+        let byte_advance =
             usize::from(instruction.size()) / size_of::<u16>() * size_of::<CoremarkInstruction>();
+        // SAFETY: Same as above: advancing by one instruction from a valid position can't go out of
+        // bounds
+        self.next_instruction = unsafe { self.next_instruction.byte_add(byte_advance) };
 
         FetchInstructionResult::Instruction(instruction)
     }
 }
 
 impl EagerInstructionFetcher {
-    /// Create a new instance with the specified instructions and base address.
+    /// Byte offset of the decoded instructions from the start of the allocation that
+    /// [`Self::state`] points at
+    const INSTRUCTIONS_OFFSET: usize = size_of::<EagerInstructionFetcherState>()
+        .next_multiple_of(align_of::<CoremarkInstruction>());
+
+    /// Layout of the allocation holding [`EagerInstructionFetcherState`] followed by
+    /// `instructions_len` decoded instructions
+    fn allocation_layout(instructions_len: usize) -> Layout {
+        let (layout, instructions_offset) = Layout::new::<EagerInstructionFetcherState>()
+            .extend(
+                Layout::array::<CoremarkInstruction>(instructions_len)
+                    .expect("Decoded instructions fit into memory, they were just allocated; qed"),
+            )
+            .expect("Decoded instructions fit into memory, they were just allocated; qed");
+
+        debug_assert_eq!(instructions_offset, Self::INSTRUCTIONS_OFFSET);
+
+        layout.pad_to_align()
+    }
+
+    fn instantiate(
+        instructions: &[CoremarkInstruction],
+        base_addr: u64,
+        return_trap_address: u64,
+    ) -> Self {
+        let instructions_len = instructions.len();
+        let layout = Self::allocation_layout(instructions_len);
+        // SAFETY: The state itself is always there, so the layout has non-zero size
+        let state = unsafe { alloc(layout) }.cast::<EagerInstructionFetcherState>();
+        let Some(state) = NonNull::new(state) else {
+            handle_alloc_error(layout);
+        };
+
+        // SAFETY: Freshly allocated for exactly this type, correctly aligned
+        unsafe {
+            state.write(EagerInstructionFetcherState {
+                instructions_len,
+                base_addr,
+                return_trap_address,
+            });
+        }
+
+        let instance = Self {
+            // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
+            // state, and the position starts at the first of them
+            next_instruction: unsafe { state.byte_add(Self::INSTRUCTIONS_OFFSET) }
+                .cast::<CoremarkInstruction>(),
+            state,
+        };
+
+        // SAFETY: The allocation was made for exactly this many instructions and is distinct from
+        // the ones being copied in
+        unsafe {
+            instance.instructions().copy_from_nonoverlapping(
+                NonNull::from(instructions).cast::<CoremarkInstruction>(),
+                instructions_len,
+            );
+        }
+
+        instance
+    }
+
+    /// Pointer to the first decoded instruction
+    #[inline(always)]
+    fn instructions(&self) -> NonNull<CoremarkInstruction> {
+        // SAFETY: Decoded instructions are stored at this offset of the same allocation as the
+        // state
+        unsafe { self.state.byte_add(Self::INSTRUCTIONS_OFFSET) }.cast::<CoremarkInstruction>()
+    }
+
+    /// Number of decoded instructions
+    #[inline(always)]
+    fn instructions_len(&self) -> usize {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).instructions_len }
+    }
+
+    /// Guest address that corresponds to the first decoded instruction
+    #[inline(always)]
+    fn base_addr(&self) -> u64 {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).base_addr }
+    }
+
+    /// Guest address at which execution stops gracefully
+    #[inline(always)]
+    fn return_trap_address(&self) -> u64 {
+        // SAFETY: State is initialized in the constructor and valid for as long as `self` is
+        unsafe { (*self.state.as_ptr()).return_trap_address }
+    }
+
+    /// Decode `instructions` and create a new instance holding the result, with the position at
+    /// the instruction `pc` points at.
     ///
-    /// `return_trap_address` is the address at which the interpreter will stop execution
-    /// (gracefully).
+    /// `base_addr` is the guest address of the first instruction, and `return_trap_address` is the
+    /// address at which the interpreter will stop execution (gracefully).
     ///
     /// # Safety
     /// The program counter must be valid and aligned, the instructions processed must end with a
@@ -286,7 +472,8 @@ impl EagerInstructionFetcher {
         base_addr: u64,
         pc: u64,
     ) -> Self {
-        let mut decoded_instructions = Vec::with_capacity(instructions.len() / size_of::<u16>());
+        let mut decoded_instructions: Vec<CoremarkInstruction> =
+            Vec::with_capacity(instructions.len() / size_of::<u16>());
 
         let mut offset = 0;
         while let Some(instruction_bytes) = instructions.get(offset..offset + size_of::<u32>()) {
@@ -357,14 +544,13 @@ impl EagerInstructionFetcher {
                 },
             ));
         }
+        let mut instance = Self::instantiate(&decoded_instructions, base_addr, return_trap_address);
 
-        let instructions = decoded_instructions.into_boxed_slice();
-        Self {
-            decoded_instruction_byte_offset: (pc - base_addr) as usize / size_of::<u16>()
-                * size_of::<CoremarkInstruction>(),
-            instructions,
-            base_addr,
-            return_trap_address,
-        }
+        let instruction_offset = (pc - base_addr) as usize / size_of::<u16>();
+        // SAFETY: Constructor's contract guarantees `pc` is valid, meaning `instruction_offset` is
+        // within bounds of the decoded stream
+        instance.next_instruction = unsafe { instance.instructions().add(instruction_offset) };
+
+        instance
     }
 }

--- a/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/interpreter.rs
@@ -446,18 +446,13 @@ where
     /// Moves within the decoded stream instead of resolving an address and converting it back,
     /// which is what going through [`Self::set_pc()`] would do.
     ///
-    /// One comparison and one test are all this needs to hand every case it does not handle itself
-    /// over to [`Self::set_pc()`]: a target past the end of the decoded stream, a backwards branch
-    /// that ran off its start, and an unaligned target. The return trap sits outside the decoded
-    /// stream, so a branch to it fails the bounds check here and is stopped by [`Self::set_pc()`]
-    /// like any other jump to it.
+    /// One comparison and one test are all this needs to recognize every target it cannot resolve:
+    /// one past the end of the decoded stream, a backwards branch that ran off its start, and an
+    /// unaligned one. The return trap sits outside the decoded stream, so a branch to it fails the
+    /// bounds check here too and is answered by [`Self::failed_branch()`] like any other target
+    /// this refuses.
     #[inline(always)]
-    fn set_pc_relative(
-        &mut self,
-        memory: &Memory,
-        instruction_size: u8,
-        offset: i32,
-    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+    unsafe fn try_set_pc_relative(&mut self, instruction_size: u8, offset: i32) -> bool {
         // Byte offset from the instruction being executed to the branch target. The program counter
         // is advanced during instruction fetching, so that instruction starts `instruction_size`
         // bytes back.
@@ -473,6 +468,11 @@ where
             .next_instruction
             .as_ptr()
             .wrapping_byte_offset(byte_delta);
+        // Stored either way: on the way out it is the target `failed_branch()` reports on, and
+        // until then nothing else is allowed to look at it
+        // SAFETY: A wrapped pointer is never null, and nothing here dereferences it
+        self.next_instruction = unsafe { NonNull::new_unchecked(new_next_instruction) };
+
         let decoded_instruction_byte_offset = new_next_instruction
             .addr()
             .wrapping_sub(self.instructions().as_ptr().addr());
@@ -480,23 +480,37 @@ where
         // A target that does not land on a decoded instruction sits between two guest
         // instructions, which makes it an unaligned instruction rather than something to round to
         // the start of one. That rule lives in `set_pc()`, so rather than restating it here, where
-        // it could drift, such a target simply fails to qualify for the fast path, as does one past
-        // the end of the decoded stream, which a backwards branch that ran off its start wraps
-        // around into.
-        if decoded_instruction_byte_offset
-            >= self.instructions_len() * size_of::<CoremarkInstruction>()
-            || !decoded_instruction_byte_offset.is_multiple_of(size_of::<CoremarkInstruction>())
-        {
-            cold_path();
-            let pc = <Self as ProgramCounter<_, Memory>>::get_pc(self);
-            return self.set_pc(memory, pc.wrapping_add_signed(offset as i64));
-        }
+        // it could drift, such a target simply fails to qualify, as does one past the end of the
+        // decoded stream, which a backwards branch that ran off its start wraps around into.
+        decoded_instruction_byte_offset < self.instructions_len() * size_of::<CoremarkInstruction>()
+            && decoded_instruction_byte_offset.is_multiple_of(size_of::<CoremarkInstruction>())
+    }
 
-        // SAFETY: Just checked that `new_next_instruction` lands exactly on a decoded instruction
-        // within the bounds of the (non-empty) decoded stream
-        self.next_instruction = unsafe { NonNull::new_unchecked(new_next_instruction) };
+    /// Turns the refused target back into an address and hands it to [`Self::set_pc()`], which is
+    /// where the rules about what is and is not an instruction address live.
+    #[cold]
+    #[inline(never)]
+    unsafe fn failed_branch(
+        &mut self,
+        memory: &Memory,
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+        // Signed, because a backwards branch that ran off the start of the decoded stream is
+        // exactly one of the targets that gets here
+        let decoded_instruction_byte_offset = self
+            .next_instruction
+            .as_ptr()
+            .addr()
+            .wrapping_sub(self.instructions().as_ptr().addr())
+            .cast_signed();
+        // Every `size_of::<u16>()` of guest code owns one decoded instruction, and the position is
+        // always that many bytes from the start of the stream, so this is exact
+        let address = self.base_addr().wrapping_add_signed(
+            (decoded_instruction_byte_offset
+                / (size_of::<CoremarkInstruction>() / size_of::<u16>()).cast_signed())
+                as i64,
+        );
 
-        Ok(ControlFlow::Continue(()))
+        self.set_pc(memory, address)
     }
 
     #[inline]

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -6,6 +6,7 @@
     const_try,
     const_try_residual,
     explicit_tail_calls,
+    fn_align,
     signed_bigint_helpers,
     try_blocks
 )]

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -17,7 +17,7 @@ mod time_csr;
 
 use crate::elf::{LoadedElf, load_elf};
 use crate::instruction::CoremarkInstruction;
-use crate::interpreter::{EagerInstructionFetcher, GuestMemory};
+use crate::interpreter::{EagerInstructions, GuestMemory};
 use crate::time_csr::TimeCsrState;
 use ab_riscv_interpreter::basic::{BasicRegisters, IllegalEcallSystemInstructionHandler};
 use ab_riscv_interpreter::prelude::*;
@@ -89,9 +89,10 @@ fn main() -> anyhow::Result<()> {
     regs.write(Reg::A0, 1);
     regs.write(Reg::A1, argv_addr);
 
-    // SAFETY: entry_point is valid and aligned; ELF was produced by a trusted compiler
-    let instruction_fetcher =
-        unsafe { EagerInstructionFetcher::new(text_data, TRAP_ADDRESS, text_addr, entry_point) };
+    // SAFETY: ELF was produced by a trusted compiler
+    let instructions = unsafe { EagerInstructions::decode(text_data, TRAP_ADDRESS, text_addr) };
+    // SAFETY: `entry_point` is valid and aligned
+    let instruction_fetcher = unsafe { instructions.fetcher(entry_point) };
 
     let ThreadedExecutionResult {
         outcome,

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -1,5 +1,6 @@
 #![expect(incomplete_features, reason = "explicit_tail_calls")]
 #![feature(
+    const_block_items,
     const_cmp,
     const_trait_impl,
     const_try,
@@ -15,11 +16,10 @@ mod interpreter;
 mod time_csr;
 
 use crate::elf::{LoadedElf, load_elf};
+use crate::instruction::CoremarkInstruction;
 use crate::interpreter::{EagerInstructionFetcher, GuestMemory};
 use crate::time_csr::TimeCsrState;
-use ab_riscv_interpreter::basic::{
-    BasicInterpreterState, BasicRegisters, IllegalEcallSystemInstructionHandler,
-};
+use ab_riscv_interpreter::basic::{BasicRegisters, IllegalEcallSystemInstructionHandler};
 use ab_riscv_interpreter::prelude::*;
 use ab_riscv_primitives::prelude::*;
 use anyhow::Context;
@@ -59,6 +59,7 @@ fn main() -> anyhow::Result<()> {
             feature to make ELF building required"
         ));
     }
+
     let mut memory = GuestMemory::<MEMORY_BASE_ADDRESS, MEMORY_SIZE>::default();
     let LoadedElf {
         entry_point,
@@ -81,7 +82,7 @@ fn main() -> anyhow::Result<()> {
 
     let host_start = std::time::Instant::now();
 
-    let mut regs = BasicRegisters::default();
+    let mut regs = BasicRegisters::<_, true>::default();
     regs.write(Reg::Ra, TRAP_ADDRESS);
     regs.write(Reg::Sp, stack_pointer);
     regs.write(Reg::Gp, global_pointer);
@@ -92,19 +93,22 @@ fn main() -> anyhow::Result<()> {
     let instruction_fetcher =
         unsafe { EagerInstructionFetcher::new(text_data, TRAP_ADDRESS, text_addr, entry_point) };
 
-    let mut state = BasicInterpreterState {
-        regs,
-        ext_state: TimeCsrState::default(),
-        memory,
+    let ThreadedExecutionResult {
+        outcome,
+        program_counter: _,
+    } = CoremarkInstruction::execute_threaded(
         instruction_fetcher,
-        system_instruction_handler: IllegalEcallSystemInstructionHandler,
-    };
+        &mut regs,
+        &mut TimeCsrState::default(),
+        &mut memory,
+        IllegalEcallSystemInstructionHandler,
+    );
 
-    state.execute().context("Coremark execution failed")?;
+    outcome.context("Coremark execution failed")?;
 
     let host_elapsed = host_start.elapsed();
 
-    let output = read_output(&state.memory, output_buf_addr, output_buf_size)
+    let output = read_output(&memory, output_buf_addr, output_buf_size)
         .context("Coremark output not found in guest memory")?;
     print!("{output}");
 

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -97,8 +97,7 @@ where
 impl<Reg> ExecutableInstructionOperands for TimeCsrInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for TimeCsrInstruction<Reg>
+impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for TimeCsrInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     ExtState: AsMut<TimeCsrState> + AsRef<TimeCsrState>,
@@ -109,7 +108,7 @@ where
         _will_write: bool,
         _raw_value: Reg::Type,
         output_value: &mut Reg::Type,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         const CSR_TIME: u16 = 0xC01;
 
         if csr_index == CSR_TIME {
@@ -126,7 +125,7 @@ where
         csr_index: u16,
         _write_value: Reg::Type,
         _output_value: &mut Reg::Type,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         const CSR_TIME: u16 = 0xC01;
 
         if csr_index == CSR_TIME {
@@ -138,8 +137,8 @@ where
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for TimeCsrInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -156,7 +155,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/Cargo.toml
+++ b/crates/execution/ab-riscv-interpreter/Cargo.toml
@@ -28,6 +28,9 @@ no-panic-const = { workspace = true, optional = true }
 replace_with = { workspace = true }
 thiserror = { workspace = true }
 
+[target.'cfg(all(target_arch = "x86_64", not(target_feature = "avx")))'.dependencies]
+cpufeatures = { workspace = true }
+
 [build-dependencies]
 ab-riscv-macros = { workspace = true, features = ["build"] }
 

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -7,8 +7,8 @@ use crate::zawrs::WrsHandler;
 use crate::{
     Address, BasicInt, ExecutableInstruction, ExecutionError, ExecutionResult,
     FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory, VirtualMemoryError,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, VirtualMemory,
+    VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 #[cfg(feature = "alloc")]
@@ -222,55 +222,6 @@ impl<Regs, ExtState, Memory, IF, InstructionHandler>
                 }
 
                 (Ok(()), instruction_fetcher)
-            },
-        )
-    }
-
-    /// Execute the program with a given basic interpreter state using tail-call-threaded dispatch.
-    ///
-    /// This is [`Self::execute()`] with the central `match` replaced by one handler function per
-    /// instruction variant, chained with guaranteed tail calls. It executes exactly the same
-    /// instruction implementations and produces the same results, trading a larger amount of
-    /// generated code for higher throughput, so which one to call is a property of the workload
-    /// rather than of the program being interpreted.
-    pub fn execute_threaded<I>(&mut self) -> Result<(), ExecutionError<Address<I>>>
-    where
-        Regs: RegisterFile<<I as Instruction>::Reg>,
-        I: for<'a> ThreadedExecutableInstruction<
-                Regs,
-                &'a mut ExtState,
-                Memory,
-                IF,
-                &'a mut InstructionHandler,
-            >,
-        Memory: VirtualMemory,
-        IF: InstructionFetcher<I, Memory>,
-    {
-        // This interpreter state owns both, so what is passed on by value is a borrow of each. A
-        // caller whose extension state and system instruction handler are zero-sized can call
-        // `I::execute_threaded()` with them directly instead and save two argument registers across
-        // the whole chain.
-        let ext_state = &mut self.ext_state;
-        let system_instruction_handler = &mut self.system_instruction_handler;
-        let regs = &mut self.regs;
-        let memory = &mut self.memory;
-
-        replace_with_or_abort_and_return(
-            &mut self.instruction_fetcher,
-            #[inline(always)]
-            |instruction_fetcher| {
-                let ThreadedExecutionResult {
-                    instruction_fetcher,
-                    outcome,
-                } = I::execute_threaded(
-                    instruction_fetcher,
-                    regs,
-                    ext_state,
-                    memory,
-                    system_instruction_handler,
-                );
-
-                (outcome, instruction_fetcher)
             },
         )
     }

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -5,16 +5,15 @@ mod tests;
 
 use crate::zawrs::WrsHandler;
 use crate::{
-    Address, BasicInt, CustomErrorPlaceholder, ExecutableInstruction, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory, VirtualMemoryError,
+    Address, BasicInt, ExecutableInstruction, ExecutionError, ExecutionResult,
+    FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory, VirtualMemoryError,
 };
 use ab_riscv_primitives::prelude::*;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use core::hint::cold_path;
-use core::marker::PhantomData;
 use core::ops::ControlFlow;
 use replace_with::replace_with_or_abort_and_return;
 
@@ -482,17 +481,15 @@ impl<const BASE_ADDR: u64, const SIZE: usize> BasicMemory<BASE_ADDR, SIZE> {
 /// Note that it loads instructions from anywhere in memory. This works, but it is likely that you
 /// want to restrict this to a specific executable region of memory.
 #[derive(Debug, Copy, Clone)]
-pub struct BasicInstructionFetcher<I, CustomError = CustomErrorPlaceholder>
+pub struct BasicInstructionFetcher<I>
 where
     I: Instruction,
 {
     return_trap_address: Address<I>,
     pc: Address<I>,
-    _phantom: PhantomData<CustomError>,
 }
 
-const impl<I, Memory, CustomError> ProgramCounter<Address<I>, Memory, CustomError>
-    for BasicInstructionFetcher<I, CustomError>
+const impl<I, Memory> ProgramCounter<Address<I>, Memory> for BasicInstructionFetcher<I>
 where
     I: [const] Instruction,
     Memory: [const] VirtualMemory,
@@ -508,8 +505,8 @@ where
         memory: &Memory,
         instruction_size: u8,
         offset: i32,
-    ) -> Result<ControlFlow<()>, ExecutionError<Address<I>, CustomError>> {
-        let old_pc = <Self as ProgramCounter<_, Memory, _>>::old_pc(self, instruction_size);
+    ) -> Result<ControlFlow<()>, ExecutionError<Address<I>>> {
+        let old_pc = <Self as ProgramCounter<_, Memory>>::old_pc(self, instruction_size);
         self.set_pc(memory, old_pc.wrapping_add_signed(offset))
     }
 
@@ -519,7 +516,7 @@ where
         &mut self,
         _memory: &Memory,
         pc: Address<I>,
-    ) -> Result<ControlFlow<()>, ExecutionError<Address<I>, CustomError>> {
+    ) -> Result<ControlFlow<()>, ExecutionError<Address<I>>> {
         if pc == self.return_trap_address {
             cold_path();
             return Ok(ControlFlow::Break(()));
@@ -538,15 +535,14 @@ where
     }
 }
 
-const impl<I, Memory, CustomError> InstructionFetcher<I, Memory, CustomError>
-    for BasicInstructionFetcher<I, CustomError>
+const impl<I, Memory> InstructionFetcher<I, Memory> for BasicInstructionFetcher<I>
 where
     I: [const] Instruction,
     Memory: [const] VirtualMemory,
 {
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
-    fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I, CustomError> {
+    fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I> {
         let instruction = match memory.read(self.pc.as_u64()).or_else(const |error| {
             cold_path();
             // Attempt to read a 16-bit compressed instruction
@@ -576,7 +572,7 @@ where
     }
 }
 
-impl<I, CustomError> BasicInstructionFetcher<I, CustomError>
+impl<I> BasicInstructionFetcher<I>
 where
     I: Instruction,
 {
@@ -589,7 +585,6 @@ where
         Self {
             return_trap_address,
             pc,
-            _phantom: PhantomData,
         }
     }
 }
@@ -599,12 +594,11 @@ where
 #[derive(Debug, Default, Clone, Copy)]
 pub struct IllegalEcallSystemInstructionHandler;
 
-const impl<Reg, Regs, Memory, PC, CustomError>
-    SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>
+const impl<Reg, Regs, Memory, PC> SystemInstructionHandler<Reg, Regs, Memory, PC>
     for IllegalEcallSystemInstructionHandler
 where
     Reg: [const] Register,
-    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: [const] ProgramCounter<Reg::Type, Memory>,
 {
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn handle_ecall(
@@ -612,7 +606,7 @@ where
         _regs: &mut Regs,
         _memory: &mut Memory,
         program_counter: &mut PC,
-    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
+    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type>> {
         Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(size_of::<u32>() as u8)),
         })

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -63,17 +63,21 @@ where
     }
 }
 
-/// A basic set of RISC-V GPRs (General Purpose Registers)
+/// A basic set of RISC-V GPRs (General Purpose Registers).
+///
+/// `ZEROSTORE` generic determines whether to zero `x0` register on write instead of checking
+/// register index on read. `match` loop usually performs better with branching, while threaded
+/// execution benefits from zeroing.
 #[derive(Debug, Clone, Copy)]
 #[repr(align(16))]
-pub struct BasicRegisters<Reg>
+pub struct BasicRegisters<Reg, const ZEROSTORE: bool = false>
 where
     Reg: BasicRegister,
 {
     regs: [Reg::Type; Reg::N],
 }
 
-impl<Reg> Default for BasicRegisters<Reg>
+impl<Reg, const ZEROSTORE: bool> Default for BasicRegisters<Reg, ZEROSTORE>
 where
     Reg: BasicRegister,
 {
@@ -85,14 +89,14 @@ where
     }
 }
 
-const impl<Reg> RegisterFile<Reg> for BasicRegisters<Reg>
+const impl<Reg, const ZEROSTORE: bool> RegisterFile<Reg> for BasicRegisters<Reg, ZEROSTORE>
 where
     Reg: [const] BasicRegister,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn read(&self, reg: Reg) -> Reg::Type {
-        if reg == Reg::ZERO {
+        if reg == Reg::ZERO && !ZEROSTORE {
             // Always zero
             return Reg::Type::default();
         }
@@ -106,6 +110,10 @@ where
     fn write(&mut self, reg: Reg, value: Reg::Type) {
         // SAFETY: register offset is always within bounds
         *unsafe { self.regs.get_unchecked_mut(usize::from(reg.offset())) } = value;
+        if ZEROSTORE {
+            // SAFETY: The register file always has at least one slot
+            *unsafe { self.regs.get_unchecked_mut(0) } = Reg::Type::default();
+        }
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -501,7 +501,7 @@ where
 {
     #[inline]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
-    fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I> {
+    fn peek_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I> {
         let instruction = match memory.read(self.pc.as_u64()).or_else(const |error| {
             cold_path();
             // Attempt to read a 16-bit compressed instruction
@@ -525,9 +525,29 @@ where
                 address: PackedAddress::new(self.pc),
             });
         };
-        self.pc += instruction.size().into();
-
         FetchInstructionResult::Instruction(instruction)
+    }
+
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    unsafe fn advance(&mut self, instruction_size: u8) {
+        self.pc = self.pc.wrapping_add_signed(i32::from(instruction_size));
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I> {
+        let result = InstructionFetcher::<I, Memory>::peek_instruction(self, memory);
+
+        if let FetchInstructionResult::Instruction(instruction) = result {
+            // SAFETY: The instruction was just peeked successfully, and this is the only place
+            // that moves past it
+            unsafe {
+                InstructionFetcher::<I, Memory>::advance(self, instruction.size());
+            }
+        }
+
+        result
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -459,14 +459,27 @@ where
     }
 
     #[inline(always)]
-    fn set_pc_relative(
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    unsafe fn try_set_pc_relative(&mut self, instruction_size: u8, offset: i32) -> bool {
+        let old_pc = <Self as ProgramCounter<_, Memory>>::old_pc(self, instruction_size);
+        let pc = old_pc.wrapping_add_signed(offset);
+        // Stored either way: on the way out it is what `failed_branch()` reports on, and until then
+        // nothing else is allowed to look at it
+        self.pc = pc;
+
+        pc != self.return_trap_address && pc.as_u64().is_multiple_of(u64::from(I::alignment()))
+    }
+
+    #[cold]
+    #[inline(never)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    unsafe fn failed_branch(
         &mut self,
         memory: &Memory,
-        instruction_size: u8,
-        offset: i32,
     ) -> Result<ControlFlow<()>, ExecutionError<Address<I>>> {
-        let old_pc = <Self as ProgramCounter<_, Memory>>::old_pc(self, instruction_size);
-        self.set_pc(memory, old_pc.wrapping_add_signed(offset))
+        // The program counter holds the refused target, and `set_pc()` is what says what is wrong
+        // with it
+        self.set_pc(memory, self.pc)
     }
 
     #[inline]

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -149,6 +149,9 @@ impl<Regs, ExtState, Memory, IF, InstructionHandler>
     /// program.
     // TODO: It might be impractical to support `no-panic` here directly in a general case, but it
     //  should be possible to do so for small extensions to verify the workflow
+    //
+    // Make sure each handler starts on a cache line boundary
+    #[rustc_align(64)]
     pub fn execute<I>(&mut self) -> Result<(), ExecutionError<Address<I>>>
     where
         Regs: RegisterFile<<I as Instruction>::Reg>,

--- a/crates/execution/ab-riscv-interpreter/src/basic/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic/tests.rs
@@ -90,14 +90,14 @@ fn test_registers_all_registers() {
 fn test_eregisters_read_write() {
     {
         // Basic read/write
-        let mut regs = BasicRegisters::default();
+        let mut regs = BasicRegisters::<_, false>::default();
         regs.write(EReg::<u64>::A0, 0xdead_beef);
         assert_eq!(regs.read(EReg::<u64>::A0), 0xdead_beef);
     }
 
     {
         // Write to multiple registers
-        let mut regs = BasicRegisters::default();
+        let mut regs = BasicRegisters::<_, false>::default();
         regs.write(EReg::<u64>::A0, 100);
         regs.write(EReg::<u64>::A1, 200);
         regs.write(EReg::<u64>::T0, 300);
@@ -109,7 +109,7 @@ fn test_eregisters_read_write() {
 
     {
         // Overwrite register
-        let mut regs = BasicRegisters::default();
+        let mut regs = BasicRegisters::<_, false>::default();
         regs.write(EReg::<u64>::A0, 100);
         regs.write(EReg::<u64>::A0, 200);
         assert_eq!(regs.read(EReg::<u64>::A0), 200);
@@ -117,7 +117,7 @@ fn test_eregisters_read_write() {
 
     {
         // Full 64-bit values
-        let mut regs = BasicRegisters::default();
+        let mut regs = BasicRegisters::<_, false>::default();
         regs.write(EReg::<u64>::A0, u64::MAX);
         assert_eq!(regs.read(EReg::<u64>::A0), u64::MAX);
 
@@ -130,20 +130,20 @@ fn test_eregisters_read_write() {
 fn test_eregisters_zero_register() {
     {
         // Zero register always reads 0
-        let regs = BasicRegisters::default();
+        let regs = BasicRegisters::<_, false>::default();
         assert_eq!(regs.read(EReg::<u64>::Zero), 0);
     }
 
     {
         // Writes to zero register are ignored
-        let mut regs = BasicRegisters::default();
+        let mut regs = BasicRegisters::<_, false>::default();
         regs.write(EReg::<u64>::Zero, 0xdead_beef);
         assert_eq!(regs.read(EReg::<u64>::Zero), 0);
     }
 
     {
         // Multiple writes to zero register
-        let mut regs = BasicRegisters::default();
+        let mut regs = BasicRegisters::<_, false>::default();
         regs.write(EReg::<u64>::Zero, 100);
         regs.write(EReg::<u64>::Zero, 200);
         regs.write(EReg::<u64>::Zero, u64::MAX);
@@ -154,7 +154,7 @@ fn test_eregisters_zero_register() {
 #[test]
 fn test_eregisters_all_registers() {
     // Test all 16 registers can be written and read independently
-    let mut regs = BasicRegisters::default();
+    let mut regs = BasicRegisters::<_, false>::default();
 
     for i in 1..16 {
         let reg = EReg::<u64>::from_bits(i).unwrap();

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -204,7 +204,9 @@ use alloc::boxed::Box;
 use core::convert::Infallible;
 use core::fmt;
 use core::hint::cold_path;
-use core::marker::Destruct;
+use core::marker::{Destruct, PhantomData};
+#[cfg(all(target_arch = "x86_64", any(not(miri), target_feature = "avx")))]
+use core::mem;
 use core::ops::{ControlFlow, FromResidual, Sub};
 
 type RegisterType<I> = <<I as Instruction>::Reg as Register>::Type;
@@ -522,6 +524,12 @@ where
     /// Custom error
     #[error("Custom error: {0:?}")]
     Custom([u8; 8]),
+    /// Threaded execution is not supported on this platform.
+    ///
+    /// See [`OpaqueThreadedExecutionResult::platform_supported()`] for what makes a platform
+    /// unsupported and why the answer is a run-time one.
+    #[error("Threaded execution is not supported on this platform")]
+    UnsupportedPlatform,
 }
 
 /// Where execution continues after an instruction, or why it could not.
@@ -999,40 +1007,272 @@ where
 /// Unlike [`ExecutionResult`], this is produced exactly once, by the handler that stops the chain
 /// and is not on the per-instruction path.
 ///
-/// The instruction fetcher travels through the chain by value and comes back here to remain
-/// available, exactly as it would be after [`ExecutableInstruction::execute()`].
+/// For performance reasons everything inside has to fit into what the platform returns in
+/// registers, in the shape of [`OpaqueThreadedExecutionResult`]. A caller that needs its fetcher
+/// after execution keeps its own copy and sets the program counter to the correct value after
+/// execution manually.
 #[derive(Debug)]
-pub struct ThreadedExecutionResult<IF, I>
+pub struct ThreadedExecutionResult<I>
 where
     I: Instruction,
 {
-    /// Instruction fetcher as of the moment execution stopped
-    pub instruction_fetcher: IF,
+    /// Program counter as of the moment execution stopped
+    pub program_counter: Address<I>,
     /// Why execution stopped
     pub outcome: Result<(), ExecutionError<Address<I>>>,
 }
 
-impl<IF, I> ThreadedExecutionResult<IF, I>
+impl<I> ThreadedExecutionResult<I>
 where
     I: Instruction,
 {
     /// Execution stopped gracefully
     #[inline(always)]
-    pub const fn stopped(instruction_fetcher: IF) -> Self {
+    pub const fn stopped(program_counter: Address<I>) -> Self {
         Self {
-            instruction_fetcher,
+            program_counter,
             outcome: Ok(()),
         }
     }
 
     /// Execution failed
     #[inline(always)]
-    pub const fn failed(instruction_fetcher: IF, error: ExecutionError<Address<I>>) -> Self {
+    pub const fn failed(program_counter: Address<I>, error: ExecutionError<Address<I>>) -> Self {
         cold_path();
         Self {
-            instruction_fetcher,
+            program_counter,
             outcome: Err(error),
         }
+    }
+}
+
+cfg_select! {
+    all(target_arch = "x86_64", any(not(miri), target_feature = "avx")) => {
+        /// x86-64 System V only returns an aggregate larger than two eightbytes in registers when
+        /// it is a single vector, hence a 256-bit one (a pair of 128-bit vectors classifies as
+        /// memory). Moving one of those needs AVX, which is what makes this the only shape here
+        /// with a run-time platform requirement.
+        type OpaqueLanes = core::arch::x86_64::__m256i;
+    }
+    all(target_arch = "aarch64", any(not(miri), target_feature = "neon")) => {
+        /// AArch64 returns an aggregate larger than 16 bytes in registers only as a homogeneous
+        /// aggregate of up to four members, hence three `u64`.
+        // TODO: `[f64; 3]` is used temporarily due to compiler bug:
+        //  https://github.com/rust-lang/rust/issues/161382
+        type OpaqueLanes = [f64; 3];
+    }
+    _ => {
+        type OpaqueLanes = [u64; 3];
+    }
+}
+
+/// [`ThreadedExecutionResult`] in the shape tail-called handlers return it in.
+///
+/// Threaded handler internally returns this rather than [`ThreadedExecutionResult`] so that the
+/// outcome travels in registers instead of through a hidden out-pointer where possible for
+/// performance reasons (primarily on x86-64 due to a limited number of usable GPRs in the ABI).
+///
+/// On x86-64 the lanes are a 256-bit vector, so producing one of these executes AVX instructions -
+/// see [`Self::platform_supported()`] and [`Self::new()`].
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub struct OpaqueThreadedExecutionResult<I> {
+    lanes: OpaqueLanes,
+    phantom: PhantomData<I>,
+}
+
+impl<I> OpaqueThreadedExecutionResult<I>
+where
+    I: Instruction,
+{
+    const TAG_STOPPED: u64 = 0;
+    const TAG_UNALIGNED_INSTRUCTION: u64 = 1;
+    const TAG_OUT_OF_BOUNDS_READ: u64 = 2;
+    const TAG_OUT_OF_BOUNDS_WRITE: u64 = 3;
+    const TAG_ECALL_UNSUPPORTED: u64 = 4;
+    const TAG_ILLEGAL_INSTRUCTION: u64 = 5;
+    const TAG_CSR_READ_ONLY: u64 = 6;
+    const TAG_CSR_ILLEGAL_READ: u64 = 7;
+    const TAG_CSR_ILLEGAL_WRITE: u64 = 8;
+    const TAG_CSR_UNKNOWN: u64 = 9;
+    const TAG_CSR_INSUFFICIENT_PRIVILEGE: u64 = 10;
+    const TAG_CUSTOM: u64 = 11;
+    const TAG_UNSUPPORTED_PLATFORM: u64 = 12;
+
+    /// Whether this platform can carry an outcome the way [`Self::new()`] does.
+    ///
+    /// It cannot on an x86-64 CPU without AVX, where the lanes are a 256-bit vector: Rust targets
+    /// x86-64-v1 by default, so a runtime check is necessary.
+    ///
+    /// This is called once within [`ThreadedExecutableInstruction::execute_threaded()`].
+    #[cfg_attr(
+        all(target_arch = "x86_64", not(target_feature = "avx")),
+        expect(
+            deprecated,
+            reason = "`cpufeatures` uses a deprecated associated function internally"
+        )
+    )]
+    #[inline(always)]
+    #[must_use]
+    pub fn platform_supported() -> bool {
+        cfg_select! {
+            all(target_arch = "x86_64", not(target_feature = "avx")) => {
+                cpufeatures::new!(cpuid_avx, "avx");
+
+                cpuid_avx::get()
+            }
+            _ => true,
+        }
+    }
+
+    /// Serialize an outcome into the shape handlers return.
+    ///
+    /// # Safety
+    /// [`Self::platform_supported()`] must return `true`.
+    #[inline(always)]
+    pub unsafe fn new(result: ThreadedExecutionResult<I>) -> Self {
+        let program_counter = result.program_counter.as_u64();
+
+        let (tag, payload) = match result.outcome {
+            Ok(()) => (Self::TAG_STOPPED, 0),
+            Err(error) => match error {
+                ExecutionError::UnalignedInstruction { address } => {
+                    (Self::TAG_UNALIGNED_INSTRUCTION, address.get().as_u64())
+                }
+                ExecutionError::OutOfBoundsRead { address } => {
+                    (Self::TAG_OUT_OF_BOUNDS_READ, address.get())
+                }
+                ExecutionError::OutOfBoundsWrite { address } => {
+                    (Self::TAG_OUT_OF_BOUNDS_WRITE, address.get())
+                }
+                ExecutionError::EcallUnsupported { address } => {
+                    (Self::TAG_ECALL_UNSUPPORTED, address.get().as_u64())
+                }
+                ExecutionError::IllegalInstruction { address } => {
+                    (Self::TAG_ILLEGAL_INSTRUCTION, address.get().as_u64())
+                }
+                ExecutionError::CsrReadOnly { csr_index } => {
+                    (Self::TAG_CSR_READ_ONLY, u64::from(csr_index))
+                }
+                ExecutionError::CsrIllegalRead { csr_index } => {
+                    (Self::TAG_CSR_ILLEGAL_READ, u64::from(csr_index))
+                }
+                ExecutionError::CsrIllegalWrite { csr_index } => {
+                    (Self::TAG_CSR_ILLEGAL_WRITE, u64::from(csr_index))
+                }
+                ExecutionError::CsrUnknown { csr_index } => {
+                    (Self::TAG_CSR_UNKNOWN, u64::from(csr_index))
+                }
+                ExecutionError::CsrInsufficientPrivilege {
+                    csr_index,
+                    required,
+                    current,
+                } => (
+                    Self::TAG_CSR_INSUFFICIENT_PRIVILEGE,
+                    u64::from(csr_index)
+                        | (u64::from(required.to_bits()) << 16)
+                        | (u64::from(current.to_bits()) << 24),
+                ),
+                ExecutionError::Custom(error) => (Self::TAG_CUSTOM, u64::from_le_bytes(error)),
+                ExecutionError::UnsupportedPlatform => (Self::TAG_UNSUPPORTED_PLATFORM, 0),
+            },
+        };
+
+        Self {
+            lanes: cfg_select! {
+                all(target_arch = "x86_64", any(not(miri), target_feature = "avx")) => {
+                    // SAFETY: Method contract guarantees that `Self::platform_supported()` was
+                    // called, which ensures that AVX is supported
+                    unsafe {
+                        core::arch::x86_64::_mm256_setr_epi64x(
+                            program_counter.cast_signed(),
+                            tag.cast_signed(),
+                            payload.cast_signed(),
+                            0,
+                        )
+                    }
+                }
+                all(target_arch = "aarch64", any(not(miri), target_feature = "neon")) => {
+                    [program_counter, tag, payload].map(f64::from_bits)
+                }
+                _ => [program_counter, tag, payload],
+            },
+            phantom: PhantomData,
+        }
+    }
+
+    /// Deserialize what [`Self::new()`] produced.
+    ///
+    /// The lanes only ever come from there, in this very crate, which is what makes the
+    /// unknown-tag arm unreachable.
+    #[inline(always)]
+    pub fn into_result(self) -> ThreadedExecutionResult<I> {
+        let [program_counter, tag, payload] =
+            cfg_select! {
+                all(target_arch = "x86_64", any(not(miri), target_feature = "avx")) => {
+                    {
+                        // SAFETY: Same size, alignment is larger than necessary
+                        let [program_counter, tag, payload, _] = unsafe {
+                            mem::transmute::<core::arch::x86_64::__m256i, [u64; 4]>(self.lanes)
+                        };
+
+                        [program_counter, tag, payload]
+                    }
+                }
+                all(target_arch = "aarch64", any(not(miri), target_feature = "neon")) => {
+                    self.lanes.map(f64::to_bits)
+                }
+                _ => self.lanes,
+            };
+
+        let program_counter = Address::<I>::truncate_from_u64(program_counter);
+        let csr_index = payload as u16;
+
+        let error = match tag {
+            Self::TAG_STOPPED => {
+                return ThreadedExecutionResult::stopped(program_counter);
+            }
+            Self::TAG_UNALIGNED_INSTRUCTION => ExecutionError::UnalignedInstruction {
+                address: PackedAddress::new(Address::<I>::truncate_from_u64(payload)),
+            },
+            Self::TAG_OUT_OF_BOUNDS_READ => ExecutionError::OutOfBoundsRead {
+                address: PackedAddress::new(payload),
+            },
+            Self::TAG_OUT_OF_BOUNDS_WRITE => ExecutionError::OutOfBoundsWrite {
+                address: PackedAddress::new(payload),
+            },
+            Self::TAG_ECALL_UNSUPPORTED => ExecutionError::EcallUnsupported {
+                address: PackedAddress::new(Address::<I>::truncate_from_u64(payload)),
+            },
+            Self::TAG_ILLEGAL_INSTRUCTION => ExecutionError::IllegalInstruction {
+                address: PackedAddress::new(Address::<I>::truncate_from_u64(payload)),
+            },
+            Self::TAG_CSR_READ_ONLY => ExecutionError::CsrReadOnly { csr_index },
+            Self::TAG_CSR_ILLEGAL_READ => ExecutionError::CsrIllegalRead { csr_index },
+            Self::TAG_CSR_ILLEGAL_WRITE => ExecutionError::CsrIllegalWrite { csr_index },
+            Self::TAG_CSR_UNKNOWN => ExecutionError::CsrUnknown { csr_index },
+            Self::TAG_CSR_INSUFFICIENT_PRIVILEGE => {
+                // SAFETY: `::new()` constructor created this value with `to_bits()`
+                let required =
+                    unsafe { PrivilegeLevel::from_bits((payload >> 16) as u8).unwrap_unchecked() };
+                // SAFETY: `::new()` constructor created this value with `to_bits()`
+                let current =
+                    unsafe { PrivilegeLevel::from_bits((payload >> 24) as u8).unwrap_unchecked() };
+
+                ExecutionError::CsrInsufficientPrivilege {
+                    csr_index,
+                    required,
+                    current,
+                }
+            }
+            Self::TAG_CUSTOM => ExecutionError::Custom(payload.to_le_bytes()),
+            Self::TAG_UNSUPPORTED_PLATFORM => ExecutionError::UnsupportedPlatform,
+            _ => {
+                unreachable!("Lanes are only ever produced by `new()`; qed");
+            }
+        };
+
+        ThreadedExecutionResult::failed(program_counter, error)
     }
 }
 
@@ -1062,7 +1302,7 @@ where
     /// until execution stops or fails.
     ///
     /// The instruction fetcher is taken by value rather than behind a reference so that it stays in
-    /// registers across the whole handler chain and is returned in [`ThreadedExecutionResult`].
+    /// registers across the whole handler chain.
     ///
     /// `ext_state` and `system_instruction_handler` are taken by value for the same reason and one
     /// more: an owned value can be a zero-sized type, which occupies no argument register at all,
@@ -1077,5 +1317,5 @@ where
         ext_state: ExtState,
         memory: &mut Memory,
         system_instruction_handler: InstructionHandler,
-    ) -> ThreadedExecutionResult<PC, Self>;
+    ) -> ThreadedExecutionResult<Self>;
 }

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -123,6 +123,7 @@
     const_trait_impl,
     const_try,
     explicit_tail_calls,
+    fn_align,
     generic_const_args,
     generic_const_items,
     impl_restriction,

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -329,18 +329,8 @@ where
     }
 }
 
-/// Placeholder for custom errors in [`ExecutionError`]
-#[derive(Debug, Copy, Clone)]
-pub struct CustomErrorPlaceholder;
-
-impl fmt::Display for CustomErrorPlaceholder {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Ok(())
-    }
-}
-
 /// Generic program counter
-pub const trait ProgramCounter<Address, Memory, CustomError = CustomErrorPlaceholder>
+pub const trait ProgramCounter<Address, Memory>
 where
     Address: Copy,
 {
@@ -375,14 +365,14 @@ where
         memory: &Memory,
         instruction_size: u8,
         offset: i32,
-    ) -> Result<ControlFlow<()>, ExecutionError<Address, CustomError>>;
+    ) -> Result<ControlFlow<()>, ExecutionError<Address>>;
 
     /// Set the current value of the program counter
     fn set_pc(
         &mut self,
         memory: &Memory,
         pc: Address,
-    ) -> Result<ControlFlow<()>, ExecutionError<Address, CustomError>>;
+    ) -> Result<ControlFlow<()>, ExecutionError<Address>>;
 }
 
 /// Address wrapper for [`ExecutionError`] with an alignment of 4 rather than its natural one.
@@ -457,10 +447,8 @@ where
 /// bytes; flattened it is 16, which is what lets `Result<_, ExecutionError>` be returned in
 /// registers instead of through a hidden out-pointer. `From` implementations for all three are
 /// provided, so `?` on them keeps working unchanged.
-///
-/// Note that a large `CustomError` will grow this type past that threshold again.
 #[derive(Debug, thiserror::Error)]
-pub enum ExecutionError<Address, CustomError = CustomErrorPlaceholder>
+pub enum ExecutionError<Address>
 where
     Address: Copy,
 {
@@ -532,8 +520,8 @@ where
         current: PrivilegeLevel,
     },
     /// Custom error
-    #[error("Custom error: {0}")]
-    Custom(CustomError),
+    #[error("Custom error: {0:?}")]
+    Custom([u8; 8]),
 }
 
 /// Where execution continues after an instruction, or why it could not.
@@ -543,7 +531,7 @@ where
 /// how the program counter is represented, which is what allows the same bodies to drive both an
 /// interpreter loop that owns a program counter and one that carries it in a register.
 #[derive(Debug)]
-pub enum ExecutionResult<Reg, CustomError = CustomErrorPlaceholder>
+pub enum ExecutionResult<Reg>
 where
     Reg: Register,
 {
@@ -573,7 +561,7 @@ where
     /// Stop execution
     Break,
     /// Execution failed
-    Err(ExecutionError<Reg::Type, CustomError>),
+    Err(ExecutionError<Reg::Type>),
 }
 
 const {
@@ -582,27 +570,23 @@ const {
     assert!(size_of::<ExecutionResult<Reg<u32>>>() <= 16);
 }
 
-const impl<Reg, CustomError> From<ExecutionError<Reg::Type, CustomError>>
-    for ExecutionResult<Reg, CustomError>
+const impl<Reg> From<ExecutionError<Reg::Type>> for ExecutionResult<Reg>
 where
     Reg: Register,
 {
     #[inline(always)]
-    fn from(error: ExecutionError<Reg::Type, CustomError>) -> Self {
+    fn from(error: ExecutionError<Reg::Type>) -> Self {
         cold_path();
         Self::Err(error)
     }
 }
 
-const impl<Reg, CustomError>
-    FromResidual<Result<Infallible, ExecutionError<Reg::Type, CustomError>>>
-    for ExecutionResult<Reg, CustomError>
+const impl<Reg> FromResidual<Result<Infallible, ExecutionError<Reg::Type>>> for ExecutionResult<Reg>
 where
     Reg: Register,
-    CustomError: [const] Destruct,
 {
     #[inline(always)]
-    fn from_residual(residual: Result<Infallible, ExecutionError<Reg::Type, CustomError>>) -> Self {
+    fn from_residual(residual: Result<Infallible, ExecutionError<Reg::Type>>) -> Self {
         match residual {
             Ok(never) => match never {},
             Err(error) => {
@@ -613,8 +597,7 @@ where
     }
 }
 
-const impl<Reg, CustomError> FromResidual<Result<Infallible, VirtualMemoryError>>
-    for ExecutionResult<Reg, CustomError>
+const impl<Reg> FromResidual<Result<Infallible, VirtualMemoryError>> for ExecutionResult<Reg>
 where
     Reg: Register,
 {
@@ -630,14 +613,12 @@ where
     }
 }
 
-const impl<Reg, CustomError> FromResidual<Result<Infallible, CsrError<CustomError>>>
-    for ExecutionResult<Reg, CustomError>
+const impl<Reg> FromResidual<Result<Infallible, CsrError>> for ExecutionResult<Reg>
 where
     Reg: Register,
-    CustomError: [const] Destruct,
 {
     #[inline(always)]
-    fn from_residual(residual: Result<Infallible, CsrError<CustomError>>) -> Self {
+    fn from_residual(residual: Result<Infallible, CsrError>) -> Self {
         match residual {
             Ok(never) => match never {},
             Err(error) => {
@@ -648,7 +629,7 @@ where
     }
 }
 
-const impl<Address, CustomError> From<VirtualMemoryError> for ExecutionError<Address, CustomError>
+const impl<Address> From<VirtualMemoryError> for ExecutionError<Address>
 where
     Address: Copy,
 {
@@ -665,14 +646,12 @@ where
     }
 }
 
-const impl<Address, CustomError> From<CsrError<CustomError>>
-    for ExecutionError<Address, CustomError>
+const impl<Address> From<CsrError> for ExecutionError<Address>
 where
     Address: Copy,
-    CustomError: [const] Destruct,
 {
     #[inline(always)]
-    fn from(value: CsrError<CustomError>) -> Self {
+    fn from(value: CsrError) -> Self {
         match value {
             CsrError::ReadOnly { csr_index } => Self::CsrReadOnly { csr_index },
             CsrError::IllegalRead { csr_index } => Self::CsrIllegalRead { csr_index },
@@ -694,7 +673,7 @@ where
 
 /// Result of [`InstructionFetcher::fetch_instruction()`] call
 #[derive(Debug)]
-pub enum FetchInstructionResult<I, CustomError = CustomErrorPlaceholder>
+pub enum FetchInstructionResult<I>
 where
     I: Instruction,
 {
@@ -705,23 +684,23 @@ where
     /// Stop execution
     Break,
     /// Fetching failed
-    Err(ExecutionError<Address<I>, CustomError>),
+    Err(ExecutionError<Address<I>>),
 }
 
 /// Generic instruction fetcher
-pub const trait InstructionFetcher<I, Memory, CustomError = CustomErrorPlaceholder>
+pub const trait InstructionFetcher<I, Memory>
 where
-    Self: ProgramCounter<Address<I>, Memory, CustomError>,
+    Self: ProgramCounter<Address<I>, Memory>,
     I: Instruction,
 {
     /// Fetch a single instruction at a specified address and advance the program counter on
     /// successful fetch
-    fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I, CustomError>;
+    fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I>;
 }
 
 /// CSR error
 #[derive(Debug, thiserror::Error)]
-pub enum CsrError<CustomError = CustomErrorPlaceholder> {
+pub enum CsrError {
     /// Read only CSR
     #[error("Read only CSR {csr_index:#x}")]
     ReadOnly {
@@ -760,15 +739,14 @@ pub enum CsrError<CustomError = CustomErrorPlaceholder> {
         current: PrivilegeLevel,
     },
     /// Custom error
-    #[error("Custom error: {0}")]
-    Custom(CustomError),
+    #[error("Custom error: {0:?}")]
+    Custom([u8; 8]),
 }
 
 /// CSRs (Control and Status Registers)
-pub const trait Csrs<Reg, CustomError = CustomErrorPlaceholder>
+pub const trait Csrs<Reg>
 where
     Reg: [const] Register,
-    CustomError: [const] Destruct,
 {
     /// Current privilege level
     #[inline(always)]
@@ -777,18 +755,17 @@ where
     }
 
     /// Reads register value
-    fn read_csr(&self, csr_index: u16) -> Result<Reg::Type, CsrError<CustomError>>;
+    fn read_csr(&self, csr_index: u16) -> Result<Reg::Type, CsrError>;
 
     /// Writes register value
-    fn write_csr(&mut self, csr_index: u16, value: Reg::Type) -> Result<(), CsrError<CustomError>>;
+    fn write_csr(&mut self, csr_index: u16, value: Reg::Type) -> Result<(), CsrError>;
 }
 
 // Convenience for threaded execution
-const impl<Reg, CustomError, T> Csrs<Reg, CustomError> for &mut T
+const impl<Reg, T> Csrs<Reg> for &mut T
 where
     Reg: [const] Register,
-    CustomError: [const] Destruct,
-    T: [const] Csrs<Reg, CustomError>,
+    T: [const] Csrs<Reg>,
 {
     #[inline(always)]
     fn privilege_level(&self) -> PrivilegeLevel {
@@ -796,24 +773,19 @@ where
     }
 
     #[inline(always)]
-    fn read_csr(&self, csr_index: u16) -> Result<Reg::Type, CsrError<CustomError>> {
+    fn read_csr(&self, csr_index: u16) -> Result<Reg::Type, CsrError> {
         T::read_csr(self, csr_index)
     }
 
     #[inline(always)]
-    fn write_csr(&mut self, csr_index: u16, value: Reg::Type) -> Result<(), CsrError<CustomError>> {
+    fn write_csr(&mut self, csr_index: u16, value: Reg::Type) -> Result<(), CsrError> {
         T::write_csr(self, csr_index, value)
     }
 }
 
 /// Custom handler for system instructions `ecall` and `ebreak`
-pub const trait SystemInstructionHandler<
-    Reg,
-    Regs,
-    Memory,
-    PC,
-    CustomError = CustomErrorPlaceholder,
-> where
+pub const trait SystemInstructionHandler<Reg, Regs, Memory, PC>
+where
     Reg: Register,
 {
     // TODO: Figure out the correct API for this method
@@ -838,7 +810,7 @@ pub const trait SystemInstructionHandler<
         regs: &mut Regs,
         memory: &mut Memory,
         program_counter: &mut PC,
-    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>>;
+    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type>>;
 
     /// Handle an `ebreak` instruction.
     ///
@@ -855,11 +827,10 @@ pub const trait SystemInstructionHandler<
 }
 
 // Convenience for threaded execution
-const impl<Reg, Regs, Memory, PC, CustomError, T>
-    SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError> for &mut T
+const impl<Reg, Regs, Memory, PC, T> SystemInstructionHandler<Reg, Regs, Memory, PC> for &mut T
 where
     Reg: [const] Register,
-    T: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    T: [const] SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     fn handle_fence(&mut self, pred: u8, succ: u8) {
@@ -877,7 +848,7 @@ where
         regs: &mut Regs,
         memory: &mut Memory,
         program_counter: &mut PC,
-    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type, CustomError>> {
+    ) -> Result<ControlFlow<()>, ExecutionError<Reg::Type>> {
         T::handle_ecall(self, regs, memory, program_counter)
     }
 
@@ -925,7 +896,7 @@ where
     fn get_rs1_rs2_operands(self) -> Rs1Rs2Operands<Self::Reg>;
 }
 
-pub const trait ExecutableInstructionCsr<ExtState, CustomError = CustomErrorPlaceholder>
+pub const trait ExecutableInstructionCsr<ExtState>
 where
     Self: Instruction,
 {
@@ -956,7 +927,7 @@ where
         will_write: bool,
         raw_value: RegisterType<Self>,
         output_value: &mut RegisterType<Self>,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         // These are for cleaner trait API without leading `_` on arguments
         let _: &ExtState = ext_state;
         let _: u16 = csr_index;
@@ -986,7 +957,7 @@ where
         csr_index: u16,
         write_value: RegisterType<Self>,
         output_value: &mut RegisterType<Self>,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         // These are for cleaner trait API without leading `_` on arguments
         let _: &mut ExtState = ext_state;
         let _: u16 = csr_index;
@@ -998,15 +969,9 @@ where
 }
 
 /// Trait for executable instructions
-pub const trait ExecutableInstruction<
-    Regs,
-    ExtState,
-    Memory,
-    PC,
-    InstructionHandler,
-    CustomError = CustomErrorPlaceholder,
-> where
-    Self: ExecutableInstructionOperands + ExecutableInstructionCsr<ExtState, CustomError>,
+pub const trait ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
+where
+    Self: ExecutableInstructionOperands + ExecutableInstructionCsr<ExtState>,
 {
     /// Execute instruction.
     ///
@@ -1026,7 +991,7 @@ pub const trait ExecutableInstruction<
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError>;
+    ) -> ExecutionResult<Self::Reg>;
 }
 
 /// Outcome of [`ThreadedExecutableInstruction::execute_threaded()`].
@@ -1037,17 +1002,17 @@ pub const trait ExecutableInstruction<
 /// The instruction fetcher travels through the chain by value and comes back here to remain
 /// available, exactly as it would be after [`ExecutableInstruction::execute()`].
 #[derive(Debug)]
-pub struct ThreadedExecutionResult<IF, I, CustomError = CustomErrorPlaceholder>
+pub struct ThreadedExecutionResult<IF, I>
 where
     I: Instruction,
 {
     /// Instruction fetcher as of the moment execution stopped
     pub instruction_fetcher: IF,
     /// Why execution stopped
-    pub outcome: Result<(), ExecutionError<Address<I>, CustomError>>,
+    pub outcome: Result<(), ExecutionError<Address<I>>>,
 }
 
-impl<IF, I, CustomError> ThreadedExecutionResult<IF, I, CustomError>
+impl<IF, I> ThreadedExecutionResult<IF, I>
 where
     I: Instruction,
 {
@@ -1062,10 +1027,7 @@ where
 
     /// Execution failed
     #[inline(always)]
-    pub const fn failed(
-        instruction_fetcher: IF,
-        error: ExecutionError<Address<I>, CustomError>,
-    ) -> Self {
+    pub const fn failed(instruction_fetcher: IF, error: ExecutionError<Address<I>>) -> Self {
         cold_path();
         Self {
             instruction_fetcher,
@@ -1091,16 +1053,10 @@ where
 /// This trait is deliberately not `const`, unlike [`ExecutableInstruction`]: dispatch goes through
 /// a table of function pointers, and calls through a function pointer are not allowed in
 /// `const fn`.
-pub trait ThreadedExecutableInstruction<
-    Regs,
-    ExtState,
-    Memory,
-    PC,
-    InstructionHandler,
-    CustomError = CustomErrorPlaceholder,
-> where
-    Self: ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>,
-    PC: InstructionFetcher<Self, Memory, CustomError>,
+pub trait ThreadedExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
+where
+    Self: ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>,
+    PC: InstructionFetcher<Self, Memory>,
 {
     /// Execute instructions starting at the instruction fetcher's current position and continue
     /// until execution stops or fails.
@@ -1121,5 +1077,5 @@ pub trait ThreadedExecutableInstruction<
         ext_state: ExtState,
         memory: &mut Memory,
         system_instruction_handler: InstructionHandler,
-    ) -> ThreadedExecutionResult<PC, Self, CustomError>;
+    ) -> ThreadedExecutionResult<PC, Self>;
 }

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -701,8 +701,31 @@ where
     Self: ProgramCounter<Address<I>, Memory>,
     I: Instruction,
 {
+    /// Read the instruction at the current position, leaving the program counter on it.
+    ///
+    /// [`Self::advance()`] is what moves past it, and the two are separate because of what deriving
+    /// the size from the instruction is costly for threaded dispatch: it makes the address of the
+    /// *next* instruction depend on decoding the current one. In threaded dispatch caller already
+    /// knows which variant it is holding and advances by a constant instead, allowing the next load
+    /// to be issued immediately.
+    fn peek_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I>;
+
+    /// Move the program counter past an instruction of `instruction_size` bytes that
+    /// [`Self::peek_instruction()`] has just returned.
+    ///
+    /// # Safety
+    /// Must be called exactly once after a successful [`Self::peek_instruction()`], with the size
+    /// of the instruction that call returned. Implementations are free to rely on that and skip
+    /// checks accordingly: one over a pre-decoded stream that is known to end with a jump, for
+    /// instance, treats the resulting position as valid without bounds-checking it.
+    unsafe fn advance(&mut self, instruction_size: u8);
+
     /// Fetch a single instruction at a specified address and advance the program counter on
-    /// successful fetch
+    /// successful fetch.
+    ///
+    /// This is [`Self::peek_instruction()`] followed by [`Self::advance()`] and exists for callers
+    /// that do not know what they are about to fetch, which is every caller that dispatches
+    /// through a `match` rather than through per-variant handlers.
     fn fetch_instruction(&mut self, memory: &Memory) -> FetchInstructionResult<I>;
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -358,15 +358,65 @@ where
     /// Apply [`ExecutionResult::Branch`], continuing `offset` bytes from the instruction being
     /// executed.
     ///
-    /// A simple implementation can resolve the offset against the program counter and call
-    /// [`Self::set_pc()`]. Implementation that keeps the program counter as a position in an
-    /// already decoded instruction stream can move within that stream directly, which avoids
-    /// converting an address back into a position.
+    /// This is [`Self::try_set_pc_relative()`] followed, if it refused the target, by
+    /// [`Self::failed_branch()`], and exists for callers that have nothing better to do with a
+    /// refused target than ask what was wrong with it right there.
+    #[inline(always)]
     fn set_pc_relative(
         &mut self,
         memory: &Memory,
         instruction_size: u8,
         offset: i32,
+    ) -> Result<ControlFlow<()>, ExecutionError<Address>>
+    where
+        Self: [const] ProgramCounter<Address, Memory>,
+    {
+        // SAFETY: A refused target is handed straight to `failed_branch()` below, before anything
+        // else can observe the program counter
+        if unsafe { self.try_set_pc_relative(instruction_size, offset) } {
+            return Ok(ControlFlow::Continue(()));
+        }
+
+        cold_path();
+
+        // SAFETY: `try_set_pc_relative()` has just refused the target
+        unsafe { self.failed_branch(memory) }
+    }
+
+    /// Move `offset` bytes from the instruction being executed for targets this can resolve.
+    ///
+    /// A simple implementation can resolve the offset against the program counter and validate it
+    /// the way [`Self::set_pc()`] does. Implementation that keeps the program counter as a position
+    /// in an already decoded instruction stream can move within that stream directly, which avoids
+    /// converting an address back into a position.
+    ///
+    /// Returns `true` when the program counter now points at the target, and `false` when the
+    /// target is not somewhere it may point at.
+    ///
+    /// Separate from [`Self::failed_branch()`] for the sake of threaded dispatch, where working out
+    /// what exactly is wrong with a target is code that no branch or jump ever runs, and inlining
+    /// it into the handler of every one of them puts it between the parts of the interpreter that
+    /// do run frequently. Split this way, a handler can hand a refused target to a cold
+    /// continuation with a tail call, which is the one call that costs it nothing, since nothing it
+    /// holds has to survive one.
+    ///
+    /// # Safety
+    /// When this returns `false`, the program counter is left holding the refused target, which is
+    /// not a position to fetch from - it is what [`Self::failed_branch()`] reads to say what was
+    /// wrong with it. That call must come next before anything else observes the program counter.
+    unsafe fn try_set_pc_relative(&mut self, instruction_size: u8, offset: i32) -> bool;
+
+    /// Say what is wrong with the target [`Self::try_set_pc_relative()`] refused.
+    ///
+    /// Implementations are expected to be `#[cold]` and `#[inline(never)]`: this is the half of
+    /// [`Self::set_pc_relative()`] that a program only reaches on its way out.
+    ///
+    /// # Safety
+    /// Must be called right after [`Self::try_set_pc_relative()`] returned `false`, with nothing in
+    /// between having observed the program counter.
+    unsafe fn failed_branch(
+        &mut self,
+        memory: &Memory,
     ) -> Result<ControlFlow<()>, ExecutionError<Address>>;
 
     /// Set the current value of the program counter

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -695,7 +695,15 @@ where
     Err(ExecutionError<Address<I>>),
 }
 
-/// Generic instruction fetcher
+/// Generic instruction fetcher.
+///
+/// # Performance considerations
+/// In threaded dispatch, the instruction fetcher is moved through the handler chain by value, so it
+/// should have 16 bytes size (next instruction pointer + pointer to extra state) and no drop glue.
+/// A fetcher that owns something is dropped by whichever handler ends execution. Every handler that
+/// can fail is a candidate for that, which forces a stack frame, callee-saved register spills, and
+/// a reload into the hot path of every load, store, branch and jump. A fetcher that only borrows
+/// what it walks (`Copy`, or at least `!needs_drop`) keeps them all frameless and fast.
 pub const trait InstructionFetcher<I, Memory>
 where
     Self: ProgramCounter<Address<I>, Memory>,

--- a/crates/execution/ab-riscv-interpreter/src/prelude.rs
+++ b/crates/execution/ab-riscv-interpreter/src/prelude.rs
@@ -38,7 +38,7 @@ pub use crate::zvbc::zvbc_helpers;
 pub use crate::{
     BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr,
     ExecutableInstructionOperands, ExecutionError, ExecutionResult, FetchInstructionResult,
-    InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
+    InstructionFetcher, OpaqueThreadedExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
     ThreadedExecutionResult, VirtualMemory, VirtualMemoryError,
 };

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
@@ -32,24 +31,20 @@ const impl<Reg> ExecutableInstructionOperands for Rv32Instruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32Instruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32Instruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for Rv32Instruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for Rv32Instruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
     Regs: [const] RegisterFile<Reg>,
     Memory: [const] VirtualMemory,
-    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
-    CustomError: [const] Destruct,
+    PC: [const] ProgramCounter<Reg::Type, Memory>,
+    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
@@ -64,7 +59,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Add { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_add(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -16,9 +16,10 @@ pub mod zk;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
@@ -59,17 +59,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32AInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32AInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32AInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for Rv32AInstruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for Rv32AInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
     Regs: [const] RegisterFile<Reg>,
@@ -89,7 +86,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
@@ -5,8 +5,9 @@ pub mod zalrsc;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZaamoInstruction<Reg> wher
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZaamoInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZaamoInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZaamoInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Amoswap {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZalrscInstruction<Reg> whe
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZalrscInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZalrscInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZalrscInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
@@ -49,7 +47,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Lr {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
@@ -6,8 +6,9 @@ mod tests;
 use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
@@ -8,8 +8,9 @@ pub mod zbs;
 use crate::rv32::b::zbb::rv32_zbb_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b.rs
@@ -21,17 +21,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32BInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32BInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32BInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for Rv32BInstruction<Reg>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for Rv32BInstruction<Reg>
 where
     Reg: Register<Type = u32>,
 {
@@ -48,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zba.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZbaInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZbaInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZbaInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZbaInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
@@ -46,7 +44,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Sh1add { rd, rs1: _, rs2: _ } => {
                 let value = (rs1_value << 1).wrapping_add(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZbbInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZbbInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZbbInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZbbInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Andn { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value & !rs2_value;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbb.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZbcInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZbcInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZbcInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZbcInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Clmul { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbc.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/b/zbs.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZbsInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZbsInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZbsInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZbsInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
@@ -46,7 +44,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Bset { rd, rs1: _, rs2: _ } => {
                 // Only the bottom 5 bits for RV32

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -5,9 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/c/zca.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv32ZcaInstruction<Reg> where
@@ -20,24 +19,21 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZcaInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZcaInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZcaInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZcaInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
     Regs: [const] RegisterFile<Reg>,
     Memory: [const] VirtualMemory,
-    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
-    CustomError: [const] Destruct,
+    PC: [const] ProgramCounter<Reg::Type, Memory>,
+    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
@@ -52,7 +48,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // Quadrant 00
             Self::CAddi4spn { rd, nzuimm } => {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
@@ -19,17 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32MInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32MInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32MInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for Rv32MInstruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for Rv32MInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
     Regs: [const] RegisterFile<Reg>,
@@ -47,7 +44,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Mul { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_mul(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m.rs
@@ -6,8 +6,9 @@ pub mod zmmul;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/m/zmmul.rs
@@ -15,16 +15,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZmmulInstruction<Reg> wher
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZmmulInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZmmulInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZmmulInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
@@ -42,7 +40,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -161,14 +161,21 @@ where
     }
 
     #[inline(always)]
-    fn set_pc_relative(
-        &mut self,
-        memory: &TestMemory,
-        instruction_size: u8,
-        offset: i32,
-    ) -> Result<ControlFlow<()>, ExecutionError<u32>> {
+    unsafe fn try_set_pc_relative(&mut self, instruction_size: u8, offset: i32) -> bool {
         let old_pc = self.old_pc(instruction_size);
-        self.set_pc(memory, old_pc.wrapping_add_signed(offset))
+        self.pc = old_pc.wrapping_add_signed(offset);
+
+        true
+    }
+
+    #[cold]
+    #[inline(never)]
+    unsafe fn failed_branch(
+        &mut self,
+        _memory: &TestMemory,
+    ) -> Result<ControlFlow<()>, ExecutionError<u32>> {
+        // Every target is accepted above, so there is never one to report on
+        unreachable!("`try_set_pc_relative()` never refuses a target")
     }
 
     fn set_pc(

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -301,7 +301,7 @@ impl ReservationSet<Reg<u32>> for ExtState {
 }
 
 pub(crate) type TestInterpreterState<Instruction> = BasicInterpreterState<
-    BasicRegisters<Reg<u32>>,
+    BasicRegisters<Reg<u32>, false>,
     ExtState,
     TestMemory,
     TestInstructionFetcher<Instruction>,
@@ -335,7 +335,7 @@ pub(crate) fn execute<I>(
 where
     I: Instruction<Reg = Reg<u32>>
         + ExecutableInstruction<
-            BasicRegisters<Reg<u32>>,
+            BasicRegisters<Reg<u32>, false>,
             ExtState,
             TestMemory,
             TestInstructionFetcher<I>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/test_utils.rs
@@ -187,7 +187,7 @@ where
     I: Instruction<Reg = Reg<u32>>,
 {
     #[inline]
-    fn fetch_instruction(&mut self, _memory: &TestMemory) -> FetchInstructionResult<I> {
+    fn peek_instruction(&mut self, _memory: &TestMemory) -> FetchInstructionResult<I> {
         if self.pc == self.return_trap_address {
             return FetchInstructionResult::Break;
         }
@@ -204,9 +204,27 @@ where
                 address: PackedAddress::new(self.pc),
             });
         };
-        self.pc += u32::from(instruction.size());
-
         FetchInstructionResult::Instruction(instruction)
+    }
+
+    #[inline]
+    unsafe fn advance(&mut self, instruction_size: u8) {
+        self.pc = self.pc.wrapping_add(u32::from(instruction_size));
+    }
+
+    #[inline]
+    fn fetch_instruction(&mut self, memory: &TestMemory) -> FetchInstructionResult<I> {
+        let result = self.peek_instruction(memory);
+
+        if let FetchInstructionResult::Instruction(instruction) = result {
+            // SAFETY: The instruction was just peeked successfully, and this is the only place that
+            // moves past it
+            unsafe {
+                self.advance(instruction.size());
+            }
+        }
+
+        result
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZabhaInstruction<Reg> wher
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZabhaInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZabhaInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZabhaInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::AmoswapB {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZacasInstruction<Reg> wher
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZacasInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZacasInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZacasInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::AmocasW {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zalasr.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZalasrInstruction<Reg> whe
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZalasrInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZalasrInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZalasrInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::LbAq { rd, rs1: _, rl: _ } => {
                 let addr = u64::from(rs1_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -21,16 +21,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZcbInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZcbInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZcbInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZcbInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -48,7 +46,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }
@@ -60,23 +58,21 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZcbOnlyInstruction<Reg> wh
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZcbOnlyInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZcbOnlyInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZcbOnlyInstruction<Reg>
 where
     Reg: Register<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
+    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -91,7 +87,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::CLbu { rd, rs1: _, uimm } => {
                 let addr = u64::from(rs1_value.wrapping_add(u32::from(uimm)));

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcb.rs
@@ -7,9 +7,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -21,16 +21,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZcmpInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZcmpInstruction<Reg>
-where
-    Reg: ZcmpRegister<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZcmpInstruction<Reg> where
+    Reg: ZcmpRegister<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZcmpInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u32>,
@@ -48,7 +46,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }
@@ -60,23 +58,21 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZcmpOnlyInstruction<Reg> w
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZcmpOnlyInstruction<Reg>
-where
-    Reg: ZcmpRegister<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZcmpOnlyInstruction<Reg> where
+    Reg: ZcmpRegister<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZcmpOnlyInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u32>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
+    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -91,7 +87,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::CmPush { urlist, stack_adj } => {
                 rv32_zcmp_helpers::do_push(regs, memory, urlist, stack_adj)

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp.rs
@@ -7,9 +7,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zce/zcmp/rv32_zcmp_helpers.rs
@@ -7,12 +7,12 @@ use ab_riscv_primitives::prelude::*;
 #[inline]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn do_push<Reg, Regs, Memory, CustomError>(
+pub fn do_push<Reg, Regs, Memory>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u8,
-) -> ExecutionResult<Reg, CustomError>
+) -> ExecutionResult<Reg>
 where
     Reg: ZcmpRegister<Type = u32>,
     Regs: RegisterFile<Reg>,
@@ -36,12 +36,12 @@ where
 #[inline]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn do_pop<Reg, Regs, Memory, CustomError>(
+pub fn do_pop<Reg, Regs, Memory>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u8,
-) -> Result<u32, ExecutionError<Reg::Type, CustomError>>
+) -> Result<u32, ExecutionError<Reg::Type>>
 where
     Reg: ZcmpRegister<Type = u32>,
     Regs: RegisterFile<Reg>,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkb.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZbkbInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZbkbInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZbkbInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZbkbInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Pack { rd, rs1: _, rs2: _ } => {
                 // Pack low 16 bits of rs1 into rd[15:0],

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
@@ -3,8 +3,9 @@
 use crate::rv32::b::zbc::rv32_zbc_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkc.rs
@@ -16,16 +16,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZbkcInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZbkcInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZbkcInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZbkcInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -43,7 +41,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZbkxInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZbkxInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZbkxInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZbkxInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Xperm4 { rd, rs1: _, rs2: _ } => ExecutionResult::Continue {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zbkx.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
@@ -25,16 +25,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZknInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZknInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZknInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZknInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -52,7 +50,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn.rs
@@ -12,8 +12,9 @@ use crate::rv32::zk::zkn::zkne::rv32_zkne_helpers;
 use crate::rv32::zk::zkn::zknh::rv32_zknh_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZkndInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZkndInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZkndInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZkndInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Aes32Dsi {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknd.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZkneInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZkneInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZkneInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZkneInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Aes32Esi {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zkne.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv32ZknhInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv32ZknhInstruction<Reg>
-where
-    Reg: Register<Type = u32>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv32ZknhInstruction<Reg> where
+    Reg: Register<Type = u32>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv32ZknhInstruction<Reg>
 where
     Reg: Register<Type = u32>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // SHA-256 (single-register)
             Self::Sha256Sig0 { rd, rs1: _ } => {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zk/zkn/zknh.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -18,9 +18,10 @@ pub mod zk;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64.rs
@@ -24,7 +24,6 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 use core::ops::ControlFlow;
 
 #[instruction_execution]
@@ -34,24 +33,20 @@ const impl<Reg> ExecutableInstructionOperands for Rv64Instruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64Instruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64Instruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for Rv64Instruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for Rv64Instruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
     Regs: [const] RegisterFile<Reg>,
     Memory: [const] VirtualMemory,
-    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
-    CustomError: [const] Destruct,
+    PC: [const] ProgramCounter<Reg::Type, Memory>,
+    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
@@ -66,7 +61,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Add { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_add(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
@@ -19,17 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64AInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64AInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64AInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for Rv64AInstruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for Rv64AInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
     Regs: [const] RegisterFile<Reg>,
@@ -49,7 +46,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
@@ -6,8 +6,9 @@ pub mod zalrsc;
 use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZaamoInstruction<Reg> wher
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZaamoInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZaamoInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZaamoInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Amoswap {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZalrscInstruction<Reg> whe
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZalrscInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZalrscInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZalrscInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
@@ -49,7 +47,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Lr {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
@@ -6,8 +6,9 @@ mod tests;
 use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
@@ -8,8 +8,9 @@ pub mod zbs;
 use crate::rv64::b::zbb::rv64_zbb_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b.rs
@@ -21,17 +21,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64BInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64BInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64BInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for Rv64BInstruction<Reg>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for Rv64BInstruction<Reg>
 where
     Reg: Register<Type = u64>,
 {
@@ -48,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zba.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZbaInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZbaInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZbaInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZbaInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
@@ -46,7 +44,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::AddUw { rd, rs1: _, rs2: _ } => {
                 let rs1_val = u64::from(rs1_value as u32);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZbbInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZbbInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZbbInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZbbInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Andn { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value & !rs2_value;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbb.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZbcInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZbcInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZbcInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZbcInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Clmul { rd, rs1: _, rs2: _ } => {
                 let a = rs1_value;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbc.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZbsInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZbsInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZbsInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZbsInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
@@ -46,7 +44,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Bset { rd, rs1: _, rs2: _ } => {
                 // Only the bottom 6 bits for RV64

--- a/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/b/zbs.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for Rv64ZcaInstruction<Reg> where
@@ -20,24 +19,21 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZcaInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZcaInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZcaInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZcaInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
     Regs: [const] RegisterFile<Reg>,
     Memory: [const] VirtualMemory,
-    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
-    CustomError: [const] Destruct,
+    PC: [const] ProgramCounter<Reg::Type, Memory>,
+    InstructionHandler: [const] SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
@@ -52,7 +48,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // Quadrant 00
             Self::CAddi4spn { rd, nzuimm } => {

--- a/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/c/zca.rs
@@ -5,9 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
@@ -6,8 +6,9 @@ pub mod zmmul;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m.rs
@@ -19,17 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64MInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64MInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64MInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for Rv64MInstruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for Rv64MInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
     Regs: [const] RegisterFile<Reg>,
@@ -47,7 +44,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Mul { rd, rs1: _, rs2: _ } => {
                 let value = rs1_value.wrapping_mul(rs2_value);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
@@ -15,16 +15,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZmmulInstruction<Reg> wher
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZmmulInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZmmulInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZmmulInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
@@ -42,7 +40,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/m/zmmul.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -191,7 +191,7 @@ where
     I: Instruction<Reg = Reg<u64>>,
 {
     #[inline]
-    fn fetch_instruction(&mut self, _memory: &TestMemory) -> FetchInstructionResult<I> {
+    fn peek_instruction(&mut self, _memory: &TestMemory) -> FetchInstructionResult<I> {
         if self.pc == self.return_trap_address {
             return FetchInstructionResult::Break;
         }
@@ -208,9 +208,27 @@ where
                 address: PackedAddress::new(self.pc),
             });
         };
-        self.pc += u64::from(instruction.size());
-
         FetchInstructionResult::Instruction(instruction)
+    }
+
+    #[inline]
+    unsafe fn advance(&mut self, instruction_size: u8) {
+        self.pc = self.pc.wrapping_add(u64::from(instruction_size));
+    }
+
+    #[inline]
+    fn fetch_instruction(&mut self, memory: &TestMemory) -> FetchInstructionResult<I> {
+        let result = self.peek_instruction(memory);
+
+        if let FetchInstructionResult::Instruction(instruction) = result {
+            // SAFETY: The instruction was just peeked successfully, and this is the only place that
+            // moves past it
+            unsafe {
+                self.advance(instruction.size());
+            }
+        }
+
+        result
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -9,7 +9,7 @@ use crate::{
     Address, BasicInt, CsrError, Csrs, ExecutableInstruction, ExecutionError, ExecutionResult,
     FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter, RegisterFile,
     Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
-    VirtualMemory, VirtualMemoryError, impl_vector_registers_for_mut_ref,
+    ThreadedExecutionResult, VirtualMemory, VirtualMemoryError, impl_vector_registers_for_mut_ref,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::collections::BTreeMap;
@@ -147,6 +147,7 @@ impl VirtualMemory for TestMemory {
 }
 
 /// Custom instruction handler for tests that returns instructions from a sequence
+#[derive(Clone)]
 pub(crate) struct TestInstructionFetcher<I> {
     instructions: Vec<Option<I>>,
     return_trap_address: u64,
@@ -596,10 +597,12 @@ where
     Ok(())
 }
 
-/// Same as [`execute()`], but driven by tail-call-threaded dispatch instead of an explicit loop
-pub(crate) fn execute_threaded<I>(
-    state: &mut TestInterpreterState<I>,
-) -> Result<(), ExecutionError<Address<I>>>
+/// Same as [`execute()`], but driven by tail-call-threaded dispatch instead of an explicit loop.
+///
+/// The fetcher is moved into the handler chain and dropped there, so this hands over a clone of
+/// the state's one and leaves the state itself intact for the test to inspect. Where [`execute()`]
+/// advances the state's fetcher, the program counter comes back as part of the result here.
+pub(crate) fn execute_threaded<I>(state: &mut TestInterpreterState<I>) -> ThreadedExecutionResult<I>
 where
     I: Instruction<Reg = Reg<u64>>
         + for<'a> ThreadedExecutableInstruction<
@@ -610,5 +613,11 @@ where
             &'a mut TestInstructionHandler,
         >,
 {
-    state.execute_threaded::<I>()
+    I::execute_threaded(
+        state.instruction_fetcher.clone(),
+        &mut state.regs,
+        &mut state.ext_state,
+        &mut state.memory,
+        &mut state.system_instruction_handler,
+    )
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -493,7 +493,7 @@ impl ExtState {
 }
 
 pub(crate) type TestInterpreterState<Instruction> = BasicInterpreterState<
-    BasicRegisters<Reg<u64>>,
+    BasicRegisters<Reg<u64>, false>,
     ExtState,
     TestMemory,
     TestInstructionFetcher<Instruction>,
@@ -527,7 +527,7 @@ pub(crate) fn execute<I>(
 where
     I: Instruction<Reg = Reg<u64>>
         + ExecutableInstruction<
-            BasicRegisters<Reg<u64>>,
+            BasicRegisters<Reg<u64>, false>,
             ExtState,
             TestMemory,
             TestInstructionFetcher<I>,
@@ -606,7 +606,7 @@ pub(crate) fn execute_threaded<I>(state: &mut TestInterpreterState<I>) -> Thread
 where
     I: Instruction<Reg = Reg<u64>>
         + for<'a> ThreadedExecutableInstruction<
-            BasicRegisters<Reg<u64>>,
+            BasicRegisters<Reg<u64>, false>,
             &'a mut ExtState,
             TestMemory,
             TestInstructionFetcher<I>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/test_utils.rs
@@ -165,14 +165,21 @@ where
     }
 
     #[inline(always)]
-    fn set_pc_relative(
-        &mut self,
-        memory: &TestMemory,
-        instruction_size: u8,
-        offset: i32,
-    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+    unsafe fn try_set_pc_relative(&mut self, instruction_size: u8, offset: i32) -> bool {
         let old_pc = self.old_pc(instruction_size);
-        self.set_pc(memory, old_pc.wrapping_add_signed(i64::from(offset)))
+        self.pc = old_pc.wrapping_add_signed(i64::from(offset));
+
+        true
+    }
+
+    #[cold]
+    #[inline(never)]
+    unsafe fn failed_branch(
+        &mut self,
+        _memory: &TestMemory,
+    ) -> Result<ControlFlow<()>, ExecutionError<u64>> {
+        // Every target is accepted above, so there is never one to report on
+        unreachable!("`try_set_pc_relative()` never refuses a target")
     }
 
     fn set_pc(

--- a/crates/execution/ab-riscv-interpreter/src/rv64/threaded_tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/threaded_tests.rs
@@ -10,12 +10,39 @@ use crate::rv64::test_utils::{
     execute_threaded, initialize_state,
 };
 use crate::{
-    ExecutableInstruction, ExecutionError, ProgramCounter, RegisterFile,
-    ThreadedExecutableInstruction, VirtualMemory,
+    ExecutableInstruction, ExecutionError, OpaqueThreadedExecutionResult, ProgramCounter,
+    RegisterFile, ThreadedExecutableInstruction, VirtualMemory,
 };
 use ab_riscv_primitives::prelude::*;
 use alloc::vec;
 use alloc::vec::Vec;
+
+/// Whether threaded dispatch can run here at all.
+///
+/// It cannot on an x86-64 CPU without AVX, see
+/// [`OpaqueThreadedExecutionResult::platform_supported()`]. Miri emulates exactly such a CPU, but
+/// the lanes fall back to a plain array there, so this is only ever `false` on real pre-2011
+/// hardware; the tests below check the reported reason in that case rather than skipping silently.
+fn threaded_dispatch_available<I>() -> bool
+where
+    I: Instruction,
+{
+    if OpaqueThreadedExecutionResult::<I>::platform_supported() {
+        return true;
+    }
+
+    let mut state = initialize_state(vec![]);
+
+    assert!(
+        matches!(
+            execute_threaded::<Rv64Instruction<Reg<u64>>>(&mut state).outcome,
+            Err(ExecutionError::UnsupportedPlatform)
+        ),
+        "Threaded dispatch must say why it did not run"
+    );
+
+    false
+}
 
 /// Runs `instructions` twice, once through each dispatch path, and asserts that the two agree on
 /// the error (if any), on every general purpose register and on the final program counter
@@ -39,6 +66,10 @@ fn assert_paths_agree<I, Instructions>(
         >,
     Instructions: IntoIterator<Item = I> + Clone,
 {
+    if !threaded_dispatch_available::<I>() {
+        return;
+    }
+
     let mut looped_state = initialize_state(instructions.clone());
     setup(&mut looped_state.regs);
     let looped_result = execute(&mut looped_state);
@@ -49,7 +80,7 @@ fn assert_paths_agree<I, Instructions>(
 
     assert_eq!(
         alloc::format!("{looped_result:?}"),
-        alloc::format!("{threaded_result:?}"),
+        alloc::format!("{:?}", threaded_result.outcome),
         "Dispatch paths disagree on the outcome"
     );
 
@@ -62,9 +93,11 @@ fn assert_paths_agree<I, Instructions>(
         );
     }
 
+    // The threaded path is handed a clone of the fetcher and hands back only where it stopped, so
+    // the state's own fetcher stays where it was and this compares against what came back
     assert_eq!(
         ProgramCounter::<u64, TestMemory>::get_pc(&looped_state.instruction_fetcher),
-        ProgramCounter::<u64, TestMemory>::get_pc(&threaded_state.instruction_fetcher),
+        threaded_result.program_counter,
         "Dispatch paths disagree on the program counter"
     );
 }
@@ -246,6 +279,10 @@ fn threaded_matches_looped_failure() {
 
 #[test]
 fn threaded_reports_the_error_it_stopped_on() {
+    if !threaded_dispatch_available::<Rv64Instruction<Reg<u64>>>() {
+        return;
+    }
+
     let mut state = initialize_state(vec![Rv64Instruction::Ld {
         rd: Reg::A3,
         rs1: Reg::A0,
@@ -255,13 +292,17 @@ fn threaded_reports_the_error_it_stopped_on() {
     state.regs.write(Reg::A0, 0xdead_0000);
 
     assert!(matches!(
-        execute_threaded(&mut state),
+        execute_threaded(&mut state).outcome,
         Err(ExecutionError::OutOfBoundsRead { .. })
     ));
 }
 
 #[test]
 fn threaded_runs_a_loop_to_completion() {
+    if !threaded_dispatch_available::<Rv64Instruction<Reg<u64>>>() {
+        return;
+    }
+
     // Counts down from 1000, which is more iterations than any stack could hold if the handler
     // chain were not made of real tail calls
     let instructions = vec![
@@ -281,13 +322,17 @@ fn threaded_runs_a_loop_to_completion() {
     let mut state = initialize_state(instructions);
     state.regs.write(Reg::A0, 1000);
 
-    execute_threaded(&mut state).unwrap();
+    execute_threaded(&mut state).outcome.unwrap();
 
     assert_eq!(state.regs.read(Reg::A0), 0);
 }
 
 #[test]
 fn threaded_leaves_memory_in_the_same_state() {
+    if !threaded_dispatch_available::<Rv64Instruction<Reg<u64>>>() {
+        return;
+    }
+
     let instructions: Vec<_> = (0..8)
         .map(|index| Rv64Instruction::Sd {
             rs1: Reg::A0,
@@ -304,7 +349,7 @@ fn threaded_leaves_memory_in_the_same_state() {
     let mut threaded_state = initialize_state(instructions);
     threaded_state.regs.write(Reg::A0, TEST_BASE_ADDR);
     threaded_state.regs.write(Reg::A1, 0xabcd);
-    execute_threaded(&mut threaded_state).unwrap();
+    execute_threaded(&mut threaded_state).outcome.unwrap();
 
     for index in 0..8 {
         let address = TEST_BASE_ADDR + index * 8;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZabhaInstruction<Reg> wher
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZabhaInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZabhaInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZabhaInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::AmoswapB {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZacasInstruction<Reg> wher
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZacasInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZacasInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZacasInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::AmocasW {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZalasrInstruction<Reg> whe
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZalasrInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZalasrInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZalasrInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::LbAq { rd, rs1: _, rl: _ } => {
                 let value = i64::from(memory.read::<i8>(rs1_value)?);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zalasr.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZcbInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZcbInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZcbInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZcbInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -46,7 +44,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }
@@ -58,23 +56,21 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZcbOnlyInstruction<Reg> wh
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZcbOnlyInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZcbOnlyInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZcbOnlyInstruction<Reg>
 where
     Reg: Register<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
+    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -89,7 +85,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::CLbu { rd, rs1: _, uimm } => {
                 let addr = rs1_value.wrapping_add(u64::from(uimm));

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcb.rs
@@ -5,9 +5,10 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    SystemInstructionHandler, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -7,9 +7,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, ProgramCounter, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, SystemInstructionHandler,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp.rs
@@ -21,16 +21,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZcmpInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZcmpInstruction<Reg>
-where
-    Reg: ZcmpRegister<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZcmpInstruction<Reg> where
+    Reg: ZcmpRegister<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZcmpInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u64>,
@@ -48,7 +46,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }
@@ -60,23 +58,21 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZcmpOnlyInstruction<Reg> w
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZcmpOnlyInstruction<Reg>
-where
-    Reg: ZcmpRegister<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZcmpOnlyInstruction<Reg> where
+    Reg: ZcmpRegister<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZcmpOnlyInstruction<Reg>
 where
     Reg: ZcmpRegister<Type = u64>,
     Regs: RegisterFile<Reg>,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
-    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
+    InstructionHandler: SystemInstructionHandler<Reg, Regs, Memory, PC>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -91,7 +87,7 @@ where
         memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::CmPush { urlist, stack_adj } => {
                 rv64_zcmp_helpers::do_push(regs, memory, urlist, stack_adj)

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zce/zcmp/rv64_zcmp_helpers.rs
@@ -7,12 +7,12 @@ use ab_riscv_primitives::prelude::*;
 #[inline]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn do_push<Reg, Regs, Memory, CustomError>(
+pub fn do_push<Reg, Regs, Memory>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u8,
-) -> ExecutionResult<Reg, CustomError>
+) -> ExecutionResult<Reg>
 where
     Reg: ZcmpRegister<Type = u64>,
     Regs: RegisterFile<Reg>,
@@ -36,12 +36,12 @@ where
 #[inline]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn do_pop<Reg, Regs, Memory, CustomError>(
+pub fn do_pop<Reg, Regs, Memory>(
     regs: &mut Regs,
     memory: &mut Memory,
     urlist: ZcmpUrlist<Reg>,
     stack_adj: u8,
-) -> Result<u64, ExecutionError<Reg::Type, CustomError>>
+) -> Result<u64, ExecutionError<Reg::Type>>
 where
     Reg: ZcmpRegister<Type = u64>,
     Regs: RegisterFile<Reg>,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkb.rs
@@ -18,16 +18,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZbkbInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZbkbInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZbkbInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZbkbInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -46,7 +44,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Pack { rd, rs1: _, rs2: _ } => {
                 // Pack lower 32 bits of rs1 into lower 32 bits of rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
@@ -3,8 +3,9 @@
 use crate::rv64::b::zbc::rv64_zbc_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkc.rs
@@ -16,16 +16,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZbkcInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZbkcInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZbkcInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZbkcInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -43,7 +41,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zbkx.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZbkxInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZbkxInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZbkxInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZbkxInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Xperm4 { rd, rs1: _, rs2: _ } => ExecutionResult::Continue {
                 rd,

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
@@ -24,16 +24,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZknInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZknInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZknInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZknInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -51,7 +49,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn.rs
@@ -11,8 +11,9 @@ use crate::rv64::zk::zkn::zkne::rv64_zkne_helpers;
 use crate::rv64::zk::zkn::zknh::rv64_zknh_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZkndInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZkndInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZkndInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZkndInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Aes64Ds { rd, rs1: _, rs2: _ } => {
                 let v1 = rs1_value;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknd.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
@@ -23,16 +23,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZkneInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZkneInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZkneInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZkneInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -51,7 +49,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Aes64Es { rd, rs1: _, rs2: _ } => {
                 let v1 = rs1_value;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zkne.rs
@@ -10,8 +10,9 @@ mod tests;
 use crate::rv64::zk::zkn::zknd::rv64_zknd_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
@@ -6,8 +6,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zk/zkn/zknh.rs
@@ -19,16 +19,14 @@ const impl<Reg> ExecutableInstructionOperands for Rv64ZknhInstruction<Reg> where
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for Rv64ZknhInstruction<Reg>
-where
-    Reg: Register<Type = u64>,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for Rv64ZknhInstruction<Reg> where
+    Reg: Register<Type = u64>
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for Rv64ZknhInstruction<Reg>
 where
     Reg: Register<Type = u64>,
@@ -47,7 +45,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Sha256Sig0 { rd, rs1: _ } => {
                 let x = rs1_value as u32;

--- a/crates/execution/ab-riscv-interpreter/src/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/tests.rs
@@ -1,5 +1,8 @@
+extern crate alloc;
+
 use crate::basic::BasicMemory;
 use crate::*;
+use ab_riscv_primitives::privilege::PrivilegeLevel;
 
 /// `?` on a memory access inside a function returning [`ExecutionResult`], in const context,
 /// which is what instruction bodies need
@@ -23,4 +26,88 @@ fn question_mark_converts_memory_errors() {
         load(&memory, 0xdead_0000),
         ExecutionResult::Err(ExecutionError::OutOfBoundsRead { .. })
     ));
+}
+
+/// Round-trip one outcome through the opaque form and compare against the original, which is only
+/// comparable through its `Debug` representation
+fn assert_round_trip<I>(result: ThreadedExecutionResult<I>)
+where
+    I: Instruction,
+{
+    let expected = alloc::format!("{result:?}");
+    // SAFETY: Tests only run on a platform they were built for
+    let opaque = unsafe { OpaqueThreadedExecutionResult::new(result) };
+    let actual = alloc::format!("{:?}", opaque.into_result());
+
+    assert_eq!(expected, actual);
+}
+
+/// Every outcome must survive the trip through [`OpaqueThreadedExecutionResult`] unchanged, since
+/// that is the only form in which a handler can report one
+fn assert_all_outcomes_round_trip<I>(address: <I::Reg as Register>::Type)
+where
+    I: Instruction,
+{
+    let program_counter = address;
+
+    assert_round_trip::<I>(ThreadedExecutionResult::stopped(program_counter));
+
+    for error in [
+        ExecutionError::UnalignedInstruction {
+            address: PackedAddress::new(address),
+        },
+        ExecutionError::OutOfBoundsRead {
+            address: PackedAddress::new(u64::MAX),
+        },
+        ExecutionError::OutOfBoundsWrite {
+            address: PackedAddress::new(u64::MAX),
+        },
+        ExecutionError::EcallUnsupported {
+            address: PackedAddress::new(address),
+        },
+        ExecutionError::IllegalInstruction {
+            address: PackedAddress::new(address),
+        },
+        ExecutionError::CsrReadOnly {
+            csr_index: u16::MAX,
+        },
+        ExecutionError::CsrIllegalRead { csr_index: 0x300 },
+        ExecutionError::CsrIllegalWrite { csr_index: 0x301 },
+        ExecutionError::CsrUnknown { csr_index: 0 },
+        ExecutionError::CsrInsufficientPrivilege {
+            csr_index: 0xc00,
+            required: PrivilegeLevel::Machine,
+            current: PrivilegeLevel::User,
+        },
+        ExecutionError::CsrInsufficientPrivilege {
+            csr_index: 0xc01,
+            required: PrivilegeLevel::Supervisor,
+            current: PrivilegeLevel::Machine,
+        },
+        ExecutionError::Custom(u64::MAX.to_le_bytes()),
+        ExecutionError::UnsupportedPlatform,
+    ] {
+        assert_round_trip::<I>(ThreadedExecutionResult::failed(program_counter, error));
+    }
+}
+
+#[test]
+fn outcomes_round_trip_rv64() {
+    assert_all_outcomes_round_trip::<Rv64Instruction<Reg<u64>>>(u64::MAX);
+    assert_all_outcomes_round_trip::<Rv64Instruction<Reg<u64>>>(0);
+}
+
+#[test]
+fn outcomes_round_trip_rv32() {
+    assert_all_outcomes_round_trip::<Rv32Instruction<Reg<u32>>>(u32::MAX);
+    assert_all_outcomes_round_trip::<Rv32Instruction<Reg<u32>>>(0);
+}
+
+#[test]
+fn opaque_outcome_fits_into_return_registers() {
+    // Not a hard requirement of the type system, but the entire reason the opaque form exists: on
+    // the platforms that return it in registers it must not be larger than what they return
+    if cfg!(any(target_arch = "x86_64", target_arch = "aarch64")) {
+        assert!(size_of::<OpaqueThreadedExecutionResult<Rv64Instruction<Reg<u64>>>>() <= 32);
+    }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
@@ -1,8 +1,7 @@
 //! Vector registers
 
-use crate::{Csrs, CustomErrorPlaceholder};
+use crate::Csrs;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 pub(crate) const VLENB_USIZE<const VLEN: Vlen>: usize = VLEN.bytes() as usize;
 
@@ -50,7 +49,7 @@ impl<const VLEN: Vlen> VectorRegisterFile<VLEN> {
 /// update semantics: `vtype` must maintain a cached decoded form and handle the XLEN-dependent vill
 /// bit, and `vl` is read-only via CSR instructions but writable by `vsetvl{i}` and fault-only-first
 /// loads.
-pub const trait VectorRegisters<CustomError = CustomErrorPlaceholder> {
+pub const trait VectorRegisters {
     /// Maximum vector element width `ELEN` in bits
     const ELEN: Elen;
     /// Vector register width `VLEN` in bits
@@ -105,12 +104,11 @@ pub const trait VectorRegisters<CustomError = CustomErrorPlaceholder> {
 /// higher-performance implementations are often possible by overriding them and, for example,
 /// caching various CSRs as separate pre-decoded values rather than going through a generic code
 /// path with XLEN-sized raw CSR values during reads.
-pub const trait VectorRegistersExt<Reg, CustomError = CustomErrorPlaceholder>
+pub const trait VectorRegistersExt<Reg>
 where
-    Self: [const] Csrs<Reg, CustomError> + [const] VectorRegisters<CustomError>,
+    Self: [const] Csrs<Reg> + [const] VectorRegisters,
     [(); SUPPORTED_ELEN_VLEN::<{ Self::ELEN }, { Self::VLEN }>]:,
     Reg: [const] Register,
-    CustomError: [const] Destruct,
 {
     /// Initialize the vector state to the recommended default configuration.
     ///

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
@@ -28,9 +28,10 @@ use crate::v::zvexx::widen_narrow::zvexx_widen_narrow_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress,
-    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher,
+    OpaqueThreadedExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx.rs
@@ -34,23 +34,19 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for ZveXxInstruction<Reg>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for ZveXxInstruction<Reg>
 where
     Reg: Register,
 {
@@ -67,7 +63,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
@@ -19,24 +19,22 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZveXxArithInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxArithInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxArithInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxArithInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -51,7 +49,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vadd
             Self::VaddVv { vd, vs2, vs1, vm } => {
@@ -72,17 +70,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -133,12 +131,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -184,12 +182,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -237,17 +235,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -297,12 +295,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -353,12 +351,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -405,12 +403,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -457,17 +455,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -517,12 +515,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -568,12 +566,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -620,17 +618,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -680,12 +678,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -731,12 +729,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -783,17 +781,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -843,12 +841,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -894,12 +892,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -946,17 +944,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1007,12 +1005,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1058,12 +1056,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1111,17 +1109,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1176,12 +1174,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1231,12 +1229,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1283,17 +1281,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1347,12 +1345,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1402,12 +1400,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1457,17 +1455,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1520,12 +1518,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1574,17 +1572,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1642,12 +1640,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1702,17 +1700,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1765,12 +1763,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1819,17 +1817,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1887,12 +1885,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1947,23 +1945,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2011,12 +2009,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2058,12 +2056,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2106,23 +2104,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2168,12 +2166,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2215,12 +2213,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2263,23 +2261,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2325,12 +2323,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2373,23 +2371,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2435,12 +2433,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2483,23 +2481,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2545,12 +2543,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2592,12 +2590,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2647,23 +2645,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2709,12 +2707,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2756,12 +2754,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2809,12 +2807,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2856,12 +2854,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2909,12 +2907,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2956,12 +2954,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith.rs
@@ -8,9 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
@@ -12,14 +12,14 @@ use core::num::NonZeroU8;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_vreg_group_alignment<Reg, Memory, PC, CustomError>(
+pub fn check_vreg_group_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vreg: VReg,
     group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let group_regs = group_regs.get();
     let vreg_idx = vreg.to_bits();
@@ -49,15 +49,15 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_mask_dest_overlap<Reg, Memory, PC, CustomError>(
+pub fn check_mask_dest_overlap<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     src_base: VReg,
     group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let group_regs = group_regs.get();
     if group_regs > 1 {
@@ -188,7 +188,7 @@ pub enum OpSrc {
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_arith_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -198,7 +198,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, Vsew) -> u64,
 {
@@ -253,7 +253,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_compare_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -263,7 +263,7 @@ pub unsafe fn execute_compare_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, Vsew) -> bool,
 {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
@@ -8,9 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry.rs
@@ -19,24 +19,22 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZveXxCarryInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxCarryInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxCarryInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxCarryInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -51,7 +49,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vadc: add with carry-in from v0, data result
             Self::VadcVvm { vd, vs2, vs1 } => {
@@ -72,17 +70,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -99,7 +97,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above; vd != v0 checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add::<true, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add::<true, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -127,12 +125,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -149,7 +147,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above; vd != v0 checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add::<true, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add::<true, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -177,12 +175,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -199,7 +197,7 @@ where
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignments checked above; vd != v0 checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add::<true, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add::<true, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -228,23 +226,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -253,7 +251,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -281,12 +279,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -296,7 +294,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -324,12 +322,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -339,7 +337,7 @@ where
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add_mask::<true, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -367,23 +365,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -392,7 +390,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -420,12 +418,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -435,7 +433,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -463,12 +461,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -478,7 +476,7 @@ where
                 let scalar = i64::from(imm).cast_unsigned();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_add_mask::<false, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -507,17 +505,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -533,7 +531,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above; vd != v0 checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_sub::<Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_sub::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -561,12 +559,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -583,7 +581,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above; vd != v0 checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_sub::<Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_sub::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -612,23 +610,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -637,7 +635,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_sub_mask::<true, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_sub_mask::<true, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -665,12 +663,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -680,7 +678,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_sub_mask::<true, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_sub_mask::<true, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -708,23 +706,23 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -733,7 +731,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_sub_mask::<false, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_sub_mask::<false, Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -761,12 +759,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _, _>(
+                zvexx_carry_helpers::check_mask_dest_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -776,7 +774,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments and mask-destination overlap checked above
                 unsafe {
-                    zvexx_carry_helpers::execute_carry_sub_mask::<false, Reg, _, _>(
+                    zvexx_carry_helpers::execute_carry_sub_mask::<false, Reg, _>(
                         ext_state,
                         vd,
                         vs2,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
@@ -42,7 +42,7 @@ pub(in super::super) unsafe fn carry_bit<const VLEN: Vlen>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, ExtState, CustomError>(
+pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -50,7 +50,7 @@ pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, ExtState, CustomErr
     sew: Vsew,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -101,7 +101,7 @@ pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, ExtState, CustomErr
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
+pub unsafe fn execute_carry_sub<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -109,7 +109,7 @@ pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
     sew: Vsew,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -162,7 +162,7 @@ pub unsafe fn execute_carry_sub<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, ExtState, CustomError>(
+pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -170,7 +170,7 @@ pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, ExtState, Cust
     sew: Vsew,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -226,7 +226,7 @@ pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, ExtState, Cust
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_carry_sub_mask<const WITH_BORROW: bool, Reg, ExtState, CustomError>(
+pub unsafe fn execute_carry_sub_mask<const WITH_BORROW: bool, Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -234,7 +234,7 @@ pub unsafe fn execute_carry_sub_mask<const WITH_BORROW: bool, Reg, ExtState, Cus
     sew: Vsew,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
@@ -7,9 +7,9 @@ pub mod zvexx_config_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher,
+    OpaqueThreadedExecutionResult, ProgramCounter, RegisterFile, Rs1Rs2OperandValues,
+    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config.rs
@@ -13,18 +13,15 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZveXxConfigInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxConfigInstruction<Reg>
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxConfigInstruction<Reg>
 where
     Reg: [const] Register,
-    ExtState: [const] Csrs<Reg, CustomError>,
-    CustomError: [const] Destruct,
+    ExtState: [const] Csrs<Reg>,
 {
     /// Validate reads to vector CSRs from Zicsr instructions.
     ///
@@ -38,7 +35,7 @@ where
         _will_write: bool,
         raw_value: Reg::Type,
         output_value: &mut Reg::Type,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         if VectorCsr::from_csr_index(csr_index).is_some() {
             *output_value = raw_value;
             Ok(true)
@@ -63,7 +60,7 @@ where
         csr_index: u16,
         write_value: Reg::Type,
         output_value: &mut Reg::Type,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         if let Some(vcsr) = VectorCsr::from_csr_index(csr_index) {
             // WARL: mask to valid bits, zero upper bits
             *output_value = match vcsr {
@@ -112,16 +109,15 @@ where
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxConfigInstruction<Reg>
 where
     Reg: [const] Register,
     Regs: [const] RegisterFile<Reg>,
-    ExtState: [const] VectorRegistersExt<Reg, CustomError>,
+    ExtState: [const] VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
-    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
-    CustomError: [const] Destruct,
+    PC: [const] ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
@@ -136,7 +132,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Vsetvli { rd, rs1, vtypei } => {
                 let rd_value = zvexx_config_helpers::apply_vsetvl(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/zvexx_config_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/config/zvexx_config_helpers.rs
@@ -5,7 +5,6 @@ use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
-use core::marker::Destruct;
 
 /// Apply `vsetvli` / `vsetvl` logic.
 ///
@@ -16,20 +15,19 @@ use core::marker::Destruct;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub const fn apply_vsetvl<Reg, ExtState, Memory, PC, CustomError>(
+pub const fn apply_vsetvl<Reg, ExtState, Memory, PC>(
     ext_state: &mut ExtState,
     program_counter: &PC,
     rd: Reg,
     rs1: Reg,
     rs1_value: Reg::Type,
     vtype_raw: Reg::Type,
-) -> Result<Reg::Type, ExecutionError<Reg::Type, CustomError>>
+) -> Result<Reg::Type, ExecutionError<Reg::Type>>
 where
     Reg: [const] Register,
-    ExtState: [const] VectorRegistersExt<Reg, CustomError>,
+    ExtState: [const] VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
-    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
-    CustomError: [const] Destruct,
+    PC: [const] ProgramCounter<Reg::Type, Memory>,
 {
     // Check whether vector instructions are enabled
     if !ext_state.vector_instructions_allowed() {
@@ -100,18 +98,17 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub const fn apply_vsetivli<Reg, ExtState, Memory, PC, CustomError>(
+pub const fn apply_vsetivli<Reg, ExtState, Memory, PC>(
     ext_state: &mut ExtState,
     program_counter: &PC,
     uimm: u8,
     vtypei: u16,
-) -> Result<Reg::Type, ExecutionError<Reg::Type, CustomError>>
+) -> Result<Reg::Type, ExecutionError<Reg::Type>>
 where
     Reg: [const] Register,
-    ExtState: [const] VectorRegistersExt<Reg, CustomError>,
+    ExtState: [const] VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
-    PC: [const] ProgramCounter<Reg::Type, Memory, CustomError>,
-    CustomError: [const] Destruct,
+    PC: [const] ProgramCounter<Reg::Type, Memory>,
 {
     // Check whether vector instructions are enabled
     if !ext_state.vector_instructions_allowed() {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
@@ -20,24 +20,22 @@ const impl<Reg> ExecutableInstructionOperands for ZveXxFixedPointInstruction<Reg
 {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxFixedPointInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxFixedPointInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxFixedPointInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -52,7 +50,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vsaddu.vv / vsaddu.vx / vsaddu.vi - saturating unsigned add
             Self::VsadduVv { vd, vs2, vs1, vm } => {
@@ -73,17 +71,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -135,12 +133,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -188,12 +186,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -244,17 +242,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -306,12 +304,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -359,12 +357,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -414,17 +412,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -476,12 +474,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -530,17 +528,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -592,12 +590,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -646,17 +644,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -708,12 +706,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -762,17 +760,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -824,12 +822,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -878,17 +876,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -940,12 +938,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -994,17 +992,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1056,12 +1054,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1119,17 +1117,17 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1190,12 +1188,12 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1244,17 +1242,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1310,12 +1308,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1366,12 +1364,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1424,17 +1422,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1488,12 +1486,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1543,12 +1541,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1600,25 +1598,22 @@ where
                 };
                 // Destination SEW must be <= 32 so that 2*SEW fits in 64 bits
                 let sew = vtype.vsew();
-                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
-                    program_counter,
-                    sew,
-                )?;
+                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _>(program_counter, sew)?;
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
                 // vs2 holds 2*SEW elements; its register group is double-width
-                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     vtype.vlmul(),
                     sew,
                 )?;
                 // vs1 is a normal SEW-wide source for the shift amount
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1669,17 +1664,14 @@ where
                     });
                 };
                 let sew = vtype.vsew();
-                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
-                    program_counter,
-                    sew,
-                )?;
+                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _>(program_counter, sew)?;
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     vtype.vlmul(),
@@ -1727,17 +1719,14 @@ where
                     });
                 };
                 let sew = vtype.vsew();
-                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
-                    program_counter,
-                    sew,
-                )?;
+                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _>(program_counter, sew)?;
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     vtype.vlmul(),
@@ -1786,23 +1775,20 @@ where
                     });
                 };
                 let sew = vtype.vsew();
-                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
-                    program_counter,
-                    sew,
-                )?;
+                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _>(program_counter, sew)?;
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     vtype.vlmul(),
                     sew,
                 )?;
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1853,17 +1839,14 @@ where
                     });
                 };
                 let sew = vtype.vsew();
-                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
-                    program_counter,
-                    sew,
-                )?;
+                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _>(program_counter, sew)?;
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     vtype.vlmul(),
@@ -1911,17 +1894,14 @@ where
                     });
                 };
                 let sew = vtype.vsew();
-                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _, _>(
-                    program_counter,
-                    sew,
-                )?;
+                zvexx_fixed_point_helpers::check_narrowing_sew::<Reg, _, _>(program_counter, sew)?;
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _, _>(
+                zvexx_fixed_point_helpers::check_vs2_narrowing_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     vtype.vlmul(),

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point.rs
@@ -8,9 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
@@ -437,7 +437,7 @@ pub unsafe fn read_wide_element_u64<const VLEN: Vlen>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_fixed_point_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -447,7 +447,7 @@ pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     // op: (vs2_elem, src_elem, sew, vxrm) -> result
     F: Fn(u64, u64, Vsew, Vxrm, &mut bool) -> u64,
@@ -502,7 +502,7 @@ pub unsafe fn execute_fixed_point_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -512,7 +512,7 @@ pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     // op: (vs2_wide_elem, shamt, sew, vxrm, vxsat) -> result
     F: Fn(u64, u32, Vsew, Vxrm, &mut bool) -> u64,
@@ -559,13 +559,13 @@ pub unsafe fn execute_narrowing_clip_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_narrowing_sew<Reg, Memory, PC, CustomError>(
+pub fn check_narrowing_sew<Reg, Memory, PC>(
     program_counter: &PC,
     sew: Vsew,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     if sew.bits_width() > 32 {
         cold_path();
@@ -588,15 +588,15 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_vs2_narrowing_alignment<Reg, Memory, PC, CustomError>(
+pub fn check_vs2_narrowing_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vs2: VReg,
     vlmul: Vlmul,
     sew: Vsew,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     // Source EEW is double the destination SEW. SEW=64 is rejected earlier by
     // `check_narrowing_sew`.

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -19,24 +19,22 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZveXxLoadInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxLoadInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxLoadInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxLoadInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -51,7 +49,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // Whole-register load: loads `nreg` consecutive registers starting at `vd` directly
             // from memory. `vd` must be aligned to `nreg`. Ignores vtype, vl, vstart, masking.
@@ -167,7 +165,7 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -196,7 +194,7 @@ where
                 //   VLMAX that bounds `vl`
                 // - mask overlap: checked above via `groups_overlap`
                 unsafe {
-                    zvexx_load_helpers::execute_unit_stride_load::<false, _, _, _, _>(
+                    zvexx_load_helpers::execute_unit_stride_load::<false, _, _, _>(
                         ext_state,
                         memory,
                         vd,
@@ -240,7 +238,7 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -262,7 +260,7 @@ where
                 }
                 // SAFETY: preconditions identical to `Vle`; see that arm for the full argument.
                 unsafe {
-                    zvexx_load_helpers::execute_unit_stride_load::<true, _, _, _, _>(
+                    zvexx_load_helpers::execute_unit_stride_load::<true, _, _, _>(
                         ext_state,
                         memory,
                         vd,
@@ -307,7 +305,7 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -385,12 +383,12 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     data_group_regs,
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     index_group_regs,
@@ -491,12 +489,12 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     data_group_regs,
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     index_group_regs,
@@ -585,7 +583,7 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                zvexx_load_helpers::validate_segment_registers::<Reg, _, _>(
                     program_counter,
                     vd,
                     vm,
@@ -601,7 +599,7 @@ where
                 // - mask overlap with v0: `validate_segment_registers` checked `vd.to_bits() != 0`
                 //   when `vm=false`, ensuring no field group contains v0
                 unsafe {
-                    zvexx_load_helpers::execute_unit_stride_load::<false, _, _, _, _>(
+                    zvexx_load_helpers::execute_unit_stride_load::<false, _, _, _>(
                         ext_state,
                         memory,
                         vd,
@@ -647,7 +645,7 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                zvexx_load_helpers::validate_segment_registers::<Reg, _, _>(
                     program_counter,
                     vd,
                     vm,
@@ -656,7 +654,7 @@ where
                 )?;
                 // SAFETY: preconditions identical to `Vlseg`; see that arm for the full argument.
                 unsafe {
-                    zvexx_load_helpers::execute_unit_stride_load::<true, _, _, _, _>(
+                    zvexx_load_helpers::execute_unit_stride_load::<true, _, _, _>(
                         ext_state,
                         memory,
                         vd,
@@ -703,7 +701,7 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                zvexx_load_helpers::validate_segment_registers::<Reg, _, _>(
                     program_counter,
                     vd,
                     vm,
@@ -771,14 +769,14 @@ where
                 // `validate_segment_registers` is called before the per-field overlap loop so
                 // that `vd.to_bits() + f * data_group_regs < 32` is established for all `f < nf`,
                 // which is required by the `VReg::from_bits` call inside the loop.
-                zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                zvexx_load_helpers::validate_segment_registers::<Reg, _, _>(
                     program_counter,
                     vd,
                     vm,
                     data_group_regs,
                     nf,
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     index_group_regs,
@@ -870,14 +868,14 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::validate_segment_registers::<Reg, _, _, _>(
+                zvexx_load_helpers::validate_segment_registers::<Reg, _, _>(
                     program_counter,
                     vd,
                     vm,
                     data_group_regs,
                     nf,
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     index_group_regs,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -8,9 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -128,14 +128,14 @@ pub fn indexed_load_overlap_allowed(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_register_group_alignment<Reg, Memory, PC, CustomError>(
+pub fn check_register_group_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let group_regs = group_regs.get();
     let vd = vd.to_bits();
@@ -156,16 +156,16 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn validate_segment_registers<Reg, Memory, PC, CustomError>(
+pub fn validate_segment_registers<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     vm: bool,
     group_regs: NonZeroU8,
     nf: Nf,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let group_regs = u32::from(group_regs.get());
     let nf = u32::from(nf.fields_per_segment());
@@ -302,13 +302,7 @@ fn read_mem_element(
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_unit_stride_load<
-    const FAULT_ONLY_FIRST: bool,
-    Reg,
-    ExtState,
-    Memory,
-    CustomError,
->(
+pub unsafe fn execute_unit_stride_load<const FAULT_ONLY_FIRST: bool, Reg, ExtState, Memory>(
     ext_state: &mut ExtState,
     memory: &Memory,
     vd: VReg,
@@ -317,10 +311,10 @@ pub unsafe fn execute_unit_stride_load<
     eew: Eew,
     group_regs: NonZeroU8,
     nf: Nf,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
 {
@@ -434,7 +428,7 @@ where
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_strided_load<Reg, ExtState, Memory, CustomError>(
+pub unsafe fn execute_strided_load<Reg, ExtState, Memory>(
     ext_state: &mut ExtState,
     memory: &Memory,
     vd: VReg,
@@ -444,10 +438,10 @@ pub unsafe fn execute_strided_load<Reg, ExtState, Memory, CustomError>(
     eew: Eew,
     group_regs: NonZeroU8,
     nf: Nf,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
 {
@@ -525,7 +519,7 @@ where
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_indexed_load<Reg, ExtState, Memory, CustomError>(
+pub unsafe fn execute_indexed_load<Reg, ExtState, Memory>(
     ext_state: &mut ExtState,
     memory: &Memory,
     vd: VReg,
@@ -536,10 +530,10 @@ pub unsafe fn execute_indexed_load<Reg, ExtState, Memory, CustomError>(
     index_eew: Eew,
     data_group_regs: NonZeroU8,
     nf: Nf,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
 {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -19,24 +19,22 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZveXxMaskInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxMaskInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxMaskInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxMaskInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -51,7 +49,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // Mask-register logical instructions (§16.1).
             // These compute the body elements [vstart, vl); prestart bits [0, vstart) are

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -8,9 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/zvexx_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/zvexx_mask_helpers.rs
@@ -19,7 +19,7 @@ use ab_riscv_primitives::prelude::*;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_mask_logical_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -27,7 +27,7 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(bool, bool) -> bool,
 {
@@ -64,14 +64,14 @@ pub unsafe fn execute_mask_logical_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vcpop<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vcpop<Reg, ExtState>(
     ext_state: &mut ExtState,
     vs2: VReg,
     vm: bool,
 ) -> Reg::Type
 where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -109,14 +109,14 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vfirst<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vfirst<Reg, ExtState>(
     ext_state: &mut ExtState,
     vs2: VReg,
     vm: bool,
 ) -> Reg::Type
 where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -167,7 +167,7 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vmsbf<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -175,7 +175,7 @@ pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
     vl: Vl,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     // SAFETY: `vl <= VLEN`
@@ -212,7 +212,7 @@ pub unsafe fn execute_vmsbf<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vmsof<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -220,7 +220,7 @@ pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
     vl: Vl,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     // SAFETY: `vl <= VLEN`
@@ -257,7 +257,7 @@ pub unsafe fn execute_vmsof<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vmsif<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -265,7 +265,7 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
     vl: Vl,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     // SAFETY: `vl <= VLEN`
@@ -311,7 +311,7 @@ pub unsafe fn execute_vmsif<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
+pub unsafe fn execute_viota<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -320,7 +320,7 @@ pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
     sew: Vsew,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     // SAFETY: `vl <= VLEN`
@@ -359,14 +359,10 @@ pub unsafe fn execute_viota<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vid<Reg, ExtState, CustomError>(
-    ext_state: &mut ExtState,
-    vd: VReg,
-    vm: bool,
-    sew: Vsew,
-) where
+pub unsafe fn execute_vid<Reg, ExtState>(ext_state: &mut ExtState, vd: VReg, vm: bool, sew: Vsew)
+where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
@@ -19,24 +19,22 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZveXxMulDivInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxMulDivInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxMulDivInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxMulDivInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -51,7 +49,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vmul.vv / vmul.vx - signed multiply, low half
             Self::VmulVv { vd, vs2, vs1, vm } => {
@@ -72,17 +70,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -132,12 +130,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -195,17 +193,17 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -266,12 +264,12 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -329,17 +327,17 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -400,12 +398,12 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -463,17 +461,17 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -535,12 +533,12 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -589,17 +587,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -655,12 +653,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -712,17 +710,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -772,12 +770,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -824,17 +822,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -894,12 +892,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -955,17 +953,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1015,12 +1013,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1086,17 +1084,17 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1110,14 +1108,14 @@ where
                     });
                 }
                 // vd and vs2/vs1 must not overlap
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -1182,12 +1180,12 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1200,7 +1198,7 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -1262,17 +1260,17 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1285,14 +1283,14 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -1359,12 +1357,12 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1377,7 +1375,7 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -1441,17 +1439,17 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1464,14 +1462,14 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -1538,12 +1536,12 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1556,7 +1554,7 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -1602,17 +1600,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1663,12 +1661,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1715,17 +1713,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1776,12 +1774,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1828,17 +1826,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1889,12 +1887,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -1942,17 +1940,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -2003,12 +2001,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -2075,17 +2073,17 @@ where
                     ),
                 })?;
                 // vd holds the 2*SEW accumulator
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -2098,14 +2096,14 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2171,12 +2169,12 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -2189,7 +2187,7 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2251,17 +2249,17 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -2274,14 +2272,14 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2348,12 +2346,12 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -2366,7 +2364,7 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2429,17 +2427,17 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -2452,14 +2450,14 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     dest_group_regs,
                     group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -2526,12 +2524,12 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -2544,7 +2542,7 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -2616,12 +2614,12 @@ where
                         program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                     ),
                 })?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -2634,7 +2632,7 @@ where
                         ),
                     });
                 }
-                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _, _>(
+                zvexx_muldiv_helpers::check_no_widening_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
@@ -8,9 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -86,16 +86,16 @@ pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<NonZeroU8> {
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_no_widening_overlap<Reg, Memory, PC, CustomError>(
+pub fn check_no_widening_overlap<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     vs: VReg,
     dest_group_regs: NonZeroU8,
     src_group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let dest_group_regs = dest_group_regs.get();
     let src_group_regs = src_group_regs.get();
@@ -166,7 +166,7 @@ unsafe fn write_wide_element_u64<const VLEN: Vlen>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_arith_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -176,7 +176,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, Vsew) -> u64,
 {
@@ -222,7 +222,7 @@ pub unsafe fn execute_arith_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_widening_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -232,7 +232,7 @@ pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, Vsew) -> u64,
 {
@@ -277,7 +277,7 @@ pub unsafe fn execute_widening_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_muladd_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     a_reg: VReg,
@@ -287,7 +287,7 @@ pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
@@ -329,7 +329,7 @@ pub unsafe fn execute_muladd_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     scalar: u64,
@@ -339,7 +339,7 @@ pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
@@ -386,7 +386,7 @@ pub unsafe fn execute_muladd_scalar_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_widening_muladd_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     a_reg: VReg,
@@ -396,7 +396,7 @@ pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
@@ -440,7 +440,7 @@ pub unsafe fn execute_widening_muladd_op<Reg, ExtState, CustomError, F>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     scalar: u64,
@@ -450,7 +450,7 @@ pub unsafe fn execute_widening_muladd_scalar_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -8,9 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -19,24 +19,22 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZveXxPermInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxPermInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxPermInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxPermInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -51,7 +49,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vmv.x.s rd, vs2
             // Copies sign-extended element 0 of vs2 (at current SEW) to GPR rd.
@@ -158,18 +156,18 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
                 // vd must not overlap vs2
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -210,17 +208,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -267,12 +265,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -315,12 +313,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -370,17 +368,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -428,12 +426,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -474,28 +472,28 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -542,17 +540,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -596,17 +594,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -652,12 +650,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -674,12 +672,12 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     index_group_regs,
                 )?;
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -687,7 +685,7 @@ where
                 )?;
                 // vd and vs1 have different group sizes (group_regs vs index_group_regs),
                 // so the symmetric helper would use the wrong size for one of the intervals.
-                zvexx_perm_helpers::check_no_overlap_asymmetric::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap_asymmetric::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -743,24 +741,24 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
                 if !vm {
                     // vmerge: vs2 is read, vd must not overlap v0
-                    zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                         program_counter,
                         vs2,
                         group_regs,
                     )?;
-                    zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                         program_counter,
                         vd,
                         VReg::V0,
@@ -799,18 +797,18 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
                 if !vm {
-                    zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                         program_counter,
                         vs2,
                         group_regs,
                     )?;
-                    zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                         program_counter,
                         vd,
                         VReg::V0,
@@ -845,18 +843,18 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
                 if !vm {
-                    zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                    zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                         program_counter,
                         vs2,
                         group_regs,
                     )?;
-                    zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                    zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                         program_counter,
                         vd,
                         VReg::V0,
@@ -902,25 +900,25 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
                 // vs1 is always a single mask register (no LMUL grouping)
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
                     group_regs,
                 )?;
                 // vs1 is a mask register; check it doesn't overlap vd
-                zvexx_perm_helpers::check_no_overlap::<Reg, _, _, _>(
+                zvexx_perm_helpers::check_no_overlap::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
@@ -17,15 +17,15 @@ use core::num::NonZeroU8;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_no_overlap<Reg, Memory, PC, CustomError>(
+pub fn check_no_overlap<Reg, Memory, PC>(
     program_counter: &PC,
     a: VReg,
     b: VReg,
     count: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let a_start = u16::from(a.to_bits());
     let b_start = u16::from(b.to_bits());
@@ -50,16 +50,16 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_no_overlap_asymmetric<Reg, Memory, PC, CustomError>(
+pub fn check_no_overlap_asymmetric<Reg, Memory, PC>(
     program_counter: &PC,
     a: VReg,
     a_count: NonZeroU8,
     b: VReg,
     b_count: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let a_start = u16::from(a.to_bits());
     let b_start = u16::from(b.to_bits());
@@ -169,7 +169,7 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
+pub unsafe fn execute_slideup<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -178,7 +178,7 @@ pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
     offset: u64,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -217,7 +217,7 @@ pub unsafe fn execute_slideup<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
+pub unsafe fn execute_slidedown<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -227,7 +227,7 @@ pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
     offset: u64,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -270,7 +270,7 @@ pub unsafe fn execute_slidedown<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
+pub unsafe fn execute_slide1up<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -279,7 +279,7 @@ pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
     scalar: u64,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -322,7 +322,7 @@ pub unsafe fn execute_slide1up<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
+pub unsafe fn execute_slide1down<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -331,7 +331,7 @@ pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
     scalar: u64,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -367,7 +367,7 @@ pub unsafe fn execute_slide1down<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
+pub unsafe fn execute_rgather_vv<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -377,7 +377,7 @@ pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
     vlmax: Vl,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -414,7 +414,7 @@ pub unsafe fn execute_rgather_vv<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
+pub unsafe fn execute_rgather_scalar<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -424,7 +424,7 @@ pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
     index: u64,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -466,7 +466,7 @@ pub unsafe fn execute_rgather_scalar<Reg, ExtState, CustomError>(
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
+pub unsafe fn execute_rgatherei16<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -477,7 +477,7 @@ pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
     index_group_regs: NonZeroU8,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let index_group_regs = index_group_regs.get();
@@ -530,7 +530,7 @@ pub unsafe fn execute_rgatherei16<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
+pub unsafe fn execute_merge_vv<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -539,7 +539,7 @@ pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
     sew: Vsew,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -579,7 +579,7 @@ pub unsafe fn execute_merge_vv<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
+pub unsafe fn execute_merge_scalar<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -588,7 +588,7 @@ pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
     scalar: u64,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -625,7 +625,7 @@ pub unsafe fn execute_merge_scalar<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
+pub unsafe fn execute_compress<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -634,7 +634,7 @@ pub unsafe fn execute_compress<Reg, ExtState, CustomError>(
     sew: Vsew,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let mask_bytes = usize::from(vl.bytes());

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
@@ -20,24 +20,22 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZveXxReductionInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxReductionInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxReductionInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxReductionInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -52,7 +50,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::Vredsum { vd, vs2, vs1, vm } => {
                 if !ext_state.vector_instructions_allowed() {
@@ -81,7 +79,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -129,7 +127,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -176,7 +174,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -223,7 +221,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -270,7 +268,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -320,7 +318,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -375,7 +373,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -425,7 +423,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -489,7 +487,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -499,7 +497,7 @@ where
                 // SAFETY: `vs2` alignment checked; widening SEW constraint checked above;
                 // `vstart == 0` checked; `vd` and `vs1` are single-register 2*SEW scalar operands
                 unsafe {
-                    zvexx_reduction_helpers::execute_widening_reduce_op::<false, _, _, _, _>(
+                    zvexx_reduction_helpers::execute_widening_reduce_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -546,7 +544,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_arith_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -555,7 +553,7 @@ where
                 let vl = ext_state.vl();
                 // SAFETY: see `Vwredsumu`
                 unsafe {
-                    zvexx_reduction_helpers::execute_widening_reduce_op::<true, _, _, _, _>(
+                    zvexx_reduction_helpers::execute_widening_reduce_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction.rs
@@ -9,9 +9,9 @@ use crate::v::zvexx::arith::zvexx_arith_helpers;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/zvexx_reduction_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/zvexx_reduction_helpers.rs
@@ -18,7 +18,7 @@ use core::hint::cold_path;
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_reduce_op<Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -29,7 +29,7 @@ pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, Vsew) -> u64,
 {
@@ -74,13 +74,7 @@ pub unsafe fn execute_reduce_op<Reg, ExtState, CustomError, F>(
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_widening_reduce_op<
-    const SIGN_EXTEND_SRC: bool,
-    Reg,
-    ExtState,
-    CustomError,
-    F,
->(
+pub unsafe fn execute_widening_reduce_op<const SIGN_EXTEND_SRC: bool, Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -91,7 +85,7 @@ pub unsafe fn execute_widening_reduce_op<
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64, Vsew) -> u64,
 {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -9,9 +9,9 @@ use crate::v::zvexx::load::zvexx_load_helpers;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -20,24 +20,22 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZveXxStoreInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxStoreInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxStoreInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxStoreInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -52,7 +50,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // Whole-register store: stores `nreg` consecutive registers starting at `vs3` directly
             // to memory as a flat byte array of `EVL = nreg * VLEN.bytes()` bytes. `vs3` must be
@@ -168,7 +166,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs3,
                     group_regs,
@@ -225,7 +223,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs3,
                     group_regs,
@@ -280,12 +278,12 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs3,
                     data_group_regs,
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     index_group_regs,
@@ -350,12 +348,12 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs3,
                     data_group_regs,
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     index_group_regs,
@@ -408,7 +406,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
+                zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _>(
                     program_counter,
                     vs3,
                     group_regs,
@@ -465,7 +463,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
+                zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _>(
                     program_counter,
                     vs3,
                     group_regs,
@@ -523,13 +521,13 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
+                zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _>(
                     program_counter,
                     vs3,
                     data_group_regs,
                     nf,
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     index_group_regs,
@@ -591,13 +589,13 @@ where
                             program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
                         ),
                     })?;
-                zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _, _>(
+                zvexx_store_helpers::validate_segment_store_registers::<Reg, _, _>(
                     program_counter,
                     vs3,
                     data_group_regs,
                     nf,
                 )?;
-                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _, _>(
+                zvexx_load_helpers::check_register_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     index_group_regs,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
@@ -49,18 +49,18 @@ fn write_mem_element(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn validate_segment_store_registers<Reg, Memory, PC, CustomError>(
+pub fn validate_segment_store_registers<Reg, Memory, PC>(
     program_counter: &PC,
     vs3: VReg,
     group_regs: NonZeroU8,
     nf: Nf,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     if let Err(error) =
-        check_register_group_alignment::<Reg, _, _, _>(program_counter, vs3, group_regs)
+        check_register_group_alignment::<Reg, _, _>(program_counter, vs3, group_regs)
     {
         cold_path();
         return Err(error);
@@ -93,7 +93,7 @@ where
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_unit_stride_store<Reg, ExtState, Memory, CustomError>(
+pub unsafe fn execute_unit_stride_store<Reg, ExtState, Memory>(
     ext_state: &mut ExtState,
     memory: &mut Memory,
     vs3: VReg,
@@ -102,10 +102,10 @@ pub unsafe fn execute_unit_stride_store<Reg, ExtState, Memory, CustomError>(
     eew: Eew,
     group_regs: NonZeroU8,
     nf: Nf,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
 {
@@ -171,7 +171,7 @@ where
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_strided_store<Reg, ExtState, Memory, CustomError>(
+pub unsafe fn execute_strided_store<Reg, ExtState, Memory>(
     ext_state: &mut ExtState,
     memory: &mut Memory,
     vs3: VReg,
@@ -181,10 +181,10 @@ pub unsafe fn execute_strided_store<Reg, ExtState, Memory, CustomError>(
     eew: Eew,
     group_regs: NonZeroU8,
     nf: Nf,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
 {
@@ -244,7 +244,7 @@ where
 #[expect(clippy::too_many_arguments, reason = "Internal API")]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_indexed_store<Reg, ExtState, Memory, CustomError>(
+pub unsafe fn execute_indexed_store<Reg, ExtState, Memory>(
     ext_state: &mut ExtState,
     memory: &mut Memory,
     vs3: VReg,
@@ -255,10 +255,10 @@ pub unsafe fn execute_indexed_store<Reg, ExtState, Memory, CustomError>(
     index_eew: Eew,
     data_group_regs: NonZeroU8,
     nf: Nf,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
 {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -8,9 +8,9 @@ use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::zvexx_helpers;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress, ProgramCounter,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    PackedAddress, ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -22,24 +22,22 @@ const impl<Reg> ExecutableInstructionOperands for ZveXxWidenNarrowInstruction<Re
 }
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZveXxWidenNarrowInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZveXxWidenNarrowInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler>
     for ZveXxWidenNarrowInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -54,7 +52,7 @@ where
         _memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vwaddu.vv - 2*SEW = zext(SEW) + zext(SEW)
             Self::VwadduVv { vd, vs2, vs1, vm } => {
@@ -105,7 +103,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -113,12 +111,12 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -133,7 +131,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_op::<true, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -197,7 +195,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -205,7 +203,7 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -222,7 +220,7 @@ where
                 let scalar = rs1_value.as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_op::<true, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -281,7 +279,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -289,12 +287,12 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -309,7 +307,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -373,7 +371,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -381,7 +379,7 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -402,7 +400,7 @@ where
                 .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -461,7 +459,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -469,12 +467,12 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -489,7 +487,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_op::<true, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -553,7 +551,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -561,7 +559,7 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -577,7 +575,7 @@ where
                 let scalar = rs1_value.as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_op::<true, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -636,7 +634,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -644,12 +642,12 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -664,7 +662,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -728,7 +726,7 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs2,
@@ -736,7 +734,7 @@ where
                     group_regs,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -756,7 +754,7 @@ where
                 .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -816,17 +814,17 @@ where
                     },
                 )?;
                 // vs2 is the wide source; vs1 is narrow
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -844,7 +842,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_w_op::<true, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_w_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -908,12 +906,12 @@ where
                     },
                 )?;
                 // For .wx scalar variants vd may alias vs2 (same wide group); no narrow vs1
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _>(
                     program_counter,
                     vd,
                     wide_group_regs,
@@ -929,7 +927,7 @@ where
                 let scalar = rs1_value.as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_w_op::<true, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_w_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -988,17 +986,17 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -1016,7 +1014,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1079,12 +1077,12 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _>(
                     program_counter,
                     vd,
                     wide_group_regs,
@@ -1104,7 +1102,7 @@ where
                 .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1163,17 +1161,17 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -1191,7 +1189,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_w_op::<true, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_w_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1254,12 +1252,12 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _>(
                     program_counter,
                     vd,
                     wide_group_regs,
@@ -1275,7 +1273,7 @@ where
                 let scalar = rs1_value.as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_w_op::<true, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_w_op::<true, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1334,17 +1332,17 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     vs1,
@@ -1362,7 +1360,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1425,12 +1423,12 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_widen_no_src_check::<Reg, _, _>(
                     program_counter,
                     vd,
                     wide_group_regs,
@@ -1450,7 +1448,7 @@ where
                 .cast_unsigned();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_widen_w_op::<false, _, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1510,17 +1508,17 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1535,7 +1533,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_narrow_shift::<false, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_narrow_shift::<false, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1598,12 +1596,12 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
@@ -1619,7 +1617,7 @@ where
                 let scalar = rs1_value.as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_narrow_shift::<false, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_narrow_shift::<false, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1677,12 +1675,12 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
@@ -1697,7 +1695,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_narrow_shift::<false, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_narrow_shift::<false, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1755,17 +1753,17 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -1780,7 +1778,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_narrow_shift::<true, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_narrow_shift::<true, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1843,12 +1841,12 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
@@ -1864,7 +1862,7 @@ where
                 let scalar = rs1_value.as_u64();
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_narrow_shift::<true, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_narrow_shift::<true, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1922,12 +1920,12 @@ where
                         ),
                     },
                 )?;
-                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vd_narrow_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_wide_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     wide_group_regs,
@@ -1942,7 +1940,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_narrow_shift::<true, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_narrow_shift::<true, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -1984,14 +1982,14 @@ where
                 // EMUL for source = LMUL / 2; src_group = max(1, group_regs / 2)
                 let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(2) / 2)
                     .expect("Not zero; qed");
-                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     src_group,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -2006,7 +2004,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_extension::<false, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_extension::<false, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -2047,14 +2045,14 @@ where
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(4) / 4)
                     .expect("Not zero; qed");
-                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     src_group,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -2069,7 +2067,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_extension::<false, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_extension::<false, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -2110,14 +2108,14 @@ where
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(8) / 8)
                     .expect("Not zero; qed");
-                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     src_group,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -2132,7 +2130,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_extension::<false, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_extension::<false, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -2172,14 +2170,14 @@ where
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(2) / 2)
                     .expect("Not zero; qed");
-                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     src_group,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -2194,7 +2192,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_extension::<true, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_extension::<true, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -2234,14 +2232,14 @@ where
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(4) / 4)
                     .expect("Not zero; qed");
-                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     src_group,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -2256,7 +2254,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_extension::<true, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_extension::<true, _, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -2296,14 +2294,14 @@ where
                 let group_regs = vtype.vlmul().register_count();
                 let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(8) / 8)
                     .expect("Not zero; qed");
-                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     src_group,
                     vd,
                     group_regs,
                 )?;
-                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvexx_widen_narrow_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
@@ -2318,7 +2316,7 @@ where
                 }
                 // SAFETY: alignment/overlap/SEW checked above
                 unsafe {
-                    zvexx_widen_narrow_helpers::execute_extension::<true, _, _, _>(
+                    zvexx_widen_narrow_helpers::execute_extension::<true, _, _>(
                         ext_state,
                         vd,
                         vs2,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
@@ -14,14 +14,14 @@ use core::num::NonZeroU8;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_vd_widen_no_src_check<Reg, Memory, PC, CustomError>(
+pub fn check_vd_widen_no_src_check<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     wide_group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let wide_group_regs = wide_group_regs.get();
     let vd_idx = vd.to_bits();
@@ -45,16 +45,16 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_vs_ext_alignment<Reg, Memory, PC, CustomError>(
+pub fn check_vs_ext_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vs2: VReg,
     src_group_regs: NonZeroU8,
     vd: VReg,
     group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let src_group_regs = src_group_regs.get();
     let group_regs = group_regs.get();
@@ -91,17 +91,17 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_vd_widen_alignment<Reg, Memory, PC, CustomError>(
+pub fn check_vd_widen_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     vs_a: VReg,
     vs_b_opt: Option<VReg>,
     group_regs: NonZeroU8,
     wide_group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let wide_group_regs = wide_group_regs.get();
     let group_regs = group_regs.get();
@@ -153,14 +153,14 @@ fn widen_src_overlap_illegal(vd_idx: u8, wide_group_regs: u8, vs_idx: u8, group_
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_vs_wide_alignment<Reg, Memory, PC, CustomError>(
+pub fn check_vs_wide_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vs: VReg,
     wide_group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let wide_group_regs = wide_group_regs.get();
     let vs_idx = vs.to_bits();
@@ -181,14 +181,14 @@ where
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn check_vd_narrow_alignment<Reg, Memory, PC, CustomError>(
+pub fn check_vd_narrow_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     group_regs: NonZeroU8,
-) -> Result<(), ExecutionError<Reg::Type, CustomError>>
+) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     let group_regs = group_regs.get();
     let vd_idx = vd.to_bits();
@@ -382,7 +382,7 @@ fn scalar_signed_for_sew(val: u64, sew: Vsew) -> u64 {
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -392,7 +392,7 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, Custom
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64) -> u64,
 {
@@ -462,7 +462,7 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, ExtState, Custom
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, CustomError, F>(
+pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, F>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -472,7 +472,7 @@ pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, Custo
     op: F,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     F: Fn(u64, u64) -> u64,
 {
@@ -539,7 +539,7 @@ pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, ExtState, Custo
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, CustomError>(
+pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -548,7 +548,7 @@ pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, Custom
     sew: Vsew,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -614,7 +614,7 @@ pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, ExtState, Custom
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_extension<const SIGN: bool, Reg, ExtState, CustomError>(
+pub unsafe fn execute_extension<const SIGN: bool, Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -623,7 +623,7 @@ pub unsafe fn execute_extension<const SIGN: bool, Reg, ExtState, CustomError>(
     factor: VsewFactor,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();

--- a/crates/execution/ab-riscv-interpreter/src/zawrs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zawrs.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zawrs.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zawrs.rs
@@ -49,17 +49,14 @@ where
 const impl<Reg> ExecutableInstructionOperands for ZawrsInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZawrsInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZawrsInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for ZawrsInstruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for ZawrsInstruction<Reg>
 where
     Reg: [const] Register,
     InstructionHandler: [const] WrsHandler,
@@ -77,7 +74,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             Self::WrsNto => {
                 system_instruction_handler.handle_wrs_nto();

--- a/crates/execution/ab-riscv-interpreter/src/zicond.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicond.rs
@@ -5,8 +5,9 @@ mod tests;
 
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
-    ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile, Rs1Rs2OperandValues,
-    Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
+    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
+    ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zicond.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicond.rs
@@ -15,17 +15,14 @@ use ab_riscv_primitives::prelude::*;
 const impl<Reg> ExecutableInstructionOperands for ZicondInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZicondInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZicondInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for ZicondInstruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for ZicondInstruction<Reg>
 where
     Reg: [const] Register,
     Regs: [const] RegisterFile<Reg>,
@@ -43,7 +40,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // Conditional zero, equal to zero.
             //

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -11,28 +11,23 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZicsrInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZicsrInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZicsrInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for ZicsrInstruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for ZicsrInstruction<Reg>
 where
     Reg: [const] Register,
     Regs: [const] RegisterFile<Reg>,
-    ExtState: [const] Csrs<Reg, CustomError>,
-    CustomError: [const] Destruct,
+    ExtState: [const] Csrs<Reg>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -47,7 +42,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // Atomic read/write CSR.
             //
@@ -79,17 +74,16 @@ where
                             return ExecutionResult::Err(ExecutionError::from(err));
                         }
                     };
-                    zicsr_helpers::process_csr_read::<Reg, ExtState, Self, CustomError>(
+                    zicsr_helpers::process_csr_read::<Reg, ExtState, Self>(
                         ext_state, csr_index, true, read_value,
                     )?
                 };
 
-                let write_output = zicsr_helpers::process_csr_write::<
-                    Reg,
-                    ExtState,
-                    Self,
-                    CustomError,
-                >(ext_state, csr_index, write_value)?;
+                let write_output = zicsr_helpers::process_csr_write::<Reg, ExtState, Self>(
+                    ext_state,
+                    csr_index,
+                    write_value,
+                )?;
                 match ext_state.write_csr(csr_index, write_output) {
                     Ok(()) => ExecutionResult::Continue {
                         rd,
@@ -121,24 +115,22 @@ where
                         return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 };
-                let read_output =
-                    zicsr_helpers::process_csr_read::<Reg, ExtState, Self, CustomError>(
-                        ext_state,
-                        csr_index,
-                        rs1 != Reg::ZERO,
-                        read_value,
-                    )?;
+                let read_output = zicsr_helpers::process_csr_read::<Reg, ExtState, Self>(
+                    ext_state,
+                    csr_index,
+                    rs1 != Reg::ZERO,
+                    read_value,
+                )?;
 
                 if rs1 == Reg::ZERO {
                     ::core::hint::cold_path();
                 } else {
                     let write_value = read_value | rs1_value;
-                    let write_output = zicsr_helpers::process_csr_write::<
-                        Reg,
-                        ExtState,
-                        Self,
-                        CustomError,
-                    >(ext_state, csr_index, write_value)?;
+                    let write_output = zicsr_helpers::process_csr_write::<Reg, ExtState, Self>(
+                        ext_state,
+                        csr_index,
+                        write_value,
+                    )?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
                         return ExecutionResult::Err(ExecutionError::from(error));
@@ -169,24 +161,22 @@ where
                         return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 };
-                let read_output =
-                    zicsr_helpers::process_csr_read::<Reg, ExtState, Self, CustomError>(
-                        ext_state,
-                        csr_index,
-                        rs1 != Reg::ZERO,
-                        read_value,
-                    )?;
+                let read_output = zicsr_helpers::process_csr_read::<Reg, ExtState, Self>(
+                    ext_state,
+                    csr_index,
+                    rs1 != Reg::ZERO,
+                    read_value,
+                )?;
 
                 if rs1 == Reg::ZERO {
                     ::core::hint::cold_path();
                 } else {
                     let write_value = read_value & !rs1_value;
-                    let write_output = zicsr_helpers::process_csr_write::<
-                        Reg,
-                        ExtState,
-                        Self,
-                        CustomError,
-                    >(ext_state, csr_index, write_value)?;
+                    let write_output = zicsr_helpers::process_csr_write::<Reg, ExtState, Self>(
+                        ext_state,
+                        csr_index,
+                        write_value,
+                    )?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
                         return ExecutionResult::Err(ExecutionError::from(error));
@@ -225,17 +215,16 @@ where
                             return ExecutionResult::Err(ExecutionError::from(error));
                         }
                     };
-                    zicsr_helpers::process_csr_read::<Reg, ExtState, Self, CustomError>(
+                    zicsr_helpers::process_csr_read::<Reg, ExtState, Self>(
                         ext_state, csr_index, true, read_value,
                     )?
                 };
 
-                let write_output = zicsr_helpers::process_csr_write::<
-                    Reg,
-                    ExtState,
-                    Self,
-                    CustomError,
-                >(ext_state, csr_index, zimm.into())?;
+                let write_output = zicsr_helpers::process_csr_write::<Reg, ExtState, Self>(
+                    ext_state,
+                    csr_index,
+                    zimm.into(),
+                )?;
                 match ext_state.write_csr(csr_index, write_output) {
                     Ok(()) => ExecutionResult::Continue {
                         rd,
@@ -271,23 +260,22 @@ where
                         return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 };
-                let read_output = zicsr_helpers::process_csr_read::<
-                    Reg,
-                    ExtState,
-                    Self,
-                    CustomError,
-                >(ext_state, csr_index, zimm != 0, read_value)?;
+                let read_output = zicsr_helpers::process_csr_read::<Reg, ExtState, Self>(
+                    ext_state,
+                    csr_index,
+                    zimm != 0,
+                    read_value,
+                )?;
 
                 if zimm == 0 {
                     ::core::hint::cold_path();
                 } else {
                     let write_value = read_value | Reg::Type::from(zimm);
-                    let write_output = zicsr_helpers::process_csr_write::<
-                        Reg,
-                        ExtState,
-                        Self,
-                        CustomError,
-                    >(ext_state, csr_index, write_value)?;
+                    let write_output = zicsr_helpers::process_csr_write::<Reg, ExtState, Self>(
+                        ext_state,
+                        csr_index,
+                        write_value,
+                    )?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
                         return ExecutionResult::Err(ExecutionError::from(error));
@@ -323,23 +311,22 @@ where
                         return ExecutionResult::Err(ExecutionError::from(error));
                     }
                 };
-                let read_output = zicsr_helpers::process_csr_read::<
-                    Reg,
-                    ExtState,
-                    Self,
-                    CustomError,
-                >(ext_state, csr_index, zimm != 0, read_value)?;
+                let read_output = zicsr_helpers::process_csr_read::<Reg, ExtState, Self>(
+                    ext_state,
+                    csr_index,
+                    zimm != 0,
+                    read_value,
+                )?;
 
                 if zimm == 0 {
                     ::core::hint::cold_path();
                 } else {
                     let write_value = read_value & !Reg::Type::from(zimm);
-                    let write_output = zicsr_helpers::process_csr_write::<
-                        Reg,
-                        ExtState,
-                        Self,
-                        CustomError,
-                    >(ext_state, csr_index, write_value)?;
+                    let write_output = zicsr_helpers::process_csr_write::<Reg, ExtState, Self>(
+                        ext_state,
+                        csr_index,
+                        write_value,
+                    )?;
                     if let Err(error) = ext_state.write_csr(csr_index, write_output) {
                         ::core::hint::cold_path();
                         return ExecutionResult::Err(ExecutionError::from(error));

--- a/crates/execution/ab-riscv-interpreter/src/zicsr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr.rs
@@ -6,8 +6,9 @@ pub mod zicsr_helpers;
 
 use crate::{
     Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher,
+    OpaqueThreadedExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
@@ -2,8 +2,9 @@ use crate::rv64::test_utils::{ExtState, execute, initialize_state};
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher,
+    OpaqueThreadedExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
@@ -1,10 +1,9 @@
 use crate::rv64::test_utils::{ExtState, execute, initialize_state};
 use crate::zicsr::zicsr_helpers;
 use crate::{
-    CsrError, Csrs, CustomErrorPlaceholder, ExecutableInstruction, ExecutableInstructionCsr,
-    ExecutableInstructionOperands, ExecutionError, ExecutionResult, FetchInstructionResult,
-    InstructionFetcher, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    ThreadedExecutableInstruction, ThreadedExecutionResult,
+    CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::{instruction, instruction_execution};
 use ab_riscv_primitives::prelude::*;
@@ -12,21 +11,14 @@ use core::{assert_matches, fmt};
 
 /// Lets [`TestZicsr`] forward to the closures configured via
 /// [`ExtState::set_prepare_csr_read_write()`]
-trait CsrMock<CustomError> {
-    fn mock_prepare_csr_read(
-        &self,
-        csr_index: u16,
-        raw_value: u64,
-    ) -> Result<u64, CsrError<CustomError>>;
+trait CsrMock {
+    fn mock_prepare_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError>;
 
-    fn mock_prepare_csr_write(
-        &mut self,
-        csr_index: u16,
-        write_value: u64,
-    ) -> Result<u64, CsrError<CustomError>>;
+    fn mock_prepare_csr_write(&mut self, csr_index: u16, write_value: u64)
+    -> Result<u64, CsrError>;
 }
 
-impl CsrMock<CustomErrorPlaceholder> for ExtState {
+impl CsrMock for ExtState {
     fn mock_prepare_csr_read(&self, csr_index: u16, raw_value: u64) -> Result<u64, CsrError> {
         self.prepare_csr_read(csr_index, raw_value)
     }
@@ -88,10 +80,10 @@ where
 impl<Reg> ExecutableInstructionOperands for TestZicsr<Reg> where Reg: Register {}
 
 #[instruction_execution]
-impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError> for TestZicsr<Reg>
+impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for TestZicsr<Reg>
 where
     Reg: Register<Type = u64>,
-    ExtState: CsrMock<CustomError>,
+    ExtState: CsrMock,
 {
     #[inline(always)]
     fn prepare_csr_read(
@@ -100,7 +92,7 @@ where
         _will_write: bool,
         raw_value: u64,
         output_value: &mut u64,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         *output_value = ext_state.mock_prepare_csr_read(csr_index, raw_value)?;
         Ok(true)
     }
@@ -111,19 +103,18 @@ where
         csr_index: u16,
         write_value: u64,
         output_value: &mut u64,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         *output_value = ext_state.mock_prepare_csr_write(csr_index, write_value)?;
         Ok(true)
     }
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for TestZicsr<Reg>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for TestZicsr<Reg>
 where
     Reg: Register<Type = u64>,
-    ExtState: Csrs<Reg, CustomError> + CsrMock<CustomError>,
+    ExtState: Csrs<Reg> + CsrMock,
 {
     #[inline(always)]
     fn execute(
@@ -137,7 +128,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/zicsr_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/zicsr_helpers.rs
@@ -3,7 +3,6 @@
 use crate::{CsrError, Csrs, ExecutableInstructionCsr};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
-use core::marker::Destruct;
 
 /// CSR privilege level check helper.
 ///
@@ -13,14 +12,10 @@ use core::marker::Destruct;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub const fn check_csr_privilege_level<Reg, C, CustomError>(
-    csrs: &C,
-    csr_index: u16,
-) -> Result<(), CsrError<CustomError>>
+pub const fn check_csr_privilege_level<Reg, C>(csrs: &C, csr_index: u16) -> Result<(), CsrError>
 where
     Reg: [const] Register,
-    C: [const] Csrs<Reg, CustomError>,
-    CustomError: [const] Destruct,
+    C: [const] Csrs<Reg>,
 {
     let current = csrs.privilege_level();
     let required_bits = ((csr_index >> 8u8) & 0b11) as u8;
@@ -50,16 +45,15 @@ where
 /// see [`ExecutableInstructionCsr::prepare_csr_read()`] for details.
 #[inline(always)]
 #[doc(hidden)]
-pub const fn process_csr_read<Reg, ExtState, I, CustomError>(
+pub const fn process_csr_read<Reg, ExtState, I>(
     ext_state: &ExtState,
     csr_index: u16,
     will_write: bool,
     raw_value: Reg::Type,
-) -> Result<Reg::Type, CsrError<CustomError>>
+) -> Result<Reg::Type, CsrError>
 where
     Reg: [const] Register,
-    I: [const] ExecutableInstructionCsr<ExtState, CustomError, Reg = Reg>,
-    CustomError: [const] Destruct,
+    I: [const] ExecutableInstructionCsr<ExtState, Reg = Reg>,
 {
     let mut out = Reg::Type::default();
     match I::prepare_csr_read(ext_state, csr_index, will_write, raw_value, &mut out) {
@@ -79,15 +73,14 @@ where
 /// instruction `I` and returning the output value on success.
 #[inline(always)]
 #[doc(hidden)]
-pub const fn process_csr_write<Reg, ExtState, I, CustomError>(
+pub const fn process_csr_write<Reg, ExtState, I>(
     ext_state: &mut ExtState,
     csr_index: u16,
     write_value: Reg::Type,
-) -> Result<Reg::Type, CsrError<CustomError>>
+) -> Result<Reg::Type, CsrError>
 where
     Reg: [const] Register,
-    I: [const] ExecutableInstructionCsr<ExtState, CustomError, Reg = Reg>,
-    CustomError: [const] Destruct,
+    I: [const] ExecutableInstructionCsr<ExtState, Reg = Reg>,
 {
     let mut out = Reg::Type::default();
     match I::prepare_csr_write(ext_state, csr_index, write_value, &mut out) {

--- a/crates/execution/ab-riscv-interpreter/src/zkr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zkr.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 /// Result of polling the entropy source behind the `Zkr` extension's `seed` CSR, corresponding to
 /// one of the specification's `OPST` states
@@ -60,12 +59,10 @@ where
 const impl<Reg> ExecutableInstructionOperands for ZkrInstruction<Reg> where Reg: [const] Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZkrInstruction<Reg>
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZkrInstruction<Reg>
 where
     Reg: [const] Register,
     ExtState: [const] ZkrSeedSource,
-    CustomError: [const] Destruct,
 {
     /// Reads of `seed` are pass-through: the raw stored value already reflects the outcome of the
     /// most recent poll (see [`Self::prepare_csr_write()`]).
@@ -80,7 +77,7 @@ where
         will_write: bool,
         raw_value: Reg::Type,
         output_value: &mut Reg::Type,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         if csr_index == SEED_CSR_INDEX {
             if will_write {
                 *output_value = raw_value;
@@ -103,7 +100,7 @@ where
         csr_index: u16,
         write_value: Reg::Type,
         output_value: &mut Reg::Type,
-    ) -> Result<bool, CsrError<CustomError>> {
+    ) -> Result<bool, CsrError> {
         // Necessary to avoid unused variable depending on instructions composition
         let _: Reg::Type = write_value;
 
@@ -117,9 +114,8 @@ where
 }
 
 #[instruction_execution]
-const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for ZkrInstruction<Reg>
+const impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for ZkrInstruction<Reg>
 where
     Reg: Register,
     ExtState: [const] ZkrSeedSource,
@@ -137,7 +133,7 @@ where
         _memory: &mut Memory,
         _program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         ExecutionResult::ContinueNoWrite
     }
 }

--- a/crates/execution/ab-riscv-interpreter/src/zkr.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zkr.rs
@@ -7,8 +7,9 @@ pub mod zkr_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, RegisterFile,
-    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher,
+    OpaqueThreadedExecutionResult, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -28,30 +28,26 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZvbbInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZvbbInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZvbbInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for ZvbbInstruction<Reg>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for ZvbbInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -66,7 +62,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vbrev: reverse all bits within each SEW-wide element
             Self::VbrevV { vd, vs2, vm } => {
@@ -95,12 +91,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -108,7 +104,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbb_helpers::execute_vbrev::<Reg, _, _>(ext_state, vd, vs2, sew, vm);
+                    zvbb_helpers::execute_vbrev::<Reg, _>(ext_state, vd, vs2, sew, vm);
                 }
             }
             // vclz: count leading zeros within each SEW-wide element; result in [0, SEW]
@@ -138,12 +134,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -151,7 +147,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbb_helpers::execute_vclz::<Reg, _, _>(ext_state, vd, vs2, sew, vm);
+                    zvbb_helpers::execute_vclz::<Reg, _>(ext_state, vd, vs2, sew, vm);
                 }
             }
             // vctz: count trailing zeros within each SEW-wide element; result in [0, SEW]
@@ -181,12 +177,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -194,7 +190,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbb_helpers::execute_vctz::<Reg, _, _>(ext_state, vd, vs2, sew, vm);
+                    zvbb_helpers::execute_vctz::<Reg, _>(ext_state, vd, vs2, sew, vm);
                 }
             }
             // vcpop: population count (number of set bits) within each SEW-wide element
@@ -224,12 +220,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -237,7 +233,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbb_helpers::execute_vcpop::<Reg, _, _>(ext_state, vd, vs2, sew, vm);
+                    zvbb_helpers::execute_vcpop::<Reg, _>(ext_state, vd, vs2, sew, vm);
                 }
             }
             // vwsll: widening shift-left-logical; vd is 2*SEW wide, vs2/src are SEW wide.
@@ -287,24 +283,24 @@ where
                         ),
                     });
                 };
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
                 )?;
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbb_helpers::execute_vwsll::<Reg, _, _>(
+                    zvbb_helpers::execute_vwsll::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -365,12 +361,12 @@ where
                         ),
                     });
                 };
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -378,7 +374,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbb_helpers::execute_vwsll::<Reg, _, _>(
+                    zvbb_helpers::execute_vwsll::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -435,19 +431,19 @@ where
                         ),
                     });
                 };
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     dest_group_regs,
                 )?;
-                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbb_helpers::execute_vwsll::<Reg, _, _>(
+                    zvbb_helpers::execute_vwsll::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,

--- a/crates/execution/ab-riscv-interpreter/src/zvbb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb.rs
@@ -22,9 +22,10 @@ use crate::zicsr::zicsr_helpers;
 use crate::zvbb::zvkb::zvkb_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress,
-    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher,
+    OpaqueThreadedExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvbb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvbb_helpers.rs
@@ -22,7 +22,7 @@ use ab_riscv_primitives::prelude::*;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vbrev<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vbrev<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -30,7 +30,7 @@ pub unsafe fn execute_vbrev<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -70,7 +70,7 @@ pub unsafe fn execute_vbrev<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vclz<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vclz<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -78,7 +78,7 @@ pub unsafe fn execute_vclz<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -115,7 +115,7 @@ pub unsafe fn execute_vclz<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vctz<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vctz<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -123,7 +123,7 @@ pub unsafe fn execute_vctz<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -159,7 +159,7 @@ pub unsafe fn execute_vctz<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vcpop<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vcpop<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -167,7 +167,7 @@ pub unsafe fn execute_vcpop<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -210,7 +210,7 @@ pub unsafe fn execute_vcpop<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vwsll<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vwsll<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -220,7 +220,7 @@ pub unsafe fn execute_vwsll<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -26,30 +26,26 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZvkbInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZvkbInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZvkbInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for ZvkbInstruction<Reg>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for ZvkbInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -64,7 +60,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vandn: vd[i] = ~vs1[i] & vs2[i]  (or ~rs1 & vs2[i])
             Self::VandnVv { vd, vs2, vs1, vm } => {
@@ -93,17 +89,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -111,7 +107,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vandn::<Reg, _, _>(
+                    zvkb_helpers::execute_vandn::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -152,12 +148,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -166,7 +162,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vandn::<Reg, _, _>(
+                    zvkb_helpers::execute_vandn::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -203,12 +199,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -216,7 +212,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vbrev8::<Reg, _, _>(ext_state, vd, vs2, sew, vm);
+                    zvkb_helpers::execute_vbrev8::<Reg, _>(ext_state, vd, vs2, sew, vm);
                 }
             }
             // vrev8: reverse bytes within each element
@@ -246,12 +242,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -259,7 +255,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vrev8::<Reg, _, _>(ext_state, vd, vs2, sew, vm);
+                    zvkb_helpers::execute_vrev8::<Reg, _>(ext_state, vd, vs2, sew, vm);
                 }
             }
             // vrol: vd[i] = rotate_left(vs2[i], src[i] % SEW)
@@ -289,17 +285,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -307,7 +303,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vrol::<Reg, _, _>(
+                    zvkb_helpers::execute_vrol::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -348,12 +344,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -362,7 +358,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vrol::<Reg, _, _>(
+                    zvkb_helpers::execute_vrol::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -399,17 +395,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -417,7 +413,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vror::<Reg, _, _>(
+                    zvkb_helpers::execute_vror::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -458,12 +454,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -472,7 +468,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vror::<Reg, _, _>(
+                    zvkb_helpers::execute_vror::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -509,12 +505,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvkb_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -522,7 +518,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvkb_helpers::execute_vror::<Reg, _, _>(
+                    zvkb_helpers::execute_vror::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb.rs
@@ -20,9 +20,10 @@ use crate::v::zvexx::zvexx_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress,
-    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher,
+    OpaqueThreadedExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/zvkb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/zvkb_helpers.rs
@@ -21,7 +21,7 @@ use ab_riscv_primitives::prelude::*;
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vandn<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vandn<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -30,7 +30,7 @@ pub unsafe fn execute_vandn<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -77,7 +77,7 @@ pub unsafe fn execute_vandn<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vbrev8<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vbrev8<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -85,7 +85,7 @@ pub unsafe fn execute_vbrev8<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -125,7 +125,7 @@ pub unsafe fn execute_vbrev8<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vrev8<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vrev8<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -133,7 +133,7 @@ pub unsafe fn execute_vrev8<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -170,7 +170,7 @@ pub unsafe fn execute_vrev8<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vrol<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vrol<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -179,7 +179,7 @@ pub unsafe fn execute_vrol<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -228,7 +228,7 @@ pub unsafe fn execute_vrol<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vror<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vror<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -237,7 +237,7 @@ pub unsafe fn execute_vror<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();

--- a/crates/execution/ab-riscv-interpreter/src/zvbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc.rs
@@ -26,30 +26,26 @@ use crate::{
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
-use core::marker::Destruct;
 
 #[instruction_execution]
 const impl<Reg> ExecutableInstructionOperands for ZvbcInstruction<Reg> where Reg: Register {}
 
 #[instruction_execution]
-const impl<Reg, ExtState, CustomError> ExecutableInstructionCsr<ExtState, CustomError>
-    for ZvbcInstruction<Reg>
-where
-    Reg: Register,
+const impl<Reg, ExtState> ExecutableInstructionCsr<ExtState> for ZvbcInstruction<Reg> where
+    Reg: Register
 {
 }
 
 #[instruction_execution]
-impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler, CustomError>
-    for ZvbcInstruction<Reg>
+impl<Reg, Regs, ExtState, Memory, PC, InstructionHandler>
+    ExecutableInstruction<Regs, ExtState, Memory, PC, InstructionHandler> for ZvbcInstruction<Reg>
 where
     Reg: Register,
     Regs: RegisterFile<Reg>,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
     Memory: VirtualMemory,
-    PC: ProgramCounter<Reg::Type, Memory, CustomError>,
+    PC: ProgramCounter<Reg::Type, Memory>,
 {
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -64,7 +60,7 @@ where
         memory: &mut Memory,
         program_counter: &mut PC,
         _system_instruction_handler: &mut InstructionHandler,
-    ) -> ExecutionResult<Self::Reg, CustomError> {
+    ) -> ExecutionResult<Self::Reg> {
         match self {
             // vclmul: vd[i] = lower SEW bits of clmul(vs2[i], vs1[i])
             Self::VclmulVv { vd, vs2, vs1, vm } => {
@@ -93,17 +89,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -111,7 +107,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbc_helpers::execute_vclmul::<Reg, _, _>(
+                    zvbc_helpers::execute_vclmul::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -152,12 +148,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -166,7 +162,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbc_helpers::execute_vclmul::<Reg, _, _>(
+                    zvbc_helpers::execute_vclmul::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -203,17 +199,17 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
                 )?;
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs1,
                     group_regs,
@@ -221,7 +217,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbc_helpers::execute_vclmulh::<Reg, _, _>(
+                    zvbc_helpers::execute_vclmulh::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,
@@ -262,12 +258,12 @@ where
                     });
                 };
                 let group_regs = vtype.vlmul().register_count();
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
                     group_regs,
                 )?;
-                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _, _>(
+                zvbc_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
                     group_regs,
@@ -276,7 +272,7 @@ where
                 let scalar = rs1_value.as_i64().cast_unsigned();
                 // SAFETY: alignments checked above
                 unsafe {
-                    zvbc_helpers::execute_vclmulh::<Reg, _, _>(
+                    zvbc_helpers::execute_vclmulh::<Reg, _>(
                         ext_state,
                         vd,
                         vs2,

--- a/crates/execution/ab-riscv-interpreter/src/zvbc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc.rs
@@ -20,9 +20,10 @@ use crate::v::zvexx::zvexx_helpers;
 use crate::zicsr::zicsr_helpers;
 use crate::{
     CsrError, Csrs, ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands,
-    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher, PackedAddress,
-    ProgramCounter, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
-    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
+    ExecutionError, ExecutionResult, FetchInstructionResult, InstructionFetcher,
+    OpaqueThreadedExecutionResult, PackedAddress, ProgramCounter, RegisterFile,
+    Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction, ThreadedExecutionResult,
+    VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/zvbc/zvbc_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc/zvbc_helpers.rs
@@ -59,7 +59,7 @@ fn vclmulh_element(a: u64, b: u64, sew: Vsew) -> u64 {
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vclmul<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vclmul<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -68,7 +68,7 @@ pub unsafe fn execute_vclmul<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();
@@ -112,7 +112,7 @@ pub unsafe fn execute_vclmul<Reg, ExtState, CustomError>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn execute_vclmulh<Reg, ExtState, CustomError>(
+pub unsafe fn execute_vclmulh<Reg, ExtState>(
     ext_state: &mut ExtState,
     vd: VReg,
     vs2: VReg,
@@ -121,7 +121,7 @@ pub unsafe fn execute_vclmulh<Reg, ExtState, CustomError>(
     vm: bool,
 ) where
     Reg: Register,
-    ExtState: VectorRegistersExt<Reg, CustomError>,
+    ExtState: VectorRegistersExt<Reg>,
     [(); SUPPORTED_ELEN_VLEN::<{ ExtState::ELEN }, { ExtState::VLEN }>]:,
 {
     let vl = ext_state.vl();

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -5,7 +5,7 @@ mod ignored_variants_remover;
 use crate::build::enum_impl::add_missing_fields::add_missing_rs_fields;
 use crate::build::enum_impl::forbidden_checker::block_contains_forbidden_syntax;
 use crate::build::enum_impl::ignored_variants_remover::remove_ignored_variants;
-use crate::build::shared::collect_all_dependencies;
+use crate::build::shared::{collect_all_dependencies, strip_const_where_predicates};
 use crate::build::state::{PendingEnumDisplayImpl, PendingEnumImpl, State};
 use ab_riscv_macros_common::code_utils::{post_process_rust_code, pre_process_rust_code};
 use anyhow::Context;
@@ -17,7 +17,7 @@ use std::rc::Rc;
 use std::{env, fs, iter};
 use syn::{
     Block, Expr, FieldPat, Fields, FnArg, Ident, ImplItem, ItemImpl, Member, Pat, PatWild, Stmt,
-    Token, Type, WherePredicate, parse_file, parse_quote, parse_str,
+    Token, Type, parse_file, parse_quote, parse_str,
 };
 
 const ORIGINAL_ENUM_DECODING_IMPL_ENV_VAR_SUFFIX: &str = "__INSTRUCTION_ENUM_ORIGINAL_IMPL_PATH";
@@ -342,6 +342,8 @@ pub(super) fn process_enum_decoding_impl(
         }
     }
 
+    let is_const = item_impl.attrs.last() == Some(&parse_quote! { #[cst] });
+
     if !all_where_predicates.is_empty() {
         let where_clause = item_impl
             .generics
@@ -361,36 +363,9 @@ pub(super) fn process_enum_decoding_impl(
         }
 
         // TODO: This is a massive hack for implementations that strips `[const]` for non-const
-        //  instructions that inherit const instructions. `Destruct` is a special case here that is
-        //  avoided altogether for non-const implementations to improve downstream user experience.
-        if item_impl.attrs.last() != Some(&parse_quote! { #[cst] }) {
-            where_clause.predicates = where_clause
-                .predicates
-                .clone()
-                .into_iter()
-                .filter_map(|mut predicate| match &mut predicate {
-                    WherePredicate::Type(predicate_type) => {
-                        // TODO: Remove `Destruct` hack once stabilized:
-                        //  https://github.com/rust-lang/rust/issues/133214
-                        if predicate_type.bounds.to_token_stream().to_string()
-                            == "BRCONST + Destruct"
-                        {
-                            return None;
-                        }
-
-                        // TODO: `BRCONST` is a hack that allows `syn` to parse unstable Rust syntax
-                        //  around const traits and such. It will change to a proper modifier once
-                        //  stabilized
-                        if predicate_type.bounds.first() == Some(&parse_quote! { BRCONST }) {
-                            predicate_type.bounds =
-                                predicate_type.bounds.clone().into_iter().skip(1).collect();
-                        }
-
-                        Some(predicate)
-                    }
-                    _ => Some(predicate),
-                })
-                .collect();
+        //  instructions that inherit const instructions
+        if !is_const {
+            strip_const_where_predicates(&mut where_clause.predicates);
         }
     }
 

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl.rs
@@ -491,7 +491,7 @@ pub(super) fn process_enum_csr_impl(
 
         // Non-const implementations that inherit arms from const ones must not keep `[const]`
         if !is_const {
-            where_clause.predicates = strip_const_where_predicates(where_clause.predicates.clone());
+            strip_const_where_predicates(&mut where_clause.predicates);
         }
     }
 
@@ -718,7 +718,7 @@ pub(super) fn process_enum_execution_impl(
 
         // Non-const implementations that inherit arms from const ones must not keep `[const]`
         if !is_const {
-            where_clause.predicates = strip_const_where_predicates(where_clause.predicates.clone());
+            strip_const_where_predicates(&mut where_clause.predicates);
         }
     } else {
         return Err(anyhow::anyhow!(

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
@@ -175,6 +175,18 @@ pub(super) fn generate_threaded_fns(
                     }
                 };
 
+                // Dispatch leaves the program counter on the instruction it read, and this is what
+                // moves it past it - by a size the compiler folds to a constant, since the variant
+                // is known here. Doing it during the fetch instead makes the address of the next
+                // instruction depend on decoding the current one, which is a load-to-load
+                // dependency in the middle of every dispatch step.
+                //
+                // SAFETY: Dispatch has just peeked this instruction successfully, and this is the
+                // only place that moves past it
+                unsafe {
+                    instruction_fetcher.advance(Instruction::size(&instruction));
+                }
+
                 let execution_result = #variant_fn_name::<#generic_params>(
                     #( #variant_call_args, )*
                     rs1_value,
@@ -332,7 +344,7 @@ pub(super) fn generate_threaded_fns(
             #where_clause
         {
             let instruction = loop {
-                match instruction_fetcher.fetch_instruction(memory) {
+                match instruction_fetcher.peek_instruction(memory) {
                     FetchInstructionResult::Instruction(instruction) => {
                         break instruction;
                     }

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
@@ -5,7 +5,7 @@ use heck::ToSnakeCase;
 use quote::{ToTokens, format_ident, quote};
 use std::env;
 use std::rc::Rc;
-use syn::{Abi, Arm, Generics, Ident, Item, Pat, Token, Type, Variant, WhereClause, parse_quote};
+use syn::{Abi, Arm, Generics, Ident, Item, Pat, Type, Variant, WhereClause, parse_quote};
 
 /// Calling convention used for functions involved in threaded execution.
 ///
@@ -34,25 +34,22 @@ fn handler_abi() -> anyhow::Result<Option<Abi>> {
 /// are for a non-`const` execution implementation, and the fetching half of the program counter is
 /// required on top of what `execute()` needs.
 fn threaded_where_clause(generics: &Generics, self_ty: &Type) -> anyhow::Result<WhereClause> {
-    let Some(where_clause) = &generics.where_clause else {
+    let Some(mut where_clause) = generics.where_clause.clone() else {
         return Err(anyhow::anyhow!("Missing where clause"));
     };
 
-    let mut predicates = strip_const_where_predicates(where_clause.predicates.clone());
+    strip_const_where_predicates(&mut where_clause.predicates);
 
-    predicates.push(parse_quote! {
-        PC: InstructionFetcher<#self_ty, Memory, CustomError>
+    where_clause.predicates.push(parse_quote! {
+        PC: InstructionFetcher<#self_ty, Memory>
     });
     // Applying an `ExecutionResult` is the executor's job rather than the instruction's, so the
     // handlers need the register file even for an extension whose own instructions never touch it
-    predicates.push(parse_quote! {
+    where_clause.predicates.push(parse_quote! {
         Regs: RegisterFile<Reg>
     });
 
-    Ok(WhereClause {
-        where_token: <Token![where]>::default(),
-        predicates,
-    })
+    Ok(where_clause)
 }
 
 /// Generates tail-call-threaded execution alongside the `match`-based `execute()`.
@@ -76,7 +73,7 @@ pub(super) fn generate_threaded_fns(
     let dispatch_fn_name = format_ident!("dispatch_{}", enum_name.to_string().to_snake_case());
     let dispatch_result_name = format_ident!("{enum_name}ThreadedDispatchResult");
     let result_ty: Type = parse_quote! {
-        ThreadedExecutionResult<PC, #self_ty, CustomError>
+        ThreadedExecutionResult<PC, #self_ty>
     };
 
     let mut generated_items = Vec::with_capacity(variants.len() + 3);
@@ -86,13 +83,13 @@ pub(super) fn generate_threaded_fns(
     // without the `Continue` variant, which dispatch resolves while fetching rather than passing
     // on. It never escapes the dispatch step it is created in, so it never materializes.
     generated_items.push(parse_quote! {
-        enum #dispatch_result_name<I, Handler, CustomError>
+        enum #dispatch_result_name<I, Handler>
         where
             I: Instruction,
         {
             Next { instruction: I, handler: Handler },
             Break,
-            Err(ExecutionError<<I::Reg as Register>::Type, CustomError>),
+            Err(ExecutionError<<I::Reg as Register>::Type>),
         }
     });
 
@@ -278,7 +275,6 @@ pub(super) fn generate_threaded_fns(
                 &mut Memory,
                 InstructionHandler,
             ) -> #result_ty,
-            CustomError,
         >
             #where_clause
         {
@@ -320,7 +316,6 @@ pub(super) fn generate_threaded_fns(
             Memory,
             PC,
             InstructionHandler,
-            CustomError,
         > for #self_ty
             #where_clause
         {

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
@@ -5,26 +5,47 @@ use heck::ToSnakeCase;
 use quote::{ToTokens, format_ident, quote};
 use std::env;
 use std::rc::Rc;
-use syn::{Abi, Arm, Generics, Ident, Item, Pat, Type, Variant, WhereClause, parse_quote};
+use syn::{
+    Abi, Arm, Attribute, Generics, Ident, Item, Pat, Type, Variant, WhereClause, parse_quote,
+};
 
-/// Calling convention used for functions involved in threaded execution.
+/// Calling convention used for functions involved in threaded execution, and the target features
+/// they need.
 ///
-/// Windows x86-64 passes only four arguments in registers, where the System V convention every
-/// other x86-64 target uses passes six, and it is critical for performance that a threaded
-/// interpreter has six registers available for arguments. `sysv64` ABI is supported on Windows too
-/// and solves this particular issue.
-fn handler_abi() -> anyhow::Result<Option<Abi>> {
+/// The default Rust calling convention returns nothing larger than a pointer pair in registers, so
+/// the outcome of execution would come back through memory, costing an argument register in every
+/// handler of the chain. An explicitly pinned convention is what makes the register return
+/// possible through `OpaqueThreadedExecutionResult`, which internally is composed of:
+/// * 256-bit vector register on x86-64 using `sysv64` ABI, which also gives handlers six argument
+///   registers on Windows
+/// * homogeneous aggregates on Aarch64
+///
+/// Everywhere else the outcome comes back through memory, and nothing special is needed for that.
+fn handler_abi() -> anyhow::Result<(Option<Abi>, Option<Attribute>)> {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").context(
         "Failed to retrieve `CARGO_CFG_TARGET_ARCH` environment variable, make sure to call \
         `process_instruction_macros` from `build.rs`",
     )?;
-    let target_os = env::var("CARGO_CFG_TARGET_OS").context(
-        "Failed to retrieve `CARGO_CFG_TARGET_OS` environment variable, make sure to call \
-        `process_instruction_macros` from `build.rs`",
-    )?;
 
-    Ok((target_arch == "x86_64" && target_os == "windows")
-        .then(|| parse_quote! { extern "sysv64" }))
+    // TODO: `extern "Rust"` returning such a value through memory where the platform's own
+    //  convention returns it in registers is a bug rather than something inherent, so this
+    //  pinning can go away (except on x86-64 Windows) once it is fixed:
+    //  https://github.com/rust-lang/rust/issues/161381
+    Ok(match target_arch.as_str() {
+        "x86_64" => (
+            Some(parse_quote! { extern "sysv64" }),
+            // Miri emulates a CPU without AVX and refuses to call a function that requires it, so
+            // unless it is running code built for AVX in the first place, the feature is disabled
+            Some(parse_quote! {
+                #[cfg_attr(
+                    any(not(miri), target_feature = "avx"),
+                    target_feature(enable = "avx")
+                )]
+            }),
+        ),
+        "aarch64" => (Some(parse_quote! { extern "C" }), None),
+        _ => (None, None),
+    })
 }
 
 /// Where clause for the generated threaded items.
@@ -69,11 +90,18 @@ pub(super) fn generate_threaded_fns(
 ) -> anyhow::Result<Vec<Item>> {
     let generic_params = &generics.params;
     let where_clause = threaded_where_clause(generics, self_ty)?;
-    let abi = handler_abi()?;
-    let dispatch_fn_name = format_ident!("dispatch_{}", enum_name.to_string().to_snake_case());
+    let (abi, target_feature) = handler_abi()?;
+    let enum_snake_case = enum_name.to_string().to_snake_case();
+    let dispatch_fn_name = format_ident!("dispatch_{enum_snake_case}");
+    let entry_fn_name = format_ident!("execute_{enum_snake_case}_threaded");
     let dispatch_result_name = format_ident!("{enum_name}ThreadedDispatchResult");
+    // What handlers return: the outcome serialized into a shape the target returns in registers
+    let handler_result_ty: Type = parse_quote! {
+        OpaqueThreadedExecutionResult<#self_ty>
+    };
+    // What execution as a whole returns, once the chain is over
     let result_ty: Type = parse_quote! {
-        ThreadedExecutionResult<PC, #self_ty>
+        ThreadedExecutionResult<#self_ty>
     };
 
     let mut generated_items = Vec::with_capacity(variants.len() + 3);
@@ -114,32 +142,31 @@ pub(super) fn generate_threaded_fns(
             });
 
         generated_items.push(parse_quote! {
-            #[cfg_attr(
-                all(target_arch = "x86_64", target_os = "windows"),
-                expect(
-                    improper_ctypes_definitions,
-                    reason = "Handlers only ever call each other, within this crate"
-                )
+            #[expect(
+                clippy::undocumented_unsafe_blocks,
+                reason = "Comments will be stripped, this will suppress some of the lints that \
+                are caused by it"
             )]
-            #abi fn #handler_fn_name<#generic_params>(
+            #[expect(clippy::allow_attributes, reason = "Attribute below")]
+            #[allow(
+                improper_ctypes_definitions,
+                reason = "Handlers only ever call each other, within this crate"
+            )]
+            #target_feature
+            unsafe #abi fn #handler_fn_name<#generic_params>(
                 instruction: #self_ty,
                 mut instruction_fetcher: PC,
                 regs: &mut Regs,
                 mut ext_state: ExtState,
                 memory: &mut Memory,
                 mut system_instruction_handler: InstructionHandler,
-            ) -> #result_ty
+            ) -> #handler_result_ty
                 #where_clause
             {
                 let Rs1Rs2Operands { rs1, rs2 } = instruction.get_rs1_rs2_operands();
                 let rs1_value = regs.read(rs1);
                 let rs2_value = regs.read(rs2);
 
-                #[expect(
-                    clippy::undocumented_unsafe_blocks,
-                    reason = "Comments will be stripped, this will suppress some of the lints that \
-                    are caused by it"
-                )]
                 let #enum_name::#variant_ident { #pat_fields } = instruction else {
                     // SAFETY: A handler is only ever reached through the dispatch arm for its own
                     // variant
@@ -179,16 +206,24 @@ pub(super) fn generate_threaded_fns(
                     }
                     ExecutionResult::Break => {
                         ::core::hint::cold_path();
-                        return ThreadedExecutionResult::stopped(
-                            instruction_fetcher,
-                        );
+                        // SAFETY: Platform support is checked before the chain is entered
+                        return unsafe {
+                            OpaqueThreadedExecutionResult::new(
+                                ThreadedExecutionResult::stopped(instruction_fetcher.get_pc()),
+                            )
+                        };
                     }
                     ExecutionResult::Err(error) => {
                         ::core::hint::cold_path();
-                        return ThreadedExecutionResult::failed(
-                            instruction_fetcher,
-                            error,
-                        );
+                        // SAFETY: Platform support is checked before the chain is entered
+                        return unsafe {
+                            OpaqueThreadedExecutionResult::new(
+                                ThreadedExecutionResult::failed(
+                                    instruction_fetcher.get_pc(),
+                                    error,
+                                ),
+                            )
+                        };
                     }
                 };
 
@@ -196,16 +231,24 @@ pub(super) fn generate_threaded_fns(
                     Ok(::core::ops::ControlFlow::Continue(())) => {}
                     Ok(::core::ops::ControlFlow::Break(())) => {
                         ::core::hint::cold_path();
-                        return ThreadedExecutionResult::stopped(
-                            instruction_fetcher,
-                        );
+                        // SAFETY: Platform support is checked before the chain is entered
+                        return unsafe {
+                            OpaqueThreadedExecutionResult::new(
+                                ThreadedExecutionResult::stopped(instruction_fetcher.get_pc()),
+                            )
+                        };
                     }
                     Err(error) => {
                         ::core::hint::cold_path();
-                        return ThreadedExecutionResult::failed(
-                            instruction_fetcher,
-                            error,
-                        );
+                        // SAFETY: Platform support is checked before the chain is entered
+                        return unsafe {
+                            OpaqueThreadedExecutionResult::new(
+                                ThreadedExecutionResult::failed(
+                                    instruction_fetcher.get_pc(),
+                                    error,
+                                ),
+                            )
+                        };
                     }
                 }
 
@@ -219,27 +262,39 @@ pub(super) fn generate_threaded_fns(
                     } => (instruction, handler),
                     #dispatch_result_name::Break => {
                         ::core::hint::cold_path();
-                        return ThreadedExecutionResult::stopped(
-                            instruction_fetcher,
-                        );
+                        // SAFETY: Platform support is checked before the chain is entered
+                        return unsafe {
+                            OpaqueThreadedExecutionResult::new(
+                                ThreadedExecutionResult::stopped(instruction_fetcher.get_pc()),
+                            )
+                        };
                     }
                     #dispatch_result_name::Err(error) => {
                         ::core::hint::cold_path();
-                        return ThreadedExecutionResult::failed(
-                            instruction_fetcher,
-                            error,
-                        );
+                        // SAFETY: Platform support is checked before the chain is entered
+                        return unsafe {
+                            OpaqueThreadedExecutionResult::new(
+                                ThreadedExecutionResult::failed(
+                                    instruction_fetcher.get_pc(),
+                                    error,
+                                ),
+                            )
+                        };
                     }
                 };
 
-                become handler(
-                    instruction,
-                    instruction_fetcher,
-                    regs,
-                    ext_state,
-                    memory,
-                    system_instruction_handler,
-                )
+                // SAFETY: Every handler carries the same target features this one does, which is
+                // what makes them unsafe to call in the first place
+                unsafe {
+                    become handler(
+                        instruction,
+                        instruction_fetcher,
+                        regs,
+                        ext_state,
+                        memory,
+                        system_instruction_handler,
+                    )
+                }
             }
         });
 
@@ -254,12 +309,10 @@ pub(super) fn generate_threaded_fns(
             reason = "`become` requires an exact signature match and a type alias cannot capture \
             the enclosing generics, so the handler type is spelled out here"
         )]
-        #[cfg_attr(
-            all(target_arch = "x86_64", target_os = "windows"),
-            expect(
-                improper_ctypes_definitions,
-                reason = "Handlers only ever call each other, within this crate"
-            )
+        #[expect(clippy::allow_attributes, reason = "Attribute below")]
+        #[allow(
+            improper_ctypes_definitions,
+            reason = "Handlers only ever call each other, within this crate"
         )]
         #[inline(always)]
         fn #dispatch_fn_name<#generic_params>(
@@ -267,14 +320,14 @@ pub(super) fn generate_threaded_fns(
             memory: &Memory,
         ) -> #dispatch_result_name<
             #self_ty,
-            #abi fn(
+            unsafe #abi fn(
                 #self_ty,
                 PC,
                 &mut Regs,
                 ExtState,
                 &mut Memory,
                 InstructionHandler,
-            ) -> #result_ty,
+            ) -> #handler_result_ty,
         >
             #where_clause
         {
@@ -309,6 +362,69 @@ pub(super) fn generate_threaded_fns(
         }
     });
 
+    // The one ordinary call in the whole chain: everything from here on is reached with `become`
+    // and nothing returns until execution stops.
+    //
+    // This is a separate function rather than the body of the trait method because it is the one
+    // that calls handlers, so it has to carry the same target features they do, and a safe trait
+    // method cannot carry target features.
+    generated_items.push(parse_quote! {
+        #[expect(
+            clippy::undocumented_unsafe_blocks,
+            reason = "Comments will be stripped, this will suppress some of the lints that are \
+            caused by it"
+        )]
+        #[inline]
+        #target_feature
+        unsafe fn #entry_fn_name<#generic_params>(
+            mut instruction_fetcher: PC,
+            regs: &mut Regs,
+            ext_state: ExtState,
+            memory: &mut Memory,
+            system_instruction_handler: InstructionHandler,
+        ) -> #result_ty
+            #where_clause
+        {
+            let (instruction, handler) = match #dispatch_fn_name::<#generic_params>(
+                &mut instruction_fetcher,
+                memory,
+            ) {
+                #dispatch_result_name::Next {
+                    instruction,
+                    handler,
+                } => (instruction, handler),
+                #dispatch_result_name::Break => {
+                    ::core::hint::cold_path();
+                    return ThreadedExecutionResult::stopped(
+                        instruction_fetcher.get_pc(),
+                    );
+                }
+                #dispatch_result_name::Err(error) => {
+                    ::core::hint::cold_path();
+                    return ThreadedExecutionResult::failed(
+                        instruction_fetcher.get_pc(),
+                        error,
+                    );
+                }
+            };
+
+            // SAFETY: This function carries the same target features every handler does, which is
+            // what makes them unsafe to call in the first place
+            let outcome = unsafe {
+                handler(
+                    instruction,
+                    instruction_fetcher,
+                    regs,
+                    ext_state,
+                    memory,
+                    system_instruction_handler,
+                )
+            };
+
+            outcome.into_result()
+        }
+    });
+
     generated_items.push(parse_quote! {
         impl<#generic_params> ThreadedExecutableInstruction<
             Regs,
@@ -319,47 +435,37 @@ pub(super) fn generate_threaded_fns(
         > for #self_ty
             #where_clause
         {
+            #[expect(
+                clippy::undocumented_unsafe_blocks,
+                reason = "Comments will be stripped, this will suppress some of the lints that \
+                are caused by it"
+            )]
             #[inline(always)]
             fn execute_threaded(
-                mut instruction_fetcher: PC,
+                instruction_fetcher: PC,
                 regs: &mut Regs,
                 ext_state: ExtState,
                 memory: &mut Memory,
                 system_instruction_handler: InstructionHandler,
             ) -> #result_ty {
-                // This is the one ordinary call in the whole chain: everything from here on is
-                // reached with `become` and nothing returns until execution stops
-                let (instruction, handler) = match #dispatch_fn_name::<#generic_params>(
-                    &mut instruction_fetcher,
-                    memory,
-                ) {
-                    #dispatch_result_name::Next {
-                        instruction,
-                        handler,
-                    } => (instruction, handler),
-                    #dispatch_result_name::Break => {
-                        ::core::hint::cold_path();
-                        return ThreadedExecutionResult::stopped(
-                            instruction_fetcher,
-                        );
-                    }
-                    #dispatch_result_name::Err(error) => {
-                        ::core::hint::cold_path();
-                        return ThreadedExecutionResult::failed(
-                            instruction_fetcher,
-                            error,
-                        );
-                    }
-                };
+                if !OpaqueThreadedExecutionResult::<#self_ty>::platform_supported() {
+                    ::core::hint::cold_path();
+                    return ThreadedExecutionResult::failed(
+                        instruction_fetcher.get_pc(),
+                        ExecutionError::UnsupportedPlatform,
+                    );
+                }
 
-                handler(
-                    instruction,
-                    instruction_fetcher,
-                    regs,
-                    ext_state,
-                    memory,
-                    system_instruction_handler,
-                )
+                // SAFETY: Platform support for what handlers need was just checked
+                unsafe {
+                    #entry_fn_name::<#generic_params>(
+                        instruction_fetcher,
+                        regs,
+                        ext_state,
+                        memory,
+                        system_instruction_handler,
+                    )
+                }
             }
         }
     });

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
@@ -251,6 +251,8 @@ pub(super) fn generate_threaded_fns(
                 improper_ctypes_definitions,
                 reason = "Handlers only ever call each other, within this crate"
             )]
+            // Make sure each handler starts on a cache line boundary
+            #[rustc_align(64)]
             #target_feature
             unsafe #abi fn #handler_fn_name<#generic_params>(
                 instruction: #self_ty,

--- a/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
+++ b/crates/execution/ab-riscv-macros/src/build/execution_impl/generate_threaded_fns.rs
@@ -95,6 +95,7 @@ pub(super) fn generate_threaded_fns(
     let dispatch_fn_name = format_ident!("dispatch_{enum_snake_case}");
     let entry_fn_name = format_ident!("execute_{enum_snake_case}_threaded");
     let dispatch_result_name = format_ident!("{enum_name}ThreadedDispatchResult");
+    let branch_failed_fn_name = format_ident!("{enum_snake_case}_threaded_branch_failed");
     // What handlers return: the outcome serialized into a shape the target returns in registers
     let handler_result_ty: Type = parse_quote! {
         OpaqueThreadedExecutionResult<#self_ty>
@@ -118,6 +119,104 @@ pub(super) fn generate_threaded_fns(
             Next { instruction: I, handler: Handler },
             Break,
             Err(ExecutionError<<I::Reg as Register>::Type>),
+        }
+    });
+
+    // Where a branch whose target `try_set_pc_relative()` refused goes. Kept out of the handlers
+    // and reached with a tail call: none of them is coming back at that point, so nothing they
+    // hold has to survive the call and none of them needs a frame for it. It takes everything a
+    // handler takes, unused arguments included, because `become` requires the two signatures to
+    // match exactly.
+    generated_items.push(parse_quote! {
+        #[expect(
+            clippy::undocumented_unsafe_blocks,
+            reason = "Comments will be stripped, this will suppress some of the lints that are \
+            caused by it"
+        )]
+        #[expect(clippy::allow_attributes, reason = "Attribute below")]
+        #[allow(
+            improper_ctypes_definitions,
+            reason = "Handlers only ever call each other, within this crate"
+        )]
+        #[cold]
+        #[inline(never)]
+        #target_feature
+        unsafe #abi fn #branch_failed_fn_name<#generic_params>(
+            _instruction: #self_ty,
+            mut instruction_fetcher: PC,
+            regs: &mut Regs,
+            ext_state: ExtState,
+            memory: &mut Memory,
+            system_instruction_handler: InstructionHandler,
+        ) -> #handler_result_ty
+            #where_clause
+        {
+            // SAFETY: Only reached from a handler whose `try_set_pc_relative()` returned `false`,
+            // with nothing in between having observed the program counter
+            match unsafe { instruction_fetcher.failed_branch(memory) } {
+                Ok(::core::ops::ControlFlow::Continue(())) => {}
+                Ok(::core::ops::ControlFlow::Break(())) => {
+                    // SAFETY: Platform support is checked before the chain is entered
+                    return unsafe {
+                        OpaqueThreadedExecutionResult::new(
+                            ThreadedExecutionResult::stopped(instruction_fetcher.get_pc()),
+                        )
+                    };
+                }
+                Err(error) => {
+                    // SAFETY: Platform support is checked before the chain is entered
+                    return unsafe {
+                        OpaqueThreadedExecutionResult::new(
+                            ThreadedExecutionResult::failed(
+                                instruction_fetcher.get_pc(),
+                                error,
+                            ),
+                        )
+                    };
+                }
+            }
+
+            let (instruction, handler) = match #dispatch_fn_name::<#generic_params>(
+                &mut instruction_fetcher,
+                memory,
+            ) {
+                #dispatch_result_name::Next {
+                    instruction,
+                    handler,
+                } => (instruction, handler),
+                #dispatch_result_name::Break => {
+                    // SAFETY: Platform support is checked before the chain is entered
+                    return unsafe {
+                        OpaqueThreadedExecutionResult::new(
+                            ThreadedExecutionResult::stopped(instruction_fetcher.get_pc()),
+                        )
+                    };
+                }
+                #dispatch_result_name::Err(error) => {
+                    // SAFETY: Platform support is checked before the chain is entered
+                    return unsafe {
+                        OpaqueThreadedExecutionResult::new(
+                            ThreadedExecutionResult::failed(
+                                instruction_fetcher.get_pc(),
+                                error,
+                            ),
+                        )
+                    };
+                }
+            };
+
+            // SAFETY: Every handler carries the same target features this one does, which is what
+            // makes them unsafe to call in the first place
+            unsafe {
+                become handler(
+                    instruction,
+                    instruction_fetcher,
+                    regs,
+                    ext_state,
+                    memory,
+                    system_instruction_handler,
+                )
+            }
         }
     });
 
@@ -207,11 +306,30 @@ pub(super) fn generate_threaded_fns(
                         Ok(::core::ops::ControlFlow::Continue(()))
                     }
                     ExecutionResult::Branch { offset } => {
-                        instruction_fetcher.set_pc_relative(
-                            memory,
-                            Instruction::size(&instruction),
-                            offset,
-                        )
+                        // SAFETY: A refused target goes straight to the continuation below, which
+                        // is what calls `failed_branch()` on it
+                        if unsafe {
+                            instruction_fetcher.try_set_pc_relative(
+                                Instruction::size(&instruction),
+                                offset,
+                            )
+                        } {
+                            Ok(::core::ops::ControlFlow::Continue(()))
+                        } else {
+                            // SAFETY: The continuation carries the same target features this
+                            // handler does, which is what makes it unsafe to call in the first
+                            // place
+                            unsafe {
+                                become #branch_failed_fn_name::<#generic_params>(
+                                    instruction,
+                                    instruction_fetcher,
+                                    regs,
+                                    ext_state,
+                                    memory,
+                                    system_instruction_handler,
+                                )
+                            }
+                        }
                     }
                     ExecutionResult::Jump { target } => {
                         instruction_fetcher.set_pc(memory, target)

--- a/crates/execution/ab-riscv-macros/src/build/shared.rs
+++ b/crates/execution/ab-riscv-macros/src/build/shared.rs
@@ -1,6 +1,6 @@
 use crate::build::state::{KnownEnumDefinition, State};
-use quote::ToTokens;
 use std::collections::{HashSet, VecDeque};
+use std::mem;
 use syn::punctuated::Punctuated;
 use syn::{Ident, Token, WherePredicate, parse_quote};
 
@@ -38,38 +38,22 @@ where
     Ok(all_dependencies)
 }
 
-/// Strips `[const]` from `where` predicates, dropping `[const] Destruct` ones altogether.
+/// Strips `[const]` from `where` predicates.
 ///
 /// Used both for a non-`const` implementation that inherits arms from `const` ones and for the
 /// threaded implementation, which is never `const`.
-pub(super) fn strip_const_where_predicates<Predicates>(
-    predicates: Predicates,
-) -> Punctuated<WherePredicate, Token![,]>
-where
-    Predicates: IntoIterator<Item = WherePredicate>,
-{
-    predicates
-        .into_iter()
-        .filter_map(|mut predicate| match &mut predicate {
-            WherePredicate::Type(predicate_type) => {
-                // TODO: Remove `Destruct` hack once stabilized, removing it from non-const
-                //  implementations improves downstream user experience:
-                //  https://github.com/rust-lang/rust/issues/133214
-                if predicate_type.bounds.to_token_stream().to_string() == "BRCONST + Destruct" {
-                    return None;
-                }
-
-                // TODO: `BRCONST` is a hack that allows `syn` to parse unstable Rust syntax
-                //  around const traits and such. It will change to a proper modifier once
-                //  stabilized
-                if predicate_type.bounds.first() == Some(&parse_quote! { BRCONST }) {
-                    predicate_type.bounds =
-                        predicate_type.bounds.clone().into_iter().skip(1).collect();
-                }
-
-                Some(predicate)
+pub(super) fn strip_const_where_predicates(predicates: &mut Punctuated<WherePredicate, Token![,]>) {
+    for predicate in predicates {
+        if let WherePredicate::Type(predicate_type) = predicate {
+            // TODO: `BRCONST` is a hack that allows `syn` to parse unstable Rust syntax
+            //  around const traits and such. It will change to a proper modifier once
+            //  stabilized
+            if predicate_type.bounds.first() == Some(&parse_quote! { BRCONST }) {
+                predicate_type.bounds = mem::take(&mut predicate_type.bounds)
+                    .into_iter()
+                    .skip(1)
+                    .collect();
             }
-            _ => Some(predicate),
-        })
-        .collect()
+        }
+    }
 }

--- a/crates/execution/ab-riscv-primitives/src/privilege.rs
+++ b/crates/execution/ab-riscv-primitives/src/privilege.rs
@@ -31,4 +31,9 @@ impl PrivilegeLevel {
             _ => None,
         }
     }
+
+    /// Encode to a 2-bit field value
+    pub const fn to_bits(self) -> u8 {
+        self as u8
+    }
 }

--- a/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/general_purpose.rs
@@ -59,6 +59,9 @@ where
     /// Convert to `u64`
     fn as_u64(&self) -> u64;
 
+    /// Convert from `u64`, truncating to this type's width
+    fn truncate_from_u64(value: u64) -> Self;
+
     /// Convert to `i64` (sign-extended)
     fn as_i64(&self) -> i64;
 
@@ -72,6 +75,11 @@ const impl RegType for u32 {
     #[inline(always)]
     fn as_u64(&self) -> u64 {
         u64::from(*self)
+    }
+
+    #[inline(always)]
+    fn truncate_from_u64(value: u64) -> Self {
+        value as Self
     }
 
     #[inline(always)]
@@ -91,6 +99,11 @@ const impl RegType for u64 {
     #[inline(always)]
     fn as_u64(&self) -> u64 {
         *self
+    }
+
+    #[inline(always)]
+    fn truncate_from_u64(value: u64) -> Self {
+        value
     }
 
     #[inline(always)]

--- a/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/lib.rs
@@ -13,7 +13,11 @@
 #![expect(incomplete_features, reason = "generic_const_*")]
 #![cfg_attr(
     all(test, not(target_arch = "spirv")),
-    feature(const_convert, const_trait_impl, maybe_uninit_fill)
+    feature(const_convert, const_trait_impl)
+)]
+#![cfg_attr(
+    all(test, not(any(miri, target_arch = "spirv"))),
+    feature(maybe_uninit_fill)
 )]
 // TODO: Remove once https://github.com/gfx-rs/wgpu/pull/9953 is released
 #![recursion_limit = "256"]

--- a/crates/shared/ab-archiving/tests/integration/main.rs
+++ b/crates/shared/ab-archiving/tests/integration/main.rs
@@ -1,4 +1,5 @@
-#![feature(const_convert, const_default, const_trait_impl)]
+#![feature(const_trait_impl)]
+#![cfg_attr(not(miri), feature(const_convert, const_default))]
 
 #[cfg(not(miri))]
 mod archiver;


### PR DESCRIPTION
This is a big follow-up to https://github.com/nazar-pc/abundance/pull/766 with various optimizations that ultimately enables uses threading dispatch in both CoreMark and contract benchmarks.

The net result is almost 2x CoreMark score increase:
```
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 13564888
Total time (secs): 13.564888
Iterations/Sec   : 2948.789551
Iterations       : 40000
Compiler version : GCC14.2.0
Compiler flags   : -O3 -march=rv64imc_zba_zbb_zbs -mabi=lp64
Memory location  : STACK
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x25b5
Correct operation validated. See readme.txt for run and reporting rules.
CoreMark 1.0 : 2948.789551 / GCC14.2.0 -O3 -march=rv64imc_zba_zbb_zbs -mabi=lp64 / STACK
Host elapsed: 17.478 s
```

Benchmarks for BLAKE3 and ed25519 signature verifications have new records:
```
blake3_hash_chunk/native
                        time:   [774.64 ns 777.91 ns 779.53 ns]
                        thrpt:  [1.2234 GiB/s 1.2259 GiB/s 1.2311 GiB/s]
blake3_hash_chunk/interpreter/threaded/eager
                        time:   [19.745 µs 20.206 µs 20.484 µs]
                        thrpt:  [47.675 MiB/s 48.330 MiB/s 49.459 MiB/s]

ed25519_verify/native   time:   [16.809 µs 16.887 µs 16.989 µs]
                        thrpt:  [58.862 Kelem/s 59.218 Kelem/s 59.492 Kelem/s]
ed25519_verify/interpreter/threaded/eager
                        time:   [852.74 µs 862.89 µs 874.82 µs]
                        thrpt:  [1.1431 Kelem/s 1.1589 Kelem/s 1.1727 Kelem/s]
```

This is ~4% and ~2% of the native AVX512 vectorized performance on Zen 4 CPU. Due to a different code structure, enabling vector support should also scale better in the interpreter now, though I have not benchmarked it yet.

Optimizations here include simplifying and reducing sizes of data structures, careful ABI management to make sure all handler arguments travel inside registers (including exploiting SIMD registers to return more than 16 bytes from handers without going through memory), function alignment and even sending jump error cases through the tail call so it stays out of the way. A lot of experimental Rust features compounded on top of each other to get here in a generic way.