### PR TITLE
Optimize vector extensions

### DIFF
--- a/crates/execution/ab-riscv-interpreter/CHANGELOG.md
+++ b/crates/execution/ab-riscv-interpreter/CHANGELOG.md
@@ -16,6 +16,7 @@ Improvements:
   below-the-base-address case into the bounds check that follows it instead of branching on it separately - one
   comparison instead of two on every memory access, with identical behavior as long as the memory region doesn't reach
   the end of the address space, which is now asserted at compile time (`BASE_ADDR + SIZE` must fit into `u64`)
+* Improved performance and APIs for vector extensions
 
 Fixes:
 

--- a/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/vector_registers.rs
@@ -2,8 +2,11 @@
 
 use crate::Csrs;
 use ab_riscv_primitives::prelude::*;
+use core::marker::Destruct;
 
 pub(crate) const VLENB_USIZE<const VLEN: Vlen>: usize = VLEN.bytes() as usize;
+/// Element width in bytes as `usize`
+const EEW_BYTES<const EEW: Eew>: usize = EEW.bytes_width() as usize;
 
 /// Alignment wrapper for vector registers
 #[derive(Debug, Clone, Copy)]
@@ -22,7 +25,7 @@ const impl<const VLEN: Vlen> Default for VectorRegisterFile<VLEN> {
 impl<const VLEN: Vlen> VectorRegisterFile<VLEN> {
     /// Get reference to a vector register
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn get(&self, index: VReg) -> &[u8; VLENB_USIZE::<VLEN>] {
         // SAFETY: Always in-range
         unsafe { self.0.get_unchecked(usize::from(index.to_bits())) }
@@ -30,10 +33,143 @@ impl<const VLEN: Vlen> VectorRegisterFile<VLEN> {
 
     /// Get mutable reference to a vector register
     #[inline(always)]
-    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic(const))]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
     pub const fn get_mut(&mut self, index: VReg) -> &mut [u8; VLENB_USIZE::<VLEN>] {
         // SAFETY: Always in-range
         unsafe { self.0.get_unchecked_mut(usize::from(index.to_bits())) }
+    }
+
+    /// All vector registers as one contiguous array of bytes.
+    ///
+    /// Register `v` occupies bytes `[v * VLENB, (v + 1) * VLENB)` of the flattened array, so a
+    /// register group is a contiguous range and its elements are at [`Self::element_offset()`].
+    #[inline(always)]
+    pub const fn as_bytes(&self) -> &[[u8; VLENB_USIZE::<VLEN>]; 32] {
+        &self.0
+    }
+
+    /// All vector registers as one contiguous mutable array of bytes, see [`Self::as_bytes()`]
+    #[inline(always)]
+    pub const fn as_bytes_mut(&mut self) -> &mut [[u8; VLENB_USIZE::<VLEN>]; 32] {
+        &mut self.0
+    }
+
+    /// Byte offset within flattened [`Self::as_bytes()`] of element `elem_i` in the register
+    /// group starting at `base_reg`, with `eew`-wide elements.
+    ///
+    /// Element widths divide `VLENB`, so elements never straddle registers and a register group
+    /// is one contiguous array of elements.
+    #[inline(always)]
+    pub const fn element_offset<W>(base_reg: VReg, elem_i: u16, eew: W) -> usize
+    where
+        W: [const] Into<Eew>,
+    {
+        usize::from(base_reg.to_bits()) * VLENB_USIZE::<VLEN>
+            + usize::from(elem_i) * usize::from(eew.into().bytes_width())
+    }
+
+    /// Read element `elem_i` of the register group starting at `base_reg`, with `eew`-wide
+    /// elements, zero-extended.
+    ///
+    /// # Safety
+    /// The element must lie within the register file, which holds for any `elem_i < vl` of a
+    /// register group `[base_reg, base_reg + group_regs)` that ends within the register file,
+    /// since `vl <= group_regs * VLENB / eew.bytes_width()`.
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    pub const unsafe fn read_element<W>(&self, base_reg: VReg, elem_i: u16, eew: W) -> u64
+    where
+        W: [const] Into<Eew> + [const] Destruct,
+    {
+        // SAFETY: Guaranteed by the caller's precondition
+        unsafe {
+            match eew.into() {
+                Eew::E8 => self.read_element_const::<{ Eew::E8 }>(base_reg, elem_i),
+                Eew::E16 => self.read_element_const::<{ Eew::E16 }>(base_reg, elem_i),
+                Eew::E32 => self.read_element_const::<{ Eew::E32 }>(base_reg, elem_i),
+                Eew::E64 => self.read_element_const::<{ Eew::E64 }>(base_reg, elem_i),
+            }
+        }
+    }
+
+    /// Write the low `eew.bytes_width()` bytes of `value` into element `elem_i` of the register
+    /// group starting at `base_reg`, with `eew`-wide elements.
+    ///
+    /// # Safety
+    /// Same as [`Self::read_element()`]
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    pub const unsafe fn write_element<W>(&mut self, base_reg: VReg, elem_i: u16, eew: W, value: u64)
+    where
+        W: [const] Into<Eew> + [const] Destruct,
+    {
+        // SAFETY: Guaranteed by the caller's precondition
+        unsafe {
+            match eew.into() {
+                Eew::E8 => self.write_element_const::<{ Eew::E8 }>(base_reg, elem_i, value),
+                Eew::E16 => self.write_element_const::<{ Eew::E16 }>(base_reg, elem_i, value),
+                Eew::E32 => self.write_element_const::<{ Eew::E32 }>(base_reg, elem_i, value),
+                Eew::E64 => self.write_element_const::<{ Eew::E64 }>(base_reg, elem_i, value),
+            }
+        }
+    }
+
+    /// [`Self::read_element()`] with the element width known at compile time, which makes the
+    /// access a fixed-size load
+    ///
+    /// # Safety
+    /// Same as [`Self::read_element()`]
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    pub const unsafe fn read_element_const<const EEW: Eew>(
+        &self,
+        base_reg: VReg,
+        elem_i: u16,
+    ) -> u64 {
+        let offset = Self::element_offset(base_reg, elem_i, EEW);
+        // SAFETY: `offset + EEW.bytes_width() <= 32 * VLENB` by the caller's precondition
+        let element = unsafe {
+            self.as_bytes()
+                .as_flattened()
+                .get_unchecked(offset..)
+                .first_chunk::<{ EEW_BYTES::<EEW> }>()
+                .unwrap_unchecked()
+        };
+        let mut bytes = 0u64.to_le_bytes();
+        if let Some((low, _)) = bytes.split_first_chunk_mut::<{ EEW_BYTES::<EEW> }>() {
+            *low = *element;
+        }
+        u64::from_le_bytes(bytes)
+    }
+
+    /// [`Self::write_element()`] with the element width known at compile time, which makes the
+    /// access a fixed-size store
+    ///
+    /// # Safety
+    /// Same as [`Self::read_element()`]
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    pub const unsafe fn write_element_const<const EEW: Eew>(
+        &mut self,
+        base_reg: VReg,
+        elem_i: u16,
+        value: u64,
+    ) {
+        let offset = Self::element_offset(base_reg, elem_i, EEW);
+        // SAFETY: `offset + EEW.bytes_width() <= 32 * VLENB` by the caller's precondition
+        let element = unsafe {
+            self.as_bytes_mut()
+                .as_flattened_mut()
+                .get_unchecked_mut(offset..)
+                .first_chunk_mut::<{ EEW_BYTES::<EEW> }>()
+                .unwrap_unchecked()
+        };
+        if let Some((low, _)) = value
+            .to_le_bytes()
+            .split_first_chunk::<{ EEW_BYTES::<EEW> }>()
+        {
+            *element = *low;
+        }
     }
 }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/tests.rs
@@ -82,17 +82,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 /// Write element `i` into a register group, given SEW
@@ -103,16 +99,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 /// Read mask bit `i` from an arbitrary vector register

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
@@ -7,6 +7,9 @@ use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
 
+/// Effective element width of a register operand at `SEW`
+const SEW_EEW<const SEW: Vsew>: Eew = SEW.as_eew();
+
 /// Check that `vreg` (`vd`/`vs`) is aligned to `group_regs` and fits within `[0, 32)`
 #[inline(always)]
 #[doc(hidden)]
@@ -136,34 +139,76 @@ pub unsafe fn execute_arith_op<Reg, Env, F>(
     [(); SUPPORTED_ELEN_VLEN::<{ Env::ELEN }, { Env::VLEN }>]:,
     F: Fn(u64, u64, Vsew) -> u64,
 {
+    // Dispatch on the element width once, so that the loop below is compiled for each width
+    // separately, with element loads and stores of a constant size
+    //
+    // SAFETY: Guaranteed by the caller's precondition
+    unsafe {
+        match sew {
+            Vsew::E8 => {
+                execute_arith_op_const::<{ Vsew::E8 }, _, _, _>(env, vd, vs2, src, vm, op);
+            }
+            Vsew::E16 => {
+                execute_arith_op_const::<{ Vsew::E16 }, _, _, _>(env, vd, vs2, src, vm, op);
+            }
+            Vsew::E32 => {
+                execute_arith_op_const::<{ Vsew::E32 }, _, _, _>(env, vd, vs2, src, vm, op);
+            }
+            Vsew::E64 => {
+                execute_arith_op_const::<{ Vsew::E64 }, _, _, _>(env, vd, vs2, src, vm, op);
+            }
+        }
+    }
+}
+
+/// [`execute_arith_op()`] with the element width known at compile time
+///
+/// # Safety
+/// Same as [`execute_arith_op()`]
+#[inline(always)]
+#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+unsafe fn execute_arith_op_const<const SEW: Vsew, Reg, Env, F>(
+    env: &mut Env,
+    vd: VReg,
+    vs2: VReg,
+    src: OpSrc,
+    vm: bool,
+    op: F,
+) where
+    Reg: Register,
+    Env: VectorRegistersExt<Reg>,
+    [(); SUPPORTED_ELEN_VLEN::<{ Env::ELEN }, { Env::VLEN }>]:,
+    F: Fn(u64, u64, Vsew) -> u64,
+{
     let vl = env.vl();
     let vstart = env.vstart();
-    // SAFETY: `vl <= VLMAX <= VLEN`, so `vl.div_ceil(8) <= VLEN.bytes()`
-    let mask_buf = unsafe { snapshot_mask(env.read_vregs(), vm, vl) };
+    let vregs = env.write_vregs();
 
     for i in vstart.range_to(vl) {
-        if !mask_bit(&mask_buf, i) {
+        // `vd` never overlaps `v0` when masked, so the mask can be read in place rather than
+        // snapshotted, no write below can modify it
+        if !vm && !mask_bit(vregs.get(VReg::V0), i) {
             continue;
         }
 
         // SAFETY: `vs2 % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
+        let a = unsafe { vregs.read_element_const::<{ SEW_EEW::<SEW> }>(vs2, i) };
 
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
+                unsafe { vregs.read_element_const::<{ SEW_EEW::<SEW> }>(vs1_base, i) }
             }
             OpSrc::Scalar(val) => val,
         };
 
-        let result = op(a, b, sew);
+        let result = op(a, b, SEW);
 
         // SAFETY: `vd % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            env.write_vregs().write_element(vd, i, sew, result);
+            vregs.write_element_const::<{ SEW_EEW::<SEW> }>(vd, i, result);
         }
     }
 

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
@@ -6,7 +6,6 @@ use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
-use core::num::NonZeroU8;
 
 /// Check that `vreg` (`vd`/`vs`) is aligned to `group_regs` and fits within `[0, 32)`
 #[inline(always)]
@@ -15,15 +14,13 @@ use core::num::NonZeroU8;
 pub fn check_vreg_group_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vreg: VReg,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory>,
 {
-    let group_regs = group_regs.get();
-    let vreg_idx = vreg.to_bits();
-    if !vreg_idx.is_multiple_of(group_regs) || vreg_idx + group_regs > 32 {
+    if !vreg.is_group_aligned(group_regs) || vreg.to_bits() + group_regs.get() > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
@@ -53,7 +50,7 @@ pub fn check_mask_dest_overlap<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     src_base: VReg,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/arith/zvexx_arith_helpers.rs
@@ -70,69 +70,6 @@ where
     Ok(())
 }
 
-/// Read a SEW-wide element from register group `[base_reg, base_reg + group_regs)` as `u64`.
-///
-/// Element `elem_i` occupies bytes at:
-///   - register `base_reg + elem_i / elems_per_reg`
-///   - byte offset `(elem_i % elems_per_reg) * sew_bytes`
-///
-/// The value is zero-extended to `u64`.
-///
-/// # Safety
-/// `base_reg + elem_i / (VLEN.bytes() / sew_bytes) < 32` must hold.
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub(crate) unsafe fn read_element_u64<const VLEN: Vlen>(
-    vregs: &VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    elem_i: u16,
-    sew: Vsew,
-) -> u64 {
-    let sew_bytes = u32::from(sew.bytes_width());
-    let elems_per_reg = VLEN.bytes() / sew_bytes;
-    let reg_off = u32::from(elem_i) / elems_per_reg;
-    let byte_off = (u32::from(elem_i) % elems_per_reg) * sew_bytes;
-    // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = vregs
-        .get(unsafe { VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked() });
-    // SAFETY: `byte_off + sew_bytes <= VLEN.bytes()` because `byte_off` is at most
-    // `(elems_per_reg - 1) * sew_bytes = VLEN.bytes() - sew_bytes`
-    let src = unsafe { reg.get_unchecked(byte_off as usize..(byte_off + sew_bytes) as usize) };
-    let mut buf = [0u8; 8];
-    // SAFETY: `sew_bytes <= 8` for all `Vsew` variants
-    unsafe { buf.get_unchecked_mut(..sew_bytes as usize) }.copy_from_slice(src);
-    u64::from_le_bytes(buf)
-}
-
-/// Write a SEW-wide element (low `sew_bytes` of `value`) into register group
-/// `[base_reg, base_reg + group_regs)` at element index `elem_i`.
-///
-/// # Safety
-/// `base_reg + elem_i / (VLEN.bytes() / sew_bytes) < 32` must hold.
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub(crate) unsafe fn write_element_u64<const VLEN: Vlen>(
-    vregs: &mut VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    elem_i: u16,
-    sew: Vsew,
-    value: u64,
-) {
-    let sew_bytes = u32::from(sew.bytes_width());
-    let elems_per_reg = VLEN.bytes() / sew_bytes;
-    let reg_off = u32::from(elem_i) / elems_per_reg;
-    let byte_off = (u32::from(elem_i) % elems_per_reg) * sew_bytes;
-    let buf = value.to_le_bytes();
-    // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = vregs
-        .get_mut(unsafe { VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked() });
-    // SAFETY: `byte_off + sew_bytes <= VLEN.bytes()` - same argument as `read_element_u64`.
-    // `sew_bytes <= 8` for all `Vsew` variants.
-    let dst = unsafe { reg.get_unchecked_mut(byte_off as usize..(byte_off + sew_bytes) as usize) };
-    // SAFETY: `sew_bytes <= 8` for all `Vsew` variants
-    dst.copy_from_slice(unsafe { buf.get_unchecked(..sew_bytes as usize) });
-}
-
 /// Write one mask bit (the comparison result for element `elem_i`) into register `vd`.
 ///
 /// Bits are stored LSB-first: element `i` lives at byte `i / 8`, bit `i % 8`.
@@ -211,12 +148,12 @@ pub unsafe fn execute_arith_op<Reg, Env, F>(
 
         // SAFETY: `vs2 % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
 
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -226,7 +163,7 @@ pub unsafe fn execute_arith_op<Reg, Env, F>(
         // SAFETY: `vd % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
 
@@ -277,12 +214,12 @@ pub unsafe fn execute_compare_op<Reg, Env, F>(
         }
 
         // SAFETY: same argument as in `execute_arith_op`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
 
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/tests.rs
@@ -63,16 +63,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn read_elem(
@@ -81,17 +78,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 /// Set mask bit `i` in register `reg`

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/carry/zvexx_carry_helpers.rs
@@ -4,9 +4,7 @@ use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{
     OpSrc, check_mask_dest_overlap, check_vreg_group_alignment,
 };
-use crate::v::zvexx::arith::zvexx_arith_helpers::{
-    read_element_u64, sew_mask, write_element_u64, write_mask_bit,
-};
+use crate::v::zvexx::arith::zvexx_arith_helpers::{sew_mask, write_mask_bit};
 use crate::v::zvexx::load::zvexx_load_helpers::mask_bit;
 use ab_riscv_primitives::prelude::*;
 
@@ -59,13 +57,13 @@ pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, Env>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds:
                 // `vs1_base + i / elems_per_reg < 32`
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -82,7 +80,7 @@ pub unsafe fn execute_carry_add<const WITH_CARRY: bool, Reg, Env>(
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
 
@@ -113,13 +111,13 @@ where
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds:
                 // `vs1_base + i / elems_per_reg < 32`
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -131,7 +129,7 @@ where
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
 
@@ -176,13 +174,13 @@ pub unsafe fn execute_carry_add_mask<const WITH_CARRY: bool, Reg, Env>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds:
                 // `vs1_base + i / elems_per_reg < 32`
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -240,13 +238,13 @@ pub unsafe fn execute_carry_sub_mask<const WITH_BORROW: bool, Reg, Env>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds:
                 // `vs1_base + i / elems_per_reg < 32`
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/tests.rs
@@ -76,16 +76,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn read_elem(
@@ -94,17 +91,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 // Write a 2*SEW-wide element into a double-width register group (for narrowing source)

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
@@ -1,11 +1,9 @@
 //! Opaque helpers for ZveXx extension
 
-use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
+use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::zvexx::arith::zvexx_arith_helpers::sign_extend;
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{
     OpSrc, check_vreg_group_alignment, sew_mask,
-};
-use crate::v::zvexx::arith::zvexx_arith_helpers::{
-    read_element_u64, sign_extend, write_element_u64,
 };
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
@@ -387,42 +385,6 @@ pub fn nclip(vs2_elem: u64, shamt: u32, sew: Vsew, mode: Vxrm, vxsat: &mut bool)
     }
 }
 
-/// Read a 2*SEW-wide element as `u64` from the double-width source register group of a narrowing
-/// instruction.
-///
-/// For narrowing instructions `vs2` holds elements of width `2*SEW`. The register group size is
-/// `2 * group_regs`. Element `i` of width `2*SEW` is located in the same way as a SEW-wide
-/// element of width `2*SEW` (i.e., treating `2*SEW` as the element width). For `SEW = 32` this
-/// reads 64-bit elements; for `SEW <= 16` it reads narrower elements but zero-extends to `u64`.
-///
-/// # Safety
-/// - `2*SEW <= 64` (Zve64x constraint: only valid for SEW <= 32; caller must verify)
-/// - `base_reg + elem_i / (VLEN.bytes() / (2*sew_bytes)) < 32`
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn read_wide_element_u64<const VLEN: Vlen>(
-    vregs: &VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    elem_i: u16,
-    sew: Vsew,
-) -> u64 {
-    let double_sew_bytes = u32::from(sew.bytes_width()) * 2;
-    let elems_per_reg = VLEN.bytes() / double_sew_bytes;
-    let reg_off = u32::from(elem_i) / elems_per_reg;
-    let byte_off = (u32::from(elem_i) % elems_per_reg) * double_sew_bytes;
-    // SAFETY: caller guarantees bounds
-    let reg = unsafe {
-        vregs.get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
-    };
-    // SAFETY: `byte_off + double_sew_bytes <= VLEN.bytes()`
-    let src =
-        unsafe { reg.get_unchecked(byte_off as usize..(byte_off + double_sew_bytes) as usize) };
-    let mut buf = [0u8; 8];
-    // SAFETY: `double_sew_bytes <= 8` (SEW <= 32 for Zve64x narrowing)
-    unsafe { buf.get_unchecked_mut(..double_sew_bytes as usize) }.copy_from_slice(src);
-    u64::from_le_bytes(buf)
-}
-
 /// Execute a single-width fixed-point arithmetic operation that may set `vxsat`.
 ///
 /// `op` receives `(vs2_elem, src_elem, sew, vxrm)` and returns `(result, saturated)`.
@@ -463,18 +425,18 @@ pub unsafe fn execute_fixed_point_op<Reg, Env, F>(
             continue;
         }
         // SAFETY: alignment and bounds checked by caller
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
         let result = op(a, b, sew, vxrm, &mut any_sat);
         // SAFETY: alignment and bounds checked by caller
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     if any_sat {
@@ -517,6 +479,8 @@ pub unsafe fn execute_narrowing_clip_op<Reg, Env, F>(
     // op: (vs2_wide_elem, shamt, sew, vxrm, vxsat) -> result
     F: Fn(u64, u32, Vsew, Vxrm, &mut bool) -> u64,
 {
+    // SAFETY: `2 * SEW <= ELEN` is a precondition, so the double width exists
+    let wide_sew = unsafe { sew.double_width().unwrap_unchecked() };
     let vl = env.vl();
     let vstart = env.vstart();
     let vxrm = env.vxrm();
@@ -531,11 +495,11 @@ pub unsafe fn execute_narrowing_clip_op<Reg, Env, F>(
         }
         // Read 2*SEW-wide source element
         // SAFETY: `vs2` double-width alignment checked by caller
-        let wide_a = unsafe { read_wide_element_u64(env.read_vregs(), vs2, i, sew) };
+        let wide_a = unsafe { env.read_vregs().read_element(vs2, i, wide_sew) };
         let shamt = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: vs1 SEW-wide alignment checked by caller
-                let raw = unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) };
+                let raw = unsafe { env.read_vregs().read_element(vs1_base, i, sew) };
                 (raw & shamt_mask) as u32
             }
             OpSrc::Scalar(val) => (val & shamt_mask) as u32,
@@ -543,7 +507,7 @@ pub unsafe fn execute_narrowing_clip_op<Reg, Env, F>(
         let result = op(wide_a, shamt, sew, vxrm, &mut any_sat);
         // SAFETY: `vd` alignment checked by caller
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     if any_sat {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/fixed_point/zvexx_fixed_point_helpers.rs
@@ -12,7 +12,6 @@ use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
-use core::num::NonZeroU8;
 
 /// Compute the rounding increment for a right shift of `val` by `shift` bits.
 ///
@@ -599,7 +598,7 @@ pub fn check_vs2_narrowing_alignment<Reg, Memory, PC>(
     vlmul: Vlmul,
     sew: Vsew,
     vd: VReg,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
@@ -625,15 +624,13 @@ where
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
         });
     };
+    let aligned = vs2.is_group_aligned(wide_group);
     let wide_group = wide_group.get();
     let vs2_idx = vs2.to_bits();
     let vd_idx = vd.to_bits();
     let group_regs = group_regs.get();
     let overlaps = vd_idx < vs2_idx + wide_group && vs2_idx < vd_idx + group_regs;
-    if !vs2_idx.is_multiple_of(wide_group)
-        || vs2_idx + wide_group > 32
-        || (overlaps && vd_idx != vs2_idx)
-    {
+    if !aligned || vs2_idx + wide_group > 32 || (overlaps && vd_idx != vs2_idx) {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load.rs
@@ -63,7 +63,7 @@ where
                         ),
                     });
                 }
-                if !vd.to_bits().is_multiple_of(nreg) {
+                if !vd.is_group_aligned(nreg) {
                     ::core::hint::cold_path();
                     return ExecutionResult::Err(ExecutionError::IllegalInstruction {
                         address: PackedAddress::new(
@@ -72,7 +72,7 @@ where
                     });
                 }
                 let base = rs1_value.as_u64();
-                for reg_off in 0..nreg {
+                for reg_off in 0..nreg.get() {
                     // SAFETY: the decoder guarantees nreg in {1,2,4,8} and vd is nreg-aligned
                     // (checked above), so vd.to_bits() + nreg - 1 <= 31.
                     let reg = unsafe { VReg::from_bits(vd.to_bits() + reg_off).unwrap_unchecked() };
@@ -169,7 +169,7 @@ where
                         vd,
                         group_regs,
                         VReg::V0,
-                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                        VRegGroupSize::R1,
                     )
                 {
                     ::core::hint::cold_path();
@@ -242,7 +242,7 @@ where
                         vd,
                         group_regs,
                         VReg::V0,
-                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                        VRegGroupSize::R1,
                     )
                 {
                     ::core::hint::cold_path();
@@ -309,7 +309,7 @@ where
                         vd,
                         group_regs,
                         VReg::V0,
-                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                        VRegGroupSize::R1,
                     )
                 {
                     ::core::hint::cold_path();
@@ -411,7 +411,7 @@ where
                         vd,
                         data_group_regs,
                         VReg::V0,
-                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                        VRegGroupSize::R1,
                     )
                 {
                     ::core::hint::cold_path();
@@ -516,7 +516,7 @@ where
                         vd,
                         data_group_regs,
                         VReg::V0,
-                        ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                        VRegGroupSize::R1,
                     )
                 {
                     ::core::hint::cold_path();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -6,7 +6,6 @@ use crate::{ExecutionError, PackedAddress, ProgramCounter, VirtualMemory, Virtua
 use ab_riscv_primitives::prelude::*;
 use core::cmp::Ordering;
 use core::hint::cold_path;
-use core::num::NonZeroU8;
 
 /// Return whether mask bit `i` is set in the mask byte slice.
 ///
@@ -59,7 +58,7 @@ pub(in super::super) unsafe fn snapshot_mask<const VLEN: Vlen>(
 #[inline(always)]
 #[doc(hidden)]
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn groups_overlap(a: VReg, a_regs: NonZeroU8, b: VReg, b_regs: NonZeroU8) -> bool {
+pub fn groups_overlap(a: VReg, a_regs: VRegGroupSize, b: VReg, b_regs: VRegGroupSize) -> bool {
     let (a, b) = (a.to_bits(), b.to_bits());
     a < b + b_regs.get() && b < a + a_regs.get()
 }
@@ -90,9 +89,9 @@ pub fn groups_overlap(a: VReg, a_regs: NonZeroU8, b: VReg, b_regs: NonZeroU8) ->
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn indexed_load_overlap_allowed(
     vd: VReg,
-    data_regs: NonZeroU8,
+    data_regs: VRegGroupSize,
     vs2: VReg,
-    index_regs: NonZeroU8,
+    index_regs: VRegGroupSize,
     index_eew: Eew,
     sew: Vsew,
     vlmul: Vlmul,
@@ -112,10 +111,9 @@ pub fn indexed_load_overlap_allowed(
         // whole-register EMUL from a fractional one clamped to a single register, so the EMUL is
         // recomputed here as `(index_eew / sew) * LMUL >= 1`.
         Ordering::Greater => {
-            let (lmul_num, lmul_den) = vlmul.as_fraction();
-            let index_emul_at_least_one = u16::from(index_eew.bits_width())
-                * u16::from(lmul_num.get())
-                >= u16::from(sew.bits_width()) * u16::from(lmul_den.get());
+            let index_emul_at_least_one = vlmul
+                .emul(index_eew, sew)
+                .is_some_and(|index_emul| !index_emul.is_fractional());
             let (vd, vs2) = (vd.to_bits(), vs2.to_bits());
             index_emul_at_least_one && vd + data_regs.get() == vs2 + index_regs.get()
         }
@@ -131,15 +129,13 @@ pub fn indexed_load_overlap_allowed(
 pub fn check_register_group_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory>,
 {
-    let group_regs = group_regs.get();
-    let vd = vd.to_bits();
-    if !vd.is_multiple_of(group_regs) || vd + group_regs > 32 {
+    if !vd.is_group_aligned(group_regs) || vd.to_bits() + group_regs.get() > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
@@ -160,19 +156,20 @@ pub fn validate_segment_registers<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     vm: bool,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory>,
 {
+    let aligned = vd.is_group_aligned(group_regs);
     let group_regs = u32::from(group_regs.get());
     let nf = u32::from(nf.fields_per_segment());
     let vd_idx = u32::from(vd.to_bits());
     // Per spec, `NFIELDS * EMUL` must not exceed 8 for segment loads/stores, regardless of whether
     // the field groups would otherwise fit within the 32 vector registers
-    if vd_idx % group_regs != 0 || nf * group_regs > 8 || vd_idx + nf * group_regs > 32 {
+    if !aligned || nf * group_regs > 8 || vd_idx + nf * group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
@@ -311,7 +308,7 @@ pub unsafe fn execute_unit_stride_load<const FAULT_ONLY_FIRST: bool, Reg, Env, M
     vm: bool,
     base: u64,
     eew: Eew,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
@@ -438,7 +435,7 @@ pub unsafe fn execute_strided_load<Reg, Env, Memory>(
     base: u64,
     stride: i64,
     eew: Eew,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
@@ -530,7 +527,7 @@ pub unsafe fn execute_indexed_load<Reg, Env, Memory>(
     base: u64,
     data_eew: Eew,
     index_eew: Eew,
-    data_group_regs: NonZeroU8,
+    data_group_regs: VRegGroupSize,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -248,12 +248,45 @@ where
     let vl = env.vl();
     let vstart = env.vstart();
     let elem_bytes = eew.bytes_width();
+
+    let range = vstart.range_to(vl);
+
+    // Unmasked non-segment load is a plain copy of a contiguous memory range into the contiguous
+    // element range of the register group, as long as the whole range is readable. If it is not,
+    // the element-wise path below is what determines the faulting element and everything before
+    // it, exactly as if the copy was never attempted (nothing was written).
+    if vm && nf.fields_per_segment() == 1 && !range.is_empty() {
+        let first = *range.start();
+        let len = range.len() * usize::from(elem_bytes);
+        let addr = base.wrapping_add(u64::from(first) * u64::from(elem_bytes));
+        let read_result = memory.read_slice(
+            addr,
+            u32::try_from(len).expect("At most 8 registers worth of bytes; qed"),
+        );
+        if let Ok(bytes) = read_result {
+            let offset = VectorRegisterFile::<{ Env::VLEN }>::element_offset(vd, first, eew);
+            // SAFETY: Elements `vstart..vl` all lie within the register group, which ends within
+            // the register file (precondition), so `offset + len <= 32 * VLEN.bytes()`
+            unsafe {
+                env.write_vregs()
+                    .as_bytes_mut()
+                    .as_flattened_mut()
+                    .get_unchecked_mut(offset..offset + len)
+                    .copy_from_slice(bytes);
+            }
+            env.mark_vs_dirty();
+            env.reset_vstart();
+            return Ok(());
+        }
+        cold_path();
+    }
+
     let segment_stride = u64::from(nf.fields_per_segment()) * u64::from(elem_bytes);
 
     // SAFETY: `vl <= VLMAX <= VLEN`
     let mask_buf = unsafe { snapshot_mask(env.read_vregs(), vm, vl) };
 
-    for i in vstart.range_to(vl) {
+    for i in range {
         if !vm && !mask_bit(&mask_buf, i) {
             continue;
         }
@@ -324,7 +357,12 @@ where
             // For `field_buf`: `f < nf <= Nf::MAX` (the same argument as in the read loop
             // above), so `f as usize < Nf::MAX = field_buf.len()`.
             unsafe {
-                env.write_vregs().write_element(field_base_reg, i, eew, u64::from_le_bytes(*field_buf.get_unchecked(f as usize)));
+                env.write_vregs().write_element(
+                    field_base_reg,
+                    i,
+                    eew,
+                    u64::from_le_bytes(*field_buf.get_unchecked(f as usize)),
+                );
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/load/zvexx_load_helpers.rs
@@ -187,79 +187,6 @@ where
     Ok(())
 }
 
-/// Read element `elem_i` from register group `[base_reg, base_reg + group_regs)` into a
-/// `[u8; Eew::MAX_BYTES]` buffer.
-///
-/// The in-register position of element `elem_i` is:
-///   - register `base_reg + elem_i / (VLEN.bytes() / eew.bytes())`
-///   - byte offset `(elem_i % (VLEN.bytes() / eew.bytes())) * eew.bytes()`
-///
-/// The result is placed in `buf[..eew.bytes()]`; the remaining bytes are zero.
-///
-/// # Safety
-/// `base_reg + elem_i / (VLEN.bytes() / eew.bytes())` must be less than 32, i.e. `elem_i` must be
-/// a valid element index within the register group.
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub(in super::super) unsafe fn read_group_element<const VLEN: Vlen>(
-    vregs: &VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    elem_i: u16,
-    eew: Eew,
-) -> [u8; const { usize::from(Eew::MAX_BYTES) }] {
-    let elem_bytes = u32::from(eew.bytes_width());
-    let elems_per_reg = VLEN.bytes() / elem_bytes;
-    let reg_off = u32::from(elem_i) / elems_per_reg;
-    let byte_off = (u32::from(elem_i) % elems_per_reg) * elem_bytes;
-    // SAFETY: `base_reg + reg_off < 32` by the caller's precondition
-    let reg = unsafe {
-        vregs.get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
-    };
-    // SAFETY: `byte_off + elem_bytes <= VLEN.bytes()`: the maximum `byte_off` is
-    // `(elems_per_reg - 1) * elem_bytes = VLEN.bytes() - elem_bytes`, so
-    // `byte_off + elem_bytes <= VLEN.bytes() - elem_bytes + elem_bytes = VLEN.bytes()`.
-    // `elem_bytes <= Eew::MAX_BYTES`: all `Eew` variants are at most E64.
-    let src = unsafe { reg.get_unchecked(byte_off as usize..(byte_off + elem_bytes) as usize) };
-    let mut buf = [0; _];
-    // SAFETY: `elem_bytes <= Eew::MAX_BYTES` as established above, so `..elem_bytes` is in bounds
-    // for `buf`
-    unsafe { buf.get_unchecked_mut(..elem_bytes as usize) }.copy_from_slice(src);
-    buf
-}
-
-/// Write `eew`-sized data from `buf[..eew.bytes()]` into element `elem_i` of register group
-/// `[base_reg, base_reg + group_regs)`.
-///
-/// The in-register position follows the same layout as [`read_group_element`].
-///
-/// # Safety
-/// `base_reg + elem_i / (VLEN.bytes() / eew.bytes())` must be less than 32, i.e. `elem_i` must be
-/// a valid element index within the register group.
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-unsafe fn write_group_element<const VLEN: Vlen>(
-    vregs: &mut VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    elem_i: u16,
-    eew: Eew,
-    buf: [u8; const { usize::from(Eew::MAX_BYTES) }],
-) {
-    let elem_bytes = u32::from(eew.bytes_width());
-    let elems_per_reg = VLEN.bytes() / elem_bytes;
-    let reg_off = u32::from(elem_i) / elems_per_reg;
-    let byte_off = (u32::from(elem_i) % elems_per_reg) * elem_bytes;
-    // SAFETY: `base_reg + reg_off < 32` by the caller's precondition
-    let reg = unsafe {
-        vregs.get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
-    };
-    // SAFETY: `byte_off + elem_bytes <= VLEN.bytes()` and `elem_bytes <= Eew::MAX_BYTES`: same
-    // argument as in `read_group_element`
-    let dst = unsafe { reg.get_unchecked_mut(byte_off as usize..(byte_off + elem_bytes) as usize) };
-    // SAFETY: `elem_bytes <= Eew::MAX_BYTES` as established above, so `..elem_bytes` is in bounds
-    // for `buf`
-    dst.copy_from_slice(unsafe { buf.get_unchecked(..elem_bytes as usize) });
-}
-
 /// Read `eew`-sized data from memory at `addr` into a `[u8; Eew::MAX_BYTES]` buffer
 /// (little-endian)
 #[inline(always)]
@@ -397,13 +324,7 @@ where
             // For `field_buf`: `f < nf <= Nf::MAX` (the same argument as in the read loop
             // above), so `f as usize < Nf::MAX = field_buf.len()`.
             unsafe {
-                write_group_element(
-                    env.write_vregs(),
-                    field_base_reg,
-                    i,
-                    eew,
-                    *field_buf.get_unchecked(f as usize),
-                );
+                env.write_vregs().write_element(field_base_reg, i, eew, u64::from_le_bytes(*field_buf.get_unchecked(f as usize)));
             }
         }
     }
@@ -488,7 +409,8 @@ where
             //
             // Therefore, `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
             unsafe {
-                write_group_element(env.write_vregs(), field_base_reg, i, eew, data);
+                env.write_vregs()
+                    .write_element(field_base_reg, i, eew, u64::from_le_bytes(data));
             }
         }
     }
@@ -557,8 +479,11 @@ where
         // `i / (VLEN.bytes() / index_eew.bytes()) < EMUL_index`, and therefore
         // `index_base_reg + i / (VLEN.bytes() / index_eew.bytes()) < index_base_reg + EMUL_index <=
         // 32`.
-        let index_buf =
-            unsafe { read_group_element(env.read_vregs(), index_base_reg, i, index_eew) };
+        let index_buf = unsafe {
+            env.read_vregs()
+                .read_element(index_base_reg, i, index_eew)
+                .to_le_bytes()
+        };
         let offset = u64::from_le_bytes(index_buf);
         let elem_addr = base.wrapping_add(offset);
 
@@ -593,7 +518,12 @@ where
             // Therefore,
             // `field_base_reg + i / data_elems_per_reg < field_base_reg + data_group_regs <= 32`.
             unsafe {
-                write_group_element(env.write_vregs(), field_base_reg, i, data_eew, data);
+                env.write_vregs().write_element(
+                    field_base_reg,
+                    i,
+                    data_eew,
+                    u64::from_le_bytes(data),
+                );
             }
         }
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask.rs
@@ -470,9 +470,8 @@ where
                         ),
                     });
                 }
-                let group_regs = vtype.vlmul().register_count().get();
-                let vd_idx = vd.to_bits();
-                if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
+                let group_regs = vtype.vlmul().register_count();
+                if !vd.is_group_aligned(group_regs) || vd.to_bits() + group_regs.get() > 32 {
                     ::core::hint::cold_path();
                     return ExecutionResult::Err(ExecutionError::IllegalInstruction {
                         address: PackedAddress::new(
@@ -483,7 +482,7 @@ where
                 // vd must not overlap vs2; vs2 is always a single mask register (group size 1).
                 let vd_start = u32::from(vd.to_bits());
                 let vs2_start = u32::from(vs2.to_bits());
-                if vd_start < vs2_start + 1 && vs2_start < vd_start + u32::from(group_regs) {
+                if vd_start < vs2_start + 1 && vs2_start < vd_start + u32::from(group_regs.get()) {
                     ::core::hint::cold_path();
                     return ExecutionResult::Err(ExecutionError::IllegalInstruction {
                         address: PackedAddress::new(
@@ -527,9 +526,8 @@ where
                         ),
                     });
                 };
-                let group_regs = vtype.vlmul().register_count().get();
-                let vd_idx = vd.to_bits();
-                if !vd_idx.is_multiple_of(group_regs) || vd_idx + group_regs > 32 {
+                let group_regs = vtype.vlmul().register_count();
+                if !vd.is_group_aligned(group_regs) || vd.to_bits() + group_regs.get() > 32 {
                     ::core::hint::cold_path();
                     return ExecutionResult::Err(ExecutionError::IllegalInstruction {
                         address: PackedAddress::new(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/tests.rs
@@ -80,17 +80,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 /// Read mask bit `i` from a vector register

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/zvexx_mask_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/mask/zvexx_mask_helpers.rs
@@ -1,7 +1,7 @@
 //! Opaque helpers for ZveXx extension
 
 use crate::v::vector_registers::VectorRegistersExt;
-use crate::v::zvexx::arith::zvexx_arith_helpers::{write_element_u64, write_mask_bit};
+use crate::v::zvexx::arith::zvexx_arith_helpers::write_mask_bit;
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use ab_riscv_primitives::prelude::*;
 
@@ -313,7 +313,7 @@ pub unsafe fn execute_viota<Reg, Env>(
         }
         // SAFETY: `vd + i / elems_per_reg < 32` by caller's alignment + vl preconditions
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, prefix_count);
+            env.write_vregs().write_element(vd, i, sew, prefix_count);
         }
         if mask_bit(&vs2_snap, i) {
             prefix_count += 1;
@@ -352,7 +352,7 @@ where
         }
         // SAFETY: `vd + i / elems_per_reg < 32` by caller's alignment + vl preconditions
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, u64::from(i));
+            env.write_vregs().write_element(vd, i, sew, u64::from(i));
         }
     }
     env.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv.rs
@@ -1074,14 +1074,13 @@ where
                 }
                 let group_regs = vtype.vlmul().register_count();
                 // dest_group_regs encodes EMUL=2*LMUL; None means EMUL>8, which is illegal
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -1170,14 +1169,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -1250,14 +1248,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -1347,14 +1344,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -1429,14 +1425,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -1526,14 +1521,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -2062,14 +2056,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 // vd holds the 2*SEW accumulator
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
@@ -2159,14 +2152,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -2239,14 +2231,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -2336,14 +2327,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -2417,14 +2407,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -2514,14 +2503,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,
@@ -2604,14 +2592,13 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let dest_group_regs = zvexx_muldiv_helpers::widening_dest_register_count(
-                    vtype.vlmul(),
-                )
-                .ok_or(ExecutionError::IllegalInstruction {
-                    address: PackedAddress::new(
-                        program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
-                    ),
-                })?;
+                let dest_group_regs = vtype.vlmul().widening_register_count().ok_or(
+                    ExecutionError::IllegalInstruction {
+                        address: PackedAddress::new(
+                            program_counter.old_pc(zvexx_helpers::INSTRUCTION_SIZE),
+                        ),
+                    },
+                )?;
                 zvexx_muldiv_helpers::check_vreg_group_alignment::<Reg, _, _>(
                     program_counter,
                     vd,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
@@ -78,17 +78,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = TEST_VLENB / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 // Wide elements are 2*SEW bytes; a register holds VLENB/wide_bytes of them, matching
@@ -119,16 +115,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = TEST_VLENB / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn write_wide_elem(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/tests.rs
@@ -1,15 +1,12 @@
 use crate::prelude::VLENB_USIZE;
 use crate::rv64::test_utils::{Env, TestInterpreterState, initialize_state};
 use crate::v::vector_registers::{VectorRegisters, VectorRegistersExt};
-use crate::v::zvexx::muldiv::zvexx_muldiv_helpers::{
-    mulh_ss, mulhsu_su, mulhu_uu, widening_dest_register_count,
-};
+use crate::v::zvexx::muldiv::zvexx_muldiv_helpers::{mulh_ss, mulhsu_su, mulhu_uu};
 use crate::{
     ExecutableInstruction, ExecutableInstructionOperands, ExecutionError, ExecutionResult,
     RegisterFile, Rs1Rs2OperandValues, Rs1Rs2Operands,
 };
 use ab_riscv_primitives::prelude::*;
-use core::num::NonZeroU8;
 
 // With TEST_VLEN=256, VLENB=32:
 //   E8/M1  -> VLMAX=32, 1 reg
@@ -2347,41 +2344,4 @@ fn set_mask_bit_helper_works() {
             i * 2 + 1
         );
     }
-}
-
-#[test]
-fn widening_dest_register_count_values() {
-    // EMUL = 2 * LMUL:
-    // Mf8 (1/8) -> 2/8 = 1/4 -> 1 reg
-    // Mf4 (1/4) -> 2/4 = 1/2 -> 1 reg
-    // Mf2 (1/2) -> 2/2 = 1   -> 1 reg
-    // M1 (1)    -> 2/1 = 2   -> 2 regs
-    // M2 (2)    -> 4/1 = 4   -> 4 regs
-    // M4 (4)    -> 8/1 = 8   -> 8 regs
-    // M8 (8)    -> 16/1 = 16 -> None (illegal)
-    assert_eq!(
-        widening_dest_register_count(Vlmul::Mf8),
-        Some(NonZeroU8::new(1).unwrap())
-    );
-    assert_eq!(
-        widening_dest_register_count(Vlmul::Mf4),
-        Some(NonZeroU8::new(1).unwrap())
-    );
-    assert_eq!(
-        widening_dest_register_count(Vlmul::Mf2),
-        Some(NonZeroU8::new(1).unwrap())
-    );
-    assert_eq!(
-        widening_dest_register_count(Vlmul::M1),
-        Some(NonZeroU8::new(2).unwrap())
-    );
-    assert_eq!(
-        widening_dest_register_count(Vlmul::M2),
-        Some(NonZeroU8::new(4).unwrap())
-    );
-    assert_eq!(
-        widening_dest_register_count(Vlmul::M4),
-        Some(NonZeroU8::new(8).unwrap())
-    );
-    assert_eq!(widening_dest_register_count(Vlmul::M8), None);
 }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -11,7 +11,6 @@ use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
-use core::num::NonZeroU8;
 
 /// Whether a widening operation is representable for the given `SEW` and `ELEN`.
 ///
@@ -28,42 +27,6 @@ use core::num::NonZeroU8;
 #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
 pub fn widening_eew_supported(sew: Vsew, elen: Elen) -> bool {
     u32::from(sew.bits_width()) * 2 <= u32::from(elen)
-}
-
-/// Compute the destination register count for a widening operation (`EMUL = 2 × LMUL`).
-///
-/// Returns `None` when the resulting EMUL falls outside the legal range `[1/8, 8]`, i.e. when
-/// `LMUL` is already `M8` (EMUL would be 16) or the caller asks for a multiplication factor that
-/// pushes the fraction past the legal lower bound.
-///
-/// The register count returned is `max(1, EMUL)`: fractional EMUL values (1/2, 1/4) still occupy
-/// exactly one physical register.
-#[inline(always)]
-#[doc(hidden)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub fn widening_dest_register_count(vlmul: Vlmul) -> Option<NonZeroU8> {
-    let (lmul_num, lmul_den) = vlmul.as_fraction();
-    // EMUL = 2 × LMUL = (2 * lmul_num) / lmul_den
-    let Some(emul_num) = 2u8.checked_mul(lmul_num.get()) else {
-        cold_path();
-        return None;
-    };
-    let emul_den = lmul_den.get();
-    // Reduce the fraction by GCD (both are powers of two so min works as GCD)
-    let g = emul_num.min(emul_den);
-    let (n, d) = (emul_num / g, emul_den / g);
-    // Legal EMUL fractions: 1/8, 1/4, 1/2, 1, 2, 4, 8
-    #[expect(clippy::unnested_or_patterns, reason = "Readability")]
-    let legal = matches!(
-        (n, d),
-        (1, 8) | (1, 4) | (1, 2) | (1, 1) | (2, 1) | (4, 1) | (8, 1)
-    );
-    if !legal {
-        cold_path();
-        return None;
-    }
-    // Register count: max(1, n/d) = n when d==1, else 1
-    Some(NonZeroU8::new(if d > 1 { 1 } else { n }).expect("Not zero; qed"))
 }
 
 /// Check that a narrower source register group does not *illegally* overlap the wider destination
@@ -91,8 +54,8 @@ pub fn check_no_widening_overlap<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
     vs: VReg,
-    dest_group_regs: NonZeroU8,
-    src_group_regs: NonZeroU8,
+    dest_group_regs: VRegGroupSize,
+    src_group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/muldiv/zvexx_muldiv_helpers.rs
@@ -1,11 +1,9 @@
 //! Opaque helpers for ZveXx extension
 
-use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
+use crate::v::vector_registers::VectorRegistersExt;
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{
     OpSrc, check_vreg_group_alignment, sew_mask, sign_extend,
 };
-use crate::v::zvexx::arith::zvexx_arith_helpers::{read_element_u64, write_element_u64};
-use crate::v::zvexx::fixed_point::zvexx_fixed_point_helpers::read_wide_element_u64;
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
@@ -84,40 +82,6 @@ where
     })
 }
 
-/// Write a 2*SEW-wide element into the widened destination register group at element index
-/// `elem_i`.
-///
-/// # Safety
-/// - `base_reg + elem_i / (VLEN.bytes() / (2*sew_bytes)) < 32` must hold.
-/// - `2 * sew.bits_width() <= 64` must hold, so that the wide element fits in a `u64` and
-///   `wide_bytes <= 8`. Callers establish this via
-///   [`widening_eew_supported()`][crate::v::zvexx::muldiv::zvexx_muldiv_helpers::widening_eew_supported],
-///   since `2*SEW <= ELEN` and `ELEN <= 64` for every supported configuration.
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-unsafe fn write_wide_element_u64<const VLEN: Vlen>(
-    vregs: &mut VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    elem_i: u16,
-    sew: Vsew,
-    value: u64,
-) {
-    let wide_bytes = u32::from(sew.bytes_width()) * 2;
-    let elems_per_reg = VLEN.bytes() / wide_bytes;
-    let reg_off = u32::from(elem_i) / elems_per_reg;
-    let byte_off = (u32::from(elem_i) % elems_per_reg) * wide_bytes;
-    let buf = value.to_le_bytes();
-    // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe {
-        vregs.get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
-    };
-    // SAFETY: `byte_off + wide_bytes <= VLEN.bytes()`; `wide_bytes <= 8` by caller's precondition
-    let dst = unsafe { reg.get_unchecked_mut(byte_off as usize..(byte_off + wide_bytes) as usize) };
-    // SAFETY: `wide_bytes <= 8` because `2*SEW <= ELEN <= 64` is enforced before widening ops are
-    // called
-    dst.copy_from_slice(unsafe { buf.get_unchecked(..wide_bytes as usize) });
-}
-
 /// Execute a single-width element-wise arithmetic operation over `vstart..vl`.
 ///
 /// `op` receives `(vs2_elem: u64, src_elem: u64, sew: Vsew)` and returns the `u64` result.
@@ -153,18 +117,16 @@ pub unsafe fn execute_arith_op<Reg, Env, F>(
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(vs1_base) => unsafe {
-                read_element_u64(env.read_vregs(), vs1_base, i, sew)
-            },
+            OpSrc::Vreg(vs1_base) => unsafe { env.read_vregs().read_element(vs1_base, i, sew) },
             OpSrc::Scalar(val) => val,
         };
         let result = op(a, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -200,6 +162,8 @@ pub unsafe fn execute_widening_op<Reg, Env, F>(
     [(); SUPPORTED_ELEN_VLEN::<{ Env::ELEN }, { Env::VLEN }>]:,
     F: Fn(u64, u64, Vsew) -> u64,
 {
+    // SAFETY: `2 * SEW <= ELEN` is a precondition, so the double width exists
+    let wide_sew = unsafe { sew.double_width().unwrap_unchecked() };
     let vl = env.vl();
     let vstart = env.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`
@@ -209,12 +173,10 @@ pub unsafe fn execute_widening_op<Reg, Env, F>(
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(vs1_base) => unsafe {
-                read_element_u64(env.read_vregs(), vs1_base, i, sew)
-            },
+            OpSrc::Vreg(vs1_base) => unsafe { env.read_vregs().read_element(vs1_base, i, sew) },
             OpSrc::Scalar(val) => val,
         };
         let result = op(a, b, sew);
@@ -222,7 +184,7 @@ pub unsafe fn execute_widening_op<Reg, Env, F>(
         // `vl <= src_group_regs * VLEN.bytes() / sew_bytes` and dest stores at 2*SEW width so
         // `i < dest_group_regs * VLEN.bytes() / (2*sew_bytes)`; `2*SEW <= ELEN <= 64` by caller
         unsafe {
-            write_wide_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, wide_sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -264,18 +226,18 @@ pub unsafe fn execute_muladd_op<Reg, Env, F>(
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let acc = unsafe { read_element_u64(env.read_vregs(), vd, i, sew) };
+        let acc = unsafe { env.read_vregs().read_element(vd, i, sew) };
         // SAFETY: register bounds verified by caller
-        let a = unsafe { read_element_u64(env.read_vregs(), a_reg, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(a_reg, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(b_reg) => unsafe { read_element_u64(env.read_vregs(), b_reg, i, sew) },
+            OpSrc::Vreg(b_reg) => unsafe { env.read_vregs().read_element(b_reg, i, sew) },
             OpSrc::Scalar(val) => val,
         };
         let result = op(acc, a, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -314,16 +276,16 @@ pub unsafe fn execute_muladd_scalar_op<Reg, Env, F>(
             continue;
         }
         // SAFETY: register bounds verified by caller
-        let acc = unsafe { read_element_u64(env.read_vregs(), vd, i, sew) };
+        let acc = unsafe { env.read_vregs().read_element(vd, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(b_reg) => unsafe { read_element_u64(env.read_vregs(), b_reg, i, sew) },
+            OpSrc::Vreg(b_reg) => unsafe { env.read_vregs().read_element(b_reg, i, sew) },
             OpSrc::Scalar(val) => val,
         };
         let result = op(acc, scalar, b, sew);
         // SAFETY: register bounds verified by caller
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -360,6 +322,8 @@ pub unsafe fn execute_widening_muladd_op<Reg, Env, F>(
     [(); SUPPORTED_ELEN_VLEN::<{ Env::ELEN }, { Env::VLEN }>]:,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
+    // SAFETY: `2 * SEW <= ELEN` is a precondition, so the double width exists
+    let wide_sew = unsafe { sew.double_width().unwrap_unchecked() };
     let vl = env.vl();
     let vstart = env.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`
@@ -371,18 +335,18 @@ pub unsafe fn execute_widening_muladd_op<Reg, Env, F>(
         // Read the existing 2*SEW accumulator from vd
         // SAFETY: vd has dest_group_regs registers; element `i` fits within them (see
         // `execute_widening_op` for the bound argument); `2*SEW <= ELEN <= 64` by caller
-        let acc = unsafe { read_wide_element_u64(env.read_vregs(), vd, i, sew) };
+        let acc = unsafe { env.read_vregs().read_element(vd, i, wide_sew) };
         // SAFETY: register bounds verified by caller
-        let a = unsafe { read_element_u64(env.read_vregs(), a_reg, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(a_reg, i, sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(b_reg) => unsafe { read_element_u64(env.read_vregs(), b_reg, i, sew) },
+            OpSrc::Vreg(b_reg) => unsafe { env.read_vregs().read_element(b_reg, i, sew) },
             OpSrc::Scalar(val) => val,
         };
         let result = op(acc, a, b, sew);
         // SAFETY: same as acc read above
         unsafe {
-            write_wide_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, wide_sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -412,6 +376,8 @@ pub unsafe fn execute_widening_muladd_scalar_op<Reg, Env, F>(
     [(); SUPPORTED_ELEN_VLEN::<{ Env::ELEN }, { Env::VLEN }>]:,
     F: Fn(u64, u64, u64, Vsew) -> u64,
 {
+    // SAFETY: `2 * SEW <= ELEN` is a precondition, so the double width exists
+    let wide_sew = unsafe { sew.double_width().unwrap_unchecked() };
     let vl = env.vl();
     let vstart = env.vstart();
     // SAFETY: `vl <= VLMAX <= VLEN`
@@ -422,16 +388,16 @@ pub unsafe fn execute_widening_muladd_scalar_op<Reg, Env, F>(
         }
         // SAFETY: vd has dest_group_regs registers; element `i` fits within them (see
         // `execute_widening_op` for the bound argument); `2*SEW <= ELEN <= 64` by caller
-        let acc = unsafe { read_wide_element_u64(env.read_vregs(), vd, i, sew) };
+        let acc = unsafe { env.read_vregs().read_element(vd, i, wide_sew) };
         let b = match src {
             // SAFETY: register bounds verified by caller
-            OpSrc::Vreg(b_reg) => unsafe { read_element_u64(env.read_vregs(), b_reg, i, sew) },
+            OpSrc::Vreg(b_reg) => unsafe { env.read_vregs().read_element(b_reg, i, sew) },
             OpSrc::Scalar(val) => val,
         };
         let result = op(acc, scalar, b, sew);
         // SAFETY: same as acc read above
         unsafe {
-            write_wide_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, wide_sew, result);
         }
     }
     env.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -903,7 +903,7 @@ where
                     program_counter,
                     vd,
                     vs1,
-                    ::core::num::NonZeroU8::new(1).expect("Not zero; qed"),
+                    VRegGroupSize::R1,
                 )?;
                 let sew = vtype.vsew();
                 let vl = env.vl();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm.rs
@@ -71,8 +71,7 @@ where
                 let sew = vtype.vsew();
                 // SAFETY: element 0 is always within register vs2, byte offset 0;
                 // VLEN.bytes() >= sew.bytes() for all legal vtype configurations.
-                let raw =
-                    unsafe { zvexx_perm_helpers::read_element_0_u64(env.read_vregs(), vs2, sew) };
+                let raw = unsafe { env.read_vregs().read_element(vs2, 0, sew) };
                 let sign_extended = zvexx_perm_helpers::sign_extend_to_reg::<Reg>(raw, sew);
                 env.mark_vs_dirty();
                 env.reset_vstart();
@@ -111,7 +110,7 @@ where
                     let scalar = rs1_value.as_i64().cast_unsigned();
                     // SAFETY: element 0 always fits.
                     unsafe {
-                        zvexx_perm_helpers::write_element_0_u64(env.write_vregs(), vd, sew, scalar);
+                        env.write_vregs().write_element(vd, 0, sew, scalar);
                     }
                 }
                 env.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/tests.rs
@@ -73,17 +73,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 fn write_elem(
@@ -93,16 +89,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn set_vreg_bytes(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
@@ -7,6 +7,7 @@ use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
+use core::ptr;
 
 /// Check that register groups `[a, a+count)` and `[b, b+count)` do not overlap.
 ///
@@ -137,14 +138,37 @@ pub unsafe fn execute_slideup<Reg, Env>(
 {
     let vl = env.vl();
     let vstart = env.vstart();
-    // SAFETY: `vl <= VLEN`
-    let mask_buf = unsafe { snapshot_mask(env.read_vregs(), vm, vl) };
     // Per spec §16.3.1: elements 0..offset are never written (vd keeps its value).
     // The active range starts at max(vstart, offset).
-    for i in vstart
-        .max(Vstart::from(offset.saturating_truncate::<u16>()))
-        .range_to(vl)
-    {
+    let first = vstart.max(Vstart::from(offset.saturating_truncate::<u16>()));
+    let range = first.range_to(vl);
+
+    // Unmasked slide is a copy of a contiguous element range between two contiguous register
+    // groups
+    if vm && !range.is_empty() {
+        let len = range.len() * usize::from(sew.bytes_width());
+        // `first >= offset`, hence the truncation is lossless
+        let src_first = *range.start() - offset.saturating_truncate::<u16>();
+        let src = VectorRegisterFile::<{ Env::VLEN }>::element_offset(vs2, src_first, sew);
+        let dst = VectorRegisterFile::<{ Env::VLEN }>::element_offset(vd, *range.start(), sew);
+        let bytes = env.write_vregs().as_bytes_mut().as_flattened_mut();
+        // SAFETY: Elements `first..vl` of `vd` and `first - offset..vl - offset` of `vs2` lie
+        // within their register groups, which end within the register file (precondition), so
+        // both ranges are within `bytes`. Overlapping ranges are fine for `ptr::copy()`. Both
+        // pointers derive from the same mutable one, a separate shared one would be invalidated
+        // by it.
+        unsafe {
+            let bytes = bytes.as_mut_ptr();
+            ptr::copy(bytes.byte_add(src), bytes.byte_add(dst), len);
+        }
+        env.mark_vs_dirty();
+        env.reset_vstart();
+        return;
+    }
+
+    // SAFETY: `vl <= VLEN`
+    let mask_buf = unsafe { snapshot_mask(env.read_vregs(), vm, vl) };
+    for i in range {
         if !mask_bit(&mask_buf, i) {
             continue;
         }
@@ -186,9 +210,48 @@ pub unsafe fn execute_slidedown<Reg, Env>(
 {
     let vl = env.vl();
     let vstart = env.vstart();
+
+    let range = vstart.range_to(vl);
+
+    // Unmasked slide is a copy of a contiguous element range between two contiguous register
+    // groups (or within one), followed by zeroing of the elements whose source is beyond `vlmax`
+    if vm && !range.is_empty() {
+        let elem_bytes = usize::from(sew.bytes_width());
+        let first = *range.start();
+        // Elements `i` with `i + offset < vlmax` have a source, the rest are zeroed
+        let with_source = u64::from(vlmax)
+            .saturating_sub(offset)
+            .saturating_sub(u64::from(first));
+        let copied = usize::try_from(with_source)
+            .map_or(range.len(), |with_source| with_source.min(range.len()));
+        let copied_len = copied * elem_bytes;
+        let len = range.len() * elem_bytes;
+        let dst = VectorRegisterFile::<{ Env::VLEN }>::element_offset(vd, first, sew);
+        let bytes = env.write_vregs().as_bytes_mut().as_flattened_mut();
+        // SAFETY: Elements `first..vl` of `vd` lie within its register group, which ends within
+        // the register file (precondition), so `dst..dst + len` is within `bytes`. So do elements
+        // `first + offset..vlmax` of `vs2` when there are any to copy: `copied > 0` implies
+        // `first + offset < vlmax`, hence the truncation of `offset` is lossless and
+        // `src..src + copied_len` is within the group. Overlapping ranges are fine for
+        // `ptr::copy()`. Both pointers derive from the same mutable one, a separate shared one
+        // would be invalidated by it.
+        unsafe {
+            if copied > 0 {
+                let src_first = first + offset.saturating_truncate::<u16>();
+                let src = VectorRegisterFile::<{ Env::VLEN }>::element_offset(vs2, src_first, sew);
+                let bytes = bytes.as_mut_ptr();
+                ptr::copy(bytes.byte_add(src), bytes.byte_add(dst), copied_len);
+            }
+            bytes.get_unchecked_mut(dst + copied_len..dst + len).fill(0);
+        }
+        env.mark_vs_dirty();
+        env.reset_vstart();
+        return;
+    }
+
     // SAFETY: `vl <= VLEN`
     let mask_buf = unsafe { snapshot_mask(env.read_vregs(), vm, vl) };
-    for i in vstart.range_to(vl) {
+    for i in range {
         if !mask_bit(&mask_buf, i) {
             continue;
         }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
@@ -2,7 +2,6 @@
 
 use crate::v::vector_registers::{VLENB_USIZE, VectorRegisterFile, VectorRegistersExt};
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::check_vreg_group_alignment;
-use crate::v::zvexx::arith::zvexx_arith_helpers::{read_element_u64, write_element_u64};
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
@@ -73,50 +72,6 @@ where
         });
     }
     Ok(())
-}
-
-/// Read element 0 of register `base_reg` as `u64`, zero-extended.
-///
-/// # Safety
-/// `sew.bytes() <= VLEN.bytes()`
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn read_element_0_u64<const VLEN: Vlen>(
-    vregs: &VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    sew: Vsew,
-) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let reg = vregs.get(base_reg);
-    let mut buf = [0u8; 8];
-    // SAFETY: `sew_bytes <= VLEN.bytes()` for all legal vtype; `sew_bytes <= 8`
-    unsafe {
-        buf.get_unchecked_mut(..sew_bytes)
-            .copy_from_slice(reg.get_unchecked(..sew_bytes));
-    }
-    u64::from_le_bytes(buf)
-}
-
-/// Write element 0 of register `base_reg` from the low `sew_bytes` of `value`.
-///
-/// # Safety
-/// `sew.bytes() <= VLEN.bytes()`
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-pub unsafe fn write_element_0_u64<const VLEN: Vlen>(
-    vregs: &mut VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    sew: Vsew,
-    value: u64,
-) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let buf = value.to_le_bytes();
-    let reg = vregs.get_mut(base_reg);
-    // SAFETY: `sew_bytes <= VLEN.bytes()`; `sew_bytes <= 8`
-    unsafe {
-        reg.get_unchecked_mut(..sew_bytes)
-            .copy_from_slice(buf.get_unchecked(..sew_bytes));
-    }
 }
 
 /// Sign-extend the low `sew.bits_width()` of `val` to the register type width.
@@ -195,10 +150,10 @@ pub unsafe fn execute_slideup<Reg, Env>(
         }
         let src_idx = i - offset.saturating_truncate::<u16>();
         // SAFETY: src_idx < vl <= group_regs * elems_per_reg, so source element is in range
-        let val = unsafe { read_element_u64(env.read_vregs(), vs2, src_idx, sew) };
+        let val = unsafe { env.read_vregs().read_element(vs2, src_idx, sew) };
         // SAFETY: i < vl <= group_regs * elems_per_reg, so dest element is in range
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -243,13 +198,13 @@ pub unsafe fn execute_slidedown<Reg, Env>(
             && src_idx < u64::from(vlmax)
         {
             // SAFETY: src_idx < vlmax <= group_regs * elems_per_reg, so element is in range
-            unsafe { read_element_u64(env.read_vregs(), vs2, src_idx as u16, sew) }
+            unsafe { env.read_vregs().read_element(vs2, src_idx as u16, sew) }
         } else {
             0
         };
         // SAFETY: i < vl <= vlmax <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -293,11 +248,11 @@ pub unsafe fn execute_slide1up<Reg, Env>(
             scalar
         } else {
             // SAFETY: i - 1 < vl <= group_regs * elems_per_reg
-            unsafe { read_element_u64(env.read_vregs(), vs2, i - 1, sew) }
+            unsafe { env.read_vregs().read_element(vs2, i - 1, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -344,13 +299,13 @@ pub unsafe fn execute_slide1down<Reg, Env>(
         }
         let val = if i < *range.end() {
             // SAFETY: i + 1 < vl <= group_regs * elems_per_reg
-            unsafe { read_element_u64(env.read_vregs(), vs2, i + 1, sew) }
+            unsafe { env.read_vregs().read_element(vs2, i + 1, sew) }
         } else {
             scalar
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -388,16 +343,16 @@ pub unsafe fn execute_rgather_vv<Reg, Env>(
             continue;
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg for vs1
-        let index = unsafe { read_element_u64(env.read_vregs(), vs1, i, sew) };
+        let index = unsafe { env.read_vregs().read_element(vs1, i, sew) };
         let val = if index < u64::from(vlmax) {
             // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(env.read_vregs(), vs2, index as u16, sew) }
+            unsafe { env.read_vregs().read_element(vs2, index as u16, sew) }
         } else {
             0u64
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -433,7 +388,7 @@ pub unsafe fn execute_rgather_scalar<Reg, Env>(
     // Pre-compute the gathered value; it's the same for all elements.
     let val = if index < u64::from(vlmax) {
         // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
-        unsafe { read_element_u64(env.read_vregs(), vs2, index as u16, sew) }
+        unsafe { env.read_vregs().read_element(vs2, index as u16, sew) }
     } else {
         0u64
     };
@@ -443,7 +398,7 @@ pub unsafe fn execute_rgather_scalar<Reg, Env>(
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -500,16 +455,16 @@ pub unsafe fn execute_rgatherei16<Reg, Env>(
         // Read 16-bit index from vs1; EEW=16 always.
         // SAFETY: i < vl <= index_capacity = index_group_regs * (VLEN.bytes() / 2), so element i
         // fits within the index register group.
-        let index = unsafe { read_element_u64(env.read_vregs(), vs1, i, Vsew::E16) };
+        let index = unsafe { env.read_vregs().read_element(vs1, i, Vsew::E16) };
         let val = if index < u64::from(vlmax) {
             // SAFETY: index < vlmax <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(env.read_vregs(), vs2, index as u16, sew) }
+            unsafe { env.read_vregs().read_element(vs2, index as u16, sew) }
         } else {
             0u64
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -550,15 +505,15 @@ pub unsafe fn execute_merge_vv<Reg, Env>(
         let mask_set = mask_bit(&mask_buf, i);
         let val = if mask_set {
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs1
-            unsafe { read_element_u64(env.read_vregs(), vs1, i, sew) }
+            unsafe { env.read_vregs().read_element(vs1, i, sew) }
         } else {
             // mask_set=false only reachable when vm=false (vmerge path).
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) }
+            unsafe { env.read_vregs().read_element(vs2, i, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -600,11 +555,11 @@ pub unsafe fn execute_merge_scalar<Reg, Env>(
             scalar
         } else {
             // SAFETY: i < vl <= group_regs * elems_per_reg for vs2
-            unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) }
+            unsafe { env.read_vregs().read_element(vs2, i, sew) }
         };
         // SAFETY: i < vl <= group_regs * elems_per_reg for vd
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, val);
+            env.write_vregs().write_element(vd, i, sew, val);
         }
     }
     env.mark_vs_dirty();
@@ -651,10 +606,10 @@ pub unsafe fn execute_compress<Reg, Env>(
             continue;
         }
         // SAFETY: i < vl <= group_regs * elems_per_reg
-        let val = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let val = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         // SAFETY: out_idx <= popcount(vs1[0..vl)) <= vl
         unsafe {
-            write_element_u64(env.write_vregs(), vd, out_idx, sew, val);
+            env.write_vregs().write_element(vd, out_idx, sew, val);
         }
         out_idx += 1;
     }

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/perm/zvexx_perm_helpers.rs
@@ -8,7 +8,6 @@ use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
-use core::num::NonZeroU8;
 
 /// Check that register groups `[a, a+count)` and `[b, b+count)` do not overlap.
 ///
@@ -21,7 +20,7 @@ pub fn check_no_overlap<Reg, Memory, PC>(
     program_counter: &PC,
     a: VReg,
     b: VReg,
-    count: NonZeroU8,
+    count: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
@@ -53,9 +52,9 @@ where
 pub fn check_no_overlap_asymmetric<Reg, Memory, PC>(
     program_counter: &PC,
     a: VReg,
-    a_count: NonZeroU8,
+    a_count: VRegGroupSize,
     b: VReg,
-    b_count: NonZeroU8,
+    b_count: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
@@ -474,7 +473,7 @@ pub unsafe fn execute_rgatherei16<Reg, Env>(
     vm: bool,
     sew: Vsew,
     vlmax: Vl,
-    index_group_regs: NonZeroU8,
+    index_group_regs: VRegGroupSize,
 ) where
     Reg: Register,
     Env: VectorRegistersExt<Reg>,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/tests.rs
@@ -62,17 +62,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 fn write_elem(
@@ -82,16 +78,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn set_mask_bit(

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/zvexx_reduction_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/reduction/zvexx_reduction_helpers.rs
@@ -1,8 +1,6 @@
 //! Opaque helpers for ZveXx extension
 use crate::v::vector_registers::VectorRegistersExt;
-use crate::v::zvexx::arith::zvexx_arith_helpers::{
-    read_element_u64, sign_extend, write_element_u64,
-};
+use crate::v::zvexx::arith::zvexx_arith_helpers::sign_extend;
 use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
@@ -42,7 +40,7 @@ pub unsafe fn execute_reduce_op<Reg, Env, F>(
         return;
     }
     // SAFETY: element 0 always fits within register vs1
-    let init = unsafe { read_element_u64(env.read_vregs(), vs1, 0, sew) };
+    let init = unsafe { env.read_vregs().read_element(vs1, 0, sew) };
     // SAFETY: `vl <= VLEN`
     let mask_buf = unsafe { snapshot_mask(env.read_vregs(), vm, vl) };
     let mut acc = init;
@@ -51,12 +49,12 @@ pub unsafe fn execute_reduce_op<Reg, Env, F>(
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `i < vl <= group_regs * elems_per_reg`
-        let elem = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let elem = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         acc = op(acc, elem, sew);
     }
     // SAFETY: element 0 always fits within register vd
     unsafe {
-        write_element_u64(env.write_vregs(), vd, 0, sew, acc);
+        env.write_vregs().write_element(vd, 0, sew, acc);
     }
     env.mark_vs_dirty();
     env.reset_vstart();
@@ -99,7 +97,7 @@ pub unsafe fn execute_widening_reduce_op<const SIGN_EXTEND_SRC: bool, Reg, Env, 
         return;
     }
     // SAFETY: element 0 always fits within register vs1
-    let init = unsafe { read_element_u64(env.read_vregs(), vs1, 0, wide_sew) };
+    let init = unsafe { env.read_vregs().read_element(vs1, 0, wide_sew) };
     // SAFETY: `vl <= VLEN`
     let mask_buf = unsafe { snapshot_mask(env.read_vregs(), vm, vl) };
     let mut acc = init;
@@ -108,7 +106,7 @@ pub unsafe fn execute_widening_reduce_op<const SIGN_EXTEND_SRC: bool, Reg, Env, 
             continue;
         }
         // SAFETY: same bounds argument as `execute_reduce_op`
-        let raw = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let raw = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let elem = if SIGN_EXTEND_SRC {
             sign_extend(raw, sew).cast_unsigned()
         } else {
@@ -118,7 +116,7 @@ pub unsafe fn execute_widening_reduce_op<const SIGN_EXTEND_SRC: bool, Reg, Env, 
     }
     // SAFETY: element 0 always fits within register vd
     unsafe {
-        write_element_u64(env.write_vregs(), vd, 0, wide_sew, acc);
+        env.write_vregs().write_element(vd, 0, wide_sew, acc);
     }
     env.mark_vs_dirty();
     env.reset_vstart();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store.rs
@@ -63,7 +63,7 @@ where
                         ),
                     });
                 }
-                if !vs3.to_bits().is_multiple_of(nreg) {
+                if !vs3.is_group_aligned(nreg) {
                     ::core::hint::cold_path();
                     return ExecutionResult::Err(ExecutionError::IllegalInstruction {
                         address: PackedAddress::new(
@@ -72,7 +72,7 @@ where
                     });
                 }
                 let vlenb = u64::from(Env::VLEN.bytes());
-                let evl = u64::from(nreg) * vlenb;
+                let evl = u64::from(nreg.get()) * vlenb;
                 let vstart = env.vstart();
                 if u64::from(u16::from(vstart)) < evl {
                     let base = rs1_value.as_u64();

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
@@ -8,7 +8,6 @@ use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter, VirtualMemory, VirtualMemoryError};
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
-use core::num::NonZeroU8;
 
 /// Interpret `buf[..index_eew.bytes()]` as a little-endian unsigned integer and return it as
 /// `u64`. Used to convert a packed index element into a byte offset.
@@ -52,7 +51,7 @@ fn write_mem_element(
 pub fn validate_segment_store_registers<Reg, Memory, PC>(
     program_counter: &PC,
     vs3: VReg,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
@@ -102,7 +101,7 @@ pub unsafe fn execute_unit_stride_store<Reg, Env, Memory>(
     vm: bool,
     base: u64,
     eew: Eew,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
@@ -180,7 +179,7 @@ pub unsafe fn execute_strided_store<Reg, Env, Memory>(
     base: u64,
     stride: i64,
     eew: Eew,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
@@ -253,7 +252,7 @@ pub unsafe fn execute_indexed_store<Reg, Env, Memory>(
     base: u64,
     data_eew: Eew,
     index_eew: Eew,
-    data_group_regs: NonZeroU8,
+    data_group_regs: VRegGroupSize,
     nf: Nf,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
@@ -1,6 +1,6 @@
 //! Opaque helpers for ZveXx extension
 
-use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::vector_registers::{VectorRegisterFile, VectorRegistersExt};
 use crate::v::zvexx::load::zvexx_load_helpers::{
     check_register_group_alignment, mask_bit, snapshot_mask,
 };
@@ -114,10 +114,37 @@ where
     let vl = env.vl();
     let vstart = env.vstart();
     let elem_bytes = eew.bytes_width();
+
+    let range = vstart.range_to(vl);
+
+    // Unmasked non-segment store is a plain copy of the contiguous element range of the register
+    // group into a contiguous memory range, as long as the whole range is writable. If it is not,
+    // the element-wise path below is what determines the faulting element and writes everything
+    // before it, which is the same outcome a partially written copy would have.
+    if vm && nf.fields_per_segment() == 1 && !range.is_empty() {
+        let first = *range.start();
+        let len = range.len() * usize::from(elem_bytes);
+        let addr = base.wrapping_add(u64::from(first) * u64::from(elem_bytes));
+        let offset = VectorRegisterFile::<{ Env::VLEN }>::element_offset(vs3, first, eew);
+        // SAFETY: Elements `vstart..vl` all lie within the register group, which ends within the
+        // register file (precondition), so `offset + len <= 32 * VLEN.bytes()`
+        let data = unsafe {
+            env.read_vregs()
+                .as_bytes()
+                .as_flattened()
+                .get_unchecked(offset..offset + len)
+        };
+        if memory.write_slice(addr, data).is_ok() {
+            env.reset_vstart();
+            return Ok(());
+        }
+        cold_path();
+    }
+
     let segment_stride = u64::from(nf.fields_per_segment() * elem_bytes);
     // SAFETY: `vl <= VLMAX <= VLEN`
     let mask_buf = unsafe { snapshot_mask(env.read_vregs(), vm, vl) };
-    for i in vstart.range_to(vl) {
+    for i in range {
         if !vm && !mask_bit(&mask_buf, i) {
             continue;
         }
@@ -140,7 +167,11 @@ where
             //
             // Therefore,
             // `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
-            let data = unsafe { env.read_vregs().read_element(field_base_reg, i, eew).to_le_bytes() };
+            let data = unsafe {
+                env.read_vregs()
+                    .read_element(field_base_reg, i, eew)
+                    .to_le_bytes()
+            };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
             if let Err(error) = write_mem_element(memory, addr, eew, data) {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/store/zvexx_store_helpers.rs
@@ -2,7 +2,7 @@
 
 use crate::v::vector_registers::VectorRegistersExt;
 use crate::v::zvexx::load::zvexx_load_helpers::{
-    check_register_group_alignment, mask_bit, read_group_element, snapshot_mask,
+    check_register_group_alignment, mask_bit, snapshot_mask,
 };
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter, VirtualMemory, VirtualMemoryError};
@@ -140,7 +140,7 @@ where
             //
             // Therefore,
             // `field_base_reg + i / elems_per_reg < field_base_reg + group_regs <= 32`.
-            let data = unsafe { read_group_element(env.read_vregs(), field_base_reg, i, eew) };
+            let data = unsafe { env.read_vregs().read_element(field_base_reg, i, eew).to_le_bytes() };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
             if let Err(error) = write_mem_element(memory, addr, eew, data) {
@@ -207,7 +207,11 @@ where
             // SAFETY: same argument as `execute_unit_stride_store`; `field_base_reg +
             // i / elems_per_reg < field_base_reg + group_regs <= vs3.to_bits() + nf *
             // group_regs <= 32`.
-            let data = unsafe { read_group_element(env.read_vregs(), field_base_reg, i, eew) };
+            let data = unsafe {
+                env.read_vregs()
+                    .read_element(field_base_reg, i, eew)
+                    .to_le_bytes()
+            };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
             if let Err(error) = write_mem_element(memory, addr, eew, data) {
@@ -274,7 +278,11 @@ where
         // SAFETY: `i < vl <= index_group_regs * VLEN.bytes() / index_eew.bytes()` (precondition),
         // so `vs2.to_bits() + i / (VLEN.bytes() / index_eew.bytes()) <
         //     vs2.to_bits() + index_group_regs <= 32`
-        let index_buf = unsafe { read_group_element(env.read_vregs(), vs2, i, index_eew) };
+        let index_buf = unsafe {
+            env.read_vregs()
+                .read_element(vs2, i, index_eew)
+                .to_le_bytes()
+        };
         // SAFETY: `index_eew.bytes() <= Eew::MAX_BYTES` always holds.
         let offset = unsafe { index_buf_to_u64(index_buf, index_eew) };
         let elem_base = base.wrapping_add(offset);
@@ -286,7 +294,11 @@ where
             // SAFETY: `i < vl <= data_group_regs * VLEN.bytes() / data_eew.bytes()` (precondition),
             // so `field_base_reg + i / elems_per_reg < field_base_reg + data_group_regs
             //                                    <= vs3.to_bits() + nf * data_group_regs <= 32`.
-            let data = unsafe { read_group_element(env.read_vregs(), field_base_reg, i, data_eew) };
+            let data = unsafe {
+                env.read_vregs()
+                    .read_element(field_base_reg, i, data_eew)
+                    .to_le_bytes()
+            };
             // Record the current element index in `vstart` so that, on a memory fault, the failing
             // element can be identified and the operation can be restarted
             if let Err(error) = write_mem_element(memory, addr, data_eew, data) {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow.rs
@@ -1990,8 +1990,7 @@ where
                 }
                 let group_regs = vtype.vlmul().register_count();
                 // EMUL for source = LMUL / 2; src_group = max(1, group_regs / 2)
-                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(2) / 2)
-                    .expect("Not zero; qed");
+                let src_group = group_regs.divide_by_factor(VsewFactor::F2);
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
@@ -2053,8 +2052,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(4) / 4)
-                    .expect("Not zero; qed");
+                let src_group = group_regs.divide_by_factor(VsewFactor::F4);
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
@@ -2116,8 +2114,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(8) / 8)
-                    .expect("Not zero; qed");
+                let src_group = group_regs.divide_by_factor(VsewFactor::F8);
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
@@ -2178,8 +2175,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(2) / 2)
-                    .expect("Not zero; qed");
+                let src_group = group_regs.divide_by_factor(VsewFactor::F2);
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
@@ -2240,8 +2236,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(4) / 4)
-                    .expect("Not zero; qed");
+                let src_group = group_regs.divide_by_factor(VsewFactor::F4);
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,
@@ -2302,8 +2297,7 @@ where
                     });
                 }
                 let group_regs = vtype.vlmul().register_count();
-                let src_group = ::core::num::NonZeroU8::new(group_regs.get().max(8) / 8)
-                    .expect("Not zero; qed");
+                let src_group = group_regs.divide_by_factor(VsewFactor::F8);
                 zvexx_widen_narrow_helpers::check_vs_ext_alignment::<Reg, _, _>(
                     program_counter,
                     vs2,

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/tests.rs
@@ -63,17 +63,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 fn write_elem(
@@ -83,16 +79,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn write_mask(state: &mut TestInterpreterState<ZveXxWidenNarrowInstruction<Reg<u64>>>, bits: u32) {

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
@@ -7,7 +7,6 @@ use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::instructions::v::Vsew;
 use ab_riscv_primitives::prelude::*;
 use core::hint::cold_path;
-use core::num::NonZeroU8;
 
 /// Check that a widening destination `vd` is aligned to `wide_group_regs` and fits within
 /// `[0,32)`, without any source overlap check
@@ -17,15 +16,13 @@ use core::num::NonZeroU8;
 pub fn check_vd_widen_no_src_check<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
-    wide_group_regs: NonZeroU8,
+    wide_group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory>,
 {
-    let wide_group_regs = wide_group_regs.get();
-    let vd_idx = vd.to_bits();
-    if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
+    if !vd.is_group_aligned(wide_group_regs) || vd.to_bits() + wide_group_regs.get() > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
@@ -48,18 +45,19 @@ where
 pub fn check_vs_ext_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vs2: VReg,
-    src_group_regs: NonZeroU8,
+    src_group_regs: VRegGroupSize,
     vd: VReg,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory>,
 {
+    let aligned = vs2.is_group_aligned(src_group_regs);
     let src_group_regs = src_group_regs.get();
     let group_regs = group_regs.get();
     let vs2_idx = vs2.to_bits();
-    if !vs2_idx.is_multiple_of(src_group_regs) || vs2_idx + src_group_regs > 32 {
+    if !aligned || vs2_idx + src_group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
@@ -96,17 +94,18 @@ pub fn check_vd_widen_alignment<Reg, Memory, PC>(
     vd: VReg,
     vs_a: VReg,
     vs_b_opt: Option<VReg>,
-    group_regs: NonZeroU8,
-    wide_group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
+    wide_group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory>,
 {
+    let aligned = vd.is_group_aligned(wide_group_regs);
     let wide_group_regs = wide_group_regs.get();
     let group_regs = group_regs.get();
     let vd_idx = vd.to_bits();
-    if !vd_idx.is_multiple_of(wide_group_regs) || vd_idx + wide_group_regs > 32 {
+    if !aligned || vd_idx + wide_group_regs > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
@@ -156,15 +155,13 @@ fn widen_src_overlap_illegal(vd_idx: u8, wide_group_regs: u8, vs_idx: u8, group_
 pub fn check_vs_wide_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vs: VReg,
-    wide_group_regs: NonZeroU8,
+    wide_group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory>,
 {
-    let wide_group_regs = wide_group_regs.get();
-    let vs_idx = vs.to_bits();
-    if !vs_idx.is_multiple_of(wide_group_regs) || vs_idx + wide_group_regs > 32 {
+    if !vs.is_group_aligned(wide_group_regs) || vs.to_bits() + wide_group_regs.get() > 32 {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),
@@ -186,22 +183,20 @@ where
 pub fn check_vd_narrow_alignment<Reg, Memory, PC>(
     program_counter: &PC,
     vd: VReg,
-    group_regs: NonZeroU8,
+    group_regs: VRegGroupSize,
     vs2: VReg,
-    wide_group_regs: NonZeroU8,
+    wide_group_regs: VRegGroupSize,
 ) -> Result<(), ExecutionError<Reg::Type>>
 where
     Reg: Register,
     PC: ProgramCounter<Reg::Type, Memory>,
 {
+    let aligned = vd.is_group_aligned(group_regs);
     let group_regs = group_regs.get();
     let vd_idx = vd.to_bits();
     let vs2_idx = vs2.to_bits();
     let overlaps = ranges_overlap(vd_idx, group_regs, vs2_idx, wide_group_regs.get());
-    if !vd_idx.is_multiple_of(group_regs)
-        || vd_idx + group_regs > 32
-        || (overlaps && vd_idx != vs2_idx)
-    {
+    if !aligned || vd_idx + group_regs > 32 || (overlaps && vd_idx != vs2_idx) {
         cold_path();
         return Err(ExecutionError::IllegalInstruction {
             address: PackedAddress::new(program_counter.old_pc(INSTRUCTION_SIZE)),

--- a/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/v/zvexx/widen_narrow/zvexx_widen_narrow_helpers.rs
@@ -1,7 +1,8 @@
 //! Opaque helpers for ZveXx extension
 
-use crate::v::vector_registers::{VLENB_USIZE, VectorRegisterFile, VectorRegistersExt};
+use crate::v::vector_registers::VectorRegistersExt;
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{OpSrc, check_vreg_group_alignment};
+use crate::v::zvexx::load::zvexx_load_helpers::{mask_bit, snapshot_mask};
 use crate::v::zvexx::zvexx_helpers::INSTRUCTION_SIZE;
 use crate::{ExecutionError, PackedAddress, ProgramCounter};
 use ab_riscv_primitives::instructions::v::Vsew;
@@ -212,98 +213,6 @@ fn ranges_overlap(a_start: u8, a_len: u8, b_start: u8, b_len: u8) -> bool {
     a_start < b_start + b_len && b_start < a_start + a_len
 }
 
-/// Return whether mask bit `i` is set in the mask byte slice (LSB-first within each byte).
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-fn mask_bit(mask: &[u8], i: u16) -> bool {
-    mask.get(usize::from(i / u8::BITS as u16))
-        .is_some_and(|b| (b >> (i % u8::BITS as u16)) & 1 != 0)
-}
-
-/// Snapshot the mask register into a stack buffer.
-///
-/// When `vm=true` (unmasked), all bytes are `0xff`.
-///
-/// # Safety
-/// `vl <= VLEN` must hold
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-unsafe fn snapshot_mask<const VLEN: Vlen>(
-    vregs: &VectorRegisterFile<VLEN>,
-    vm: bool,
-    vl: Vl,
-) -> [u8; VLENB_USIZE::<VLEN>] {
-    let mut buf = [0u8; _];
-    if vm {
-        buf = [0xffu8; _];
-    } else {
-        let mask_bytes = usize::from(vl.bytes());
-        // SAFETY: `mask_bytes <= VLEN.bytes()` by precondition
-        unsafe {
-            buf.get_unchecked_mut(..mask_bytes)
-                .copy_from_slice(vregs.get(VReg::V0).get_unchecked(..mask_bytes));
-        }
-    }
-    buf
-}
-
-/// Read the low `sew.bytes_width()` of the element `elem_i` from the register group `base_reg`,
-/// zero-extended to `u64`.
-///
-/// # Safety
-/// `base_reg + elem_i / (VLEN.bytes() / sew.bytes_width()) < 32`
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-unsafe fn read_element_u64<const VLEN: Vlen>(
-    vregs: &VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    elem_i: u16,
-    sew: Vsew,
-) -> u64 {
-    let sew_bytes = u32::from(sew.bytes_width());
-    let elems_per_reg = VLEN.bytes() / sew_bytes;
-    let reg_off = u32::from(elem_i) / elems_per_reg;
-    let byte_off = (u32::from(elem_i) % elems_per_reg) * sew_bytes;
-    // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe {
-        vregs.get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
-    };
-    // SAFETY: `byte_off + sew_bytes <= VLEN.bytes()`
-    let src = unsafe { reg.get_unchecked(byte_off as usize..(byte_off + sew_bytes) as usize) };
-    let mut buf = [0u8; 8];
-    // SAFETY: `sew_bytes <= 8`
-    unsafe { buf.get_unchecked_mut(..sew_bytes as usize) }.copy_from_slice(src);
-    u64::from_le_bytes(buf)
-}
-
-/// Write the low `sew.bytes_width()` of `value` into element `elem_i` in register group `base_reg`.
-///
-/// # Safety
-/// `base_reg + elem_i / (VLEN.bytes() / sew.bytes_width()) < 32`
-#[inline(always)]
-#[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-unsafe fn write_element_u64<const VLEN: Vlen>(
-    vregs: &mut VectorRegisterFile<VLEN>,
-    base_reg: VReg,
-    elem_i: u16,
-    sew: Vsew,
-    value: u64,
-) {
-    let sew_bytes = u32::from(sew.bytes_width());
-    let elems_per_reg = VLEN.bytes() / sew_bytes;
-    let reg_off = u32::from(elem_i) / elems_per_reg;
-    let byte_off = (u32::from(elem_i) % elems_per_reg) * sew_bytes;
-    let buf = value.to_le_bytes();
-    // SAFETY: `base_reg + reg_off < 32` by caller's precondition
-    let reg = unsafe {
-        vregs.get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap_unchecked())
-    };
-    // SAFETY: `byte_off + sew_bytes <= VLEN.bytes()`
-    let dst = unsafe { reg.get_unchecked_mut(byte_off as usize..(byte_off + sew_bytes) as usize) };
-    // SAFETY: `sew_bytes <= 8`
-    dst.copy_from_slice(unsafe { buf.get_unchecked(..sew_bytes as usize) });
-}
-
 /// Sign-extend the low `sew.bits_width()` of `val` to `i64`.
 #[inline(always)]
 #[doc(hidden)]
@@ -414,7 +323,7 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, Env, F>(
         }
         // SAFETY: `vs2` aligned to `group_regs`;
         // `i < vl <= group_regs * (VLEN.bytes() / sew.bytes_width())`
-        let raw_a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let raw_a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let wide_a = if ZERO_EXTEND_AB {
             raw_a
         } else {
@@ -423,7 +332,7 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, Env, F>(
         let wide_b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same argument as vs2
-                let raw_b = unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) };
+                let raw_b = unsafe { env.read_vregs().read_element(vs1_base, i, sew) };
                 if ZERO_EXTEND_AB {
                     raw_b
                 } else {
@@ -444,7 +353,7 @@ pub unsafe fn execute_widen_op<const ZERO_EXTEND_AB: bool, Reg, Env, F>(
         // `i < 2*group_regs * (VLEN.bytes() / wide_sew.bytes_width())` - element fits in the wide
         // group
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, wide_sew, result);
+            env.write_vregs().write_element(vd, i, wide_sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -494,13 +403,13 @@ pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, Env, F>(
         }
         // vs2 is already 2×SEW; read at wide width
         // SAFETY: `vs2` aligned to `2*group_regs`; element `i` fits within it
-        let wide_a = unsafe { read_element_u64(env.read_vregs(), vs2, i, wide_sew) };
+        let wide_a = unsafe { env.read_vregs().read_element(vs2, i, wide_sew) };
         let wide_b = match src {
             OpSrc::Vreg(vs1) => {
                 // SAFETY: `vs1` is aligned to `group_regs` and fits within `[0, 32)`,
                 // verified by caller; `i < vl <= group_regs * (VLEN.bytes() / sew.bytes_width())`,
                 // so `vs1_base + i / elems_per_reg < vs1_base + group_regs <= 32`
-                let raw_b = unsafe { read_element_u64(env.read_vregs(), vs1, i, sew) };
+                let raw_b = unsafe { env.read_vregs().read_element(vs1, i, sew) };
                 if ZERO_EXTEND_B {
                     raw_b
                 } else {
@@ -518,7 +427,7 @@ pub unsafe fn execute_widen_w_op<const ZERO_EXTEND_B: bool, Reg, Env, F>(
         let result = op(wide_a, wide_b);
         // SAFETY: same as `execute_widen_op` for vd
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, wide_sew, result);
+            env.write_vregs().write_element(vd, i, wide_sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -570,13 +479,13 @@ pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, Env>(
             continue;
         }
         // SAFETY: `vs2` is the wide source group
-        let wide_val = unsafe { read_element_u64(env.read_vregs(), vs2, i, wide_sew) };
+        let wide_val = unsafe { env.read_vregs().read_element(vs2, i, wide_sew) };
         let shamt = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: `vs1` is aligned to `group_regs` and fits within `[0, 32)`,
                 // verified by caller; `i < vl <= group_regs * (VLEN.bytes() / sew.bytes_width())`,
                 // so `vs1_base + i / elems_per_reg < vs1_base + group_regs <= 32`
-                let raw = unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) };
+                let raw = unsafe { env.read_vregs().read_element(vs1_base, i, sew) };
                 raw & shamt_mask
             }
             // Scalar shift amount: only the low log2(2*SEW) bits are used per spec
@@ -594,7 +503,7 @@ pub unsafe fn execute_narrow_shift<const ARITHMETIC: bool, Reg, Env>(
         let result = result_wide & ((1u64 << sew.bits_width()) - 1);
         // SAFETY: `vd` is the narrow destination group
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -643,7 +552,7 @@ pub unsafe fn execute_extension<const SIGN: bool, Reg, Env>(
             continue;
         }
         // SAFETY: vs2 group covers `vl` narrow elements
-        let raw = unsafe { read_element_u64(env.read_vregs(), vs2, i, src_sew) };
+        let raw = unsafe { env.read_vregs().read_element(vs2, i, src_sew) };
         let result = if SIGN {
             sign_extend_bits(raw, src_sew).cast_unsigned()
         } else {
@@ -651,7 +560,7 @@ pub unsafe fn execute_extension<const SIGN: bool, Reg, Env>(
         };
         // SAFETY: vd group covers `vl` wide elements
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/tests.rs
@@ -58,16 +58,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn read_elem(
@@ -76,17 +73,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 fn set_mask_bit(

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvbb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvbb_helpers.rs
@@ -2,7 +2,6 @@
 
 use crate::v::vector_registers::VectorRegistersExt;
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{OpSrc, check_vreg_group_alignment};
-use crate::v::zvexx::arith::zvexx_arith_helpers::{read_element_u64, write_element_u64};
 use crate::v::zvexx::load::zvexx_load_helpers::mask_bit;
 use ab_riscv_primitives::prelude::*;
 
@@ -35,7 +34,7 @@ where
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let elem = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let elem = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         // `elem` is zero-extended from SEW bits to u64; reverse_bits() on the primitive type
         // of exactly SEW width naturally handles the upper zero bits from zero-extension
         let result = match sew {
@@ -46,7 +45,7 @@ where
         };
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -79,14 +78,14 @@ where
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let elem = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let elem = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         // `elem` is zero-extended from SEW bits to u64; `leading_zeros()` on a u64 therefore counts
         // the extra (64 - SEW) upper zero bits introduced by zero-extension. Subtracting them gives
         // the count within the SEW-wide field.
         let clz = elem.leading_zeros() - (64 - sew_bits);
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, u64::from(clz));
+            env.write_vregs().write_element(vd, i, sew, u64::from(clz));
         }
     }
     env.mark_vs_dirty();
@@ -119,14 +118,14 @@ where
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let elem = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let elem = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         // For non-zero `elem`, `trailing_zeros()` on the zero-extended u64 value is correct: the
         // upper zero bits do not affect the trailing count. For zero, `trailing_zeros()` returns
         // 64, but the spec result is SEW; cap at `sew_bits` handles both cases.
         let ctz = elem.trailing_zeros().min(sew_bits);
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, u64::from(ctz));
+            env.write_vregs().write_element(vd, i, sew, u64::from(ctz));
         }
     }
     env.mark_vs_dirty();
@@ -157,13 +156,13 @@ where
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let elem = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let elem = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         // `elem` is zero-extended from SEW bits; upper bits are already zero, so `count_ones()`
         // directly gives the population count within the SEW-wide field
         let cpop = elem.count_ones();
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, u64::from(cpop));
+            env.write_vregs().write_element(vd, i, sew, u64::from(cpop));
         }
     }
     env.mark_vs_dirty();
@@ -213,22 +212,22 @@ pub unsafe fn execute_vwsll<Reg, Env>(
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let amount = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same alignment constraint as vs2; same index bound
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
-        let shift = (amount & (double_sew_bits - 1)) as u32;
+        let shift = (amount % double_sew_bits) as u32;
         // `a` is zero-extended from SEW bits; `shift < double_sew_bits <= 64`, so this never shifts
         // by >= 64. The caller guarantees SEW <= E32, hence `double_sew_bits <= 64`.
         let result = a << shift;
         // SAFETY: `vd % dest_group_regs == 0` and `vd + dest_group_regs <= 32`; `i < vl`;
         // `write_element_u64` with `double_sew` writes exactly 2*SEW bits of `result`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, double_sew, result);
+            env.write_vregs().write_element(vd, i, double_sew, result);
         }
     }
     env.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/tests.rs
@@ -58,16 +58,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn read_elem(
@@ -76,17 +73,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 fn set_mask_bit(

--- a/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/zvkb_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbb/zvkb/zvkb_helpers.rs
@@ -1,8 +1,8 @@
 //! Opaque helpers for Zvkb extension
 
 use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::zvexx::arith::zvexx_arith_helpers::sew_mask;
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{OpSrc, check_vreg_group_alignment};
-use crate::v::zvexx::arith::zvexx_arith_helpers::{read_element_u64, sew_mask, write_element_u64};
 use crate::v::zvexx::load::zvexx_load_helpers::mask_bit;
 use ab_riscv_primitives::prelude::*;
 
@@ -42,12 +42,12 @@ pub unsafe fn execute_vandn<Reg, Env>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified that the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -58,7 +58,7 @@ pub unsafe fn execute_vandn<Reg, Env>(
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -91,7 +91,7 @@ where
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let elem = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let elem = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         // Decompose into bytes (LE = index 0 is least-significant), reverse bits within each active
         // byte, then reassemble; bytes beyond sew_bytes are already zero because `read_element_u64`
         // zero-extends to u64
@@ -102,7 +102,7 @@ where
         let result = u64::from_le_bytes(bytes);
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -134,7 +134,7 @@ where
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let elem = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let elem = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         // Reverse the byte slice covering exactly the SEW-wide element; bytes beyond sew_bytes are
         // zero (from zero-extension) and are left untouched
         let mut bytes = elem.to_le_bytes();
@@ -142,7 +142,7 @@ where
         let result = u64::from_le_bytes(bytes);
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -181,11 +181,11 @@ pub unsafe fn execute_vrol<Reg, Env>(
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let amount = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same alignment constraint as vs2; same index bound
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -198,7 +198,7 @@ pub unsafe fn execute_vrol<Reg, Env>(
         let result = hi | lo;
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -239,11 +239,11 @@ pub unsafe fn execute_vror<Reg, Env>(
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let amount = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same alignment constraint as vs2; same index bound
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -256,7 +256,7 @@ pub unsafe fn execute_vror<Reg, Env>(
         let result = lo | hi;
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();

--- a/crates/execution/ab-riscv-interpreter/src/zvbc/tests.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc/tests.rs
@@ -58,16 +58,13 @@ fn write_elem(
     sew: Vsew,
     value: u64,
 ) {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .write_vregs()
-        .get_mut(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let buf = value.to_le_bytes();
-    reg[byte_off..byte_off + sew_bytes].copy_from_slice(&buf[..sew_bytes]);
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .write_vregs()
+            .write_element(base_reg, u16::try_from(elem_i).unwrap(), sew, value);
+    }
 }
 
 fn read_elem(
@@ -76,17 +73,13 @@ fn read_elem(
     elem_i: usize,
     sew: Vsew,
 ) -> u64 {
-    let sew_bytes = usize::from(sew.bytes_width());
-    let elems_per_reg = 32 / sew_bytes;
-    let reg_off = elem_i / elems_per_reg;
-    let byte_off = (elem_i % elems_per_reg) * sew_bytes;
-    let reg = state
-        .env
-        .read_vregs()
-        .get(VReg::from_bits(base_reg.to_bits() + reg_off as u8).unwrap());
-    let mut buf = [0u8; 8];
-    buf[..sew_bytes].copy_from_slice(&reg[byte_off..byte_off + sew_bytes]);
-    u64::from_le_bytes(buf)
+    // SAFETY: Test elements are always within the register group
+    unsafe {
+        state
+            .env
+            .read_vregs()
+            .read_element(base_reg, u16::try_from(elem_i).unwrap(), sew)
+    }
 }
 
 fn set_mask_bit(

--- a/crates/execution/ab-riscv-interpreter/src/zvbc/zvbc_helpers.rs
+++ b/crates/execution/ab-riscv-interpreter/src/zvbc/zvbc_helpers.rs
@@ -2,8 +2,8 @@
 
 use crate::rv64::b::zbc::rv64_zbc_helpers;
 use crate::v::vector_registers::VectorRegistersExt;
+use crate::v::zvexx::arith::zvexx_arith_helpers::sew_mask;
 pub use crate::v::zvexx::arith::zvexx_arith_helpers::{OpSrc, check_vreg_group_alignment};
-use crate::v::zvexx::arith::zvexx_arith_helpers::{read_element_u64, sew_mask, write_element_u64};
 use crate::v::zvexx::load::zvexx_load_helpers::mask_bit;
 use ab_riscv_primitives::prelude::*;
 
@@ -80,12 +80,12 @@ pub unsafe fn execute_vclmul<Reg, Env>(
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32` (caller precondition);
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vs2 + i / elems_per_reg < vs2 + group_regs <= 32`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: caller verified the vs1 register group satisfies the same alignment
                 // constraint as vs2; the index argument is identical, so the same bound holds
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
@@ -94,7 +94,7 @@ pub unsafe fn execute_vclmul<Reg, Env>(
         // `i < vl <= group_regs * elems_per_reg`, so
         // `vd + i / elems_per_reg < vd + group_regs <= 32`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();
@@ -131,18 +131,18 @@ pub unsafe fn execute_vclmulh<Reg, Env>(
             continue;
         }
         // SAFETY: `vs2 % group_regs == 0` and `vs2 + group_regs <= 32`; `i < vl`
-        let a = unsafe { read_element_u64(env.read_vregs(), vs2, i, sew) };
+        let a = unsafe { env.read_vregs().read_element(vs2, i, sew) };
         let b = match src {
             OpSrc::Vreg(vs1_base) => {
                 // SAFETY: same alignment constraint as vs2; same index bound
-                unsafe { read_element_u64(env.read_vregs(), vs1_base, i, sew) }
+                unsafe { env.read_vregs().read_element(vs1_base, i, sew) }
             }
             OpSrc::Scalar(val) => val,
         };
         let result = vclmulh_element(a, b, sew);
         // SAFETY: `vd % group_regs == 0` and `vd + group_regs <= 32`; `i < vl`
         unsafe {
-            write_element_u64(env.write_vregs(), vd, i, sew, result);
+            env.write_vregs().write_element(vd, i, sew, result);
         }
     }
     env.mark_vs_dirty();

--- a/crates/execution/ab-riscv-primitives/CHANGELOG.md
+++ b/crates/execution/ab-riscv-primitives/CHANGELOG.md
@@ -3,6 +3,7 @@
 Breaking changes:
 
 * `Instruction::alignment()` is replaced by the `Instruction::ALIGNMENT` associated constant
+* Changed APIs around vector extensions for better type safety and performance
 
 # 0.2.0
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -567,14 +567,21 @@ impl VsewFactor {
     /// Return the numeric divisor used to scale down a [`Vsew`] bit-width
     #[inline(always)]
     pub const fn factor(self) -> u8 {
-        self as u8
+        let factor = self as u8;
+        // TODO: Remove once rustc tells LLVM which values an enum can have rather than their
+        //  range, which hides the power of two: https://github.com/rust-lang/rust/issues/162513
+        // SAFETY: Every variant is a power of two
+        unsafe {
+            assert_unchecked(factor.is_power_of_two());
+        }
+        factor
     }
 }
 
 /// Selected element width (SEW).
 ///
 /// Encoded in `vtype[5:3]` as `vsew`. `SEW = 8 * 2^vsew`.
-#[derive(Debug, Clone, Copy)]
+#[derive(ConstParamTy, Debug, Clone, Copy)]
 #[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum Vsew {
@@ -731,8 +738,10 @@ impl fmt::Display for Vsew {
     }
 }
 
-/// Effective element width for vector memory operations
-#[derive(Debug, Clone, Copy)]
+/// Effective element width of a vector operand.
+///
+/// Memory operands carry it in the instruction, register operands derive it from `SEW`.
+#[derive(ConstParamTy, Debug, Clone, Copy)]
 #[derive_const(PartialEq, Eq)]
 #[repr(u8)]
 pub enum Eew {
@@ -799,12 +808,26 @@ impl Eew {
     /// Guaranteed to be `<= Self::MAX_BYTES`.
     #[inline(always)]
     pub const fn bytes_width(self) -> u8 {
-        match self {
+        let bytes: u8 = match self {
             Self::E8 => 1,
             Self::E16 => 2,
             Self::E32 => 4,
             Self::E64 => 8,
+        };
+        // TODO: Remove once rustc stops folding this `match` into a cast, which hides the
+        //  power of two from LLVM: https://github.com/rust-lang/rust/issues/162513
+        // SAFETY: Every variant is a power of two
+        unsafe {
+            assert_unchecked(bytes.is_power_of_two());
         }
+        bytes
+    }
+}
+
+const impl From<Vsew> for Eew {
+    #[inline(always)]
+    fn from(sew: Vsew) -> Self {
+        sew.as_eew()
     }
 }
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -1,5 +1,7 @@
 //! V extension
 
+#[cfg(test)]
+mod tests;
 pub mod zvexx;
 
 use crate::instructions::Instruction;
@@ -7,7 +9,6 @@ use crate::registers::general_purpose::{RegType, Register};
 use core::any::TypeId;
 use core::hint::{assert_unchecked, cold_path};
 use core::marker::ConstParamTy;
-use core::num::NonZeroU8;
 use core::ops::RangeInclusive;
 use core::{cmp, fmt};
 
@@ -366,36 +367,96 @@ impl Vlmul {
     /// Integer `LMUL` values occupy 1, 2, 4, or 8 registers respectively.
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    pub const fn register_count(self) -> NonZeroU8 {
-        let register_count = match self {
-            Self::Mf8 | Self::Mf4 | Self::Mf2 | Self::M1 => 1,
-            Self::M2 => 2,
-            Self::M4 => 4,
-            Self::M8 => 8,
-        };
-        NonZeroU8::new(register_count).expect("Not zero; qed")
+    pub const fn register_count(self) -> VRegGroupSize {
+        match self {
+            Self::Mf8 | Self::Mf4 | Self::Mf2 | Self::M1 => VRegGroupSize::R1,
+            Self::M2 => VRegGroupSize::R2,
+            Self::M4 => VRegGroupSize::R4,
+            Self::M8 => VRegGroupSize::R8,
+        }
     }
 
-    /// LMUL as a `(numerator, denominator)` fraction where `LMUL = num / den`.
-    ///
-    /// Both values are powers of two with exactly one equal to `1`. Useful for computing
-    /// `EMUL = (EEW / SEW) * LMUL` without floating-point arithmetic.
+    /// Whether this is a fractional multiplier, so a register group is a part of one register
     #[inline(always)]
-    pub const fn as_fraction(self) -> (NonZeroU8, NonZeroU8) {
-        let (numerator, denominator) = match self {
-            Self::Mf8 => (1, 8),
-            Self::Mf4 => (1, 4),
-            Self::Mf2 => (1, 2),
-            Self::M1 => (1, 1),
-            Self::M2 => (2, 1),
-            Self::M4 => (4, 1),
-            Self::M8 => (8, 1),
-        };
+    pub const fn is_fractional(self) -> bool {
+        matches!(self, Self::Mf8 | Self::Mf4 | Self::Mf2)
+    }
 
-        (
-            NonZeroU8::new(numerator).expect("Not zero; qed"),
-            NonZeroU8::new(denominator).expect("Not zero; qed"),
-        )
+    /// Twice this multiplier, `None` above `M8`
+    #[inline(always)]
+    pub const fn double(self) -> Option<Self> {
+        match self {
+            Self::Mf8 => Some(Self::Mf4),
+            Self::Mf4 => Some(Self::Mf2),
+            Self::Mf2 => Some(Self::M1),
+            Self::M1 => Some(Self::M2),
+            Self::M2 => Some(Self::M4),
+            Self::M4 => Some(Self::M8),
+            Self::M8 => {
+                cold_path();
+                None
+            }
+        }
+    }
+
+    /// `LMUL` in eighths, so that fractional multipliers are integers too
+    #[inline(always)]
+    const fn eighths(self) -> u32 {
+        let eighths: u32 = match self {
+            Self::Mf8 => 1,
+            Self::Mf4 => 2,
+            Self::Mf2 => 4,
+            Self::M1 => 8,
+            Self::M2 => 16,
+            Self::M4 => 32,
+            Self::M8 => 64,
+        };
+        // TODO: Remove once rustc stops folding this `match` into a cast, which hides the
+        //  power of two from LLVM: https://github.com/rust-lang/rust/issues/162513
+        // SAFETY: Every variant is a power of two
+        unsafe {
+            assert_unchecked(eighths.is_power_of_two());
+        }
+        eighths
+    }
+
+    /// Inverse of [`Self::eighths()`], `None` outside the legal range `[1/8, 8]`
+    #[inline(always)]
+    const fn from_eighths(eighths: u32) -> Option<Self> {
+        match eighths {
+            1 => Some(Self::Mf8),
+            2 => Some(Self::Mf4),
+            4 => Some(Self::Mf2),
+            8 => Some(Self::M1),
+            16 => Some(Self::M2),
+            32 => Some(Self::M4),
+            64 => Some(Self::M8),
+            _ => {
+                cold_path();
+                None
+            }
+        }
+    }
+
+    /// Effective multiplier `EMUL = LMUL * EEW / SEW` of an operand with element width `eew`
+    /// under this `LMUL` and `sew`.
+    ///
+    /// Returns `None` when `EMUL` falls outside the legal range `[1/8, 8]`.
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    pub const fn emul(self, eew: Eew, sew: Vsew) -> Option<Self> {
+        let eighths = self.eighths() * u32::from(eew.bits_width()) / u32::from(sew.bits_width());
+        Self::from_eighths(eighths)
+    }
+
+    /// Number of vector registers occupied by the destination group of a widening instruction,
+    /// whose `EMUL = 2 * LMUL`.
+    ///
+    /// Returns `None` for `M8`, where `EMUL` would be `16`.
+    #[inline(always)]
+    #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
+    pub const fn widening_register_count(self) -> Option<VRegGroupSize> {
+        Some(self.double()?.register_count())
     }
 
     /// Compute `EMUL` for an indexed load: `EMUL = (index_eew / sew) * LMUL`.
@@ -404,25 +465,8 @@ impl Vlmul {
     /// outside the legal range `[1/8, 8]`.
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    pub const fn index_register_count(self, index_eew: Eew, sew: Vsew) -> Option<NonZeroU8> {
-        let (lmul_num, lmul_den) = self.as_fraction();
-        let num = u16::from(index_eew.bits_width()) * u16::from(lmul_num.get());
-        let den = u16::from(sew.bits_width()) * u16::from(lmul_den.get());
-        // Both are products of powers of two; GCD equals the smaller value.
-        let g = if num < den { num } else { den };
-        let (n, d) = (num / g, den / g);
-        // Legal EMUL fractions: 1/8, 1/4, 1/2, 1, 2, 4, 8
-        #[expect(clippy::unnested_or_patterns, reason = "Readability")]
-        let legal = matches!(
-            (n, d),
-            (1, 8) | (1, 4) | (1, 2) | (1, 1) | (2, 1) | (4, 1) | (8, 1)
-        );
-        if !legal {
-            cold_path();
-            return None;
-        }
-        // Register count is max(1, n/d) = n when d==1, else 1
-        Some(NonZeroU8::new(if d > 1 { 1 } else { n as u8 }).expect("Not zero; qed"))
+    pub const fn index_register_count(self, index_eew: Eew, sew: Vsew) -> Option<VRegGroupSize> {
+        Some(self.emul(index_eew, sew)?.register_count())
     }
 
     /// Compute EMUL for a data operand of a memory instruction with a given effective element
@@ -436,7 +480,7 @@ impl Vlmul {
     /// Returns `None` when the resulting EMUL falls outside the legal range `[1/8, 8]`.
     #[inline(always)]
     #[cfg_attr(feature = "no-panic", no_panic_const::no_panic)]
-    pub const fn data_register_count(self, eew: Eew, sew: Vsew) -> Option<NonZeroU8> {
+    pub const fn data_register_count(self, eew: Eew, sew: Vsew) -> Option<VRegGroupSize> {
         self.index_register_count(eew, sew)
     }
 }
@@ -452,6 +496,57 @@ impl fmt::Display for Vlmul {
             Self::Mf4 => write!(f, "mf4"),
             Self::Mf2 => write!(f, "mf2"),
         }
+    }
+}
+
+/// Number of vector registers in a register group.
+///
+/// Register groups always consist of a power of two number of registers, whether from
+/// `LMUL`, `EMUL` of a memory operand or a whole-register move.
+#[derive(Debug, Clone, Copy)]
+#[derive_const(PartialEq, Eq)]
+#[repr(u8)]
+pub enum VRegGroupSize {
+    /// A single register
+    R1 = 1,
+    /// Two registers
+    R2 = 2,
+    /// Four registers
+    R4 = 4,
+    /// Eight registers
+    R8 = 8,
+}
+
+impl VRegGroupSize {
+    /// Number of registers in the group
+    #[inline(always)]
+    pub const fn get(self) -> u8 {
+        let count = self as u8;
+        // TODO: Remove once rustc tells LLVM which values an enum can have rather than their
+        //  range, which hides the power of two: https://github.com/rust-lang/rust/issues/162513
+        // SAFETY: Every variant is a power of two
+        unsafe {
+            assert_unchecked(count.is_power_of_two());
+        }
+        count
+    }
+
+    /// Size of a group with `factor` times fewer registers, at least one.
+    ///
+    /// This is the source group of a `vzext`/`vsext`, whose `EMUL = LMUL / factor`.
+    #[inline(always)]
+    pub const fn divide_by_factor(self, factor: VsewFactor) -> Self {
+        match self.get() / factor.factor() {
+            2 => Self::R2,
+            4 => Self::R4,
+            _ => Self::R1,
+        }
+    }
+}
+
+impl fmt::Display for VRegGroupSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.get())
     }
 }
 

--- a/crates/execution/ab-riscv-primitives/src/instructions/v.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v.rs
@@ -5,7 +5,7 @@ pub mod zvexx;
 use crate::instructions::Instruction;
 use crate::registers::general_purpose::{RegType, Register};
 use core::any::TypeId;
-use core::hint::cold_path;
+use core::hint::{assert_unchecked, cold_path};
 use core::marker::ConstParamTy;
 use core::num::NonZeroU8;
 use core::ops::RangeInclusive;
@@ -576,23 +576,37 @@ impl Vsew {
     /// Element width in bits
     #[inline(always)]
     pub const fn bits_width(self) -> u8 {
-        match self {
+        let bits: u8 = match self {
             Self::E8 => 8,
             Self::E16 => 16,
             Self::E32 => 32,
             Self::E64 => 64,
+        };
+        // TODO: Remove once rustc stops folding this `match` into a cast, which hides the
+        //  power of two from LLVM: https://github.com/rust-lang/rust/issues/162513
+        // SAFETY: Every variant is a power of two
+        unsafe {
+            assert_unchecked(bits.is_power_of_two());
         }
+        bits
     }
 
     /// Element width in bytes
     #[inline(always)]
     pub const fn bytes_width(self) -> u8 {
-        match self {
+        let bytes: u8 = match self {
             Self::E8 => 1,
             Self::E16 => 2,
             Self::E32 => 4,
             Self::E64 => 8,
+        };
+        // TODO: Remove once rustc stops folding this `match` into a cast, which hides the
+        //  power of two from LLVM: https://github.com/rust-lang/rust/issues/162513
+        // SAFETY: Every variant is a power of two
+        unsafe {
+            assert_unchecked(bytes.is_power_of_two());
         }
+        bytes
     }
 
     /// Convert to the corresponding `Eew` variant.
@@ -670,12 +684,19 @@ impl Eew {
     /// Element width in bits
     #[inline(always)]
     pub const fn bits_width(self) -> u8 {
-        match self {
+        let bits: u8 = match self {
             Self::E8 => 8,
             Self::E16 => 16,
             Self::E32 => 32,
             Self::E64 => 64,
+        };
+        // TODO: Remove once rustc stops folding this `match` into a cast, which hides the
+        //  power of two from LLVM: https://github.com/rust-lang/rust/issues/162513
+        // SAFETY: Every variant is a power of two
+        unsafe {
+            assert_unchecked(bits.is_power_of_two());
         }
+        bits
     }
 
     /// Element width in bytes.

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/tests.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/tests.rs
@@ -1,0 +1,38 @@
+use crate::instructions::v::{VRegGroupSize, Vlmul};
+
+#[test]
+fn widening_register_count_values() {
+    // EMUL = 2 * LMUL:
+    // Mf8 (1/8) -> 2/8 = 1/4 -> 1 reg
+    // Mf4 (1/4) -> 2/4 = 1/2 -> 1 reg
+    // Mf2 (1/2) -> 2/2 = 1   -> 1 reg
+    // M1 (1)    -> 2/1 = 2   -> 2 regs
+    // M2 (2)    -> 4/1 = 4   -> 4 regs
+    // M4 (4)    -> 8/1 = 8   -> 8 regs
+    // M8 (8)    -> 16/1 = 16 -> None (illegal)
+    assert_eq!(
+        Vlmul::widening_register_count(Vlmul::Mf8),
+        Some(VRegGroupSize::R1)
+    );
+    assert_eq!(
+        Vlmul::widening_register_count(Vlmul::Mf4),
+        Some(VRegGroupSize::R1)
+    );
+    assert_eq!(
+        Vlmul::widening_register_count(Vlmul::Mf2),
+        Some(VRegGroupSize::R1)
+    );
+    assert_eq!(
+        Vlmul::widening_register_count(Vlmul::M1),
+        Some(VRegGroupSize::R2)
+    );
+    assert_eq!(
+        Vlmul::widening_register_count(Vlmul::M2),
+        Some(VRegGroupSize::R4)
+    );
+    assert_eq!(
+        Vlmul::widening_register_count(Vlmul::M4),
+        Some(VRegGroupSize::R8)
+    );
+    assert_eq!(Vlmul::widening_register_count(Vlmul::M8), None);
+}

--- a/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/load.rs
+++ b/crates/execution/ab-riscv-primitives/src/instructions/v/zvexx/load.rs
@@ -4,7 +4,7 @@
 mod tests;
 
 use crate::instructions::Instruction;
-use crate::instructions::v::{Eew, V};
+use crate::instructions::v::{Eew, V, VRegGroupSize};
 use crate::registers::general_purpose::Register;
 use crate::registers::vector::VReg;
 use ab_riscv_macros::instruction;
@@ -139,8 +139,13 @@ impl LoadStoreNreg {
 
     /// Get the number of registers
     #[inline(always)]
-    pub const fn num_registers(&self) -> u8 {
-        *self as u8
+    pub const fn num_registers(&self) -> VRegGroupSize {
+        match self {
+            Self::N1 => VRegGroupSize::R1,
+            Self::N2 => VRegGroupSize::R2,
+            Self::N4 => VRegGroupSize::R4,
+            Self::N8 => VRegGroupSize::R8,
+        }
     }
 }
 

--- a/crates/execution/ab-riscv-primitives/src/prelude.rs
+++ b/crates/execution/ab-riscv-primitives/src/prelude.rs
@@ -65,8 +65,8 @@ pub use crate::instructions::v::zvexx::reduction::ZveXxReductionInstruction;
 pub use crate::instructions::v::zvexx::store::ZveXxStoreInstruction;
 pub use crate::instructions::v::zvexx::widen_narrow::ZveXxWidenNarrowInstruction;
 pub use crate::instructions::v::{
-    Eew, Elen, SUPPORTED_ELEN_VLEN, V, Vl, Vlen, Vlmul, VsStatus, Vsew, VsewFactor, Vstart, Vtype,
-    Vxrm,
+    Eew, Elen, SUPPORTED_ELEN_VLEN, V, VRegGroupSize, Vl, Vlen, Vlmul, VsStatus, Vsew, VsewFactor,
+    Vstart, Vtype, Vxrm,
 };
 pub use crate::instructions::zawrs::ZawrsInstruction;
 pub use crate::instructions::zicond::ZicondInstruction;

--- a/crates/execution/ab-riscv-primitives/src/registers/vector.rs
+++ b/crates/execution/ab-riscv-primitives/src/registers/vector.rs
@@ -1,5 +1,6 @@
 //! RISC-V vector registers
 
+use crate::instructions::v::VRegGroupSize;
 use core::fmt;
 
 /// RISC-V vector register (v0-v31)
@@ -118,6 +119,14 @@ impl VReg {
     #[inline(always)]
     pub const fn to_bits(self) -> u8 {
         self as u8
+    }
+
+    /// Whether this register can be the base of a register group of `group` registers.
+    ///
+    /// The base of a register group must be a multiple of the group size.
+    #[inline(always)]
+    pub const fn is_group_aligned(self, group: VRegGroupSize) -> bool {
+        self.to_bits().is_multiple_of(group.get())
     }
 }
 


### PR DESCRIPTION
A bunch of changes here improve vector extension performance from various angles, including workarounds for missing compiler optimizations.

ed25519 signature verification is vectorized in a beneficial way (portable BLAKE3 is apparently written in a way that doesn't vectorize well and doesn't benefit) with new record performance when vector extensions are enabled:
```
ed25519_verify/interpreter/threaded/eager
                        time:   [681.60 µs 688.86 µs 701.25 µs]
                        thrpt:  [1.4260 Kelem/s 1.4517 Kelem/s 1.4671 Kelem/s]
```

PGO currently regresses performance for it due to https://github.com/llvm/llvm-project/issues/222292, which I'm working on resolving.

And overall a lot of places look much nicer now with better type safety.