### PR TITLE
Update ACT4 to the latest version and minor fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -791,7 +791,7 @@ jobs:
 
   act4:
     env:
-      ACT4_REPO_REVISION: 482611e0918a79eb7d5dcf253f4f6d37a27f240c
+      ACT4_REPO_REVISION: f7ba06c3d1a01428b172fe851ab56931a0624fee
 
     strategy:
       matrix:
@@ -866,6 +866,7 @@ jobs:
             -v ./res/abundance:/act4/config/abundance:ro \
             -e CONFIG_FILES="config/abundance/abundance-rv32i-max/test_config.yaml config/abundance/abundance-rv64i-max/test_config.yaml" \
             -e FAST=True \
+            -e CLEAN_INTERMEDIATES=True \
             ${{ steps.build.outputs.imageid }} \
             make
         if: steps.restore-cache.outputs.cache-hit != 'true'

--- a/crates/execution/ab-riscv-act4-runner/res/Dockerfile
+++ b/crates/execution/ab-riscv-act4-runner/res/Dockerfile
@@ -32,7 +32,7 @@ ARG CLANG_VERSION=22
 #
 # HOME=/home/shared is used so all caches (mise, uv, udb, etc.) land in a single directory that is copied to the final
 # image.
-FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb AS mise-fetcher
+FROM ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b AS mise-fetcher
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -77,7 +77,7 @@ RUN cd /act4 \
   && chmod -R 777 /act4 /home/shared
 
 # Stage 2: final runtime image
-FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb AS act4-build
+FROM ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b AS act4-build
 
 LABEL description="RISC-V Architectural Certification Tests (ACT4) build env"
 LABEL org.opencontainers.image.source="https://github.com/riscv/riscv-arch-test"
@@ -140,7 +140,6 @@ COPY --chmod=777 . /act4
 # are actually missing bits keeps the copy-up (and therefore the layer) down to what uv rewrote
 RUN make tests \
   && make vector-tests \
-  && find tests ! -perm -0777 -exec chmod 0777 {} + \
   && find /act4/.venv ! -perm -0777 -exec chmod 0777 {} +
 
 # Default user with ID 1000 matching typical desktop installation

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/abundance-rv32i-max.yaml
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/abundance-rv32i-max.yaml
@@ -73,13 +73,13 @@ params:
   # --- mtval ---
   MTVAL_WIDTH: 32
   REPORT_VA_IN_MTVAL_ON_BREAKPOINT: false
-  REPORT_VA_IN_MTVAL_ON_INSTRUCTION_ACCESS_FAULT: false
+  REPORT_VA_IN_MTVAL_ON_INSTRUCTION_ACCESS_FAULT: true
   REPORT_VA_IN_MTVAL_ON_INSTRUCTION_MISALIGNED: false
-  REPORT_VA_IN_MTVAL_ON_LOAD_ACCESS_FAULT: false
+  REPORT_VA_IN_MTVAL_ON_LOAD_ACCESS_FAULT: true
   REPORT_VA_IN_MTVAL_ON_LOAD_MISALIGNED: false
-  REPORT_VA_IN_MTVAL_ON_STORE_AMO_ACCESS_FAULT: false
+  REPORT_VA_IN_MTVAL_ON_STORE_AMO_ACCESS_FAULT: true
   REPORT_VA_IN_MTVAL_ON_STORE_AMO_MISALIGNED: false
-  REPORT_ENCODING_IN_MTVAL_ON_ILLEGAL_INSTRUCTION: false
+  REPORT_ENCODING_IN_MTVAL_ON_ILLEGAL_INSTRUCTION: true
 
   # --- Trap behavior ---
   PRECISE_SYNCHRONOUS_EXCEPTIONS: true
@@ -180,10 +180,13 @@ params:
   MISALIGNED_SPLIT_STRATEGY: sequential_bytes
 
   # --- Atomics ---
-  # Misaligned AMOs and LR/SC are allowed, same as plain loads/stores above.
+  # Misaligned AMOs are allowed, same as plain loads/stores above. `lr`/`sc` are the exception:
+  # Zalrsc unconditionally requires them to be naturally aligned, regardless of MISALIGNED_AMO -
+  # upstream's `LRSC_MISALIGNED_BEHAVIOR` doc comment claiming it only applies when
+  # MISALIGNED_AMO is false is inaccurate; the reference IDL for `lr`/`sc` checks alignment
+  # unconditionally.
   MISALIGNED_AMO: true
-  # Only used when MISALIGNED_AMO is false, which it never is here.
-  LRSC_MISALIGNED_BEHAVIOR: "always raise access fault"
+  LRSC_MISALIGNED_BEHAVIOR: "always raise misaligned exception"
   # The interpreter tracks a single reservation address and requires an exact
   # match for `sc` to succeed.
   LRSC_RESERVATION_STRATEGY: "reserve exactly enough to cover the access"

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/sail.json
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv32i-max/sail.json
@@ -151,7 +151,7 @@
         // A misaligned LR/SC currently always faults, and this field can specify
         // whether it generates an access fault (use `"AccessFault"`)
         // or a misaligned exception (use `"AlignmentException"`).
-        "lrsc": "AccessFault",
+        "lrsc": "AlignmentException",
         // Misaligned AMOs are allowed, same as scalar/vector loads and stores above.
         "amo": {
           "None": null
@@ -239,7 +239,9 @@
           "writable": true,
           "read_idempotent": true,
           "write_idempotent": true,
-          // Handles misaligned loads/stores in hardware; no per-region fault.
+          // Handles misaligned loads/stores in hardware; no per-region fault. AMOs are also
+          // handled without a fault as long as they stay within misaligned_atomicity_granule_size_exp
+          // below - only an AMO that straddles that granule boundary reaches this "amo" field.
           "misaligned_exceptions": {
             "load_store": {
               "None": null

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/abundance-rv64i-max.yaml
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/abundance-rv64i-max.yaml
@@ -73,13 +73,13 @@ params:
   # --- mtval ---
   MTVAL_WIDTH: 64
   REPORT_VA_IN_MTVAL_ON_BREAKPOINT: false
-  REPORT_VA_IN_MTVAL_ON_INSTRUCTION_ACCESS_FAULT: false
+  REPORT_VA_IN_MTVAL_ON_INSTRUCTION_ACCESS_FAULT: true
   REPORT_VA_IN_MTVAL_ON_INSTRUCTION_MISALIGNED: false
-  REPORT_VA_IN_MTVAL_ON_LOAD_ACCESS_FAULT: false
+  REPORT_VA_IN_MTVAL_ON_LOAD_ACCESS_FAULT: true
   REPORT_VA_IN_MTVAL_ON_LOAD_MISALIGNED: false
-  REPORT_VA_IN_MTVAL_ON_STORE_AMO_ACCESS_FAULT: false
+  REPORT_VA_IN_MTVAL_ON_STORE_AMO_ACCESS_FAULT: true
   REPORT_VA_IN_MTVAL_ON_STORE_AMO_MISALIGNED: false
-  REPORT_ENCODING_IN_MTVAL_ON_ILLEGAL_INSTRUCTION: false
+  REPORT_ENCODING_IN_MTVAL_ON_ILLEGAL_INSTRUCTION: true
 
   # --- Trap behavior ---
   PRECISE_SYNCHRONOUS_EXCEPTIONS: true
@@ -180,10 +180,13 @@ params:
   MISALIGNED_SPLIT_STRATEGY: sequential_bytes
 
   # --- Atomics ---
-  # Misaligned AMOs and LR/SC are allowed, same as plain loads/stores above.
+  # Misaligned AMOs are allowed, same as plain loads/stores above. `lr`/`sc` are the exception:
+  # Zalrsc unconditionally requires them to be naturally aligned, regardless of MISALIGNED_AMO -
+  # upstream's `LRSC_MISALIGNED_BEHAVIOR` doc comment claiming it only applies when
+  # MISALIGNED_AMO is false is inaccurate; the reference IDL for `lr`/`sc` checks alignment
+  # unconditionally.
   MISALIGNED_AMO: true
-  # Only used when MISALIGNED_AMO is false, which it never is here.
-  LRSC_MISALIGNED_BEHAVIOR: "always raise access fault"
+  LRSC_MISALIGNED_BEHAVIOR: "always raise misaligned exception"
   # The interpreter tracks a single reservation address and requires an exact
   # match for `sc` to succeed.
   LRSC_RESERVATION_STRATEGY: "reserve exactly enough to cover the access"

--- a/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/sail.json
+++ b/crates/execution/ab-riscv-act4-runner/res/abundance/abundance-rv64i-max/sail.json
@@ -151,7 +151,7 @@
         // A misaligned LR/SC currently always faults, and this field can specify
         // whether it generates an access fault (use `"AccessFault"`)
         // or a misaligned exception (use `"AlignmentException"`).
-        "lrsc": "AccessFault",
+        "lrsc": "AlignmentException",
         // Misaligned AMOs are allowed, same as scalar/vector loads and stores above.
         "amo": {
           "None": null
@@ -239,7 +239,9 @@
           "writable": true,
           "read_idempotent": true,
           "write_idempotent": true,
-          // Handles misaligned loads/stores in hardware; no per-region fault.
+          // Handles misaligned loads/stores in hardware; no per-region fault. AMOs are also
+          // handled without a fault as long as they stay within misaligned_atomicity_granule_size_exp
+          // below - only an AMO that straddles that granule boundary reaches this "amo" field.
           "misaligned_exceptions": {
             "load_store": {
               "None": null

--- a/crates/execution/ab-riscv-act4-runner/src/main.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/main.rs
@@ -540,6 +540,58 @@ where
                     }
                 }
             }
+            // Out-of-bounds memory accesses (e.g. a vector indexed load/store whose computed
+            // effective address wraps or otherwise lands outside of RAM) are load/store access
+            // faults on real hardware, not a hard interpreter error - dispatch through the trap
+            // handler exactly like the illegal-instruction case above. `mtval` carries the
+            // faulting virtual address, per `REPORT_VA_IN_MTVAL_ON_{LOAD,STORE_AMO}_ACCESS_FAULT`
+            // in the DUT config.
+            //
+            // `lr`/`sc` additionally require natural alignment (unlike ordinary loads/stores,
+            // which this core allows misaligned per `MISALIGNED_LDST`): the Zalrsc extension
+            // mandates that a misaligned `lr`/`sc` always raises an exception, and this DUT
+            // config's `LRSC_MISALIGNED_BEHAVIOR: "always raise misaligned exception"` picks an
+            // address-misaligned exception over an access fault for it - a different `mcause`
+            // than an out-of-bounds access, and per `REPORT_VA_IN_MTVAL_ON_{LOAD,STORE_AMO}
+            // _MISALIGNED` (both `false`) `mtval` is left at zero rather than the address.
+            ExecutionResult::Err(
+                error @ (ExecutionError::OutOfBoundsRead { .. }
+                | ExecutionError::OutOfBoundsWrite { .. }
+                | ExecutionError::MisalignedRead { .. }
+                | ExecutionError::MisalignedWrite { .. }),
+            ) => {
+                let (cause, tval) = match error {
+                    ExecutionError::OutOfBoundsRead { address } => (
+                        MCauseException::LoadAccessFault,
+                        RegisterType::<I>::truncate_from_u64(address.get()),
+                    ),
+                    ExecutionError::OutOfBoundsWrite { address } => (
+                        MCauseException::StoreAccessFault,
+                        RegisterType::<I>::truncate_from_u64(address.get()),
+                    ),
+                    ExecutionError::MisalignedRead { .. } => (
+                        MCauseException::LoadAddressMisaligned,
+                        RegisterType::<I>::default(),
+                    ),
+                    ExecutionError::MisalignedWrite { .. } => (
+                        MCauseException::StoreAddressMisaligned,
+                        RegisterType::<I>::default(),
+                    ),
+                    _ => unreachable!(),
+                };
+                let epc =
+                    ProgramCounter::<RegisterType<I>, Box<BasicMemory<RAM_BASE, RAM_SIZE>>>::old_pc(
+                        &state.instruction_fetcher,
+                        instruction.size(),
+                    );
+                let trap_pc = state.env.take_trap(cause, epc, tval).ok_or(error)?;
+                match state.instruction_fetcher.set_pc(&state.memory, trap_pc)? {
+                    ControlFlow::Continue(()) => {}
+                    ControlFlow::Break(()) => {
+                        break;
+                    }
+                }
+            }
             ExecutionResult::Err(error) => {
                 if state
                     .memory

--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -524,6 +524,20 @@ where
         /// Address of the out-of-bounds write
         address: PackedAddress<u64>,
     },
+    /// Misaligned read from an instruction that requires natural alignment (e.g. `lr`), unlike
+    /// ordinary loads
+    #[error("Misaligned read at address {address}")]
+    MisalignedRead {
+        /// Address of the misaligned read
+        address: PackedAddress<u64>,
+    },
+    /// Misaligned write from an instruction that requires natural alignment (e.g. `sc`), unlike
+    /// ordinary stores
+    #[error("Misaligned write at address {address}")]
+    MisalignedWrite {
+        /// Address of the misaligned write
+        address: PackedAddress<u64>,
+    },
     /// Unsupported `ecall` instruction
     #[error("Unsupported `ecall` instruction at address {address:#x}")]
     EcallUnsupported {
@@ -573,15 +587,15 @@ where
         /// Current privilege level
         current: PrivilegeLevel,
     },
-    /// Custom error
-    #[error("Custom error: {0:?}")]
-    Custom([u8; 8]),
     /// Threaded execution is not supported on this platform.
     ///
     /// See [`OpaqueThreadedExecutionResult::platform_supported()`] for what makes a platform
     /// unsupported and why the answer is a run-time one.
     #[error("Threaded execution is not supported on this platform")]
     UnsupportedPlatform,
+    /// Custom error
+    #[error("Custom error: {0:?}")]
+    Custom([u8; 8]),
 }
 
 /// Where execution continues after an instruction, or why it could not.
@@ -1171,15 +1185,17 @@ where
     const TAG_UNALIGNED_INSTRUCTION: u64 = 1;
     const TAG_OUT_OF_BOUNDS_READ: u64 = 2;
     const TAG_OUT_OF_BOUNDS_WRITE: u64 = 3;
-    const TAG_ECALL_UNSUPPORTED: u64 = 4;
-    const TAG_ILLEGAL_INSTRUCTION: u64 = 5;
-    const TAG_CSR_READ_ONLY: u64 = 6;
-    const TAG_CSR_ILLEGAL_READ: u64 = 7;
-    const TAG_CSR_ILLEGAL_WRITE: u64 = 8;
-    const TAG_CSR_UNKNOWN: u64 = 9;
-    const TAG_CSR_INSUFFICIENT_PRIVILEGE: u64 = 10;
-    const TAG_CUSTOM: u64 = 11;
-    const TAG_UNSUPPORTED_PLATFORM: u64 = 12;
+    const TAG_MISALIGNED_READ: u64 = 4;
+    const TAG_MISALIGNED_WRITE: u64 = 5;
+    const TAG_ECALL_UNSUPPORTED: u64 = 6;
+    const TAG_ILLEGAL_INSTRUCTION: u64 = 7;
+    const TAG_CSR_READ_ONLY: u64 = 8;
+    const TAG_CSR_ILLEGAL_READ: u64 = 9;
+    const TAG_CSR_ILLEGAL_WRITE: u64 = 10;
+    const TAG_CSR_UNKNOWN: u64 = 11;
+    const TAG_CSR_INSUFFICIENT_PRIVILEGE: u64 = 12;
+    const TAG_UNSUPPORTED_PLATFORM: u64 = 13;
+    const TAG_CUSTOM: u64 = 14;
 
     /// Whether this platform can carry an outcome the way [`Self::new()`] does.
     ///
@@ -1226,6 +1242,12 @@ where
                 }
                 ExecutionError::OutOfBoundsWrite { address } => {
                     (Self::TAG_OUT_OF_BOUNDS_WRITE, address.get())
+                }
+                ExecutionError::MisalignedRead { address } => {
+                    (Self::TAG_MISALIGNED_READ, address.get())
+                }
+                ExecutionError::MisalignedWrite { address } => {
+                    (Self::TAG_MISALIGNED_WRITE, address.get())
                 }
                 ExecutionError::EcallUnsupported { address } => {
                     (Self::TAG_ECALL_UNSUPPORTED, address.get().as_u64())
@@ -1323,6 +1345,12 @@ where
             Self::TAG_OUT_OF_BOUNDS_WRITE => ExecutionError::OutOfBoundsWrite {
                 address: PackedAddress::new(payload),
             },
+            Self::TAG_MISALIGNED_READ => ExecutionError::MisalignedRead {
+                address: PackedAddress::new(payload),
+            },
+            Self::TAG_MISALIGNED_WRITE => ExecutionError::MisalignedWrite {
+                address: PackedAddress::new(payload),
+            },
             Self::TAG_ECALL_UNSUPPORTED => ExecutionError::EcallUnsupported {
                 address: PackedAddress::new(Address::<I>::truncate_from_u64(payload)),
             },
@@ -1347,8 +1375,8 @@ where
                     current,
                 }
             }
-            Self::TAG_CUSTOM => ExecutionError::Custom(payload.to_le_bytes()),
             Self::TAG_UNSUPPORTED_PLATFORM => ExecutionError::UnsupportedPlatform,
+            Self::TAG_CUSTOM => ExecutionError::Custom(payload.to_le_bytes()),
             _ => {
                 unreachable!("Lanes are only ever produced by `new()`; qed");
             }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a.rs
@@ -6,8 +6,8 @@ pub mod zalrsc;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc.rs
@@ -7,8 +7,8 @@ use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -54,6 +54,12 @@ where
                 aq: _,
                 rl: _,
             } => {
+                if !rs1_value.is_multiple_of(4) {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedRead {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let value = memory.read::<u32>(u64::from(rs1_value))?;
                 env.set_reservation(rs1_value);
                 ExecutionResult::Continue { rd, value }
@@ -65,6 +71,12 @@ where
                 aq: _,
                 rl: _,
             } => {
+                if !rs1_value.is_multiple_of(4) {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedWrite {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let success = env.reservation() == Some(rs1_value);
                 env.clear_reservation();
 

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zalrsc/tests.rs
@@ -1,6 +1,7 @@
 use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 #[test]
 fn test_lr_reads_value() {
@@ -144,31 +145,40 @@ fn test_sc_fails_after_second_sc() {
 }
 
 #[test]
-fn test_lr_sc_supports_misaligned_access() {
-    let mut state = initialize_state([
-        Rv32ZalrscInstruction::Lr {
-            rd: Reg::A1,
-            rs1: Reg::A0,
-            aq: false,
-            rl: false,
-            rs2: Reg::Zero,
-        },
-        Rv32ZalrscInstruction::Sc {
-            rd: Reg::A2,
-            rs1: Reg::A0,
-            rs2: Reg::A3,
-            aq: false,
-            rl: false,
-        },
-    ]);
+fn test_lr_rejects_misaligned_access() {
+    let mut state = initialize_state([Rv32ZalrscInstruction::Lr {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        aq: false,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
     // Not 4-byte aligned
     let addr = TEST_BASE_ADDR + 0x101;
-    state.memory.write::<u32>(u64::from(addr), 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedRead { .. })
+    );
+}
+
+#[test]
+fn test_sc_rejects_misaligned_access() {
+    let mut state = initialize_state([Rv32ZalrscInstruction::Sc {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A3,
+        aq: false,
+        rl: false,
+    }]);
+    // Not 4-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
     state.regs.write(Reg::A0, addr);
     state.regs.write(Reg::A3, 42);
 
-    execute(&mut state).unwrap();
-
-    assert_eq!(state.regs.read(Reg::A2), 0);
-    assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 42);
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedWrite { .. })
+    );
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a.rs
@@ -7,8 +7,8 @@ use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc.rs
@@ -7,8 +7,8 @@ use crate::rv32::a::ReservationSet;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -54,6 +54,12 @@ where
                 aq: _,
                 rl: _,
             } => {
+                if !rs1_value.is_multiple_of(4) {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedRead {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let value = memory.read::<i32>(rs1_value)?;
                 env.set_reservation(rs1_value);
                 ExecutionResult::Continue {
@@ -68,6 +74,12 @@ where
                 aq: _,
                 rl: _,
             } => {
+                if !rs1_value.is_multiple_of(4) {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedWrite {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let success = env.reservation() == Some(rs1_value);
                 env.clear_reservation();
 
@@ -84,6 +96,12 @@ where
                 aq: _,
                 rl: _,
             } => {
+                if !rs1_value.is_multiple_of(8) {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedRead {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let value = memory.read::<u64>(rs1_value)?;
                 env.set_reservation(rs1_value);
                 ExecutionResult::Continue { rd, value }
@@ -95,6 +113,12 @@ where
                 aq: _,
                 rl: _,
             } => {
+                if !rs1_value.is_multiple_of(8) {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedWrite {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let success = env.reservation() == Some(rs1_value);
                 env.clear_reservation();
 

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zalrsc/tests.rs
@@ -1,6 +1,7 @@
 use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 #[test]
 fn test_lr_w_sign_extends() {
@@ -155,31 +156,79 @@ fn test_sc_d_fails_for_different_address() {
 }
 
 #[test]
-fn test_lr_d_sc_d_supports_misaligned_access() {
-    let mut state = initialize_state([
-        Rv64ZalrscInstruction::LrD {
-            rd: Reg::A1,
-            rs1: Reg::A0,
-            aq: false,
-            rl: false,
-            rs2: Reg::Zero,
-        },
-        Rv64ZalrscInstruction::ScD {
-            rd: Reg::A2,
-            rs1: Reg::A0,
-            rs2: Reg::A3,
-            aq: false,
-            rl: false,
-        },
-    ]);
-    // Not 8-byte aligned
+fn test_lr_rejects_misaligned_access() {
+    let mut state = initialize_state([Rv64ZalrscInstruction::Lr {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        aq: false,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    // Not 4-byte aligned
     let addr = TEST_BASE_ADDR + 0x101;
-    state.memory.write::<u64>(addr, 1).unwrap();
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedRead { .. })
+    );
+}
+
+#[test]
+fn test_sc_rejects_misaligned_access() {
+    let mut state = initialize_state([Rv64ZalrscInstruction::Sc {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A3,
+        aq: false,
+        rl: false,
+    }]);
+    // Not 4-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
     state.regs.write(Reg::A0, addr);
     state.regs.write(Reg::A3, 42);
 
-    execute(&mut state).unwrap();
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedWrite { .. })
+    );
+}
 
-    assert_eq!(state.regs.read(Reg::A2), 0);
-    assert_eq!(state.memory.read::<u64>(addr).unwrap(), 42);
+#[test]
+fn test_lr_d_rejects_misaligned_access() {
+    let mut state = initialize_state([Rv64ZalrscInstruction::LrD {
+        rd: Reg::A1,
+        rs1: Reg::A0,
+        aq: false,
+        rl: false,
+        rs2: Reg::Zero,
+    }]);
+    // Not 8-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedRead { .. })
+    );
+}
+
+#[test]
+fn test_sc_d_rejects_misaligned_access() {
+    let mut state = initialize_state([Rv64ZalrscInstruction::ScD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A3,
+        aq: false,
+        rl: false,
+    }]);
+    // Not 8-byte aligned
+    let addr = TEST_BASE_ADDR + 0x101;
+    state.regs.write(Reg::A0, addr);
+    state.regs.write(Reg::A3, 42);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedWrite { .. })
+    );
 }


### PR DESCRIPTION
There were some inconsequential (for now) mismatches between DUT and sail configs as well as (currently unchecked by ACT4) missing misaligned access checks in Zalrsc extension implementation. All those are now fixed.