### PR TITLE
Improve `ab-erasure-coding` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,9 @@ dependencies = [
 name = "ab-erasure-coding"
 version = "0.1.0"
 dependencies = [
+ "ab-core-primitives",
  "chacha20 0.10.1",
+ "criterion",
  "reed-solomon-simd",
  "thiserror 2.0.20",
 ]

--- a/crates/farmer/ab-farmer-components/src/plotting.rs
+++ b/crates/farmer/ab-farmer-components/src/plotting.rs
@@ -603,7 +603,7 @@ fn record_encoding<PosTable>(
 
     // Erasure code source record chunks
     erasure_coding
-        .extend(record.iter(), parity_record_chunks.iter_mut())
+        .extend(record, &mut parity_record_chunks)
         .expect("Statically guaranteed valid inputs; qed");
 
     *record_chunks_used = pos_proofs.found_proofs;

--- a/crates/farmer/ab-farmer-components/src/proving.rs
+++ b/crates/farmer/ab-farmer-components/src/proving.rs
@@ -4,9 +4,7 @@
 //! before they can be sent to the node and this is exactly what this module is about.
 
 use crate::auditing::ChunkCandidate;
-use crate::reading::{
-    ReadingError, read_record_metadata, read_sector_record_chunks, recover_extended_record_chunks,
-};
+use crate::reading::{ReadingError, read_record_metadata, read_sector_record_chunks};
 use crate::sector::{
     RecordMetadata, SectorContentsMap, SectorContentsMapFromBytesError, SectorMetadataChecksummed,
 };
@@ -245,29 +243,43 @@ where
                 &pos_proofs,
                 &self.sector,
             );
-            let sector_record_chunks = sector_record_chunks_fut
+            let mut sector_record_chunks = sector_record_chunks_fut
                 .now_or_never()
                 .expect("Sync reader; qed")
                 .map_err(ProvingError::RecordReadingError)?;
 
-            let chunk = sector_record_chunks
-                .get(usize::from(self.s_bucket))
-                .expect("Within s-bucket range; qed")
-                .expect("Winning chunk was plotted; qed");
+            let chunk = sector_record_chunks.get_chunk(self.s_bucket);
 
-            let chunks = recover_extended_record_chunks(
-                &sector_record_chunks,
-                piece_offset,
-                self.erasure_coding,
-            )
-            .map_err(ProvingError::RecordReadingError)?;
+            self.erasure_coding
+                .recover_all(
+                    &mut sector_record_chunks.source,
+                    &mut sector_record_chunks.parity,
+                    &sector_record_chunks.present,
+                )
+                .map_err(|error| ReadingError::FailedToErasureDecodeRecord {
+                    piece_offset,
+                    error,
+                })
+                .map_err(ProvingError::RecordReadingError)?;
+
+            // TODO: Remove this extra allocation
+            // SAFETY: Data structure filled with zeroes is a valid invariant
+            let mut record_chunks = unsafe {
+                Box::<[[u8; RecordChunk::SIZE]; Record::NUM_S_BUCKETS]>::new_zeroed().assume_init()
+            };
+
+            for (target, source) in record_chunks.iter_mut().zip(
+                sector_record_chunks
+                    .source
+                    .iter()
+                    .chain(sector_record_chunks.parity.iter()),
+            ) {
+                *target = *source;
+            }
+
+            let record_merkle_tree =
+                BalancedMerkleTree::<{ Record::NUM_S_BUCKETS }>::new_boxed(&record_chunks);
             drop(sector_record_chunks);
-
-            let record_merkle_tree = BalancedMerkleTree::<{ Record::NUM_S_BUCKETS }>::new_boxed(
-                RecordChunk::slice_to_repr(chunks.as_slice())
-                    .try_into()
-                    .expect("Statically guaranteed to have correct length; qed"),
-            );
 
             // NOTE: We do not check plot consistency using checksum because it is more
             // expensive and consensus will verify validity of the proof anyway

--- a/crates/farmer/ab-farmer-components/src/reading.rs
+++ b/crates/farmer/ab-farmer-components/src/reading.rs
@@ -12,7 +12,7 @@ use crate::{ReadAt, ReadAtAsync, ReadAtSync};
 use ab_core_primitives::hashes::Blake3Hash;
 use ab_core_primitives::pieces::{Piece, PieceOffset, Record, RecordChunk};
 use ab_core_primitives::sectors::{SBucket, SectorId};
-use ab_erasure_coding::{ErasureCoding, ErasureCodingError, RecoveryShardState};
+use ab_erasure_coding::{ErasureCoding, ErasureCodingError, ShardsPresent};
 use ab_proof_of_space::{PosProofs, Table, TableGenerator};
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -92,7 +92,41 @@ impl ReadingError {
     }
 }
 
-/// Read sector record chunks, only plotted s-buckets are returned (in decoded form).
+/// Record chunks read from a sector.
+///
+/// Source and parity chunks are separate allocations so that a caller which only needs the source
+/// record can drop the parity one as soon as recovery is done. Contents of chunks that are not
+/// present are unspecified.
+#[derive(Debug)]
+pub struct SectorRecordChunks {
+    /// Source chunks
+    pub source: Box<Record>,
+    /// Parity chunks
+    pub parity: Box<Record>,
+    /// Which chunks are present
+    pub present: ShardsPresent<{ Record::NUM_CHUNKS }>,
+}
+
+impl SectorRecordChunks {
+    /// Returns the chunk at the given s-bucket
+    #[inline]
+    pub fn get_chunk(&self, s_bucket: SBucket) -> RecordChunk {
+        let s_bucket = usize::from(s_bucket);
+        RecordChunk::from(
+            *if let Some(parity_index) = s_bucket.checked_sub(Record::NUM_CHUNKS) {
+                self.parity
+                    .get(parity_index)
+                    .expect("Within correct range; qed")
+            } else {
+                self.source
+                    .get(s_bucket)
+                    .expect("Within correct range; qed")
+            },
+        )
+    }
+}
+
+/// Read sector record chunks, only plotted s-buckets are marked as present (in decoded form).
 ///
 /// NOTE: This is an async function, but it also does CPU-intensive operation internally, while it
 /// is not very long, make sure it is okay to do so in your context.
@@ -103,31 +137,40 @@ pub async fn read_sector_record_chunks<S, A>(
     sector_contents_map: &SectorContentsMap,
     pos_proofs: &PosProofs,
     sector: &ReadAt<S, A>,
-) -> Result<Box<[Option<RecordChunk>; Record::NUM_S_BUCKETS]>, ReadingError>
+) -> Result<SectorRecordChunks, ReadingError>
 where
     S: ReadAtSync,
     A: ReadAtAsync,
 {
-    let mut record_chunks = Box::<[Option<RecordChunk>; Record::NUM_S_BUCKETS]>::try_from(
-        vec![None::<RecordChunk>; Record::NUM_S_BUCKETS].into_boxed_slice(),
-    )
-    .expect("Correct size; qed");
+    let mut source = Record::new_boxed();
+    let mut parity = Record::new_boxed();
+    let mut present = ShardsPresent::none();
 
-    let read_chunks_inputs = record_chunks
+    let read_chunks_inputs = source
         .par_iter_mut()
+        .chain(parity.par_iter_mut())
         .zip(sector_contents_map.par_iter_record_chunk_to_plot(piece_offset))
         .zip(s_bucket_offsets.par_iter())
+        .enumerate()
         .map(
-            |((maybe_record_chunk, maybe_chunk_offset), &s_bucket_offset)| {
+            |(index, ((record_chunk, maybe_chunk_offset), &s_bucket_offset))| {
                 let chunk_offset = maybe_chunk_offset?;
 
                 let chunk_location = chunk_offset as u64 + u64::from(s_bucket_offset);
 
-                Some((maybe_record_chunk, chunk_location))
+                Some((index, record_chunk, chunk_location))
             },
         )
         .flatten()
         .collect::<Vec<_>>();
+
+    for &(index, _, _) in &read_chunks_inputs {
+        if let Some(parity_index) = index.checked_sub(Record::NUM_CHUNKS) {
+            present.parity.set(parity_index);
+        } else {
+            present.source.set(index);
+        }
+    }
 
     let sector_contents_map_size = SectorContentsMap::encoded_size(pieces_in_sector) as u64;
     match sector {
@@ -135,7 +178,7 @@ where
             read_chunks_inputs
                 .into_par_iter()
                 .zip(&pos_proofs.proofs)
-                .try_for_each(|((maybe_record_chunk, chunk_location), pos_proof)| {
+                .try_for_each(|((_index, output_chunk, chunk_location), pos_proof)| {
                     let mut record_chunk = [0; RecordChunk::SIZE];
                     sector
                         .read_at(
@@ -151,7 +194,7 @@ where
                     record_chunk =
                         Simd::to_array(Simd::from(record_chunk) ^ Simd::from(*pos_proof.hash()));
 
-                    maybe_record_chunk.replace(RecordChunk::from(record_chunk));
+                    *output_chunk = record_chunk;
 
                     Ok::<_, ReadingError>(())
                 })?;
@@ -161,7 +204,7 @@ where
                 .into_iter()
                 .zip(&pos_proofs.proofs)
                 .map(
-                    |((maybe_record_chunk, chunk_location), pos_proof)| async move {
+                    |((_index, output_chunk, chunk_location), pos_proof)| async move {
                         let mut record_chunk = [0; RecordChunk::SIZE];
                         record_chunk.copy_from_slice(
                             &sector
@@ -182,7 +225,7 @@ where
                             Simd::from(record_chunk) ^ Simd::from(*pos_proof.hash()),
                         );
 
-                        maybe_record_chunk.replace(RecordChunk::from(record_chunk));
+                        *output_chunk = record_chunk;
 
                         Ok::<_, ReadingError>(())
                     },
@@ -197,108 +240,36 @@ where
         }
     }
 
-    Ok(record_chunks)
+    Ok(SectorRecordChunks {
+        source,
+        parity,
+        present,
+    })
 }
 
-/// Given sector record chunks recover extended record chunks (both source and parity)
-pub fn recover_extended_record_chunks(
-    sector_record_chunks: &[Option<RecordChunk>; Record::NUM_S_BUCKETS],
-    piece_offset: PieceOffset,
-    erasure_coding: &ErasureCoding,
-) -> Result<Box<[RecordChunk; Record::NUM_S_BUCKETS]>, ReadingError> {
-    // Restore source record scalars
-
-    let mut recovered_sector_record_chunks = vec![[0u8; RecordChunk::SIZE]; Record::NUM_S_BUCKETS];
-    {
-        let (source_sector_record_chunks, parity_sector_record_chunks) =
-            sector_record_chunks.split_at(Record::NUM_CHUNKS);
-        let (source_recovered_sector_record_chunks, parity_recovered_sector_record_chunks) =
-            recovered_sector_record_chunks.split_at_mut(Record::NUM_CHUNKS);
-
-        let source = source_sector_record_chunks
-            .iter()
-            .zip(source_recovered_sector_record_chunks.iter_mut())
-            .map(
-                |(maybe_input_chunk, output_chunk)| match maybe_input_chunk {
-                    Some(input_chunk) => {
-                        output_chunk.copy_from_slice(input_chunk.as_slice());
-                        RecoveryShardState::Present(input_chunk.as_slice())
-                    }
-                    None => RecoveryShardState::MissingRecover(output_chunk.as_mut_slice()),
-                },
-            );
-        let parity = parity_sector_record_chunks
-            .iter()
-            .zip(parity_recovered_sector_record_chunks.iter_mut())
-            .map(
-                |(maybe_input_chunk, output_chunk)| match maybe_input_chunk {
-                    Some(input_chunk) => {
-                        output_chunk.copy_from_slice(input_chunk.as_slice());
-                        RecoveryShardState::Present(input_chunk.as_slice())
-                    }
-                    None => RecoveryShardState::MissingRecover(output_chunk.as_mut_slice()),
-                },
-            );
-        erasure_coding.recover(source, parity).map_err(|error| {
-            ReadingError::FailedToErasureDecodeRecord {
-                piece_offset,
-                error,
-            }
-        })?;
-    }
-
-    // Allocation in vector can be larger than contents, we need to make sure allocation is the same
-    // as the contents, this should also contain fast path if allocation matches contents
-    let record_chunks = recovered_sector_record_chunks
-        .into_iter()
-        .map(RecordChunk::from)
-        .collect::<Box<_>>();
-    // SAFETY: Size of the data is guaranteed above
-    let record_chunks = unsafe {
-        Box::from_raw(Box::into_raw(record_chunks).cast::<[RecordChunk; Record::NUM_S_BUCKETS]>())
-    };
-
-    Ok(record_chunks)
-}
-
-/// Given sector record chunks recover source record chunks in form of an iterator.
+/// Given sector record chunks recover the source record
 pub fn recover_source_record(
-    sector_record_chunks: &[Option<RecordChunk>; Record::NUM_S_BUCKETS],
+    sector_record_chunks: SectorRecordChunks,
     piece_offset: PieceOffset,
     erasure_coding: &ErasureCoding,
 ) -> Result<Box<Record>, ReadingError> {
-    // Restore source record scalars
-    let mut recovered_record = Record::new_boxed();
+    let SectorRecordChunks {
+        mut source,
+        parity,
+        present,
+    } = sector_record_chunks;
 
-    let (source_sector_record_chunks, parity_sector_record_chunks) =
-        sector_record_chunks.split_at(Record::NUM_CHUNKS);
-    let source = source_sector_record_chunks
-        .iter()
-        .zip(recovered_record.iter_mut())
-        .map(
-            |(maybe_input_chunk, output_chunk)| match maybe_input_chunk {
-                Some(input_chunk) => {
-                    output_chunk.copy_from_slice(input_chunk.as_slice());
-                    RecoveryShardState::Present(input_chunk.as_slice())
-                }
-                None => RecoveryShardState::MissingRecover(output_chunk.as_mut_slice()),
-            },
-        );
-    let parity =
-        parity_sector_record_chunks
-            .iter()
-            .map(|maybe_input_chunk| match maybe_input_chunk {
-                Some(input_chunk) => RecoveryShardState::Present(input_chunk.as_slice()),
-                None => RecoveryShardState::MissingIgnore,
-            });
-    erasure_coding.recover(source, parity).map_err(|error| {
-        ReadingError::FailedToErasureDecodeRecord {
+    erasure_coding
+        .recover_source(&mut source, &parity, &present)
+        .map_err(|error| ReadingError::FailedToErasureDecodeRecord {
             piece_offset,
             error,
-        }
-    })?;
+        })?;
 
-    Ok(recovered_record)
+    // Parity chunks are no longer needed, dropping them here keeps peak memory usage down
+    drop(parity);
+
+    Ok(source)
 }
 
 /// Read metadata (roots and proof) for record
@@ -378,7 +349,7 @@ where
     )
     .await?;
     // Restore source record scalars
-    let record = recover_source_record(&sector_record_chunks, piece_offset, erasure_coding)?;
+    let record = recover_source_record(sector_record_chunks, piece_offset, erasure_coding)?;
 
     let RecordMetadata {
         piece_header,

--- a/crates/farmer/ab-proof-of-space-gpu/src/host.rs
+++ b/crates/farmer/ab-proof-of-space-gpu/src/host.rs
@@ -293,7 +293,7 @@ impl RecordsEncoder for GpuRecordsEncoder {
                     // TODO: Do erasure coding on the GPU
                     // Erasure code source record chunks
                     self.erasure_coding
-                        .extend(record.iter(), parity_record_chunks.iter_mut())
+                        .extend(record, &mut parity_record_chunks)
                         .expect("Statically guaranteed valid inputs; qed");
 
                     if abort_early.load(Ordering::Relaxed) {

--- a/crates/shared/ab-archiving/src/archiver.rs
+++ b/crates/shared/ab-archiving/src/archiver.rs
@@ -673,14 +673,10 @@ impl Archiver {
             // Segment is quite big and no longer necessary
             drop(segment);
 
-            let (source_shards, parity_shards) =
-                pieces.split_at_mut(RecordedHistorySegment::NUM_RAW_RECORDS);
+            let (source_records, parity_records) = pieces.split_records_mut();
 
             self.erasure_coding
-                .extend(
-                    source_shards.iter().map(|shard| &shard.record),
-                    parity_shards.iter_mut().map(|shard| &mut shard.record),
-                )
+                .extend_scattered(source_records.map(|record| &*record), parity_records)
                 .expect("Statically correct parameters; qed");
 
             pieces
@@ -703,7 +699,7 @@ impl Archiver {
                     let mut parity_chunks = Record::new_boxed();
 
                     self.erasure_coding
-                        .extend(piece.record.iter(), parity_chunks.iter_mut())
+                        .extend(&piece.record, &mut parity_chunks)
                         .expect(
                             "Erasure coding instance is deliberately configured to support this \
                             input; qed",

--- a/crates/shared/ab-archiving/src/piece_reconstructor.rs
+++ b/crates/shared/ab-archiving/src/piece_reconstructor.rs
@@ -6,7 +6,7 @@ use ab_core_primitives::segments::{
     SegmentRoot, SuperSegmentIndex,
 };
 use ab_core_primitives::shard::ShardIndex;
-use ab_erasure_coding::{ErasureCoding, ErasureCodingError, RecoveryShardState};
+use ab_erasure_coding::{ErasureCoding, ErasureCodingError, ShardsPresent};
 use ab_merkle_tree::balanced::BalancedMerkleTree;
 use alloc::vec::Vec;
 #[cfg(feature = "parallel")]
@@ -64,60 +64,46 @@ impl PiecesReconstructor {
             let (source_reconstructed_pieces, parity_reconstructed_pieces) =
                 reconstructed_pieces.split_at_mut(RecordedHistorySegment::NUM_RAW_RECORDS);
 
-            let source = source_input_pieces
+            let mut present = ShardsPresent::none();
+
+            for (index, (maybe_input_piece, output_piece)) in source_input_pieces
                 .iter()
-                .zip(source_reconstructed_pieces)
-                .map(
-                    |(maybe_input_piece, output_piece)| match maybe_input_piece {
-                        Some(input_piece) => {
-                            if shared_piece_details.is_none() {
-                                shared_piece_details.replace(SharedPieceDetails {
-                                    shard_index: input_piece.header.shard_index.as_inner(),
-                                    local_segment_index: input_piece
-                                        .header
-                                        .local_segment_index
-                                        .as_inner(),
-                                    super_segment_index: input_piece
-                                        .header
-                                        .super_segment_index
-                                        .as_inner(),
-                                    segment_position: input_piece
-                                        .header
-                                        .segment_position
-                                        .as_inner(),
-                                    segment_root: input_piece.header.segment_root,
-                                    segment_proof: input_piece.header.segment_proof,
-                                });
-                            }
-                            // Fancy way to insert value to avoid going through stack (if naive
-                            // dereferencing is used) and potentially causing stack overflow as the
-                            // result
-                            output_piece.record.copy_from_slice(&*input_piece.record);
-                            RecoveryShardState::Present(input_piece.record.as_flattened())
-                        }
-                        None => RecoveryShardState::MissingRecover(
-                            output_piece.record.as_flattened_mut(),
-                        ),
-                    },
-                );
-            let parity = parity_input_pieces
+                .zip(source_reconstructed_pieces.iter_mut())
+                .enumerate()
+            {
+                if let Some(input_piece) = maybe_input_piece {
+                    if shared_piece_details.is_none() {
+                        shared_piece_details.replace(SharedPieceDetails {
+                            shard_index: input_piece.header.shard_index.as_inner(),
+                            local_segment_index: input_piece.header.local_segment_index.as_inner(),
+                            super_segment_index: input_piece.header.super_segment_index.as_inner(),
+                            segment_position: input_piece.header.segment_position.as_inner(),
+                            segment_root: input_piece.header.segment_root,
+                            segment_proof: input_piece.header.segment_proof,
+                        });
+                    }
+                    // Fancy way to insert value to avoid going through stack (if naive
+                    // dereferencing is used) and potentially causing stack overflow as the result
+                    output_piece.record.copy_from_slice(&*input_piece.record);
+                    present.source.set(index);
+                }
+            }
+
+            for (index, (maybe_input_piece, output_piece)) in parity_input_pieces
                 .iter()
                 .zip(parity_reconstructed_pieces.iter_mut())
-                .map(
-                    |(maybe_input_piece, output_piece)| match maybe_input_piece {
-                        Some(input_piece) => {
-                            // Fancy way to insert value to avoid going through stack (if naive
-                            // dereferencing is used) and potentially causing stack overflow as the
-                            // result
-                            output_piece.record.copy_from_slice(&*input_piece.record);
-                            RecoveryShardState::Present(input_piece.record.as_flattened())
-                        }
-                        None => RecoveryShardState::MissingRecover(
-                            output_piece.record.as_flattened_mut(),
-                        ),
-                    },
-                );
-            self.erasure_coding.recover(source, parity)?;
+                .enumerate()
+            {
+                if let Some(input_piece) = maybe_input_piece {
+                    output_piece.record.copy_from_slice(&*input_piece.record);
+                    present.parity.set(index);
+                }
+            }
+
+            let (source_records, parity_records) = reconstructed_pieces.split_records_mut();
+
+            self.erasure_coding
+                .recover_all_scattered(source_records, parity_records, &present)?;
         }
         let SharedPieceDetails {
             shard_index,
@@ -149,7 +135,7 @@ impl PiecesReconstructor {
                         let mut parity_chunks = Record::new_boxed();
 
                         self.erasure_coding
-                            .extend(piece.record.iter(), parity_chunks.iter_mut())?;
+                            .extend(&piece.record, &mut parity_chunks)?;
 
                         let source_chunks_root = *piece.record.source_chunks_root();
                         let parity_chunks_root =

--- a/crates/shared/ab-archiving/src/reconstructor.rs
+++ b/crates/shared/ab-archiving/src/reconstructor.rs
@@ -5,9 +5,9 @@ use ab_core_primitives::segments::{
     ArchivedHistorySegment, LastArchivedBlock, LocalSegmentIndex, RecordedHistorySegment,
     SegmentHeader,
 };
-use ab_erasure_coding::{ErasureCoding, ErasureCodingError, RecoveryShardState};
+use ab_erasure_coding::{ErasureCoding, ErasureCodingError, ShardsBitmap};
 use alloc::vec::Vec;
-use core::mem;
+use core::{array, mem};
 use parity_scale_codec::Decode;
 
 /// Reconstructor-related instantiation error
@@ -71,6 +71,7 @@ impl Reconstructor {
     /// Does not modify the internal state of the reconstructor.
     pub fn reconstruct_segment(
         &self,
+        // TODO: Improve API to not use `Option` anymore
         segment_pieces: &[Option<Piece>],
     ) -> Result<Segment, ReconstructorError> {
         if segment_pieces.len() < ArchivedHistorySegment::NUM_PIECES {
@@ -98,28 +99,43 @@ impl Reconstructor {
             // coding
             let (source_segment_pieces, parity_segment_pieces) =
                 segment_pieces.split_at(RecordedHistorySegment::NUM_RAW_RECORDS);
-            let source = segment_data.iter_mut().zip(source_segment_pieces).map(
-                |(output_record, maybe_source_piece)| match maybe_source_piece {
-                    Some(input_piece) => {
-                        // Fancy way to insert value to avoid going through stack (if naive
-                        // dereferencing is used) and potentially causing stack overflow as the
-                        // result
-                        output_record.copy_from_slice(&*input_piece.record);
-                        RecoveryShardState::Present(input_piece.record.as_flattened())
-                    }
-                    None => RecoveryShardState::MissingRecover(output_record.as_flattened_mut()),
+
+            let mut source_present = ShardsBitmap::none();
+            for (index, (output_record, maybe_source_piece)) in segment_data
+                .iter_mut()
+                .zip(source_segment_pieces)
+                .enumerate()
+            {
+                if let Some(input_piece) = maybe_source_piece {
+                    // Fancy way to insert value to avoid going through stack (if naive
+                    // dereferencing is used) and potentially causing stack overflow as the result
+                    output_record.copy_from_slice(&*input_piece.record);
+                    source_present.set(index);
+                }
+            }
+
+            // Parity records are read-only here, so missing ones simply have no memory
+            let parity_records = array::from_fn(|index| {
+                parity_segment_pieces[index]
+                    .as_ref()
+                    .map(|input_piece| &input_piece.record)
+            });
+
+            self.erasure_coding.recover_source_scattered(
+                {
+                    let records: &mut [_; RecordedHistorySegment::NUM_RAW_RECORDS] =
+                        segment_data.as_mut();
+                    let mut records = records.iter_mut();
+
+                    array::from_fn::<_, { RecordedHistorySegment::NUM_RAW_RECORDS }, _>(|_| {
+                        records
+                            .next()
+                            .expect("Number of records matches the array size; qed")
+                    })
                 },
-            );
-            let parity =
-                parity_segment_pieces
-                    .iter()
-                    .map(|maybe_source_piece| match maybe_source_piece {
-                        Some(input_piece) => {
-                            RecoveryShardState::Present(input_piece.record.as_flattened())
-                        }
-                        None => RecoveryShardState::MissingIgnore,
-                    });
-            self.erasure_coding.recover(source, parity)?;
+                &source_present,
+                parity_records,
+            )?;
         }
 
         let segment = Segment::decode(&mut AsRef::<[u8]>::as_ref(segment_data.as_ref()))

--- a/crates/shared/ab-archiving/tests/integration/archiver.rs
+++ b/crates/shared/ab-archiving/tests/integration/archiver.rs
@@ -687,7 +687,7 @@ fn object_on_the_edge_of_segment() {
 
     // Ensure bytes are mapped correctly
     assert_eq!(
-        archived_segments[1].pieces.as_ref()[0]
+        archived_segments[1].pieces[PiecePosition::from(0)]
             .record
             .as_flattened()[object_mapping[0].offset as usize..][..mapped_bytes.len()],
         mapped_bytes

--- a/crates/shared/ab-core-primitives/src/pieces.rs
+++ b/crates/shared/ab-core-primitives/src/pieces.rs
@@ -412,6 +412,21 @@ impl AsRef<[u8]> for Record {
     }
 }
 
+impl AsRef<[u8; Record::SIZE]> for Record {
+    #[inline(always)]
+    fn as_ref(&self) -> &[u8; Record::SIZE] {
+        self.as_bytes()
+    }
+}
+
+impl AsMut<[u8; Record::SIZE]> for Record {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut [u8; Record::SIZE] {
+        // SAFETY: `Record` is a plain byte array, any bit pattern is valid for it
+        unsafe { self.as_bytes_mut() }
+    }
+}
+
 impl AsMut<[u8]> for Record {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {

--- a/crates/shared/ab-core-primitives/src/segments/archival_history_segment.rs
+++ b/crates/shared/ab-core-primitives/src/segments/archival_history_segment.rs
@@ -1,12 +1,69 @@
-use crate::pieces::{FlatPieces, InnerPiece, Piece, PiecePosition};
+use crate::pieces::{FlatPieces, InnerPiece, Piece, PiecePosition, Record};
 use crate::segments::RecordedHistorySegment;
 use derive_more::{Deref, DerefMut};
 use std::ops::{Index, IndexMut};
+use std::{array, mem};
 
 /// Archived history segment after archiving is applied.
 #[derive(Debug, Clone, Eq, PartialEq, Deref, DerefMut)]
 #[repr(transparent)]
 pub struct ArchivedHistorySegment(FlatPieces);
+
+impl AsRef<[InnerPiece; Self::NUM_PIECES]> for ArchivedHistorySegment {
+    #[inline(always)]
+    fn as_ref(&self) -> &[InnerPiece; Self::NUM_PIECES] {
+        self.0
+            .as_ref()
+            .try_into()
+            .expect("Constructor always produces correct length; qed")
+    }
+}
+
+impl AsMut<[InnerPiece; Self::NUM_PIECES]> for ArchivedHistorySegment {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut [InnerPiece; Self::NUM_PIECES] {
+        self.0
+            .as_mut()
+            .try_into()
+            .expect("Constructor always produces correct length; qed")
+    }
+}
+
+impl AsRef<[[InnerPiece; RecordedHistorySegment::NUM_RAW_RECORDS]; 2]> for ArchivedHistorySegment {
+    #[inline(always)]
+    fn as_ref(&self) -> &[[InnerPiece; RecordedHistorySegment::NUM_RAW_RECORDS]; 2] {
+        const {
+            assert!(
+                RecordedHistorySegment::NUM_PIECES == RecordedHistorySegment::NUM_RAW_RECORDS * 2
+            );
+        }
+        // SAFETY: The same size and layout
+        unsafe {
+            mem::transmute::<
+                &[InnerPiece; Self::NUM_PIECES],
+                &[[InnerPiece; RecordedHistorySegment::NUM_RAW_RECORDS]; 2],
+            >(self.as_ref())
+        }
+    }
+}
+
+impl AsMut<[[InnerPiece; RecordedHistorySegment::NUM_RAW_RECORDS]; 2]> for ArchivedHistorySegment {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut [[InnerPiece; RecordedHistorySegment::NUM_RAW_RECORDS]; 2] {
+        const {
+            assert!(
+                RecordedHistorySegment::NUM_PIECES == RecordedHistorySegment::NUM_RAW_RECORDS * 2
+            );
+        }
+        // SAFETY: The same size and layout
+        unsafe {
+            mem::transmute::<
+                &mut [InnerPiece; Self::NUM_PIECES],
+                &mut [[InnerPiece; RecordedHistorySegment::NUM_RAW_RECORDS]; 2],
+            >(self.as_mut())
+        }
+    }
+}
 
 impl Default for ArchivedHistorySegment {
     #[inline]
@@ -32,6 +89,33 @@ impl IndexMut<PiecePosition> for ArchivedHistorySegment {
 }
 
 impl ArchivedHistorySegment {
+    /// All records of this segment, split into source and parity halves
+    #[inline(always)]
+    pub fn split_records_mut(
+        &mut self,
+    ) -> (
+        [&mut Record; RecordedHistorySegment::NUM_RAW_RECORDS],
+        [&mut Record; RecordedHistorySegment::NUM_RAW_RECORDS],
+    ) {
+        let [source, parity]: &mut [[_; RecordedHistorySegment::NUM_RAW_RECORDS]; 2] =
+            self.as_mut();
+        let mut source = source.iter_mut().map(|piece| &mut piece.record);
+        let mut parity = parity.iter_mut().map(|piece| &mut piece.record);
+
+        (
+            array::from_fn(|_| {
+                source
+                    .next()
+                    .expect("Number of pieces matches the array size; qed")
+            }),
+            array::from_fn(|_| {
+                parity
+                    .next()
+                    .expect("Number of pieces matches the array size; qed")
+            }),
+        )
+    }
+
     /// Number of pieces in one segment of archived history.
     pub const NUM_PIECES: usize = RecordedHistorySegment::NUM_PIECES;
     /// Size of archived history segment in bytes.

--- a/crates/shared/ab-erasure-coding/Cargo.toml
+++ b/crates/shared/ab-erasure-coding/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2024"
 include = [
+    "/benches",
     "/src",
     "/tests",
     "/Cargo.toml",
@@ -14,14 +15,22 @@ include = [
 [package.metadata.docs.rs]
 all-features = true
 
-# TODO: Benches
+[lib]
+# Necessary for CLI options to work on benches
+bench = false
+
+[[bench]]
+name = "erasure-coding"
+harness = false
 
 [dependencies]
 reed-solomon-simd = { workspace = true }
 thiserror = { workspace = true, default-features = false }
 
 [dev-dependencies]
+ab-core-primitives = { workspace = true }
 chacha20 = { workspace = true, features = ["rng"] }
+criterion = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/shared/ab-erasure-coding/benches/erasure-coding.rs
+++ b/crates/shared/ab-erasure-coding/benches/erasure-coding.rs
@@ -1,0 +1,125 @@
+use ab_core_primitives::pieces::{Record, RecordChunk};
+use ab_core_primitives::segments::RecordedHistorySegment;
+use ab_erasure_coding::{ErasureCoding, RecoveryShardState};
+use chacha20::ChaCha8Rng;
+use chacha20::rand_core::{Rng, SeedableRng};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::iter;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Many small shards: erasure coding of record chunks, as done during archiving, plotting and
+    // farming
+    erasure_coding(c, "record", Record::NUM_CHUNKS, RecordChunk::SIZE);
+    // Few large shards: erasure coding of records within a segment, as done when archiving history
+    // and reconstructing it back
+    erasure_coding(
+        c,
+        "segment",
+        RecordedHistorySegment::NUM_RAW_RECORDS,
+        Record::SIZE,
+    );
+}
+
+fn erasure_coding(c: &mut Criterion, name: &str, num_shards: usize, shard_size: usize) {
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+
+    let source_shards = iter::repeat_with(|| {
+        let mut shard = vec![0u8; shard_size].into_boxed_slice();
+        rng.fill_bytes(&mut shard);
+        shard
+    })
+    .take(num_shards)
+    .collect::<Vec<_>>();
+    let mut parity_shards = vec![vec![0u8; shard_size].into_boxed_slice(); num_shards];
+
+    let erasure_coding = ErasureCoding::new();
+
+    c.bench_function(&format!("{name}/extend"), |b| {
+        b.iter(|| {
+            erasure_coding
+                .extend(
+                    black_box(source_shards.iter()),
+                    black_box(parity_shards.iter_mut()),
+                )
+                .unwrap();
+        });
+    });
+
+    erasure_coding
+        .extend(source_shards.iter(), parity_shards.iter_mut())
+        .unwrap();
+
+    // Half of the shards missing is the worst case that is still recoverable with 1/2 erasure
+    // coding rate
+    let num_missing = num_shards / 2;
+    let mut recovered_source_shards = vec![vec![0u8; shard_size].into_boxed_slice(); num_shards];
+    let mut recovered_parity_shards = vec![vec![0u8; shard_size].into_boxed_slice(); num_shards];
+
+    // Recover source shards only, the way it is done when reconstructing a segment or reading a
+    // record from a sector
+    c.bench_function(&format!("{name}/recover-source"), |b| {
+        b.iter(|| {
+            let source = source_shards
+                .iter()
+                .zip(recovered_source_shards.iter_mut())
+                .enumerate()
+                .map(|(index, (input, output))| {
+                    if index < num_missing {
+                        RecoveryShardState::MissingRecover(output.as_mut())
+                    } else {
+                        RecoveryShardState::Present(input.as_ref())
+                    }
+                });
+            // Exactly as many parity shards as necessary to recover the missing source shards, the
+            // rest is not even looked at
+            let parity = parity_shards.iter().enumerate().map(|(index, input)| {
+                if index < num_missing {
+                    RecoveryShardState::Present(input.as_ref())
+                } else {
+                    RecoveryShardState::MissingIgnore
+                }
+            });
+
+            erasure_coding
+                .recover(black_box(source), black_box(parity))
+                .unwrap();
+        });
+    });
+
+    // Recover both source and parity shards, the way it is done when recovering all record chunks
+    // of a piece or reconstructing a whole piece
+    c.bench_function(&format!("{name}/recover-all"), |b| {
+        b.iter(|| {
+            let source = source_shards
+                .iter()
+                .zip(recovered_source_shards.iter_mut())
+                .enumerate()
+                .map(|(index, (input, output))| {
+                    if index < num_missing {
+                        RecoveryShardState::MissingRecover(output.as_mut())
+                    } else {
+                        RecoveryShardState::Present(input.as_ref())
+                    }
+                });
+            let parity = parity_shards
+                .iter()
+                .zip(recovered_parity_shards.iter_mut())
+                .enumerate()
+                .map(|(index, (input, output))| {
+                    if index < num_missing {
+                        RecoveryShardState::Present(input.as_ref())
+                    } else {
+                        RecoveryShardState::MissingRecover(output.as_mut())
+                    }
+                });
+
+            erasure_coding
+                .recover(black_box(source), black_box(parity))
+                .unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/shared/ab-erasure-coding/benches/erasure-coding.rs
+++ b/crates/shared/ab-erasure-coding/benches/erasure-coding.rs
@@ -1,88 +1,76 @@
 use ab_core_primitives::pieces::{Record, RecordChunk};
 use ab_core_primitives::segments::RecordedHistorySegment;
-use ab_erasure_coding::{ErasureCoding, RecoveryShardState};
+use ab_erasure_coding::{ErasureCoding, ShardsPresent};
 use chacha20::ChaCha8Rng;
 use chacha20::rand_core::{Rng, SeedableRng};
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
-use std::iter;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Many small shards: erasure coding of record chunks, as done during archiving, plotting and
     // farming
-    erasure_coding(c, "record", Record::NUM_CHUNKS, RecordChunk::SIZE);
+    erasure_coding::<{ Record::NUM_CHUNKS }, { RecordChunk::SIZE }>(c, "record");
     // Few large shards: erasure coding of records within a segment, as done when archiving history
     // and reconstructing it back
-    erasure_coding(
-        c,
-        "segment",
-        RecordedHistorySegment::NUM_RAW_RECORDS,
-        Record::SIZE,
-    );
+    erasure_coding::<{ RecordedHistorySegment::NUM_RAW_RECORDS }, { Record::SIZE }>(c, "segment");
 }
 
-fn erasure_coding(c: &mut Criterion, name: &str, num_shards: usize, shard_size: usize) {
+fn boxed_shards<const NUM_SHARDS: usize, const SHARD_BYTES: usize>()
+-> Box<[[u8; SHARD_BYTES]; NUM_SHARDS]> {
+    // SAFETY: Data structure filled with zeroes is a valid invariant
+    unsafe { Box::<[[u8; SHARD_BYTES]; NUM_SHARDS]>::new_zeroed().assume_init() }
+}
+
+fn erasure_coding<const NUM_SHARDS: usize, const SHARD_BYTES: usize>(
+    c: &mut Criterion,
+    name: &str,
+) {
     let mut rng = ChaCha8Rng::from_seed(Default::default());
 
-    let source_shards = iter::repeat_with(|| {
-        let mut shard = vec![0u8; shard_size].into_boxed_slice();
-        rng.fill_bytes(&mut shard);
-        shard
-    })
-    .take(num_shards)
-    .collect::<Vec<_>>();
-    let mut parity_shards = vec![vec![0u8; shard_size].into_boxed_slice(); num_shards];
+    let mut source_shards = boxed_shards::<NUM_SHARDS, SHARD_BYTES>();
+    for shard in &mut *source_shards {
+        rng.fill_bytes(shard);
+    }
+    let mut parity_shards = boxed_shards::<NUM_SHARDS, SHARD_BYTES>();
 
     let erasure_coding = ErasureCoding::new();
 
     c.bench_function(&format!("{name}/extend"), |b| {
         b.iter(|| {
             erasure_coding
-                .extend(
-                    black_box(source_shards.iter()),
-                    black_box(parity_shards.iter_mut()),
-                )
+                .extend(black_box(&*source_shards), black_box(&mut *parity_shards))
                 .unwrap();
         });
     });
 
     erasure_coding
-        .extend(source_shards.iter(), parity_shards.iter_mut())
+        .extend(&source_shards, &mut parity_shards)
         .unwrap();
 
     // Half of the shards missing is the worst case that is still recoverable with 1/2 erasure
     // coding rate
-    let num_missing = num_shards / 2;
-    let mut recovered_source_shards = vec![vec![0u8; shard_size].into_boxed_slice(); num_shards];
-    let mut recovered_parity_shards = vec![vec![0u8; shard_size].into_boxed_slice(); num_shards];
+    let num_missing = NUM_SHARDS / 2;
+    let mut present = ShardsPresent::<NUM_SHARDS>::all();
+    for index in 0..num_missing {
+        present.source.unset(index);
+        // Exactly as many parity shards as necessary to recover the missing source shards, the
+        // rest is not even looked at
+        present.parity.unset(index + num_missing);
+    }
+
+    let mut recovered_source_shards = source_shards.clone();
+    let mut recovered_parity_shards = parity_shards.clone();
 
     // Recover source shards only, the way it is done when reconstructing a segment or reading a
     // record from a sector
     c.bench_function(&format!("{name}/recover-source"), |b| {
         b.iter(|| {
-            let source = source_shards
-                .iter()
-                .zip(recovered_source_shards.iter_mut())
-                .enumerate()
-                .map(|(index, (input, output))| {
-                    if index < num_missing {
-                        RecoveryShardState::MissingRecover(output.as_mut())
-                    } else {
-                        RecoveryShardState::Present(input.as_ref())
-                    }
-                });
-            // Exactly as many parity shards as necessary to recover the missing source shards, the
-            // rest is not even looked at
-            let parity = parity_shards.iter().enumerate().map(|(index, input)| {
-                if index < num_missing {
-                    RecoveryShardState::Present(input.as_ref())
-                } else {
-                    RecoveryShardState::MissingIgnore
-                }
-            });
-
             erasure_coding
-                .recover(black_box(source), black_box(parity))
+                .recover_source(
+                    black_box(&mut *recovered_source_shards),
+                    black_box(&parity_shards),
+                    black_box(&present),
+                )
                 .unwrap();
         });
     });
@@ -91,31 +79,12 @@ fn erasure_coding(c: &mut Criterion, name: &str, num_shards: usize, shard_size: 
     // of a piece or reconstructing a whole piece
     c.bench_function(&format!("{name}/recover-all"), |b| {
         b.iter(|| {
-            let source = source_shards
-                .iter()
-                .zip(recovered_source_shards.iter_mut())
-                .enumerate()
-                .map(|(index, (input, output))| {
-                    if index < num_missing {
-                        RecoveryShardState::MissingRecover(output.as_mut())
-                    } else {
-                        RecoveryShardState::Present(input.as_ref())
-                    }
-                });
-            let parity = parity_shards
-                .iter()
-                .zip(recovered_parity_shards.iter_mut())
-                .enumerate()
-                .map(|(index, (input, output))| {
-                    if index < num_missing {
-                        RecoveryShardState::Present(input.as_ref())
-                    } else {
-                        RecoveryShardState::MissingRecover(output.as_mut())
-                    }
-                });
-
             erasure_coding
-                .recover(black_box(source), black_box(parity))
+                .recover_all(
+                    black_box(&mut *recovered_source_shards),
+                    black_box(&mut *recovered_parity_shards),
+                    black_box(&present),
+                )
                 .unwrap();
         });
     });

--- a/crates/shared/ab-erasure-coding/src/lib.rs
+++ b/crates/shared/ab-erasure-coding/src/lib.rs
@@ -1,53 +1,150 @@
-#![feature(trusted_len)]
+#![expect(incomplete_features, reason = "generic_const_*")]
+#![feature(
+    generic_const_args,
+    generic_const_items,
+    macroless_generic_const_args,
+    min_generic_const_args
+)]
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-use alloc::vec::Vec;
-use core::iter::TrustedLen;
-use core::mem::MaybeUninit;
+use core::fmt;
 use reed_solomon_simd::Error;
 use reed_solomon_simd::engine::DefaultEngine;
 use reed_solomon_simd::rate::{HighRateDecoder, HighRateEncoder, RateDecoder, RateEncoder};
 
-/// Error that occurs when calling [`ErasureCoding::recover()`]
+/// Error that occurs when erasure coding data
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum ErasureCodingError {
     /// Decoder error
     #[error("Decoder error: {0}")]
     DecoderError(#[from] Error),
-    /// Ignored source shard
-    #[error("Ignored source shard {index}")]
-    IgnoredSourceShard {
-        /// Shard index
-        index: usize,
-    },
-    /// Wrong source shard byte length
-    #[error("Wrong source shard byte length: expected {expected}, actual {actual}")]
-    WrongSourceShardByteLength { expected: usize, actual: usize },
-    /// Wrong parity shard byte length
-    #[error("Wrong parity shard byte length: expected {expected}, actual {actual}")]
-    WrongParityShardByteLength { expected: usize, actual: usize },
 }
 
-/// State of the shard for recovery
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum RecoveryShardState<PresentShard, MissingShard> {
-    /// Shard is present and will be used for recovery
-    Present(PresentShard),
-    /// Shard is missing and needs to be recovered
-    MissingRecover(MissingShard),
-    /// Shard is missing and does not need to be recovered.
-    ///
-    /// This is only allowed for parity shards, all source shards must always be present or
-    /// recovered.
-    MissingIgnore,
+/// Number of `u64` words needed for a bit per shard
+const NUM_WORDS<const NUM_SHARDS: usize>: usize = NUM_SHARDS.div_ceil(u64::BITS as usize);
+
+/// A bit per shard, typically saying whether that shard is present.
+///
+/// Bit `index % 64` of word `index / 64` corresponds to shard `index`, which is the same layout
+/// `reed_solomon_simd::rate::ReceivedShards` uses.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ShardsBitmap<const NUM_SHARDS: usize> {
+    words: [u64; NUM_WORDS::<NUM_SHARDS>],
+}
+
+impl<const NUM_SHARDS: usize> fmt::Debug for ShardsBitmap<NUM_SHARDS> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShardsBitmap")
+            .field("num_shards", &NUM_SHARDS)
+            .field("num_set", &self.count())
+            .finish()
+    }
+}
+
+impl<const NUM_SHARDS: usize> Default for ShardsBitmap<NUM_SHARDS> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+impl<const NUM_SHARDS: usize> ShardsBitmap<NUM_SHARDS> {
+    /// Bitmap with no shards set
+    #[inline(always)]
+    pub const fn none() -> Self {
+        Self {
+            words: [0; NUM_WORDS::<NUM_SHARDS>],
+        }
+    }
+
+    /// Bitmap with all shards set
+    #[inline(always)]
+    pub const fn all() -> Self {
+        let mut this = Self {
+            words: [u64::MAX; NUM_WORDS::<NUM_SHARDS>],
+        };
+
+        // Bits past the last shard must not be set
+        let unused_bits = NUM_WORDS::<NUM_SHARDS> * u64::BITS as usize - NUM_SHARDS;
+        if unused_bits > 0 {
+            this.words[NUM_WORDS::<NUM_SHARDS> - 1] >>= unused_bits;
+        }
+
+        this
+    }
+
+    /// Whether the shard at `index` is set, `false` if `index` is out of bounds
+    #[inline(always)]
+    pub const fn get(&self, index: usize) -> bool {
+        if index >= NUM_SHARDS {
+            return false;
+        }
+
+        (self.words[index / u64::BITS as usize] >> (index % u64::BITS as usize)) & 1 == 1
+    }
+
+    /// Sets the shard at `index`, does nothing if `index` is out of bounds
+    #[inline(always)]
+    pub const fn set(&mut self, index: usize) {
+        if index < NUM_SHARDS {
+            self.words[index / u64::BITS as usize] |= 1 << (index % u64::BITS as usize);
+        }
+    }
+
+    /// Unsets the shard at `index`, does nothing if `index` is out of bounds
+    #[inline(always)]
+    pub const fn unset(&mut self, index: usize) {
+        if index < NUM_SHARDS {
+            self.words[index / u64::BITS as usize] &= !(1 << (index % u64::BITS as usize));
+        }
+    }
+
+    /// Number of shards that are set
+    #[inline]
+    pub const fn count(&self) -> usize {
+        let mut count = 0;
+        let mut word_index = 0;
+        while word_index < NUM_WORDS::<NUM_SHARDS> {
+            count += self.words[word_index].count_ones() as usize;
+            word_index += 1;
+        }
+
+        count
+    }
+}
+
+/// Which source and parity shards are present
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub struct ShardsPresent<const NUM_SHARDS: usize> {
+    /// Which source shards are present
+    pub source: ShardsBitmap<NUM_SHARDS>,
+    /// Which parity shards are present
+    pub parity: ShardsBitmap<NUM_SHARDS>,
+}
+
+impl<const NUM_SHARDS: usize> ShardsPresent<NUM_SHARDS> {
+    /// Nothing is present
+    #[inline(always)]
+    pub const fn none() -> Self {
+        Self {
+            source: ShardsBitmap::none(),
+            parity: ShardsBitmap::none(),
+        }
+    }
+
+    /// Everything is present
+    #[inline(always)]
+    pub const fn all() -> Self {
+        Self {
+            source: ShardsBitmap::all(),
+            parity: ShardsBitmap::all(),
+        }
+    }
 }
 
 /// Erasure coding abstraction.
 ///
-/// Supports creation of parity records and recovery of missing data.
+/// Supports creation of parity shards and recovery of missing data.
 #[derive(Debug, Clone)]
 pub struct ErasureCoding;
 
@@ -63,31 +160,13 @@ impl ErasureCoding {
         Self {}
     }
 
-    /// Extend sources using erasure coding
-    pub fn extend<'a, SourceIter, ParityIter, SourceBytes, ParityBytes>(
+    /// Extend contiguously stored source shards with parity shards
+    pub fn extend<const NUM_SHARDS: usize, const SHARD_BYTES: usize>(
         &self,
-        source: SourceIter,
-        parity: ParityIter,
-    ) -> Result<(), ErasureCodingError>
-    where
-        SourceIter: TrustedLen<Item = SourceBytes>,
-        ParityIter: TrustedLen<Item = ParityBytes>,
-        SourceBytes: AsRef<[u8]> + 'a,
-        ParityBytes: AsMut<[u8]> + 'a,
-    {
-        let mut source = source.peekable();
-        let shard_byte_len = source
-            .peek()
-            .map(|shard| shard.as_ref().len())
-            .unwrap_or_default();
-
-        let mut encoder = HighRateEncoder::new(
-            source.size_hint().0,
-            parity.size_hint().0,
-            shard_byte_len,
-            DefaultEngine::new(),
-            None,
-        )?;
+        source: &[[u8; SHARD_BYTES]; NUM_SHARDS],
+        parity: &mut [[u8; SHARD_BYTES]; NUM_SHARDS],
+    ) -> Result<(), ErasureCodingError> {
+        let mut encoder = new_encoder::<NUM_SHARDS, SHARD_BYTES>()?;
 
         for shard in source {
             encoder.add_original_shard(shard)?;
@@ -95,161 +174,260 @@ impl ErasureCoding {
 
         let result = encoder.encode()?;
 
-        for (input, mut output) in result.recovery_iter().zip(parity) {
-            let output = output.as_mut();
-            if output.len() != shard_byte_len {
-                return Err(ErasureCodingError::WrongParityShardByteLength {
-                    expected: shard_byte_len,
-                    actual: output.len(),
-                });
-            }
+        for (input, output) in result.recovery_iter().zip(parity) {
             output.copy_from_slice(input);
         }
 
         Ok(())
     }
 
-    /// Recover missing shards
-    pub fn recover<'a, SourceIter, ParityIter>(
+    /// Extend source shards with parity shards, where shards are not stored contiguously
+    pub fn extend_scattered<
+        const NUM_SHARDS: usize,
+        const SHARD_BYTES: usize,
+        SourceShard,
+        ParityShard,
+    >(
         &self,
-        source: SourceIter,
-        parity: ParityIter,
+        source: [SourceShard; NUM_SHARDS],
+        parity: [ParityShard; NUM_SHARDS],
     ) -> Result<(), ErasureCodingError>
     where
-        SourceIter: TrustedLen<Item = RecoveryShardState<&'a [u8], &'a mut [u8]>>,
-        ParityIter: TrustedLen<Item = RecoveryShardState<&'a [u8], &'a mut [u8]>>,
+        SourceShard: AsRef<[u8; SHARD_BYTES]>,
+        ParityShard: AsMut<[u8; SHARD_BYTES]>,
     {
-        let num_source = source.size_hint().0;
-        let num_parity = parity.size_hint().0;
-        let mut source = source.enumerate().peekable();
-        let mut parity = parity.enumerate().peekable();
-        let mut shard_byte_len = 0;
+        let mut encoder = new_encoder::<NUM_SHARDS, SHARD_BYTES>()?;
 
-        while let Some((_, shard)) = source.peek_mut() {
-            match shard {
-                RecoveryShardState::Present(shard_bytes) => {
-                    shard_byte_len = shard_bytes.len();
-                    break;
-                }
-                RecoveryShardState::MissingRecover(shard_bytes) => {
-                    shard_byte_len = shard_bytes.len();
-                    break;
-                }
-                RecoveryShardState::MissingIgnore => {
-                    // Skip, it is inconsequential here
-                    source.next();
-                }
+        for shard in &source {
+            encoder.add_original_shard(shard.as_ref())?;
+        }
+
+        let result = encoder.encode()?;
+
+        let mut parity = parity;
+        for (input, output) in result.recovery_iter().zip(&mut parity) {
+            output.as_mut().copy_from_slice(input);
+        }
+
+        Ok(())
+    }
+
+    /// Recover missing source shards in place, with everything stored contiguously.
+    ///
+    /// Parity shards are inputs only, missing ones are simply not used. Prefer this over
+    /// [`Self::recover_all()`] when parity shards are not needed.
+    pub fn recover_source<const NUM_SHARDS: usize, const SHARD_BYTES: usize>(
+        &self,
+        source: &mut [[u8; SHARD_BYTES]; NUM_SHARDS],
+        parity: &[[u8; SHARD_BYTES]; NUM_SHARDS],
+        present: &ShardsPresent<NUM_SHARDS>,
+    ) -> Result<(), ErasureCodingError> {
+        let mut decoder = new_decoder::<NUM_SHARDS, SHARD_BYTES>()?;
+
+        for (index, shard) in source.iter().enumerate() {
+            if present.source.get(index) {
+                decoder.add_original_shard(index, shard)?;
             }
         }
-        if shard_byte_len == 0 {
-            while let Some((_, shard)) = parity.peek_mut() {
-                match shard {
-                    RecoveryShardState::Present(shard_bytes) => {
-                        shard_byte_len = shard_bytes.len();
-                        break;
-                    }
-                    RecoveryShardState::MissingRecover(shard_bytes) => {
-                        shard_byte_len = shard_bytes.len();
-                        break;
-                    }
-                    RecoveryShardState::MissingIgnore => {
-                        // Skip, it is inconsequential here
-                        parity.next();
-                    }
-                }
+        for (index, shard) in parity.iter().enumerate() {
+            if present.parity.get(index) {
+                decoder.add_recovery_shard(index, shard)?;
             }
         }
 
-        let mut all_source_shards = vec![MaybeUninit::uninit(); num_source];
-        let mut parity_shards_to_recover = Vec::new();
+        let result = decoder.decode()?;
 
-        {
-            let mut decoder = HighRateDecoder::new(
-                num_source,
-                num_parity,
-                shard_byte_len,
-                DefaultEngine::new(),
-                None,
-            )?;
-
-            let mut source_shards_to_recover = Vec::new();
-            for (index, shard) in source {
-                match shard {
-                    RecoveryShardState::Present(shard_bytes) => {
-                        all_source_shards[index].write(shard_bytes);
-                        decoder.add_original_shard(index, shard_bytes)?;
-                    }
-                    RecoveryShardState::MissingRecover(shard_bytes) => {
-                        source_shards_to_recover.push((index, shard_bytes));
-                    }
-                    RecoveryShardState::MissingIgnore => {
-                        return Err(ErasureCodingError::IgnoredSourceShard { index });
-                    }
-                }
-            }
-
-            for (index, shard) in parity {
-                match shard {
-                    RecoveryShardState::Present(shard_bytes) => {
-                        decoder.add_recovery_shard(index, shard_bytes)?;
-                    }
-                    RecoveryShardState::MissingRecover(shard_bytes) => {
-                        parity_shards_to_recover.push((index, shard_bytes));
-                    }
-                    RecoveryShardState::MissingIgnore => {}
-                }
-            }
-
-            let result = decoder.decode()?;
-
-            for (index, output) in source_shards_to_recover {
-                if output.len() != shard_byte_len {
-                    return Err(ErasureCodingError::WrongSourceShardByteLength {
-                        expected: shard_byte_len,
-                        actual: output.len(),
-                    });
-                }
-                let shard = result
-                    .restored_original(index)
-                    .expect("Always corresponds to a missing original shard; qed");
-                output.copy_from_slice(shard);
-                all_source_shards[index].write(output);
-            }
-        }
-
-        if !parity_shards_to_recover.is_empty() {
-            // SAFETY: All `all_source_shards` are either initialized from the start or recovered
-            let all_source_shards = unsafe { all_source_shards.assume_init_ref() };
-
-            let mut encoder = HighRateEncoder::new(
-                num_source,
-                num_parity,
-                shard_byte_len,
-                DefaultEngine::new(),
-                None,
-            )?;
-
-            for shard in all_source_shards {
-                encoder.add_original_shard(shard)?;
-            }
-
-            let result = encoder.encode()?;
-
-            for (index, output) in parity_shards_to_recover {
-                if output.len() != shard_byte_len {
-                    return Err(ErasureCodingError::WrongParityShardByteLength {
-                        expected: shard_byte_len,
-                        actual: output.len(),
-                    });
-                }
-                output.copy_from_slice(
-                    result
-                        .recovery(index)
-                        .expect("Always corresponds to a missing parity shard; qed"),
-                );
+        for (index, shard) in source.iter_mut().enumerate() {
+            if !present.source.get(index) {
+                shard.copy_from_slice(restored_original(&result, index));
             }
         }
 
         Ok(())
     }
+
+    /// Recover missing source shards in place, where shards are not stored contiguously.
+    ///
+    /// Parity shards are inputs only, so missing ones simply have no memory.
+    pub fn recover_source_scattered<
+        const NUM_SHARDS: usize,
+        const SHARD_BYTES: usize,
+        SourceShard,
+        ParityShard,
+    >(
+        &self,
+        source: [SourceShard; NUM_SHARDS],
+        source_present: &ShardsBitmap<NUM_SHARDS>,
+        parity: [Option<ParityShard>; NUM_SHARDS],
+    ) -> Result<(), ErasureCodingError>
+    where
+        SourceShard: AsMut<[u8; SHARD_BYTES]>,
+        ParityShard: AsRef<[u8; SHARD_BYTES]>,
+    {
+        let mut decoder = new_decoder::<NUM_SHARDS, SHARD_BYTES>()?;
+
+        let mut source = source;
+        for (index, shard) in source.iter_mut().enumerate() {
+            if source_present.get(index) {
+                decoder.add_original_shard(index, shard.as_mut().as_slice())?;
+            }
+        }
+        for (index, shard) in parity.iter().enumerate() {
+            if let Some(shard) = shard {
+                decoder.add_recovery_shard(index, shard.as_ref())?;
+            }
+        }
+
+        let result = decoder.decode()?;
+
+        for (index, shard) in source.iter_mut().enumerate() {
+            if !source_present.get(index) {
+                shard
+                    .as_mut()
+                    .copy_from_slice(restored_original(&result, index));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Recover missing source and parity shards in place, with everything stored contiguously.
+    ///
+    /// Use [`Self::recover_source()`] instead if parity shards are not needed.
+    pub fn recover_all<const NUM_SHARDS: usize, const SHARD_BYTES: usize>(
+        &self,
+        source: &mut [[u8; SHARD_BYTES]; NUM_SHARDS],
+        parity: &mut [[u8; SHARD_BYTES]; NUM_SHARDS],
+        present: &ShardsPresent<NUM_SHARDS>,
+    ) -> Result<(), ErasureCodingError> {
+        self.recover_source(source, parity, present)?;
+
+        if present.parity.count() == NUM_SHARDS {
+            return Ok(());
+        }
+
+        // Source shards are complete at this point, so missing parity shards are simply encoded
+        // again
+        let mut encoder = new_encoder::<NUM_SHARDS, SHARD_BYTES>()?;
+
+        for shard in &*source {
+            encoder.add_original_shard(shard)?;
+        }
+
+        let result = encoder.encode()?;
+
+        for (index, shard) in parity.iter_mut().enumerate() {
+            if !present.parity.get(index) {
+                shard.copy_from_slice(recovery(&result, index));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Recover missing source and parity shards in place, where shards are not stored contiguously
+    pub fn recover_all_scattered<
+        const NUM_SHARDS: usize,
+        const SHARD_BYTES: usize,
+        SourceShard,
+        ParityShard,
+    >(
+        &self,
+        source: [SourceShard; NUM_SHARDS],
+        parity: [ParityShard; NUM_SHARDS],
+        present: &ShardsPresent<NUM_SHARDS>,
+    ) -> Result<(), ErasureCodingError>
+    where
+        SourceShard: AsMut<[u8; SHARD_BYTES]>,
+        ParityShard: AsMut<[u8; SHARD_BYTES]>,
+    {
+        let mut source = source;
+        let mut parity = parity;
+
+        {
+            let mut decoder = new_decoder::<NUM_SHARDS, SHARD_BYTES>()?;
+
+            for (index, shard) in source.iter_mut().enumerate() {
+                if present.source.get(index) {
+                    decoder.add_original_shard(index, shard.as_mut().as_slice())?;
+                }
+            }
+            for (index, shard) in parity.iter_mut().enumerate() {
+                if present.parity.get(index) {
+                    decoder.add_recovery_shard(index, shard.as_mut().as_slice())?;
+                }
+            }
+
+            let result = decoder.decode()?;
+
+            for (index, shard) in source.iter_mut().enumerate() {
+                if !present.source.get(index) {
+                    shard
+                        .as_mut()
+                        .copy_from_slice(restored_original(&result, index));
+                }
+            }
+        }
+
+        if present.parity.count() == NUM_SHARDS {
+            return Ok(());
+        }
+
+        let mut encoder = new_encoder::<NUM_SHARDS, SHARD_BYTES>()?;
+
+        for shard in &mut source {
+            encoder.add_original_shard(shard.as_mut().as_slice())?;
+        }
+
+        let result = encoder.encode()?;
+
+        for (index, shard) in parity.iter_mut().enumerate() {
+            if !present.parity.get(index) {
+                shard.as_mut().copy_from_slice(recovery(&result, index));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[inline(always)]
+fn new_encoder<const NUM_SHARDS: usize, const SHARD_BYTES: usize>()
+-> Result<HighRateEncoder<DefaultEngine>, ErasureCodingError> {
+    Ok(HighRateEncoder::new(
+        NUM_SHARDS,
+        NUM_SHARDS,
+        SHARD_BYTES,
+        DefaultEngine::new(),
+        None,
+    )?)
+}
+
+#[inline(always)]
+fn new_decoder<const NUM_SHARDS: usize, const SHARD_BYTES: usize>()
+-> Result<HighRateDecoder<DefaultEngine>, ErasureCodingError> {
+    Ok(HighRateDecoder::new(
+        NUM_SHARDS,
+        NUM_SHARDS,
+        SHARD_BYTES,
+        DefaultEngine::new(),
+        None,
+    )?)
+}
+
+#[inline(always)]
+fn restored_original<'a>(
+    result: &'a reed_solomon_simd::DecoderResult<'_>,
+    index: usize,
+) -> &'a [u8] {
+    result
+        .restored_original(index)
+        .expect("Always corresponds to a missing source shard; qed")
+}
+
+#[inline(always)]
+fn recovery<'a>(result: &'a reed_solomon_simd::EncoderResult<'_>, index: usize) -> &'a [u8] {
+    result
+        .recovery(index)
+        .expect("Always corresponds to a missing parity shard; qed")
 }

--- a/crates/shared/ab-erasure-coding/tests/integration.rs
+++ b/crates/shared/ab-erasure-coding/tests/integration.rs
@@ -1,111 +1,196 @@
-#![feature(trusted_len)]
-
-use ab_erasure_coding::{ErasureCoding, ErasureCodingError, RecoveryShardState};
+use ab_erasure_coding::{ErasureCoding, ErasureCodingError, ShardsBitmap, ShardsPresent};
 use chacha20::ChaCha8Rng;
 use chacha20::rand_core::{Rng, SeedableRng};
 use reed_solomon_simd::Error;
-use std::iter::TrustedLen;
 use std::ops::Range;
-use std::{assert_matches, iter};
+use std::{array, assert_matches};
 
-fn corrupt_shards<'a, Iter>(
-    iter: Iter,
+// Miri is very slow, use less data for it
+const NUM_SHARDS: usize = if cfg!(miri) {
+    2usize.pow(3)
+} else {
+    2usize.pow(8)
+};
+const NUM_SOURCE: usize = NUM_SHARDS / 2;
+const SHARD_BYTES: usize = 32;
+
+/// Corrupts shards in `range` and unsets them in `present`
+fn corrupt_shards(
+    shards: &mut [[u8; SHARD_BYTES]; NUM_SOURCE],
+    present: &mut ShardsBitmap<NUM_SOURCE>,
     range: Range<usize>,
-) -> impl TrustedLen<Item = RecoveryShardState<&'a [u8], &'a mut [u8]>>
-where
-    Iter: TrustedLen<Item = &'a mut [u8; 32]>,
-{
-    iter.enumerate().map(move |(index, shard)| {
-        if range.contains(&index) {
-            // Corrupt the shard and mark as shard that needs to be recovered
-            *shard = [index as u8; 32];
-            RecoveryShardState::MissingRecover(shard.as_mut_slice())
-        } else {
-            RecoveryShardState::Present(shard.as_slice())
-        }
-    })
+) {
+    for index in range {
+        shards[index] = [index as u8; SHARD_BYTES];
+        present.unset(index);
+    }
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
 fn basic_data() {
     let mut rng = ChaCha8Rng::from_seed(Default::default());
-    let num_shards = 2usize.pow(if cfg!(miri) {
-        // Miri is very slow, use less data for it
-        3
-    } else {
-        8
-    });
     let ec = ErasureCoding::new();
 
-    let source_shards = iter::repeat_with(|| {
-        let mut bytes = [0u8; 32];
-        rng.fill_bytes(&mut bytes);
-        bytes
-    })
-    .take(num_shards / 2)
-    .collect::<Vec<_>>();
-    let mut parity_shards = vec![[0u8; 32]; source_shards.len()];
+    let mut source_shards = [[0u8; SHARD_BYTES]; NUM_SOURCE];
+    for shard in &mut source_shards {
+        rng.fill_bytes(shard);
+    }
+    let mut parity_shards = [[0u8; SHARD_BYTES]; NUM_SOURCE];
 
-    ec.extend(source_shards.iter(), parity_shards.iter_mut())
-        .unwrap();
+    ec.extend(&source_shards, &mut parity_shards).unwrap();
 
     assert_ne!(source_shards, parity_shards);
 
-    let mut recovered_source_shards = source_shards.clone();
-    let mut recovered_parity_shards = parity_shards.clone();
-
-    ec.recover(
-        corrupt_shards(recovered_source_shards.iter_mut(), 0..num_shards / 4),
+    // Both source and parity shards are recovered
+    {
+        let mut recovered_source_shards = source_shards;
+        let mut recovered_parity_shards = parity_shards;
+        let mut present = ShardsPresent::<NUM_SOURCE>::all();
         corrupt_shards(
-            recovered_parity_shards.iter_mut(),
-            num_shards / 4..num_shards * 2 / 4,
-        ),
-    )
-    .unwrap();
+            &mut recovered_source_shards,
+            &mut present.source,
+            0..NUM_SHARDS / 4,
+        );
+        corrupt_shards(
+            &mut recovered_parity_shards,
+            &mut present.parity,
+            NUM_SHARDS / 4..NUM_SHARDS * 2 / 4,
+        );
 
-    assert_eq!(recovered_source_shards, source_shards);
-    assert_eq!(recovered_parity_shards, parity_shards);
+        ec.recover_all(
+            &mut recovered_source_shards,
+            &mut recovered_parity_shards,
+            &present,
+        )
+        .unwrap();
 
-    // Source and parity shards have different size
-    assert_matches!(
-        ec.extend(
-            source_shards.iter(),
-            vec![[0u8; 34]; source_shards.len()].iter_mut(),
-        ),
-        Err(ErasureCodingError::WrongParityShardByteLength {
-            expected: 32,
-            actual: 34,
-        })
-    );
+        assert_eq!(recovered_source_shards, source_shards);
+        assert_eq!(recovered_parity_shards, parity_shards);
+    }
+
+    // Only source shards are recovered, parity shards are inputs only
+    {
+        let mut recovered_source_shards = source_shards;
+        let mut present = ShardsPresent::<NUM_SOURCE>::all();
+        corrupt_shards(
+            &mut recovered_source_shards,
+            &mut present.source,
+            0..NUM_SHARDS / 4,
+        );
+
+        ec.recover_source(&mut recovered_source_shards, &parity_shards, &present)
+            .unwrap();
+
+        assert_eq!(recovered_source_shards, source_shards);
+    }
 
     // Shards must have even length
     assert_matches!(
-        ec.extend(
-            vec![[0u8; 31]; source_shards.len()].iter(),
-            vec![[0u8; 31]; source_shards.len()].iter_mut(),
-        ),
+        ec.extend(&[[0u8; 31]; NUM_SOURCE], &mut [[0u8; 31]; NUM_SOURCE]),
         Err(ErasureCodingError::DecoderError(Error::InvalidShardSize {
             shard_bytes: 31
         }))
     );
 
     // Too many corrupted shards
-    assert_matches!(
-        ec.recover(
-            corrupt_shards(
-                recovered_source_shards.clone().iter_mut(),
-                0..num_shards / 4 + 1
+    {
+        let mut recovered_source_shards = source_shards;
+        let mut recovered_parity_shards = parity_shards;
+        let mut present = ShardsPresent::<NUM_SOURCE>::all();
+        corrupt_shards(
+            &mut recovered_source_shards,
+            &mut present.source,
+            0..NUM_SHARDS / 4 + 1,
+        );
+        corrupt_shards(
+            &mut recovered_parity_shards,
+            &mut present.parity,
+            NUM_SHARDS / 4..NUM_SHARDS * 2 / 4,
+        );
+
+        assert_matches!(
+            ec.recover_all(
+                &mut recovered_source_shards,
+                &mut recovered_parity_shards,
+                &present,
             ),
-            corrupt_shards(
-                recovered_parity_shards.clone().iter_mut(),
-                num_shards / 4..num_shards * 2 / 4,
-            ),
-        ),
-        Err(ErasureCodingError::DecoderError(Error::NotEnoughShards {
-            original_count: _,
-            original_received_count: _,
-            recovery_received_count: _,
-        }))
-    );
+            Err(ErasureCodingError::DecoderError(Error::NotEnoughShards {
+                original_count: _,
+                original_received_count: _,
+                recovery_received_count: _,
+            }))
+        );
+    }
+}
+
+/// A shard stored inside a larger data structure, the way records live inside pieces
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+struct Shard {
+    bytes: [u8; SHARD_BYTES],
+    _unrelated_metadata: u32,
+}
+
+impl AsRef<[u8; SHARD_BYTES]> for Shard {
+    fn as_ref(&self) -> &[u8; SHARD_BYTES] {
+        &self.bytes
+    }
+}
+
+impl AsMut<[u8; SHARD_BYTES]> for Shard {
+    fn as_mut(&mut self) -> &mut [u8; SHARD_BYTES] {
+        &mut self.bytes
+    }
+}
+
+/// Shards do not have to live in one contiguous allocation
+#[test]
+#[cfg_attr(miri, ignore)]
+fn scattered_shards() {
+    let mut rng = ChaCha8Rng::from_seed(Default::default());
+    let ec = ErasureCoding::new();
+
+    let mut source_shards = [[0u8; SHARD_BYTES]; NUM_SOURCE];
+    for shard in &mut source_shards {
+        rng.fill_bytes(shard);
+    }
+    let mut parity_shards = [[0u8; SHARD_BYTES]; NUM_SOURCE];
+    ec.extend(&source_shards, &mut parity_shards).unwrap();
+
+    // Same thing, but through shards that live inside a larger data structure
+    let mut scattered_source: [Shard; NUM_SOURCE] = array::from_fn(|index| Shard {
+        bytes: source_shards[index],
+        _unrelated_metadata: index as u32,
+    });
+    let mut scattered_parity = [Shard::default(); NUM_SOURCE];
+    {
+        let mut source_iter = scattered_source.iter();
+        let source_refs: [&Shard; NUM_SOURCE] = array::from_fn(|_| source_iter.next().unwrap());
+        let mut parity_iter = scattered_parity.iter_mut();
+        let parity_refs: [&mut Shard; NUM_SOURCE] = array::from_fn(|_| parity_iter.next().unwrap());
+
+        ec.extend_scattered(source_refs, parity_refs).unwrap();
+    }
+    for (scattered, expected) in scattered_parity.iter().zip(&parity_shards) {
+        assert_eq!(&scattered.bytes, expected);
+    }
+
+    // Recovery through optional references, where missing parity shards have no memory at all
+    let mut source_present = ShardsBitmap::<NUM_SOURCE>::all();
+    for (index, shard) in scattered_source.iter_mut().enumerate().take(NUM_SHARDS / 4) {
+        shard.bytes = [index as u8; SHARD_BYTES];
+        source_present.unset(index);
+    }
+
+    let parity_refs: [Option<&Shard>; NUM_SOURCE] =
+        array::from_fn(|index| (index < NUM_SHARDS / 4).then_some(&scattered_parity[index]));
+    let mut source_iter = scattered_source.iter_mut();
+    let source_refs: [&mut Shard; NUM_SOURCE] = array::from_fn(|_| source_iter.next().unwrap());
+
+    ec.recover_source_scattered(source_refs, &source_present, parity_refs)
+        .unwrap();
+
+    for (scattered, expected) in scattered_source.iter().zip(&source_shards) {
+        assert_eq!(&scattered.bytes, expected);
+    }
 }


### PR DESCRIPTION
Stepping stone towards leveraging https://github.com/AndersTrier/reed-solomon-simd/issues/64. This should be a slightly nicer and eventually more efficient API.