### PR TITLE
Improve alignment handling

### DIFF
--- a/crates/contracts/core/ab-contract-file/src/instruction.rs
+++ b/crates/contracts/core/ab-contract-file/src/instruction.rs
@@ -226,16 +226,13 @@ pub enum ContractInstruction<Reg = ContractRegister> {}
 
 #[instruction]
 const impl<Reg> Instruction for ContractInstruction<Reg> {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv32i_max.rs
@@ -39,16 +39,13 @@ pub(crate) enum AbundanceRv32IMaxInstructionPrototype<Reg> {}
 
 #[instruction]
 const impl<Reg> Instruction for AbundanceRv32IMaxInstructionPrototype<Reg> {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/abundance_rv64i_max.rs
@@ -39,16 +39,13 @@ pub(crate) enum AbundanceRv64IMaxInstructionPrototype<Reg> {}
 
 #[instruction]
 const impl<Reg> Instruction for AbundanceRv64IMaxInstructionPrototype<Reg> {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-act4-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-act4-runner/src/instruction.rs
@@ -12,16 +12,13 @@ pub(crate) enum MachineModePlaceholder<Reg> {}
 
 #[instruction]
 const impl<Reg> Instruction for MachineModePlaceholder<Reg> {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
+++ b/crates/execution/ab-riscv-benchmarks/src/host_utils.rs
@@ -167,7 +167,7 @@ where
 
         pc != self.return_trap_address
             && pc.is_multiple_of(u64::from(
-                ContractInstruction::<ContractRegister>::alignment(),
+                ContractInstruction::<ContractRegister>::ALIGNMENT,
             ))
     }
 
@@ -190,7 +190,7 @@ where
         }
 
         if !pc.is_multiple_of(u64::from(
-            ContractInstruction::<ContractRegister>::alignment(),
+            ContractInstruction::<ContractRegister>::ALIGNMENT,
         )) {
             cold_path();
             return Err(ExecutionError::UnalignedInstruction {

--- a/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/instruction.rs
@@ -22,16 +22,13 @@ pub(crate) enum CoremarkInstruction<Reg = CoremarkRegister> {}
 
 #[instruction]
 const impl<Reg> Instruction for CoremarkInstruction<Reg> {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-coremark-runner/src/main.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/main.rs
@@ -1,6 +1,5 @@
 #![expect(incomplete_features, reason = "explicit_tail_calls")]
 #![feature(
-    const_cmp,
     const_trait_impl,
     const_try,
     const_try_residual,

--- a/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
+++ b/crates/execution/ab-riscv-coremark-runner/src/time_csr.rs
@@ -85,16 +85,13 @@ pub(crate) enum TimeCsrInstruction<Reg> {}
 
 #[instruction]
 const impl<Reg> Instruction for TimeCsrInstruction<Reg> {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-interpreter/src/basic.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic.rs
@@ -482,7 +482,7 @@ where
         // nothing else is allowed to look at it
         self.pc = pc;
 
-        pc != self.return_trap_address && pc.as_u64().is_multiple_of(u64::from(I::alignment()))
+        pc != self.return_trap_address && pc.as_u64().is_multiple_of(u64::from(I::ALIGNMENT))
     }
 
     #[cold]
@@ -509,7 +509,7 @@ where
             return Ok(ControlFlow::Break(()));
         }
 
-        if !pc.as_u64().is_multiple_of(u64::from(I::alignment())) {
+        if !pc.as_u64().is_multiple_of(u64::from(I::ALIGNMENT)) {
             cold_path();
             return Err(ExecutionError::UnalignedInstruction {
                 address: PackedAddress::new(pc),

--- a/crates/execution/ab-riscv-interpreter/src/basic/eager_instruction_fetcher.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic/eager_instruction_fetcher.rs
@@ -195,7 +195,7 @@ where
     /// # Safety
     /// `pc` must be the address of one of the instructions [`Self::decode()`] was given, meaning
     /// it is within `base_addr..base_addr + instructions.len()` and is a multiple of
-    /// [`Instruction::alignment()`], with `base_addr` and `instructions` being what that call
+    /// [`Instruction::ALIGNMENT`], with `base_addr` and `instructions` being what that call
     /// received.
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
@@ -249,7 +249,7 @@ where
     /// * `return_trap_address` must not fall inside the instructions. Instruction fetching does not
     ///   compare against the return trap, so an address inside them would stop execution when
     ///   jumped to, but not when reached by falling through.
-    /// * `base_addr` must be a multiple of [`Instruction::alignment()`], since it is the address of
+    /// * `base_addr` must be a multiple of [`Instruction::ALIGNMENT`], since it is the address of
     ///   the first decoded instruction, and every position within the decoded stream is resolved
     ///   relative to it.
     /// * `base_addr + instructions.len()` must not overflow the address space, which is what makes
@@ -444,7 +444,7 @@ where
 
         let address = pc.as_u64();
 
-        if !address.is_multiple_of(u64::from(I::alignment())) {
+        if !address.is_multiple_of(u64::from(I::ALIGNMENT)) {
             cold_path();
             return Err(ExecutionError::UnalignedInstruction {
                 address: PackedAddress::new(pc),
@@ -529,7 +529,7 @@ where
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn alignment_byte_step() -> usize {
-        usize::from(I::alignment()) / size_of::<u16>() * size_of::<I>()
+        usize::from(I::ALIGNMENT) / size_of::<u16>() * size_of::<I>()
     }
 
     /// Pointer to the first decoded instruction

--- a/crates/execution/ab-riscv-interpreter/src/basic/eager_instruction_fetcher.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic/eager_instruction_fetcher.rs
@@ -45,11 +45,13 @@ where
 /// decoded program in memory and of not seeing writes the program makes to the memory it was
 /// decoded from.
 ///
-/// The decoded stream has one slot per [`size_of::<u16>()`](size_of) bytes of guest code, which is
-/// the granularity at which RISC-V instructions can start. The second half of a 32-bit instruction
-/// gets a slot of its own that is only ever reached by jumping into the middle of an instruction,
-/// which [`BasicEagerInstructionFetcher`] refuses on instruction sets where such an address is not
-/// aligned, and which executes whatever those bytes decode to on instruction sets where it is.
+/// The decoded stream has one slot per [`Instruction::ALIGNMENT`] bytes of guest code, which is
+/// the granularity at which an instruction of this instruction set can start, and what makes an
+/// address a position within the stream and back. With compressed instructions that is a halfword,
+/// so the second half of a 32-bit instruction gets a slot of its own, holding whatever those bytes
+/// decode to, which is only ever reached by jumping into the middle of an instruction. Without
+/// them, no address in the middle of an instruction is aligned in the first place, so there is
+/// nothing to hold a slot for and the stream is half the size.
 ///
 /// Ownership of the allocation lives here rather than in the fetcher because the fetcher is moved
 /// through tail-called instruction handlers by value. A destructor on it would make every handler
@@ -105,6 +107,21 @@ where
     /// [`Self::state`] points at
     const INSTRUCTIONS_OFFSET: usize =
         size_of::<BasicEagerInstructionFetcherState<I>>().next_multiple_of(align_of::<I>());
+    /// Bytes of guest code that one slot of the decoded stream corresponds to.
+    ///
+    /// This is what turns a guest address into a position within the decoded stream and back, so
+    /// an instruction set whose slot is not a whole number of alignment steps has no such mapping
+    /// and is refused right here, at compile time.
+    const GUEST_BYTES_PER_SLOT: usize = {
+        assert!(
+            size_of::<I>().is_multiple_of(usize::from(I::ALIGNMENT)),
+            "Decoded instruction size must be a multiple of instruction alignment"
+        );
+
+        usize::from(I::ALIGNMENT)
+    };
+    /// Bytes of the decoded stream that one byte of guest code covers
+    const STREAM_BYTES_PER_GUEST_BYTE: usize = size_of::<I>() / Self::GUEST_BYTES_PER_SLOT;
 
     /// Layout of the allocation holding [`BasicEagerInstructionFetcherState`] followed by
     /// `instructions_len` decoded instructions
@@ -216,7 +233,7 @@ where
         }
 
         let instruction_offset =
-            (pc.as_u64() - self.base_addr().as_u64()) as usize / size_of::<u16>();
+            (pc.as_u64() - self.base_addr().as_u64()) as usize / Self::GUEST_BYTES_PER_SLOT;
 
         BasicEagerInstructionFetcher {
             // SAFETY: Guaranteed by function contract, meaning `instruction_offset` is within
@@ -232,11 +249,11 @@ where
     /// `base_addr` is the guest address of the first instruction and `return_trap_address` is the
     /// address at which the interpreter will stop execution (gracefully).
     ///
-    /// Every halfword of guest code owns a slot of the decoded stream, including the second half
-    /// of a 32-bit instruction, which is only ever reached by jumping into the middle of one. Such
-    /// a slot may or may not decode into a valid instruction on its own, and `fallback` is what is
-    /// stored when it doesn't, so it only has to fail when executed (`unimp` is the canonical
-    /// choice).
+    /// Every [`Instruction::ALIGNMENT`] bytes of guest code own a slot of the decoded stream,
+    /// including, where instructions may be compressed, the second half of a 32-bit instruction,
+    /// which is only ever reached by jumping into the middle of one. Such a slot may or may not
+    /// decode into a valid instruction on its own, and `fallback` is what is stored when it
+    /// doesn't, so it only has to fail when executed (`unimp` is the canonical choice).
     ///
     /// # Safety
     /// Execution of the resulting instruction stream skips the checks that
@@ -264,34 +281,42 @@ where
         return_trap_address: Address<I>,
         base_addr: Address<I>,
     ) -> Self {
-        // Exactly as many slots as there are halfwords of guest code, which is what the capacity
-        // below is, so this never grows the allocation
+        // Exactly as many slots as there are alignment steps of guest code, which is what the
+        // capacity below is, so this never grows the allocation
         let mut decoded_instructions =
-            Vec::<I>::with_capacity(instructions.len() / size_of::<u16>());
+            Vec::<I>::with_capacity(instructions.len() / Self::GUEST_BYTES_PER_SLOT);
 
         let mut offset = 0;
         while let Some(instruction) = Self::decode_instruction(instructions, offset, fallback) {
             decoded_instructions.push(instruction);
-            offset += size_of::<u16>();
+            offset += Self::GUEST_BYTES_PER_SLOT;
         }
 
         Self::instantiate(&decoded_instructions, base_addr, return_trap_address)
     }
 
     /// Decode the instruction that the decoded stream's slot at `offset` bytes into `instructions`
-    /// holds, returning `None` once `offset` is past the last halfword of guest code.
+    /// holds, returning `None` once there is no whole alignment step of guest code left there for
+    /// a slot to correspond to.
     ///
     /// This is where all of the decoding lives, so that what remains of [`Self::decode()`] is the
     /// allocation, which is the only part of it that can't be proven panic-free.
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     fn decode_instruction(instructions: &[u8], offset: usize, fallback: I) -> Option<I> {
-        let instruction = match instructions.get(offset..)? {
+        let instruction_bytes = instructions.get(offset..)?;
+
+        if instruction_bytes.len() < Self::GUEST_BYTES_PER_SLOT {
+            return None;
+        }
+
+        let instruction = match instruction_bytes {
             [byte_0, byte_1, byte_2, byte_3, ..] => {
                 u32::from_le_bytes([*byte_0, *byte_1, *byte_2, *byte_3])
             }
-            // A halfword at the very end of the guest code has nothing following it to read, so it
-            // is zero-extended into a word, which only decodes if it is a compressed instruction
+            // Only reachable where instructions may be compressed: the last halfword of guest code
+            // has nothing following it to read, so it is zero-extended into a word, which decodes
+            // only if it is a compressed instruction
             [byte_0, byte_1, ..] => u32::from_le_bytes([*byte_0, *byte_1, 0, 0]),
             _ => {
                 return None;
@@ -354,8 +379,9 @@ where
 
         Address::<I>::truncate_from_u64(
             self.base_addr().as_u64()
-                + decoded_instruction_byte_offset as u64 * size_of::<u16>() as u64
-                    / size_of::<I>() as u64,
+                + (decoded_instruction_byte_offset
+                    / BasicEagerInstructions::<I>::STREAM_BYTES_PER_GUEST_BYTE)
+                    as u64,
         )
     }
 
@@ -374,9 +400,10 @@ where
         // is advanced during instruction fetching, so that instruction starts `instruction_size`
         // bytes back.
         let offset = (offset as isize).wrapping_sub(isize::from(instruction_size));
-        // Every `size_of::<u16>()` of guest code owns one decoded instruction, so the target is
+        // Every alignment step of guest code owns one decoded instruction, so the target is
         // reached by moving within the decoded stream
-        let byte_delta = offset * (size_of::<I>() / size_of::<u16>()).cast_signed();
+        let byte_delta =
+            offset * BasicEagerInstructions::<I>::STREAM_BYTES_PER_GUEST_BYTE.cast_signed();
         // This may land outside the decoded stream (including before its start), which is fine:
         // `wrapping_byte_offset()` only computes an address, it never dereferences the pointer, and
         // the bounds check below rejects such a target before it is ever used
@@ -399,7 +426,7 @@ where
         // it could drift, such a target simply fails to qualify, as does one past the end of the
         // decoded stream, which a backwards branch that ran off its start wraps around into.
         decoded_instruction_byte_offset < self.instructions_len() * size_of::<I>()
-            && decoded_instruction_byte_offset.is_multiple_of(Self::alignment_byte_step())
+            && decoded_instruction_byte_offset.is_multiple_of(size_of::<I>())
     }
 
     /// Turns the refused target back into an address and hands it to [`Self::set_pc()`], which is
@@ -419,12 +446,13 @@ where
             .addr()
             .wrapping_sub(self.instructions().as_ptr().addr())
             .cast_signed();
-        // Every `size_of::<u16>()` of guest code owns one decoded instruction, and the position is
-        // always that many bytes from the start of the stream, so this is exact
+        // Every alignment step of guest code owns one decoded instruction, and the position is
+        // always a whole number of them from the start of the stream, so this is exact
         let address =
             Address::<I>::truncate_from_u64(self.base_addr().as_u64().wrapping_add_signed(
                 (decoded_instruction_byte_offset
-                    / (size_of::<I>() / size_of::<u16>()).cast_signed()) as i64,
+                    / BasicEagerInstructions::<I>::STREAM_BYTES_PER_GUEST_BYTE.cast_signed())
+                    as i64,
             ));
 
         self.set_pc(memory, address)
@@ -457,7 +485,8 @@ where
                 address: PackedAddress::new(address),
             });
         };
-        let instruction_offset = offset as usize / size_of::<u16>();
+        let instruction_offset =
+            offset as usize / BasicEagerInstructions::<I>::GUEST_BYTES_PER_SLOT;
 
         if instruction_offset >= self.instructions_len() {
             cold_path();
@@ -490,7 +519,8 @@ where
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     unsafe fn advance(&mut self, instruction_size: u8) {
-        let byte_advance = usize::from(instruction_size) / size_of::<u16>() * size_of::<I>();
+        let byte_advance = usize::from(instruction_size)
+            * BasicEagerInstructions::<I>::STREAM_BYTES_PER_GUEST_BYTE;
         // Wrapping because nothing here dereferences the pointer: the contract of this method is
         // what makes the resulting position a decoded instruction, and the bounds check that
         // matters lives in `set_pc()`
@@ -525,13 +555,6 @@ impl<I> BasicEagerInstructionFetcher<'_, I>
 where
     I: Instruction,
 {
-    /// Distance within the decoded stream that one instruction alignment step of guest code covers
-    #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    fn alignment_byte_step() -> usize {
-        usize::from(I::ALIGNMENT) / size_of::<u16>() * size_of::<I>()
-    }
-
     /// Pointer to the first decoded instruction
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]

--- a/crates/execution/ab-riscv-interpreter/src/basic/eager_instruction_fetcher/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic/eager_instruction_fetcher/tests.rs
@@ -55,11 +55,15 @@ fn new_instructions(return_trap_address: u64) -> BasicEagerInstructions<I> {
 }
 
 #[test]
-fn every_halfword_of_guest_code_owns_a_slot() {
+fn every_alignment_step_of_guest_code_owns_a_slot() {
+    // This instruction set has no compressed instructions, so its slots are words rather than
+    // halfwords and there is nothing to decode in the middle of an instruction
+    assert_eq!(I::ALIGNMENT, size_of::<u32>() as u8);
+
     let code = code();
 
     // Including guest code that ends in the middle of an instruction, which decodes as far as
-    // whole halfwords go and leaves the odd byte out
+    // whole alignment steps go and leaves the trailing bytes out
     for len in 0..=code.len() {
         // SAFETY: Nothing is executed here, only the decoded stream is inspected, so what
         // execution may reach doesn't come into play
@@ -68,7 +72,7 @@ fn every_halfword_of_guest_code_owns_a_slot() {
 
         assert_eq!(
             instructions.instructions_len(),
-            len / size_of::<u16>(),
+            len / usize::from(I::ALIGNMENT),
             "{len} bytes of guest code"
         );
     }
@@ -198,9 +202,8 @@ fn branch_to_an_unaligned_target_is_rejected() {
 
 #[test]
 fn branch_into_the_middle_of_an_instruction_is_rejected() {
-    // The decoded stream has a slot per halfword of guest code, but this instruction set has
-    // no compressed instructions, so a halfword-aligned target lands between two instructions
-    // and must be refused rather than executed as whatever those bytes decoded to
+    // This instruction set has no compressed instructions, so a halfword-aligned target lands
+    // between two instructions and must be refused rather than rounded to one
     assert_eq!(I::ALIGNMENT, size_of::<u32>() as u8);
 
     let instructions = new_instructions(0);

--- a/crates/execution/ab-riscv-interpreter/src/basic/eager_instruction_fetcher/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/basic/eager_instruction_fetcher/tests.rs
@@ -201,7 +201,7 @@ fn branch_into_the_middle_of_an_instruction_is_rejected() {
     // The decoded stream has a slot per halfword of guest code, but this instruction set has
     // no compressed instructions, so a halfword-aligned target lands between two instructions
     // and must be refused rather than executed as whatever those bytes decoded to
-    assert_eq!(I::alignment(), size_of::<u32>() as u8);
+    assert_eq!(I::ALIGNMENT, size_of::<u32>() as u8);
 
     let instructions = new_instructions(0);
     let mut fetcher = new_fetcher(&instructions);

--- a/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zicsr/tests.rs
@@ -49,16 +49,13 @@ impl<Reg> Instruction for TestZicsr<Reg>
 where
     Reg: Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-macros/CHANGELOG.md
+++ b/crates/execution/ab-riscv-macros/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+Breaking changes:
+
+* `#[instruction]` now takes instruction alignment from an `ALIGNMENT` associated constant instead of an `alignment()`
+  method
+
 Improvements:
 
 * Support instruction macros in non-src directories (tests, examples, etc.)

--- a/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
+++ b/crates/execution/ab-riscv-macros/src/build/enum_impl.rs
@@ -70,13 +70,13 @@ pub(super) fn collect_original_enum_decoding_impls_from_dependencies()
 
 pub(super) struct InstructionImplBlocks<'a> {
     try_decode: &'a Block,
-    alignment: &'a Block,
+    alignment: &'a Expr,
     size: &'a Block,
 }
 
 pub(super) struct InstructionImplBlocksMut<'a> {
     try_decode: &'a mut Block,
-    alignment: &'a mut Block,
+    alignment: &'a mut Expr,
     size: &'a mut Block,
 }
 
@@ -88,13 +88,17 @@ fn extract_instruction_blocks_from_impl(
     let mut size = None;
 
     for item in impl_items {
-        if let ImplItem::Fn(impl_item_fn) = item {
-            match impl_item_fn.sig.ident.to_string().as_str() {
+        match item {
+            ImplItem::Const(impl_item_const) => {
+                if impl_item_const.ident == "ALIGNMENT" {
+                    alignment.replace(&impl_item_const.expr);
+                } else {
+                    // Something else
+                }
+            }
+            ImplItem::Fn(impl_item_fn) => match impl_item_fn.sig.ident.to_string().as_str() {
                 "try_decode" => {
                     try_decode.replace(&impl_item_fn.block);
-                }
-                "alignment" => {
-                    alignment.replace(&impl_item_fn.block);
                 }
                 "size" => {
                     size.replace(&impl_item_fn.block);
@@ -102,6 +106,9 @@ fn extract_instruction_blocks_from_impl(
                 _ => {
                     // Something else
                 }
+            },
+            _ => {
+                // Something else
             }
         }
     }
@@ -121,13 +128,17 @@ fn extract_instruction_blocks_from_impl_mut(
     let mut size = None;
 
     for item in impl_items {
-        if let ImplItem::Fn(impl_item_fn) = item {
-            match impl_item_fn.sig.ident.to_string().as_str() {
+        match item {
+            ImplItem::Const(impl_item_const) => {
+                if impl_item_const.ident == "ALIGNMENT" {
+                    alignment.replace(&mut impl_item_const.expr);
+                } else {
+                    // Something else
+                }
+            }
+            ImplItem::Fn(impl_item_fn) => match impl_item_fn.sig.ident.to_string().as_str() {
                 "try_decode" => {
                     try_decode.replace(&mut impl_item_fn.block);
-                }
-                "alignment" => {
-                    alignment.replace(&mut impl_item_fn.block);
                 }
                 "size" => {
                     size.replace(&mut impl_item_fn.block);
@@ -135,6 +146,9 @@ fn extract_instruction_blocks_from_impl_mut(
                 _ => {
                     // Something else
                 }
+            },
+            _ => {
+                // Something else
             }
         }
     }
@@ -275,8 +289,8 @@ pub(super) fn process_enum_decoding_impl(
 
     let Some(blocks) = extract_instruction_blocks_from_impl_mut(&mut item_impl.items) else {
         return Err(anyhow::anyhow!(
-            "Expected `#[instruction] impl Instruction for {}` to contain `try_decode`, \
-            `alignment`, and `size` methods, but at least one was not found",
+            "Expected `#[instruction] impl Instruction for {}` to contain an `ALIGNMENT` constant \
+            and `try_decode` and `size` methods, but at least one was not found",
             item_impl.self_ty.to_token_stream()
         ));
     };
@@ -416,9 +430,10 @@ pub(super) fn process_enum_decoding_impl(
 
     add_missing_rs_fields(try_decode_block);
 
-    // Process `alignment()` method: combine all unique bodies with `.min(...)` calls, keeping
-    // the own block last. Bodies that are token-identical are deduplicated to avoid redundant
-    // comparisons at runtime.
+    // Process `ALIGNMENT` constant: the instruction set can start an instruction wherever any of
+    // the instruction sets it is composed of can, which is the smallest alignment of all of them.
+    // Initializers that are token-identical are deduplicated, and comparisons are spelled out
+    // rather than done with `Ord::min()`, which is not usable in a constant.
     if !all_dependency_alignment_blocks.is_empty() {
         let own_tokens = alignment_block.to_token_stream().to_string();
 
@@ -430,13 +445,16 @@ pub(super) fn process_enum_decoding_impl(
 
         if unique_dep_blocks.peek().is_some() {
             *alignment_block = parse_quote! {{
-                #[expect(clippy::allow_attributes, reason = "Attribute below")]
-                #[allow(
-                    unused_braces,
-                    reason = "Combining blocks often results in `.min({expr})`, where `{expr}` is \
-                    very simple, which makes `{}` redundant"
-                )]
-                { #alignment_block #( .min(#unique_dep_blocks) )* }
+                let mut alignment = #alignment_block;
+                #(
+                    {
+                        let dependency_alignment = #unique_dep_blocks;
+                        if dependency_alignment < alignment {
+                            alignment = dependency_alignment;
+                        }
+                    }
+                )*
+                alignment
             }};
         }
     }
@@ -513,12 +531,17 @@ pub(super) fn process_enum_decoding_impl(
                     .then_some(dependency_enum_name)
             });
 
-    item_impl.items.push(parse_quote! {
-        const IMPLEMENTED_EXTENSIONS: &'static [::core::any::TypeId] = &[
-            ::core::any::TypeId::of::<Self>(),
-            #( ::core::any::TypeId::of::<#implemented_extensions<Reg>>(), )*
-        ];
-    });
+    // Associated constants come before everything else in an implementation, and the constant
+    // taken from the implementation being processed is already the first item in it
+    item_impl.items.insert(
+        0,
+        parse_quote! {
+            const IMPLEMENTED_EXTENSIONS: &'static [::core::any::TypeId] = &[
+                ::core::any::TypeId::of::<Self>(),
+                #( ::core::any::TypeId::of::<#implemented_extensions<Reg>>(), )*
+            ];
+        },
+    );
 
     output_processed_enum_decoding_impl(&enum_name, original_item_impl, item_impl, out_dir, state)
 }

--- a/crates/execution/ab-riscv-primitives/CHANGELOG.md
+++ b/crates/execution/ab-riscv-primitives/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Breaking changes:
+
+* `Instruction::alignment()` is replaced by the `Instruction::ALIGNMENT` associated constant
+
 # 0.2.0
 
 New features:

--- a/crates/execution/ab-riscv-primitives/src/instructions.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions.rs
@@ -29,14 +29,14 @@ pub const trait Instruction:
     /// specified explicitly (and if done, will cause conflicts at compile time).
     const IMPLEMENTED_EXTENSIONS: &'static [TypeId];
 
+    /// Instruction alignment in bytes, also known as `IALIGN`
+    const ALIGNMENT: u8;
+
     /// A register type used by the instruction
     type Reg: [const] Register;
 
     /// Try to decode a single valid instruction
     fn try_decode(instruction: u32) -> Option<Self>;
-
-    /// Instruction alignment in bytes
-    fn alignment() -> u8;
 
     /// Instruction size in bytes
     fn size(&self) -> u8;

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32.rs
@@ -95,6 +95,8 @@ const impl<Reg> Instruction for Rv32Instruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -285,11 +287,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/a.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/a.rs
@@ -23,17 +23,14 @@ const impl<Reg> Instruction for Rv32AInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zaamo.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zaamo.rs
@@ -30,6 +30,8 @@ const impl<Reg> Instruction for Rv32ZaamoInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -121,11 +123,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/a/zalrsc.rs
@@ -23,6 +23,8 @@ const impl<Reg> Instruction for Rv32ZalrscInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -61,11 +63,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b.rs
@@ -26,17 +26,14 @@ const impl<Reg> Instruction for Rv32BInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zba.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zba.rs
@@ -23,6 +23,8 @@ const impl<Reg> Instruction for Rv32ZbaInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -50,11 +52,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbb.rs
@@ -38,6 +38,8 @@ const impl<Reg> Instruction for Rv32ZbbInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -142,11 +144,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbc.rs
@@ -23,6 +23,8 @@ const impl<Reg> Instruction for Rv32ZbcInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -50,11 +52,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/b/zbs.rs
@@ -35,6 +35,8 @@ const impl<Reg> Instruction for Rv32ZbsInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -76,11 +78,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/c/zca.rs
@@ -84,6 +84,8 @@ const impl<Reg> Instruction for Rv32ZcaInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -462,11 +464,6 @@ where
             // Quadrant 11 = 32-bit instructions
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/m.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/m.rs
@@ -29,6 +29,8 @@ const impl<Reg> Instruction for Rv32MInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -61,11 +63,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/m/zmmul.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/m/zmmul.rs
@@ -21,17 +21,14 @@ const impl<Reg> Instruction for Rv32ZmmulInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zabha.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zabha.rs
@@ -46,6 +46,8 @@ const impl<Reg> Instruction for Rv32ZabhaInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -220,11 +222,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zacas.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zacas.rs
@@ -27,6 +27,8 @@ const impl<Reg> Instruction for Rv32ZacasInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -85,11 +87,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zalasr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zalasr.rs
@@ -37,6 +37,8 @@ const impl<Reg> Instruction for Rv32ZalasrInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -93,11 +95,6 @@ where
             },
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcb.rs
@@ -25,17 +25,14 @@ const impl<Reg> Instruction for Rv32ZcbInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]
@@ -102,6 +99,8 @@ const impl<Reg> Instruction for Rv32ZcbOnlyInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -211,11 +210,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zce/zcmp.rs
@@ -318,17 +318,14 @@ const impl<Reg> Instruction for Rv32ZcmpInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]
@@ -392,6 +389,8 @@ const impl<Reg> Instruction for Rv32ZcmpOnlyInstruction<Reg>
 where
     Reg: [const] ZcmpRegister<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -467,11 +466,6 @@ where
             // funct2_12_11 values 0b00 and 0b10 are not defined by Zcmp
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkb.rs
@@ -37,6 +37,8 @@ const impl<Reg> Instruction for Rv32ZbkbInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -83,11 +85,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkc.rs
@@ -21,17 +21,14 @@ const impl<Reg> Instruction for Rv32ZbkcInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zbkx.rs
@@ -22,6 +22,8 @@ const impl<Reg> Instruction for Rv32ZbkxInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -47,11 +49,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn.rs
@@ -37,17 +37,14 @@ const impl<Reg> Instruction for Rv32ZknInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknd.rs
@@ -106,6 +106,8 @@ const impl<Reg> Instruction for Rv32ZkndInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -139,11 +141,6 @@ where
             0b1_0111 => Some(Self::Aes32Dsmi { rd, rs1, rs2, bs }),
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zkne.rs
@@ -60,6 +60,8 @@ const impl<Reg> Instruction for Rv32ZkneInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -93,11 +95,6 @@ where
             0b1_0011 => Some(Self::Aes32Esmi { rd, rs1, rs2, bs }),
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv32/zk/zkn/zknh.rs
@@ -45,6 +45,8 @@ const impl<Reg> Instruction for Rv32ZknhInstruction<Reg>
 where
     Reg: [const] Register<Type = u32>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -104,11 +106,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64.rs
@@ -111,6 +111,8 @@ const impl<Reg> Instruction for Rv64Instruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -342,11 +344,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/a.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/a.rs
@@ -23,17 +23,14 @@ const impl<Reg> Instruction for Rv64AInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zaamo.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zaamo.rs
@@ -40,6 +40,8 @@ const impl<Reg> Instruction for Rv64ZaamoInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -200,11 +202,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zalrsc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/a/zalrsc.rs
@@ -26,6 +26,8 @@ const impl<Reg> Instruction for Rv64ZalrscInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -81,11 +83,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b.rs
@@ -26,17 +26,14 @@ const impl<Reg> Instruction for Rv64BInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zba.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zba.rs
@@ -28,6 +28,8 @@ const impl<Reg> Instruction for Rv64ZbaInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -103,11 +105,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbb.rs
@@ -45,6 +45,8 @@ const impl<Reg> Instruction for Rv64ZbbInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -195,11 +197,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbc.rs
@@ -23,6 +23,8 @@ const impl<Reg> Instruction for Rv64ZbcInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -50,11 +52,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/b/zbs.rs
@@ -35,6 +35,8 @@ const impl<Reg> Instruction for Rv64ZbsInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -77,11 +79,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/c/zca.rs
@@ -96,6 +96,8 @@ const impl<Reg> Instruction for Rv64ZcaInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -526,11 +528,6 @@ where
             // Quadrant 11 = 32-bit instructions
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/m.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/m.rs
@@ -36,6 +36,8 @@ const impl<Reg> Instruction for Rv64MInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -82,11 +84,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/m/zmmul.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/m/zmmul.rs
@@ -21,17 +21,14 @@ const impl<Reg> Instruction for Rv64ZmmulInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zabha.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zabha.rs
@@ -46,6 +46,8 @@ const impl<Reg> Instruction for Rv64ZabhaInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -220,11 +222,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zacas.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zacas.rs
@@ -29,6 +29,8 @@ const impl<Reg> Instruction for Rv64ZacasInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -103,11 +105,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zalasr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zalasr.rs
@@ -41,6 +41,8 @@ const impl<Reg> Instruction for Rv64ZalasrInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -107,11 +109,6 @@ where
             },
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcb.rs
@@ -25,17 +25,14 @@ const impl<Reg> Instruction for Rv64ZcbInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]
@@ -105,6 +102,8 @@ const impl<Reg> Instruction for Rv64ZcbOnlyInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -216,11 +215,6 @@ where
 
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zce/zcmp.rs
@@ -24,17 +24,14 @@ const impl<Reg> Instruction for Rv64ZcmpInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]
@@ -98,6 +95,8 @@ const impl<Reg> Instruction for Rv64ZcmpOnlyInstruction<Reg>
 where
     Reg: [const] ZcmpRegister<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u16>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -173,11 +172,6 @@ where
             // funct2_12_11 values 0b00 and 0b10 are not defined by Zcmp
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u16>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkb.rs
@@ -33,6 +33,8 @@ const impl<Reg> Instruction for Rv64ZbkbInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -84,11 +86,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkc.rs
@@ -21,17 +21,14 @@ const impl<Reg> Instruction for Rv64ZbkcInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zbkx.rs
@@ -22,6 +22,8 @@ const impl<Reg> Instruction for Rv64ZbkxInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -47,11 +49,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn.rs
@@ -37,17 +37,14 @@ const impl<Reg> Instruction for Rv64ZknInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknd.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknd.rs
@@ -101,6 +101,8 @@ const impl<Reg> Instruction for Rv64ZkndInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -154,11 +156,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zkne.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zkne.rs
@@ -29,6 +29,8 @@ const impl<Reg> Instruction for Rv64ZkneInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -60,11 +62,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknh.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/rv64/zk/zkn/zknh.rs
@@ -28,6 +28,8 @@ const impl<Reg> Instruction for Rv64ZknhInstruction<Reg>
 where
     Reg: [const] Register<Type = u64>,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -65,11 +67,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -893,16 +893,13 @@ where
 {
     const IMPLEMENTED_EXTENSIONS: &'static [TypeId] = &[];
 
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     fn try_decode(_instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx.rs
@@ -72,17 +72,14 @@ const impl<Reg> Instruction for ZveXxInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/arith.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/arith.rs
@@ -154,6 +154,8 @@ const impl<Reg> Instruction for ZveXxArithInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -278,11 +280,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/carry.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/carry.rs
@@ -78,6 +78,8 @@ const impl<Reg> Instruction for ZveXxCarryInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -138,11 +140,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/config.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/config.rs
@@ -40,6 +40,8 @@ const impl<Reg> Instruction for ZveXxConfigInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -95,11 +97,6 @@ where
                 Some(Self::Vsetvl { rd, rs1, rs2 })
             }
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/fixed_point.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/fixed_point.rs
@@ -94,6 +94,8 @@ const impl<Reg> Instruction for ZveXxFixedPointInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -341,11 +343,6 @@ where
 
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/load.rs
@@ -209,6 +209,8 @@ const impl<Reg> Instruction for ZveXxLoadInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -379,11 +381,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/mask.rs
@@ -89,6 +89,8 @@ const impl<Reg> Instruction for ZveXxMaskInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -181,11 +183,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/muldiv.rs
@@ -119,6 +119,8 @@ const impl<Reg> Instruction for ZveXxMulDivInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -205,11 +207,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/perm.rs
@@ -109,6 +109,8 @@ const impl<Reg> Instruction for ZveXxPermInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -317,11 +319,6 @@ where
             },
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/reduction.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/reduction.rs
@@ -48,6 +48,8 @@ const impl<Reg> Instruction for ZveXxReductionInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -92,11 +94,6 @@ where
             },
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/store.rs
@@ -68,6 +68,8 @@ const impl<Reg> Instruction for ZveXxStoreInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -221,11 +223,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/widen_narrow.rs
@@ -122,6 +122,8 @@ const impl<Reg> Instruction for ZveXxWidenNarrowInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -314,11 +316,6 @@ where
             },
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/zawrs.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zawrs.rs
@@ -24,6 +24,8 @@ const impl<Reg> Instruction for ZawrsInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -40,11 +42,6 @@ where
             (0b111_0011, 0b000, 0, 0, 0x01d) => Some(Self::WrsSto),
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/zicond.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zicond.rs
@@ -24,6 +24,8 @@ const impl<Reg> Instruction for ZicondInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -50,11 +52,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/zicsr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zicsr.rs
@@ -26,6 +26,8 @@ const impl<Reg> Instruction for ZicsrInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -85,11 +87,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/zifencei.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zifencei.rs
@@ -22,6 +22,8 @@ const impl<Reg> Instruction for ZifenceiInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -38,11 +40,6 @@ where
         // `rd`, `rs1` and the immediate are all reserved and must be ignored by implementations
         // rather than checked, so any encoding with funct3=001 in this opcode is a valid `fence.i`
         Some(Self::FenceI)
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/zkr.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zkr.rs
@@ -27,17 +27,14 @@ const impl<Reg> Instruction for ZkrInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
     fn try_decode(instruction: u32) -> Option<Self> {
         None
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbb.rs
@@ -83,6 +83,8 @@ const impl<Reg> Instruction for ZvbbInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -147,11 +149,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbb/zvkb.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbb/zvkb.rs
@@ -90,6 +90,8 @@ const impl<Reg> Instruction for ZvkbInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -157,11 +159,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]

--- a/crates/execution/ab-riscv-primitives/src/instructions/zvbc.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/zvbc.rs
@@ -61,6 +61,8 @@ const impl<Reg> Instruction for ZvbcInstruction<Reg>
 where
     Reg: [const] Register,
 {
+    const ALIGNMENT: u8 = align_of::<u32>() as u8;
+
     type Reg = Reg;
 
     #[inline(always)]
@@ -100,11 +102,6 @@ where
             }
             _ => None,
         }
-    }
-
-    #[inline(always)]
-    fn alignment() -> u8 {
-        align_of::<u32>() as u8
     }
 
     #[inline(always)]


### PR DESCRIPTION
Eager instruction fetcher worked correctly as is, but was wasteful in terms of memory when compressed instructions are not used