### PR TITLE
Avoid copying uninitialized padding into test memory

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,6 +120,7 @@ jobs:
             name: Install kache
             uses: kunobi-ninja/kache-action@a257c055543c2840700a9bbca8f9c3094a421b1b # No release with Windows support yet
             with:
+              version: v0.15.0-rc.3
               # TODO: Enable for C++ too once https://github.com/kunobi-ninja/kache-action/issues/13 is implemented
               cache-executables: 'true'
               github-cache: 'false'

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -36,6 +36,14 @@ pub struct Blake3HashChunkInternalArgs {
     result: [u8; OUT_LEN],
 }
 
+const _: () = {
+    assert!(
+        size_of::<Blake3HashChunkInternalArgs>()
+            == offset_of!(Blake3HashChunkInternalArgs, result) + size_of::<[u8; OUT_LEN]>(),
+        "`Blake3HashChunkInternalArgs` must not have implicit padding"
+    );
+};
+
 impl Blake3HashChunkInternalArgs {
     /// Create a new instance
     pub fn new(internal_args_addr: u64, chunk: [u8; CHUNK_LEN]) -> Self {
@@ -77,7 +85,20 @@ pub struct Ed25519VerifyInternalArgs {
     pub signature: Ed25519Signature,
     pub message: [u8; OUT_LEN],
     pub result: Bool,
+    /// Explicit trailing padding.
+    ///
+    /// The host copies the byte representation of this data structure into guest memory, which is
+    /// only sound if every byte of it is initialized, hence implicit padding must not exist here.
+    pub padding: [u8; 7],
 }
+
+const _: () = {
+    assert!(
+        size_of::<Ed25519VerifyInternalArgs>()
+            == offset_of!(Ed25519VerifyInternalArgs, padding) + size_of::<[u8; 7]>(),
+        "`Ed25519VerifyInternalArgs` must not have implicit padding"
+    );
+};
 
 impl Ed25519VerifyInternalArgs {
     /// Create a new instance
@@ -102,6 +123,7 @@ impl Ed25519VerifyInternalArgs {
             signature,
             message,
             result: Bool::new(false),
+            padding: [0; _],
         }
     }
 

--- a/crates/execution/ab-riscv-benchmarks/tests/basic.rs
+++ b/crates/execution/ab-riscv-benchmarks/tests/basic.rs
@@ -63,7 +63,7 @@ where
 
     {
         let internal_args = create_internal_args(internal_args_addr);
-        // SAFETY: Byte representation of `#[repr(C)]` without internal padding
+        // SAFETY: Byte representation of `#[repr(C)]` without any padding, hence fully initialized
         let internal_args_bytes = unsafe {
             slice::from_raw_parts(ptr::from_ref(&internal_args).cast::<u8>(), size_of::<IA>())
         };
@@ -120,7 +120,7 @@ where
         }
     };
 
-    // SAFETY: Byte representation of `#[repr(C)]` without internal padding
+    // SAFETY: Byte representation of `#[repr(C)]` without any padding, hence fully initialized
     *unsafe {
         memory
             .read_slice(internal_args_addr, size_of::<IA>() as u32)


### PR DESCRIPTION
The test is too slow to run in CI, so UB was not caught there. This is benchmark-only thing though.

Kache version is fixed to include pre-release fixes that cause repeated flaky CI failures.