### PR TITLE
Store B-type branch offsets as `i16` rather than `I24`

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/rv32.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32.rs
@@ -240,7 +240,7 @@ where
             } => {
                 if rs1_value == rs2_value {
                     return ExecutionResult::Branch {
-                        offset: imm.to_i32(),
+                        offset: i32::from(imm),
                     };
                 }
 
@@ -253,7 +253,7 @@ where
             } => {
                 if rs1_value != rs2_value {
                     return ExecutionResult::Branch {
-                        offset: imm.to_i32(),
+                        offset: i32::from(imm),
                     };
                 }
 
@@ -266,7 +266,7 @@ where
             } => {
                 if rs1_value.cast_signed() < rs2_value.cast_signed() {
                     return ExecutionResult::Branch {
-                        offset: imm.to_i32(),
+                        offset: i32::from(imm),
                     };
                 }
 
@@ -279,7 +279,7 @@ where
             } => {
                 if rs1_value.cast_signed() >= rs2_value.cast_signed() {
                     return ExecutionResult::Branch {
-                        offset: imm.to_i32(),
+                        offset: i32::from(imm),
                     };
                 }
 
@@ -292,7 +292,7 @@ where
             } => {
                 if rs1_value < rs2_value {
                     return ExecutionResult::Branch {
-                        offset: imm.to_i32(),
+                        offset: i32::from(imm),
                     };
                 }
 
@@ -305,7 +305,7 @@ where
             } => {
                 if rs1_value >= rs2_value {
                     return ExecutionResult::Branch {
-                        offset: imm.to_i32(),
+                        offset: i32::from(imm),
                     };
                 }
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/tests.rs
@@ -576,7 +576,7 @@ fn test_beq_taken() {
     let mut state = initialize_state([Rv32Instruction::Beq {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(8),
+        imm: 8,
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -597,7 +597,7 @@ fn test_beq_not_taken() {
         Rv32Instruction::Beq {
             rs1: Reg::A0,
             rs2: Reg::A1,
-            imm: I24::from_i32(8),
+            imm: 8,
         },
         Rv32Instruction::Addi {
             rd: Reg::A2,
@@ -622,7 +622,7 @@ fn test_bne_taken() {
     let mut state = initialize_state([Rv32Instruction::Bne {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(8),
+        imm: 8,
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -642,7 +642,7 @@ fn test_blt_taken() {
     let mut state = initialize_state([Rv32Instruction::Blt {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(12),
+        imm: 12,
     }]);
 
     state.regs.write(Reg::A0, (-10i32).cast_unsigned());
@@ -662,7 +662,7 @@ fn test_bge_taken() {
     let mut state = initialize_state([Rv32Instruction::Bge {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(16),
+        imm: 16,
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -682,7 +682,7 @@ fn test_bltu_taken() {
     let mut state = initialize_state([Rv32Instruction::Bltu {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(20),
+        imm: 20,
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -702,7 +702,7 @@ fn test_bgeu_taken() {
     let mut state = initialize_state([Rv32Instruction::Bgeu {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(24),
+        imm: 24,
     }]);
 
     state.regs.write(Reg::A0, 20);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/tests.rs
@@ -764,7 +764,7 @@ fn test_beq_taken() {
         rs1: Reg::A0,
         rs2: Reg::A1,
         // Branch offset from PC before increment
-        imm: I24::from_i32(8),
+        imm: 8,
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -788,7 +788,7 @@ fn test_beq_not_taken() {
         Rv64Instruction::Beq {
             rs1: Reg::A0,
             rs2: Reg::A1,
-            imm: I24::from_i32(8),
+            imm: 8,
         },
         Rv64Instruction::Addi {
             rd: Reg::A2,
@@ -813,7 +813,7 @@ fn test_bne_taken() {
     let mut state = initialize_state([Rv64Instruction::Bne {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(8),
+        imm: 8,
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -833,7 +833,7 @@ fn test_blt_taken() {
     let mut state = initialize_state([Rv64Instruction::Blt {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(12),
+        imm: 12,
     }]);
 
     state.regs.write(Reg::A0, (-10i64).cast_unsigned());
@@ -853,7 +853,7 @@ fn test_bge_taken() {
     let mut state = initialize_state([Rv64Instruction::Bge {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(16),
+        imm: 16,
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -873,7 +873,7 @@ fn test_bltu_taken() {
     let mut state = initialize_state([Rv64Instruction::Bltu {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(20),
+        imm: 20,
     }]);
 
     state.regs.write(Reg::A0, 10);
@@ -893,7 +893,7 @@ fn test_bgeu_taken() {
     let mut state = initialize_state([Rv64Instruction::Bgeu {
         rs1: Reg::A0,
         rs2: Reg::A1,
-        imm: I24::from_i32(24),
+        imm: 24,
     }]);
 
     state.regs.write(Reg::A0, 20);

--- a/crates/execution/ab-riscv-interpreter/src/rv64/threaded_tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/threaded_tests.rs
@@ -162,7 +162,7 @@ fn threaded_matches_looped_taken_branch() {
             Rv64Instruction::Beq {
                 rs1: Reg::A0,
                 rs2: Reg::A1,
-                imm: I24::from_i32(8),
+                imm: 8,
             },
             Rv64Instruction::Addi {
                 rd: Reg::A2,
@@ -191,7 +191,7 @@ fn threaded_matches_looped_untaken_branch() {
             Rv64Instruction::Beq {
                 rs1: Reg::A0,
                 rs2: Reg::A1,
-                imm: I24::from_i32(8),
+                imm: 8,
             },
             Rv64Instruction::Addi {
                 rd: Reg::A2,
@@ -309,7 +309,7 @@ fn threaded_runs_a_loop_to_completion() {
         Rv64Instruction::Bne {
             rs1: Reg::A0,
             rs2: Reg::Zero,
-            imm: I24::from_i32(-4),
+            imm: -4,
         },
     ];
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
@@ -62,12 +62,12 @@ pub enum Rv32Instruction<Reg> {
     Sw { rs2: Reg, rs1: Reg, imm: i16 },
 
     // B-type
-    Beq { rs1: Reg, rs2: Reg, imm: I24 },
-    Bne { rs1: Reg, rs2: Reg, imm: I24 },
-    Blt { rs1: Reg, rs2: Reg, imm: I24 },
-    Bge { rs1: Reg, rs2: Reg, imm: I24 },
-    Bltu { rs1: Reg, rs2: Reg, imm: I24 },
-    Bgeu { rs1: Reg, rs2: Reg, imm: I24 },
+    Beq { rs1: Reg, rs2: Reg, imm: i16 },
+    Bne { rs1: Reg, rs2: Reg, imm: i16 },
+    Blt { rs1: Reg, rs2: Reg, imm: i16 },
+    Bge { rs1: Reg, rs2: Reg, imm: i16 },
+    Bltu { rs1: Reg, rs2: Reg, imm: i16 },
+    Bgeu { rs1: Reg, rs2: Reg, imm: i16 },
 
     // Lui (U-type)
     Lui { rd: Reg, imm: I24WithZeroedBits<12> },
@@ -211,7 +211,7 @@ where
                 let imm11 = ((instruction >> 7) & 1).cast_signed();
                 let imm = (imm12 << 12) | (imm11 << 11) | (imm10_5 << 5) | (imm4_1 << 1);
                 // Sign extend
-                let imm = I24::from_i32((imm << 19) >> 19);
+                let imm = ((imm << 19) >> 19) as i16;
                 match funct3 {
                     0b000 => Some(Self::Beq { rs1, rs2, imm }),
                     0b001 => Some(Self::Bne { rs1, rs2, imm }),

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/tests.rs
@@ -687,6 +687,25 @@ fn test_no_sd() {
 // B-type
 
 #[test]
+fn test_beq_immediate_range() {
+    // A B-type offset is thirteen bits signed with an implicit zero low bit, so it spans
+    // -4096..=4094 in steps of two, and that is what has to survive being stored in an `i16`
+    for imm in [4094, 4092, 2, -2, -4094, -4096] {
+        let inst = make_b_type(0b110_0011, 0b000, 1, 2, imm);
+        let decoded = Rv32Instruction::<Reg<u32>>::try_decode(inst).unwrap();
+        assert_eq!(
+            decoded,
+            Rv32Instruction::Beq {
+                rs1: Reg::Ra,
+                rs2: Reg::Sp,
+                imm: imm as i16
+            },
+            "offset {imm} did not round-trip"
+        );
+    }
+}
+
+#[test]
 fn test_beq() {
     {
         // Positive offset
@@ -697,7 +716,7 @@ fn test_beq() {
             Rv32Instruction::Beq {
                 rs1: Reg::Ra,
                 rs2: Reg::Sp,
-                imm: I24::from_i32(0x100)
+                imm: 0x100
             }
         );
     }
@@ -711,7 +730,7 @@ fn test_beq() {
             Rv32Instruction::Beq {
                 rs1: Reg::Ra,
                 rs2: Reg::Sp,
-                imm: I24::from_i32(-8)
+                imm: -8
             }
         );
     }
@@ -726,7 +745,7 @@ fn test_bne() {
         Rv32Instruction::Bne {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }
@@ -740,7 +759,7 @@ fn test_blt() {
         Rv32Instruction::Blt {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }
@@ -754,7 +773,7 @@ fn test_bge() {
         Rv32Instruction::Bge {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }
@@ -768,7 +787,7 @@ fn test_bltu() {
         Rv32Instruction::Bltu {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }
@@ -782,7 +801,7 @@ fn test_bgeu() {
         Rv32Instruction::Bgeu {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
@@ -78,12 +78,12 @@ pub enum Rv64Instruction<Reg> {
     Sd { rs2: Reg, rs1: Reg, imm: i16 },
 
     // B-type
-    Beq { rs1: Reg, rs2: Reg, imm: I24 },
-    Bne { rs1: Reg, rs2: Reg, imm: I24 },
-    Blt { rs1: Reg, rs2: Reg, imm: I24 },
-    Bge { rs1: Reg, rs2: Reg, imm: I24 },
-    Bltu { rs1: Reg, rs2: Reg, imm: I24 },
-    Bgeu { rs1: Reg, rs2: Reg, imm: I24 },
+    Beq { rs1: Reg, rs2: Reg, imm: i16 },
+    Bne { rs1: Reg, rs2: Reg, imm: i16 },
+    Blt { rs1: Reg, rs2: Reg, imm: i16 },
+    Bge { rs1: Reg, rs2: Reg, imm: i16 },
+    Bltu { rs1: Reg, rs2: Reg, imm: i16 },
+    Bgeu { rs1: Reg, rs2: Reg, imm: i16 },
 
     // Lui (U-type)
     Lui { rd: Reg, imm: I24WithZeroedBits<12> },
@@ -268,7 +268,7 @@ where
                 let imm11 = ((instruction >> 7) & 1).cast_signed();
                 let imm = (imm12 << 12) | (imm11 << 11) | (imm10_5 << 5) | (imm4_1 << 1);
                 // Sign extend
-                let imm = I24::from_i32((imm << 19) >> 19);
+                let imm = ((imm << 19) >> 19) as i16;
                 match funct3 {
                     0b000 => Some(Self::Beq { rs1, rs2, imm }),
                     0b001 => Some(Self::Bne { rs1, rs2, imm }),

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/tests.rs
@@ -943,6 +943,25 @@ fn test_sd() {
 // B-type
 
 #[test]
+fn test_beq_immediate_range() {
+    // A B-type offset is thirteen bits signed with an implicit zero low bit, so it spans
+    // -4096..=4094 in steps of two, and that is what has to survive being stored in an `i16`
+    for imm in [4094, 4092, 2, -2, -4094, -4096] {
+        let inst = make_b_type(0b110_0011, 0b000, 1, 2, imm);
+        let decoded = Rv64Instruction::<Reg<u64>>::try_decode(inst).unwrap();
+        assert_eq!(
+            decoded,
+            Rv64Instruction::Beq {
+                rs1: Reg::Ra,
+                rs2: Reg::Sp,
+                imm: imm as i16
+            },
+            "offset {imm} did not round-trip"
+        );
+    }
+}
+
+#[test]
 fn test_beq() {
     {
         // Positive offset
@@ -953,7 +972,7 @@ fn test_beq() {
             Rv64Instruction::Beq {
                 rs1: Reg::Ra,
                 rs2: Reg::Sp,
-                imm: I24::from_i32(0x100)
+                imm: 0x100
             }
         );
     }
@@ -967,7 +986,7 @@ fn test_beq() {
             Rv64Instruction::Beq {
                 rs1: Reg::Ra,
                 rs2: Reg::Sp,
-                imm: I24::from_i32(-8)
+                imm: -8
             }
         );
     }
@@ -982,7 +1001,7 @@ fn test_bne() {
         Rv64Instruction::Bne {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }
@@ -996,7 +1015,7 @@ fn test_blt() {
         Rv64Instruction::Blt {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }
@@ -1010,7 +1029,7 @@ fn test_bge() {
         Rv64Instruction::Bge {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }
@@ -1024,7 +1043,7 @@ fn test_bltu() {
         Rv64Instruction::Bltu {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }
@@ -1038,7 +1057,7 @@ fn test_bgeu() {
         Rv64Instruction::Bgeu {
             rs1: Reg::Ra,
             rs2: Reg::Sp,
-            imm: I24::from_i32(0x100)
+            imm: 0x100
         }
     );
 }


### PR DESCRIPTION
Turned out it 24 bits are unnecessary here. there is only 13 bits of information there