### PR TITLE
Reject AMOs whose misaligned access crosses the atomicity granule

### DIFF
--- a/crates/execution/ab-riscv-interpreter/src/lib.rs
+++ b/crates/execution/ab-riscv-interpreter/src/lib.rs
@@ -538,6 +538,13 @@ where
         /// Address of the misaligned write
         address: PackedAddress<u64>,
     },
+    /// Misaligned atomic access (e.g. AMO) whose accessed bytes are not all within the same
+    /// misaligned atomicity granule, unlike an ordinary misaligned read or write
+    #[error("Misaligned atomic access at address {address}")]
+    MisalignedAtomic {
+        /// Address of the misaligned atomic access
+        address: PackedAddress<u64>,
+    },
     /// Unsupported `ecall` instruction
     #[error("Unsupported `ecall` instruction at address {address:#x}")]
     EcallUnsupported {
@@ -1187,15 +1194,16 @@ where
     const TAG_OUT_OF_BOUNDS_WRITE: u64 = 3;
     const TAG_MISALIGNED_READ: u64 = 4;
     const TAG_MISALIGNED_WRITE: u64 = 5;
-    const TAG_ECALL_UNSUPPORTED: u64 = 6;
-    const TAG_ILLEGAL_INSTRUCTION: u64 = 7;
-    const TAG_CSR_READ_ONLY: u64 = 8;
-    const TAG_CSR_ILLEGAL_READ: u64 = 9;
-    const TAG_CSR_ILLEGAL_WRITE: u64 = 10;
-    const TAG_CSR_UNKNOWN: u64 = 11;
-    const TAG_CSR_INSUFFICIENT_PRIVILEGE: u64 = 12;
-    const TAG_UNSUPPORTED_PLATFORM: u64 = 13;
-    const TAG_CUSTOM: u64 = 14;
+    const TAG_MISALIGNED_ATOMIC: u64 = 6;
+    const TAG_ECALL_UNSUPPORTED: u64 = 7;
+    const TAG_ILLEGAL_INSTRUCTION: u64 = 8;
+    const TAG_CSR_READ_ONLY: u64 = 9;
+    const TAG_CSR_ILLEGAL_READ: u64 = 10;
+    const TAG_CSR_ILLEGAL_WRITE: u64 = 11;
+    const TAG_CSR_UNKNOWN: u64 = 12;
+    const TAG_CSR_INSUFFICIENT_PRIVILEGE: u64 = 13;
+    const TAG_UNSUPPORTED_PLATFORM: u64 = 14;
+    const TAG_CUSTOM: u64 = 15;
 
     /// Whether this platform can carry an outcome the way [`Self::new()`] does.
     ///
@@ -1248,6 +1256,9 @@ where
                 }
                 ExecutionError::MisalignedWrite { address } => {
                     (Self::TAG_MISALIGNED_WRITE, address.get())
+                }
+                ExecutionError::MisalignedAtomic { address } => {
+                    (Self::TAG_MISALIGNED_ATOMIC, address.get())
                 }
                 ExecutionError::EcallUnsupported { address } => {
                     (Self::TAG_ECALL_UNSUPPORTED, address.get().as_u64())
@@ -1349,6 +1360,9 @@ where
                 address: PackedAddress::new(payload),
             },
             Self::TAG_MISALIGNED_WRITE => ExecutionError::MisalignedWrite {
+                address: PackedAddress::new(payload),
+            },
+            Self::TAG_MISALIGNED_ATOMIC => ExecutionError::MisalignedAtomic {
                 address: PackedAddress::new(payload),
             },
             Self::TAG_ECALL_UNSUPPORTED => ExecutionError::EcallUnsupported {

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo.rs
@@ -6,8 +6,8 @@ mod tests;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -53,6 +53,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), rs2_value)?;
                 ExecutionResult::Continue { rd, value: old }
@@ -64,6 +72,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), old.wrapping_add(rs2_value))?;
                 ExecutionResult::Continue { rd, value: old }
@@ -75,6 +91,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), old ^ rs2_value)?;
                 ExecutionResult::Continue { rd, value: old }
@@ -86,6 +110,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), old & rs2_value)?;
                 ExecutionResult::Continue { rd, value: old }
@@ -97,6 +129,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), old | rs2_value)?;
                 ExecutionResult::Continue { rd, value: old }
@@ -108,6 +148,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 let new = if old.cast_signed() < rs2_value.cast_signed() {
                     old
@@ -124,6 +172,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 let new = if old.cast_signed() > rs2_value.cast_signed() {
                     old
@@ -140,6 +196,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 let new = if old < rs2_value { old } else { rs2_value };
                 memory.write(u64::from(rs1_value), new)?;
@@ -152,6 +216,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<u32>(u64::from(rs1_value))?;
                 let new = if old > rs2_value { old } else { rs2_value };
                 memory.write(u64::from(rs1_value), new)?;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/a/zaamo/tests.rs
@@ -1,6 +1,7 @@
 use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 #[test]
 fn test_amoswap() {
@@ -243,4 +244,24 @@ fn test_amoswap_supports_misaligned_access() {
 
     assert_eq!(state.regs.read(Reg::A2), 111);
     assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 222);
+}
+
+#[test]
+fn test_amoadd_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv32ZaamoInstruction::Amoadd {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // 3 bytes before a 4096-byte misaligned atomicity granule boundary: the 4-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xffd;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zabha.rs
@@ -6,8 +6,8 @@ mod tests;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -67,6 +67,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 memory.write(u64::from(rs1_value), rs2_value as u16)?;
                 ExecutionResult::Continue {
@@ -96,6 +104,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned().wrapping_add(rs2_value as u16);
                 memory.write(u64::from(rs1_value), new)?;
@@ -126,6 +142,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() ^ (rs2_value as u16);
                 memory.write(u64::from(rs1_value), new)?;
@@ -156,6 +180,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() & (rs2_value as u16);
                 memory.write(u64::from(rs1_value), new)?;
@@ -186,6 +218,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = old.cast_unsigned() | (rs2_value as u16);
                 memory.write(u64::from(rs1_value), new)?;
@@ -220,6 +260,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = if old < (rs2_value as u16).cast_signed() {
                     old.cast_unsigned()
@@ -258,6 +306,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = if old > (rs2_value as u16).cast_signed() {
                     old.cast_unsigned()
@@ -296,6 +352,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = if old.cast_unsigned() < (rs2_value as u16) {
                     old.cast_unsigned()
@@ -334,6 +398,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 let new = if old.cast_unsigned() > (rs2_value as u16) {
                     old.cast_unsigned()
@@ -371,6 +443,14 @@ where
                 rl: _,
             } => {
                 let compare = regs.read(rd) as u16;
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(u64::from(rs1_value)),
+                    });
+                }
                 let old = memory.read::<i16>(u64::from(rs1_value))?;
                 if old.cast_unsigned() == compare {
                     memory.write(u64::from(rs1_value), rs2_value as u16)?;

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zabha/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zabha/tests.rs
@@ -1,6 +1,7 @@
 use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 #[test]
 fn test_amoswap_b_sign_extends() {
@@ -194,4 +195,24 @@ fn test_amoadd_w_inherited_from_zaamo() {
 
     assert_eq!(state.regs.read(Reg::A2), 10);
     assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 42);
+}
+
+#[test]
+fn test_amoadd_h_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv32ZabhaInstruction::AmoaddH {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // 1 byte before a 4096-byte misaligned atomicity granule boundary: the 2-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xfff;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zacas.rs
@@ -6,8 +6,8 @@ mod tests;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -54,6 +54,14 @@ where
                 rl: _,
             } => {
                 let addr = u64::from(rs1_value);
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if addr / 4096 != (addr + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(addr),
+                    });
+                }
                 let compare = regs.read(rd);
                 let old = memory.read::<u32>(addr)?;
                 if old == compare {
@@ -71,6 +79,14 @@ where
                 rl: _,
             } => {
                 let addr = u64::from(rs1_value);
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if addr / 4096 != (addr + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(addr),
+                    });
+                }
                 // Per spec, when the first register of a pair is `x0`, BOTH halves of that pair
                 // read as zero - not just the literal `x0` half. `compare_lo`/`rs2_value` are
                 // already 0 in that case since `x0` is hardwired, but `compare_hi`/`swap_hi`

--- a/crates/execution/ab-riscv-interpreter/src/rv32/zacas/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv32/zacas/tests.rs
@@ -1,6 +1,7 @@
 use crate::rv32::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 #[test]
 fn test_amocas_w_succeeds_on_match() {
@@ -180,4 +181,46 @@ fn test_amoadd_inherited_from_zaamo() {
 
     assert_eq!(state.regs.read(Reg::A2), 10);
     assert_eq!(state.memory.read::<u32>(u64::from(addr)).unwrap(), 42);
+}
+
+#[test]
+fn test_amocasw_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv32ZacasInstruction::AmocasW {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // 3 bytes before a 4096-byte misaligned atomicity granule boundary: the 4-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xffd;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
+}
+
+#[test]
+fn test_amocasd_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv32ZacasInstruction::AmocasD {
+        rd: Reg::A2,
+        rd_hi: Reg::A3,
+        rs1: Reg::A0,
+        rs2: Reg::A4,
+        rs2_hi: Reg::A5,
+        aq: false,
+        rl: false,
+    }]);
+    // 5 bytes before a 4096-byte misaligned atomicity granule boundary: the two 4-byte halves
+    // (8 bytes total) straddle it
+    let addr = TEST_BASE_ADDR + 0xffb;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo.rs
@@ -6,8 +6,8 @@ mod tests;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -53,6 +53,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 memory.write(rs1_value, rs2_value as u32)?;
                 ExecutionResult::Continue {
@@ -67,6 +75,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = (old.cast_unsigned()).wrapping_add(rs2_value as u32);
                 memory.write(rs1_value, new)?;
@@ -82,6 +98,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = old.cast_unsigned() ^ (rs2_value as u32);
                 memory.write(rs1_value, new)?;
@@ -97,6 +121,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = old.cast_unsigned() & (rs2_value as u32);
                 memory.write(rs1_value, new)?;
@@ -112,6 +144,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = old.cast_unsigned() | (rs2_value as u32);
                 memory.write(rs1_value, new)?;
@@ -127,6 +167,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = if old < (rs2_value as u32).cast_signed() {
                     old.cast_unsigned()
@@ -146,6 +194,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = if old > (rs2_value as u32).cast_signed() {
                     old.cast_unsigned()
@@ -165,6 +221,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = if old.cast_unsigned() < (rs2_value as u32) {
                     old.cast_unsigned()
@@ -184,6 +248,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i32>(rs1_value)?;
                 let new = if old.cast_unsigned() > (rs2_value as u32) {
                     old.cast_unsigned()
@@ -204,6 +276,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, rs2_value)?;
                 ExecutionResult::Continue { rd, value: old }
@@ -215,6 +295,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, old.wrapping_add(rs2_value))?;
                 ExecutionResult::Continue { rd, value: old }
@@ -226,6 +314,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, old ^ rs2_value)?;
                 ExecutionResult::Continue { rd, value: old }
@@ -237,6 +333,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, old & rs2_value)?;
                 ExecutionResult::Continue { rd, value: old }
@@ -248,6 +352,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 memory.write(rs1_value, old | rs2_value)?;
                 ExecutionResult::Continue { rd, value: old }
@@ -259,6 +371,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 let new = if old.cast_signed() < rs2_value.cast_signed() {
                     old
@@ -275,6 +395,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 let new = if old.cast_signed() > rs2_value.cast_signed() {
                     old
@@ -291,6 +419,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 let new = if old < rs2_value { old } else { rs2_value };
                 memory.write(rs1_value, new)?;
@@ -303,6 +439,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<u64>(rs1_value)?;
                 let new = if old > rs2_value { old } else { rs2_value };
                 memory.write(rs1_value, new)?;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/a/zaamo/tests.rs
@@ -1,6 +1,7 @@
 use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 #[test]
 fn test_amoswap_w_sign_extends() {
@@ -182,4 +183,44 @@ fn test_amoxor_d_supports_misaligned_access() {
 
     assert_eq!(state.regs.read(Reg::A2), 0b1010);
     assert_eq!(state.memory.read::<u64>(addr).unwrap(), 0b1100);
+}
+
+#[test]
+fn test_amoadd_w_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::Amoadd {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // 3 bytes before a 4096-byte misaligned atomicity granule boundary: the 4-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xffd;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
+}
+
+#[test]
+fn test_amoadd_d_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv64ZaamoInstruction::AmoaddD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // 6 bytes before a 4096-byte misaligned atomicity granule boundary: the 8-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xffa;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zabha.rs
@@ -6,8 +6,8 @@ mod tests;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -67,6 +67,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 memory.write(rs1_value, rs2_value as u16)?;
                 ExecutionResult::Continue {
@@ -96,6 +104,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = old.cast_unsigned().wrapping_add(rs2_value as u16);
                 memory.write(rs1_value, new)?;
@@ -126,6 +142,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = old.cast_unsigned() ^ (rs2_value as u16);
                 memory.write(rs1_value, new)?;
@@ -156,6 +180,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = old.cast_unsigned() & (rs2_value as u16);
                 memory.write(rs1_value, new)?;
@@ -186,6 +218,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = old.cast_unsigned() | (rs2_value as u16);
                 memory.write(rs1_value, new)?;
@@ -220,6 +260,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = if old < (rs2_value as u16).cast_signed() {
                     old.cast_unsigned()
@@ -258,6 +306,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = if old > (rs2_value as u16).cast_signed() {
                     old.cast_unsigned()
@@ -296,6 +352,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = if old.cast_unsigned() < (rs2_value as u16) {
                     old.cast_unsigned()
@@ -334,6 +398,14 @@ where
                 aq: _,
                 rl: _,
             } => {
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 let new = if old.cast_unsigned() > (rs2_value as u16) {
                     old.cast_unsigned()
@@ -371,6 +443,14 @@ where
                 rl: _,
             } => {
                 let compare = regs.read(rd) as u16;
+                // The 2-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if rs1_value / 4096 != (rs1_value + 1) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(rs1_value),
+                    });
+                }
                 let old = memory.read::<i16>(rs1_value)?;
                 if old.cast_unsigned() == compare {
                     memory.write(rs1_value, rs2_value as u16)?;

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zabha/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zabha/tests.rs
@@ -1,6 +1,7 @@
 use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 #[test]
 fn test_amoswap_b_sign_extends_to_64_bits() {
@@ -125,4 +126,24 @@ fn test_amoadd_d_inherited_from_zaamo() {
 
     assert_eq!(state.regs.read(Reg::A2), 10);
     assert_eq!(state.memory.read::<u64>(addr).unwrap(), 42);
+}
+
+#[test]
+fn test_amoadd_h_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv64ZabhaInstruction::AmoaddH {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // 1 byte before a 4096-byte misaligned atomicity granule boundary: the 2-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xfff;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
 }

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zacas.rs
@@ -6,8 +6,8 @@ mod tests;
 use crate::{
     ExecutableInstruction, ExecutableInstructionCsr, ExecutableInstructionOperands, ExecutionError,
     ExecutionResult, FetchInstructionResult, InstructionFetcher, OpaqueThreadedExecutionResult,
-    RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands, ThreadedExecutableInstruction,
-    ThreadedExecutionResult, VirtualMemory,
+    PackedAddress, RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
+    ThreadedExecutableInstruction, ThreadedExecutionResult, VirtualMemory,
 };
 use ab_riscv_macros::instruction_execution;
 use ab_riscv_primitives::prelude::*;
@@ -54,6 +54,14 @@ where
                 rl: _,
             } => {
                 let addr = rs1_value;
+                // The 4-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if addr / 4096 != (addr + 3) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(addr),
+                    });
+                }
                 // Ignore the upper bits of `rd` when comparing, per spec
                 let compare = regs.read(rd) as u32;
                 let old = memory.read::<i32>(addr)?;
@@ -73,6 +81,14 @@ where
                 rl: _,
             } => {
                 let addr = rs1_value;
+                // The 8-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if addr / 4096 != (addr + 7) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(addr),
+                    });
+                }
                 let compare = regs.read(rd);
                 let old = memory.read::<u64>(addr)?;
                 if old == compare {
@@ -90,6 +106,14 @@ where
                 rl: _,
             } => {
                 let addr = rs1_value;
+                // The 16-byte access must not cross a misaligned atomicity granule (4096 bytes)
+                // boundary
+                if addr / 4096 != (addr + 15) / 4096 {
+                    ::core::hint::cold_path();
+                    return ExecutionResult::Err(ExecutionError::MisalignedAtomic {
+                        address: PackedAddress::new(addr),
+                    });
+                }
                 // Per spec, when the first register of a pair is `x0`, BOTH halves of that pair
                 // read as zero - not just the literal `x0` half. `compare_lo`/`rs2_value` are
                 // already 0 in that case since `x0` is hardwired, but `compare_hi`/`swap_hi`

--- a/crates/execution/ab-riscv-interpreter/src/rv64/zacas/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/rv64/zacas/tests.rs
@@ -1,6 +1,7 @@
 use crate::rv64::test_utils::{TEST_BASE_ADDR, execute, initialize_state};
-use crate::{RegisterFile, VirtualMemory};
+use crate::{ExecutionError, RegisterFile, VirtualMemory};
 use ab_riscv_primitives::prelude::*;
+use core::assert_matches;
 
 #[test]
 fn test_amocas_w_succeeds_and_sign_extends() {
@@ -246,4 +247,66 @@ fn test_amoaddd_inherited_from_zaamo() {
 
     assert_eq!(state.regs.read(Reg::A2), 10);
     assert_eq!(state.memory.read::<u64>(addr).unwrap(), 42);
+}
+
+#[test]
+fn test_amocasw_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasW {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // 3 bytes before a 4096-byte misaligned atomicity granule boundary: the 4-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xffd;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
+}
+
+#[test]
+fn test_amocasd_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasD {
+        rd: Reg::A2,
+        rs1: Reg::A0,
+        rs2: Reg::A1,
+        aq: false,
+        rl: false,
+    }]);
+    // 6 bytes before a 4096-byte misaligned atomicity granule boundary: the 8-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xffa;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
+}
+
+#[test]
+fn test_amocasq_rejects_misaligned_atomicity_granule_crossing() {
+    let mut state = initialize_state([Rv64ZacasInstruction::AmocasQ {
+        rd: Reg::A2,
+        rd_hi: Reg::A3,
+        rs1: Reg::A0,
+        rs2: Reg::A4,
+        rs2_hi: Reg::A5,
+        aq: false,
+        rl: false,
+    }]);
+    // 15 bytes before a 4096-byte misaligned atomicity granule boundary: the 16-byte access
+    // straddles it
+    let addr = TEST_BASE_ADDR + 0xff1;
+    state.regs.write(Reg::A0, addr);
+
+    assert_matches!(
+        execute(&mut state),
+        Err(ExecutionError::MisalignedAtomic { .. })
+    );
 }


### PR DESCRIPTION
ACT4 doesn't check any of this yet either (https://github.com/riscv/riscv-arch-test/issues/2203), which is why it wasn't caught earlier